### PR TITLE
* large overhaul of everything involved in the zone options mgmt.

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -2,7 +2,8 @@ PROG:=tdns-cli
 
 GOOS ?= $(shell uname -s | tr A-Z a-z)
 # We need CGO because we now need sqlite also in tdns-cli
-GO:=GOOS=$(GOOS) CGO_ENABLED=1 go
+# GO:=GOOS=$(GOOS) CGO_ENABLED=1 go
+GO:=CGO_ENABLED=1 go
 include ../utils/Makefile.common
 
 install:

--- a/cli/cmd/zone_cmds.go
+++ b/cli/cmd/zone_cmds.go
@@ -253,6 +253,10 @@ var zoneListCmd = &cobra.Command{
 			out = append(out, hdr)
 		}
 		for zname, zconf := range cr.Zones {
+			opts := []string{}
+			for _, opt := range zconf.Options {
+				opts = append(opts, tdns.ZoneOptionToString[opt])
+			}
 			line := fmt.Sprintf("%s|%s|%s|", zname, zconf.Type, zconf.Store)
 			if showprimary {
 				line += fmt.Sprintf("%s|", zconf.Primary)
@@ -263,7 +267,7 @@ var zoneListCmd = &cobra.Command{
 			if showfile {
 				line += fmt.Sprintf("%s|", zconf.Zonefile)
 			}
-			line += fmt.Sprintf("%t|%t|%v", zconf.Frozen, zconf.Dirty, zconf.Options)
+			line += fmt.Sprintf("%t|%t|%v", zconf.Frozen, zconf.Dirty, opts)
 			out = append(out, line)
 		}
 		fmt.Printf("%s\n", columnize.SimpleFormat(out))

--- a/dog/Makefile
+++ b/dog/Makefile
@@ -1,7 +1,8 @@
 PROG:=dog
 
 GOOS ?= $(shell uname -s | tr A-Z a-z)
-GO:=GOOS=$(GOOS) CGO_ENABLED=0 go
+# GO:=GOOS=$(GOOS) CGO_ENABLED=0 go
+GO:=CGO_ENABLED=0 go
 include ../utils/Makefile.common
 
 install:

--- a/tdns/dnskey_ops.go
+++ b/tdns/dnskey_ops.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (zd *ZoneData) PublishDnskeyRRs(dak *DnssecKeys) error {
-	if !zd.Options["allow-updates"] {
+	if !zd.Options[OptAllowUpdates] {
 		return fmt.Errorf("Zone %s does not allow updates", zd.ZoneName)
 	}
 

--- a/tdns/dnsutils.go
+++ b/tdns/dnsutils.go
@@ -285,7 +285,7 @@ func (zd *ZoneData) ReadZoneFile(filename string, force bool) (bool, uint32, err
 func (zd *ZoneData) SortFunc(rr dns.RR, firstSoaSeen bool) bool {
 	owner := rr.Header().Name
 	// if zd.FoldCase {
-	if zd.Options["fold-case"] {
+	if zd.Options[OptFoldCase] {
 		owner = strings.ToLower(owner)
 	}
 	rrtype := rr.Header().Rrtype

--- a/tdns/enums.go
+++ b/tdns/enums.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package tdns
+
+type ZoneOption uint8
+
+const (
+	OptDelSyncParent ZoneOption = iota + 1
+	OptDelSyncChild
+	OptAllowUpdates
+	OptAllowChildUpdates
+	OptFoldCase
+	OptBlackLies
+	OptDontPublishKey
+	OptOnlineSigning
+	OptMultiSigner
+	OptDirty
+	OptFrozen
+	OptAgent // XXX: Hmm. Is this needed?
+)
+
+var ZoneOptionToString = map[ZoneOption]string{
+	OptDelSyncParent:     "delegation-sync-parent",
+	OptDelSyncChild:      "delegation-sync-child",
+	OptAllowUpdates:      "allow-updates",
+	OptAllowChildUpdates: "allow-child-updates",
+	OptFoldCase:          "fold-case",
+	OptBlackLies:         "black-lies",
+	OptDontPublishKey:    "dont-publish-key",
+	OptOnlineSigning:     "online-signing",
+	OptMultiSigner:       "multisigner",
+	OptDirty:             "dirty",
+	OptFrozen:            "frozen",
+	OptAgent:             "agent",
+}
+
+var StringToZoneOption = map[string]ZoneOption{
+	"delegation-sync-parent": OptDelSyncParent,
+	"delegation-sync-child":  OptDelSyncChild,
+	"allow-updates":          OptAllowUpdates,
+	"allow-child-updates":    OptAllowChildUpdates,
+	"fold-case":              OptFoldCase,
+	"black-lies":             OptBlackLies,
+	"dont-publish-key":       OptDontPublishKey,
+	"online-signing":         OptOnlineSigning,
+	"multisigner":            OptMultiSigner,
+	"dirty":                  OptDirty,
+	"frozen":                 OptFrozen,
+	"agent":                  OptAgent,
+}

--- a/tdns/key_ops.go
+++ b/tdns/key_ops.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (zd *ZoneData) PublishKeyRRs(sak *Sig0ActiveKeys) error {
-	if zd.Options["dont-publish-key"] {
+	if zd.Options[OptDontPublishKey] {
 		return fmt.Errorf("Zone %s does not allow KEY RR publication", zd.ZoneName)
 	}
 

--- a/tdns/queryresponder.go
+++ b/tdns/queryresponder.go
@@ -23,7 +23,7 @@ func (zd *ZoneData) ApexResponder(w dns.ResponseWriter, r *dns.Msg, qname string
 			log.Printf("ApexResponder: MaybeSignRRset: Warning: dak is nil")
 			return rrset
 		}
-		if zd.Options["online-signing"] && dak != nil && len(dak.ZSKs) > 0 && len(rrset.RRSIGs) == 0 {
+		if zd.Options[OptOnlineSigning] && dak != nil && len(dak.ZSKs) > 0 && len(rrset.RRSIGs) == 0 {
 			_, err := zd.SignRRset(&rrset, qname, dak, false)
 			if err != nil {
 				log.Printf("Error signing %s: %v", qname, err)
@@ -143,7 +143,7 @@ func (zd *ZoneData) QueryResponder(w dns.ResponseWriter, r *dns.Msg, qname strin
 			log.Printf("QueryResponder: MaybeSignRRset: Warning: dak is nil")
 			return rrset
 		}
-		if zd.Options["online-signing"] && dak != nil && len(dak.ZSKs) > 0 && len(rrset.RRSIGs) == 0 {
+		if zd.Options[OptOnlineSigning] && dak != nil && len(dak.ZSKs) > 0 && len(rrset.RRSIGs) == 0 {
 			_, err := zd.SignRRset(&rrset, qname, dak, false)
 			if err != nil {
 				log.Printf("Error signing %s: %v", qname, err)
@@ -315,7 +315,7 @@ func (zd *ZoneData) QueryResponder(w dns.ResponseWriter, r *dns.Msg, qname strin
 
 				log.Printf("Should we sign qname %s %s (origqname: %s)?", qname, dns.TypeToString[qtype], origqname)
 				// if zd.OnlineSigning && cs != nil {
-				if zd.Options["online-signing"] && dak != nil && len(dak.ZSKs) > 0 {
+				if zd.Options[OptOnlineSigning] && dak != nil && len(dak.ZSKs) > 0 {
 					if qname == origqname {
 						owner.RRtypes[qtype] = MaybeSignRRset(owner.RRtypes[qtype], qname)
 					}

--- a/tdns/refreshengine.go
+++ b/tdns/refreshengine.go
@@ -63,7 +63,7 @@ func RefreshEngine(conf *Config, stopch chan struct{}, appMode string) {
 			}
 			if zone != "" {
 				if zd, exist := Zones.Get(zone); exist {
-					if zd.ZoneType == Primary && zd.Options["dirty"] {
+					if zd.ZoneType == Primary && zd.Options[OptDirty] {
 						resp.Msg = fmt.Sprintf("RefreshEngine: Zone %s has modifications, reload not possible", zone)
 						log.Printf(resp.Msg)
 						if zr.Response != nil {

--- a/tdns/sign.go
+++ b/tdns/sign.go
@@ -59,7 +59,7 @@ func SignMsg(m dns.Msg, signer string, sak *Sig0ActiveKeys) (*dns.Msg, error) {
 
 func (zd *ZoneData) SignRRset(rrset *RRset, name string, dak *DnssecKeys, force bool) (bool, error) {
 
-	if !zd.Options["online-signing"] {
+	if !zd.Options[OptOnlineSigning] {
 		return false, fmt.Errorf("SignRRset: zone %s does not allow online signing", zd.ZoneName)
 	}
 
@@ -170,11 +170,11 @@ func NeedsResigning(rrsig *dns.RRSIG) bool {
 // At the end, is anything hass been signed, then we must end by bumping the
 // SOA Serial and resigning the SOA.
 func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
-	if !zd.Options["online-signing"] {
+	if !zd.Options[OptOnlineSigning] {
 		return 0, fmt.Errorf("SignZone: zone %s should not be signed here (option online-signing=false)", zd.ZoneName)
 	}
 
-	if !zd.Options["allow-updates"] {
+	if !zd.Options[OptAllowUpdates] {
 		return 0, fmt.Errorf("SignZone: zone %s is not allowed to be updated", zd.ZoneName)
 	}
 
@@ -263,7 +263,7 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 	newrrsigs := 0
 
 	// It's either black lies or we need a traditional NSEC chain
-	if !zd.Options["black-lies"] {
+	if !zd.Options[OptBlackLies] {
 		err = zd.GenerateNsecChain(kdb)
 		if err != nil {
 			return 0, err
@@ -365,7 +365,7 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 }
 
 func (zd *ZoneData) GenerateNsecChain(kdb *KeyDB) error {
-	if !zd.Options["allow-updates"] {
+	if !zd.Options[OptAllowUpdates] {
 		return fmt.Errorf("GenerateNsecChain: zone %s is not allowed to be updated", zd.ZoneName)
 	}
 	dak, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
@@ -421,7 +421,7 @@ func (zd *ZoneData) GenerateNsecChain(kdb *KeyDB) error {
 				tmap = append(tmap, int(rrt))
 			}
 		}
-		if hasRRSIG || (zd.Options["online-signing"] && len(dak.KSKs) > 0) {
+		if hasRRSIG || (zd.Options[OptOnlineSigning] && len(dak.KSKs) > 0) {
 			tmap = append(tmap, int(dns.TypeRRSIG))
 		}
 

--- a/tdns/structs.go
+++ b/tdns/structs.go
@@ -78,7 +78,7 @@ type ZoneData struct {
 	ParentNS         []string // names of parent nameservers
 	ParentServers    []string // addresses of parent nameservers
 	Children         map[string]*ChildDelegationData
-	Options          map[string]bool
+	Options          map[ZoneOption]bool
 	UpdatePolicy     UpdatePolicy
 	DnssecPolicy     *DnssecPolicy
 	MultiSigner      *MultiSignerConf
@@ -93,9 +93,10 @@ type ZoneConf struct {
 	Store        string `validate:"required"` // xfr | map | slice | reg
 	Primary      string // upstream, for secondary zones
 	Notify       []string
-	Options      []string
-	Frozen       bool // true if zone is frozen; not a config param
-	Dirty        bool // true if zone has been modified; not a config param
+	OptionsStrs  []string     `yaml:"options"`
+	Options      []ZoneOption `yaml:"-"` // not used by yaml, but by code
+	Frozen       bool         // true if zone is frozen; not a config param
+	Dirty        bool         // true if zone has been modified; not a config param
 	UpdatePolicy UpdatePolicyConf
 	DnssecPolicy string
 	Template     string
@@ -109,7 +110,7 @@ type TemplateConf struct {
 	Store        string
 	Primary      string // upstream, for secondary zones
 	Notify       []string
-	Options      []string
+	OptionsStrs  []string `yaml:"options"`
 	UpdatePolicy UpdatePolicyConf
 	DnssecPolicy string
 	MultiSigner  string
@@ -243,7 +244,7 @@ type ZoneRefresher struct {
 	Notify       []string
 	ZoneStore    ZoneStore // 1=xfr, 2=map, 3=slice
 	Zonefile     string
-	Options      map[string]bool
+	Options      map[ZoneOption]bool
 	UpdatePolicy UpdatePolicy
 	DnssecPolicy string
 	MultiSigner  string

--- a/tdns/updateresponder.go
+++ b/tdns/updateresponder.go
@@ -115,7 +115,7 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	// dump.P(zd.Options)
 	// dump.P(zd.UpdatePolicy)
 
-	if zd.Options["frozen"] {
+	if zd.Options[OptFrozen] {
 		log.Printf("UpdateResponder: zone %s is frozen (i.e. updates not possible). Ignoring update.",
 			zd.ZoneName, qname)
 		m.SetRcode(r, dns.RcodeRefused)
@@ -132,7 +132,7 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 		dur.Status.Type = "ZONE-UPDATE"
 		zd.Logger.Printf("UpdateResponder: zone %s: qname %s is the apex of this zone",
 			zd.ZoneName, qname)
-		if !zd.Options["allow-updates"] {
+		if !zd.Options[OptAllowUpdates] {
 			log.Printf("UpdateResponder: zone %s does not allow updates to auth data %s. Ignoring update.",
 				zd.ZoneName, qname)
 			m.SetRcode(r, dns.RcodeRefused)
@@ -156,7 +156,7 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 
 		default:
 			dur.Status.Type = "CHILD-UPDATE"
-			if !zd.Options["allow-child-updates"] {
+			if !zd.Options[OptAllowChildUpdates] {
 				log.Printf("UpdateResponder: zone %s does not allow child updates like %s. Ignoring update.",
 					zd.ZoneName, qname)
 				m.SetRcode(r, dns.RcodeRefused)
@@ -170,7 +170,7 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	} else {
 		dur.Status.Type = "ZONE-UPDATE"
 		zd.Logger.Printf("UpdateResponder: qname %s is in auth zone %s", qname, zd.ZoneName)
-		if !zd.Options["allow-updates"] {
+		if !zd.Options[OptAllowUpdates] {
 			log.Printf("UpdateResponder: zone %s does not allow updates to auth data %s. Ignoring update.",
 				zd.ZoneName, qname)
 			m.SetRcode(r, dns.RcodeRefused)

--- a/tdns/zone_updater.go
+++ b/tdns/zone_updater.go
@@ -74,7 +74,7 @@ func (kdb *KeyDB) ZoneUpdaterEngine(stopchan chan struct{}) error {
 					// or we are a secondary (i.e. we are an agent) in which case we have the ability to record the changes in the DB).
 					log.Printf("ZoneUpdater: Request for update of child delegation data for zone %s (%d actions).", ur.ZoneName, len(ur.Actions))
 					log.Printf("ZoneUpdater: CHILD-UPDATE Actions:\n%s", SprintUpdates(ur.Actions))
-					if zd.Options["allow-child-updates"] {
+					if zd.Options[OptAllowChildUpdates] {
 						var updated bool
 						var err error
 
@@ -91,7 +91,7 @@ func (kdb *KeyDB) ZoneUpdaterEngine(stopchan chan struct{}) error {
 							}
 						}
 						if updated {
-							zd.Options["dirty"] = true
+							zd.Options[OptDirty] = true
 						}
 					}
 
@@ -100,14 +100,14 @@ func (kdb *KeyDB) ZoneUpdaterEngine(stopchan chan struct{}) error {
 					// (i.e. not child delegation information).
 					log.Printf("ZoneUpdater: Request for update of authoritative data for zone %s (%d actions).", ur.ZoneName, len(ur.Actions))
 					log.Printf("ZoneUpdater: ZONE-UPDATE Actions:\n%s", SprintUpdates(ur.Actions))
-					if zd.Options["allow-updates"] {
+					if zd.Options[OptAllowUpdates] {
 						dss, err := zd.ZoneUpdateChangesDelegationDataNG(ur)
 						if err != nil {
 							log.Printf("Error from ZoneUpdateChangesDelegationData: %v", err)
 						}
 						log.Printf("ZoneUpdater: dss.InSync: %t", dss.InSync)
 
-						if zd.Options["delegation-sync-child"] && !dss.InSync {
+						if zd.Options[OptDelSyncChild] && !dss.InSync {
 							log.Printf("ZoneUpdater: Zone %s has delegation sync enabled and is out of sync. Sending SYNC-DELEGATION request. len(zd.DelegationSyncCh): %d", zd.ZoneName, len(zd.DelegationSyncCh))
 							zd.DelegationSyncCh <- DelegationSyncRequest{
 								Command:    "SYNC-DELEGATION",
@@ -135,7 +135,7 @@ func (kdb *KeyDB) ZoneUpdaterEngine(stopchan chan struct{}) error {
 						}
 						if updated && !ur.InternalUpdate {
 							log.Printf("ZoneUpdater: Zone %s was updated. Setting dirty flag.", zd.ZoneName)
-							zd.Options["dirty"] = true
+							zd.Options[OptDirty] = true
 						}
 					} else {
 						log.Printf("ZoneUpdater: Zone %s has updates disallowed", zd.ZoneName)
@@ -411,7 +411,7 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 			rrset.RRs = append(rrset.RRs, rrcopy)
 			rrset.RRSIGs = []dns.RR{}
 			updated = true
-			zd.Options["dirty"] = true
+			zd.Options[OptDirty] = true
 		}
 		owner.RRtypes[rrtype] = rrset
 		// log.Printf("ApplyUpdateToZoneData: Add %s with RR=%s", rrtypestr, rrcopy.String())
@@ -439,10 +439,10 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 	}()
 
 	dak, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
-	if err != nil && zd.Options["online-signing"] {
+	if err != nil && zd.Options[OptOnlineSigning] {
 		return false, err
 	}
-	if len(dak.KSKs) == 0 && zd.Options["online-signing"] {
+	if len(dak.KSKs) == 0 && zd.Options[OptOnlineSigning] {
 		return false, fmt.Errorf("Zone %s has no active KSKs and online-signing is enabled. Zone update is rejected.", zd.ZoneName)
 	}
 

--- a/tdns/zone_utils.go
+++ b/tdns/zone_utils.go
@@ -22,7 +22,7 @@ func (zd *ZoneData) Refresh(verbose, debug, force bool) (bool, error) {
 	// 	ZoneTypeToString[zd.ZoneType], force)
 
 	// if zd.FoldCase {
-	if zd.Options["fold-case"] {
+	if zd.Options[OptFoldCase] {
 		zd.Logger.Printf("zd.Refresh(): folding case for zone %s", zd.ZoneName)
 		zd.ZoneName = strings.ToLower(zd.ZoneName)
 	}
@@ -148,7 +148,7 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool) (bool, error) {
 	// zd.Logger.Printf("FetchFromFile: Zone %s: delegation sync is enabled", zd.ZoneName)
 	var delchanged bool
 	var dss DelegationSyncStatus
-	if zd.Options["delegation-sync-child"] {
+	if zd.Options[OptDelSyncChild] {
 		delchanged, dss, err = zd.DelegationDataChangedNG(&new_zd)
 		if err != nil {
 			zd.Logger.Printf("Error from DelegationDataChanged(%s): %v", zd.ZoneName, err)
@@ -170,7 +170,7 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool) (bool, error) {
 	zd.mu.Unlock()
 
 	// If the delegation has changed, send an update to the DelegationSyncEngine
-	if zd.Options["delegation-sync-child"] && delchanged {
+	if zd.Options[OptDelSyncChild] && delchanged {
 		zd.Logger.Printf("FetchFromFile: Zone %s: delegation data has changed. Sending update to DelegationSyncEngine", zd.ZoneName)
 		zd.DelegationSyncCh <- DelegationSyncRequest{
 			Command:    "SYNC-DELEGATION",
@@ -234,7 +234,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool) (bool, error) {
 	// zd.Logger.Printf("FetchFromUpstream: Zone %s: delegation sync is enabled", zd.ZoneName)
 	var delchanged bool
 	var dss DelegationSyncStatus
-	if zd.Options["delegation-sync-child"] {
+	if zd.Options[OptDelSyncChild] {
 		delchanged, dss, err = zd.DelegationDataChangedNG(&new_zd)
 		if err != nil {
 			zd.Logger.Printf("Error from DelegationDataChanged(%s): %v", zd.ZoneName, err)
@@ -256,7 +256,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool) (bool, error) {
 	zd.mu.Unlock()
 
 	// Can only test for differences between old and new zone data if the zone data is ready.
-	if zd.Options["delegation-sync-child"] && delchanged {
+	if zd.Options[OptDelSyncChild] && delchanged {
 		zd.Logger.Printf("FetchFromUpstream: Zone %s: delegation data has changed. Sending update to DelegationSyncEngine", zd.ZoneName)
 		zd.DelegationSyncCh <- DelegationSyncRequest{
 			Command:    "SYNC-DELEGATION",
@@ -341,21 +341,21 @@ func (zd *ZoneData) WriteZone(tosource bool, force bool) (string, error) {
 			return err.Error(), err
 		}
 	}
-	if !zd.Options["dirty"] && !force {
+	if !zd.Options[OptDirty] && !force {
 		return fmt.Sprintf("Zone %s not modified, writing to disk not needed", zd.ZoneName), nil
 	}
 	_, err = zd.WriteFile(fname)
 	if err == nil {
 		zd.mu.Lock()
-		zd.Options["dirty"] = false
+		zd.Options[OptDirty] = false
 		zd.mu.Unlock()
 	}
 	return fmt.Sprintf("Zone %s written to %s", zd.ZoneName, fname), err
 }
 
-func (zd *ZoneData) SetOption(name string, value bool) {
+func (zd *ZoneData) SetOption(option ZoneOption, value bool) {
 	zd.mu.Lock()
-	zd.Options[name] = value
+	zd.Options[option] = value
 	zd.mu.Unlock()
 }
 
@@ -641,7 +641,7 @@ func (zd *ZoneData) BumpSerial() (BumperResponse, error) {
 	resp.OldSerial = zd.CurrentSerial
 	zd.CurrentSerial++
 	resp.NewSerial = zd.CurrentSerial
-	if zd.Options["online-signing"] {
+	if zd.Options[OptOnlineSigning] {
 		//		dak, err := zd.KeyDB.GetDnssecActiveKeys(zd.ZoneName)
 		//		if err != nil {
 		//			log.Printf("SignZone: failed to get dnssec active keys for zone %s", zd.ZoneName)
@@ -721,7 +721,7 @@ func (zd *ZoneData) FetchChildDelegationData(childname string) (*ChildDelegation
 }
 
 func (zd *ZoneData) SetupZoneSync() error {
-	if zd.Options["agent"] {
+	if zd.Options[OptAgent] {
 		return nil // this zone does not allow any modifications
 	}
 
@@ -732,7 +732,7 @@ func (zd *ZoneData) SetupZoneSync() error {
 	}
 
 	// Is this a parent zone and should we then publish a DSYNC RRset?
-	if zd.Options["delegation-sync-parent"] {
+	if zd.Options[OptDelSyncParent] {
 		// For the moment we receive both updates and notifies on the same address as the rest of
 		// the DNS service. Doesn't have to be that way, but for now it is.
 
@@ -750,12 +750,12 @@ func (zd *ZoneData) SetupZoneSync() error {
 		}
 	}
 
-	if zd.Options["delegation-sync-child"] {
+	if zd.Options[OptDelSyncChild] {
 		for _, scheme := range viper.GetStringSlice("delegationsync.child.schemes") {
 			switch scheme {
 			case "update":
 				// 1. Is there a KEY RRset already?
-				if !zd.Options["dont-publish-keys"] {
+				if !zd.Options[OptDontPublishKey] {
 					err := zd.VerifyPublishedKeyRRs()
 					if err != nil {
 						zd.Logger.Printf("Error from VerifyPublishedKeyRRs(%s): %v", zd.ZoneName, err)
@@ -776,15 +776,15 @@ func (zd *ZoneData) SetupZoneSync() error {
 }
 
 func (zd *ZoneData) SetupZoneSigning(resignq chan *ZoneData) error {
-	if !zd.Options["online-signing"] { // XXX: Need to sort out whether to use the sign-zone or online-signing option
+	if !zd.Options[OptOnlineSigning] { // XXX: Need to sort out whether to use the sign-zone or online-signing option
 		return nil // this zone should not be signed (at least not by us)
 	}
 
-	if !zd.Options["allow-updates"] {
+	if !zd.Options[OptAllowUpdates] {
 		return nil // this zone does not allow any modifications
 	}
 
-	if zd.Options["agent"] {
+	if zd.Options[OptAgent] {
 		return nil // this zone does not allow any modifications
 	}
 
@@ -807,7 +807,7 @@ func (zd *ZoneData) SetupZoneSigning(resignq chan *ZoneData) error {
 }
 
 func (zd *ZoneData) ReloadZone(refreshCh chan<- ZoneRefresher, force bool) (string, error) {
-	if zd.Options["dirty"] {
+	if zd.Options[OptDirty] {
 		msg := fmt.Sprintf("Zone %s: zone has been modified, reload not possible", zd.ZoneName)
 		return msg, fmt.Errorf(msg)
 	}


### PR DESCRIPTION
  zd.Options[] is no longer a map[string]bool but instead a
  map[ZoneOption]bool where ZoneOption is an uint8.

  The reason is that previously there were lurking bugs where we checked
  for an option, but there was no difference between the option existing
  with the value false and the option not existing (because of a spelling
  error).

  Now all that is much tighter and also all the strings are gone.