### PR TITLE
* restructured the onboarding of new zones; fixing issue #71

### DIFF
--- a/tdns/delegation_sync.go
+++ b/tdns/delegation_sync.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gookit/goutil/dump"
 	"github.com/miekg/dns"
@@ -17,8 +16,6 @@ import (
 )
 
 func (kdb *KeyDB) DelegationSyncher(delsyncq chan DelegationSyncRequest, notifyq chan NotifyRequest) error {
-	// func DelegationSyncher(delsyncq chan tdns.DelegationSyncRequest, kdb *tdns.KeyDB) error {
-	//delsyncq := conf.Internal.DelegationSyncQ
 	var ds DelegationSyncRequest
 	var imr = viper.GetString("resolver.address")
 	if imr == "" {
@@ -26,110 +23,7 @@ func (kdb *KeyDB) DelegationSyncher(delsyncq chan DelegationSyncRequest, notifyq
 		return fmt.Errorf("DelegationSyncEngine: resolver address not specified")
 	}
 
-	// If we support syncing with parent via DNS UPDATE then we must ensure that a KEY RR for the zone is published.
-	time.Sleep(5 * time.Second) // Allow time for zones to load
-
-	for zname, zd := range Zones.Items() {
-		if !zd.Options[OptDelSyncChild] {
-			log.Printf("DelegationSyncher: Zone %s does not have child-side delegation sync enabled. Skipping.", zname)
-			continue
-		}
-		log.Printf("DelegationSyncher: Checking whether zone %s allows updates and if so has a KEY RRset published.", zname)
-		apex, _ := zd.GetOwner(zd.ZoneName)
-		_, keyrrexist := apex.RRtypes[dns.TypeKEY]
-
-		// 1. Are updates to the zone data allowed?
-		if !zd.Options[OptAllowUpdates] {
-			if keyrrexist {
-				log.Printf("DelegationSyncher: Zone %s does not allow updates, but a KEY RRset is already published in the zone.", zd.ZoneName)
-			} else {
-				log.Printf("DelegationSyncher: Zone %s does not allow updates. Cannot publish a KEY RRset.", zd.ZoneName)
-			}
-			continue
-		}
-
-		log.Printf("DelegationSyncher: Zone %s allows updates. KEY RR exist: %v, dont-publish-key: %v", zd.ZoneName, keyrrexist, zd.Options[OptDontPublishKey])
-
-		// 2. Updates allowed, but there is no KEY RRset published.
-		if !keyrrexist && !zd.Options[OptDontPublishKey] {
-			log.Printf("DelegationSyncher: Fetching the private SIG(0) key for %s", zd.ZoneName)
-			sak, err := kdb.GetSig0Keys(zd.ZoneName, Sig0StateActive)
-			if err != nil {
-				log.Printf("DelegationSyncher: Error from kdb.GetSig0Keys(%s, %s): %v. Parent sync via UPDATE not possible.", zd.ZoneName, Sig0StateActive, err)
-				continue
-			}
-			if len(sak.Keys) == 0 {
-				log.Printf("DelegationSyncher: No active SIG(0) key found for zone %s. Will generate new key to enable parent sync via UPDATE.", zd.ZoneName)
-
-				algstr := viper.GetString("delegationsync.child.update.keygen.algorithm")
-				alg := dns.StringToAlgorithm[strings.ToUpper(algstr)]
-				if alg == 0 {
-					log.Printf("DelegationSyncher: Unknown keygen algorithm: \"%s\"", algstr)
-					continue
-				}
-				pkc, msg, err := kdb.GenerateKeypair(zd.ZoneName, "del-sync", "active", dns.TypeKEY, alg, "", nil) // nil = no tx
-				if err != nil {
-					zd.Logger.Printf("Error from kdb.GeneratePrivateKey(%s, KEY, %s): %v", zd.ZoneName, algstr, err)
-					continue
-				}
-				zd.Logger.Printf("DelegationSyncher: %s", msg)
-				sak = &Sig0ActiveKeys{
-					Keys: []*PrivateKeyCache{pkc},
-				}
-			}
-
-			if len(sak.Keys) == 0 {
-				log.Printf("DelegationSyncher: No active SIG(0) key found for zone %s. Parent sync via UPDATE not possible.", zd.ZoneName)
-				continue
-			}
-			log.Printf("DelegationSyncher: Publishing KEY RR for zone %s", zd.ZoneName)
-			err = zd.PublishKeyRRs(sak)
-			if err != nil {
-				log.Printf("DelegationSyncher: Error from PublishKeyRRs(): %s", err)
-			} else {
-				keyrrexist = true
-			}
-		}
-
-		// 3. There is a KEY RRset, question is whether it is signed or not
-		if keyrrexist && zd.Options[OptOnlineSigning] {
-			log.Printf("DelegationSyncher: Fetching the private DNSSEC key for %s in prep for signing KEY RRset", zd.ZoneName)
-			//			dak, err := kdb.GetDnssecActiveKeys(zd.ZoneName)
-			//			if err != nil {
-			//				log.Printf("DelegationSyncher: Error from kdb.GetDnssecActiveKeys(%s): %v. Parent sync via UPDATE not possible.", zd.ZoneName, err)
-			//				continue
-			//			}
-			rrset := apex.RRtypes[dns.TypeKEY]
-			_, err := zd.SignRRset(&rrset, zd.ZoneName, nil, false)
-			if err != nil {
-				log.Printf("Error signing %s KEY RRset: %v", zd.ZoneName, err)
-			} else {
-				apex.RRtypes[dns.TypeKEY] = rrset
-				log.Printf("Successfully signed %s KEY RRset", zd.ZoneName)
-			}
-		} else {
-			log.Printf("DelegationSyncher: Zone %s does not allow online signing, KEY RRset cannot be re-signed", zd.ZoneName)
-		}
-
-		// 4. There is a KEY RRset, we have tried to sign it if possible. But has it been uploaded to the parent?
-		// XXX: This is a bit of a hack, but we need to bootstrap the parent with the child's SIG(0) key. In the future
-		// we should keep state of whether successful key bootstrapping has been done or not in the keystore.
-		algstr := viper.GetString("delegationsync.child.update.keygen.algorithm")
-		alg := dns.StringToAlgorithm[strings.ToUpper(algstr)]
-		if alg == 0 {
-			log.Printf("DelegationSyncher: Unknown keygen algorithm: \"%s\", using ED25519", algstr)
-			alg = dns.ED25519
-		}
-		msg, err, ur := zd.BootstrapSig0KeyWithParent(alg)
-		if err != nil {
-			log.Printf("DelegationSyncher: Zone %s: Error from BootstrapSig0KeyWithParent(): %v.", ds.ZoneName, err)
-			for _, tes := range ur.TargetStatus {
-				log.Printf("DelegationSyncher: Zone %s: TargetUpdateStatus: %v", zd.ZoneName, tes)
-			}
-			continue
-		}
-		log.Printf("DelegationSyncher: Zone %s: SIG(0) key bootstrap: %s", zd.ZoneName, msg)
-	}
+	// time.Sleep(5 * time.Second) // Allow time for zones to load
 
 	log.Printf("*** DelegationSyncher: starting ***")
 	var wg sync.WaitGroup
@@ -141,6 +35,14 @@ func (kdb *KeyDB) DelegationSyncher(delsyncq chan DelegationSyncRequest, notifyq
 			dss := ds.SyncStatus
 
 			switch ds.Command {
+
+			case "DELEGATION-SYNC-SETUP":
+				// This is the initial setup request, when we first load a zone that has the delegation-sync-child option set.
+				err = zd.DelegationSyncSetup(kdb)
+				if err != nil {
+					log.Printf("DelegationSyncher: Zone %s: Error from DelegationSyncSetup(): %v. Ignoring sync request.", ds.ZoneName, err)
+					continue
+				}
 
 			case "INITIAL-KEY-UPLOAD":
 				// This case is not yet used, intended for automating the initial key upload to parent
@@ -251,6 +153,141 @@ func (kdb *KeyDB) DelegationSyncher(delsyncq chan DelegationSyncRequest, notifyq
 	wg.Wait()
 
 	log.Println("DelegationSyncher: terminating")
+	return nil
+}
+
+func (zd *ZoneData) DelegationSyncSetup(kdb *KeyDB) error {
+	log.Printf("DelegationSyncSetup: setting up zone %s", zd.ZoneName)
+	if !zd.Options[OptDelSyncChild] {
+		log.Printf("DelegationSyncSetup: Zone %s does not have child-side delegation sync enabled. Skipping.", zd.ZoneName)
+		return nil
+	}
+
+	log.Printf("DelegationSyncSetup: Checking whether zone %s allows updates and if so has a KEY RRset published.", zd.ZoneName)
+	apex, _ := zd.GetOwner(zd.ZoneName)
+	_, keyrrexist := apex.RRtypes[dns.TypeKEY]
+
+	if keyrrexist && !zd.Options[OptDontPublishKey] {
+		err := zd.VerifyPublishedKeyRRs()
+		if err != nil {
+			zd.Logger.Printf("Error from VerifyPublishedKeyRRs(%s): %v", zd.ZoneName, err)
+			return err
+		}
+		zd.Logger.Printf("DelegationSyncSetup: Zone %s: Verified published KEY RRset", zd.ZoneName)
+	}
+
+	algstr := viper.GetString("delegationsync.child.update.keygen.algorithm")
+	alg := dns.StringToAlgorithm[strings.ToUpper(algstr)]
+	if alg == 0 {
+		log.Printf("DelegationSyncSetup: Unknown keygen algorithm: \"%s\", using ED25519", algstr)
+		alg = dns.ED25519
+	}
+
+	// 1. Are updates to the zone data allowed?
+	if !zd.Options[OptAllowUpdates] {
+		if keyrrexist {
+			log.Printf("DelegationSyncSetup: Zone %s does not allow updates, but a KEY RRset is already published in the zone.", zd.ZoneName)
+		} else {
+			log.Printf("DelegationSyncSetup: Zone %s does not allow updates. Cannot publish a KEY RRset.", zd.ZoneName)
+		}
+		return nil
+	}
+
+	log.Printf("DelegationSyncSetup: Zone %s allows updates. KEY RR exist: %v, dont-publish-key: %v", zd.ZoneName, keyrrexist, zd.Options[OptDontPublishKey])
+
+	// 2. Updates allowed, but there is no KEY RRset published.
+	if !keyrrexist && !zd.Options[OptDontPublishKey] {
+		log.Printf("DelegationSyncSetup: Fetching the private SIG(0) key for %s", zd.ZoneName)
+		sak, err := kdb.GetSig0Keys(zd.ZoneName, Sig0StateActive)
+		if err != nil {
+			log.Printf("DelegationSyncSetup: Error from kdb.GetSig0Keys(%s, %s): %v. Parent sync via UPDATE not possible.", zd.ZoneName, Sig0StateActive, err)
+			return err
+		}
+		if len(sak.Keys) == 0 {
+			log.Printf("DelegationSyncSetup: No active SIG(0) key found for zone %s. Will generate new key to enable parent sync via UPDATE.", zd.ZoneName)
+
+			kp := KeystorePost{
+				Command:    "sig0-mgmt",
+				SubCommand: "generate",
+				Zone:       zd.ZoneName,
+				Algorithm:  alg,
+				State:      Sig0StateActive,
+				Creator:    "del-sync-setup",
+			}
+			resp, err := zd.KeyDB.Sig0KeyMgmt(nil, kp)
+			if err != nil {
+				return fmt.Errorf("DelegationSyncSetup(%s) failed to generate keypair: %v", zd.ZoneName, err)
+			}
+			zd.Logger.Printf(resp.Msg)
+
+			sak, err = zd.KeyDB.GetSig0Keys(zd.ZoneName, Sig0StateActive)
+			if err != nil {
+				return fmt.Errorf("DelegationSyncSetup(%s, after key generation) failed to get SIG(0) active keys: %v", zd.ZoneName, err)
+			}
+
+			//			algstr := viper.GetString("delegationsync.child.update.keygen.algorithm")
+			//			alg := dns.StringToAlgorithm[strings.ToUpper(algstr)]
+			//			if alg == 0 {
+			//				log.Printf("DelegationSynchSetup: Unknown keygen algorithm: \"%s\"", algstr)
+			//				return fmt.Errorf("unknown keygen algorithm: %s", algstr)
+			//			}
+			//			pkc, msg, err := kdb.GenerateKeypair(zd.ZoneName, "del-sync", "active", dns.TypeKEY, alg, "", nil) // nil = no tx
+			//			if err != nil {
+			//				zd.Logger.Printf("Error from kdb.GeneratePrivateKey(%s, KEY, %s): %v", zd.ZoneName, algstr, err)
+			//				return err
+			//			}
+			//			zd.Logger.Printf("DelegationSynchSetup: %s", msg)
+			//			sak = &Sig0ActiveKeys{
+			//				Keys: []*PrivateKeyCache{pkc},
+			//			}
+		}
+
+		if len(sak.Keys) == 0 {
+			log.Printf("DelegationSyncSetup: No active SIG(0) key found for zone %s. Parent sync via UPDATE not possible.", zd.ZoneName)
+			return fmt.Errorf("no active SIG(0) key found for zone %s. Parent sync via UPDATE not possible.", zd.ZoneName)
+		}
+		log.Printf("DelegationSyncSetup: Publishing KEY RR for zone %s", zd.ZoneName)
+		err = zd.PublishKeyRRs(sak)
+		if err != nil {
+			log.Printf("DelegationSyncSetup: Error from PublishKeyRRs(): %s", err)
+			return err
+		} else {
+			keyrrexist = true
+		}
+	}
+
+	// 3. There is a KEY RRset, question is whether it is signed or not
+	if keyrrexist && zd.Options[OptOnlineSigning] {
+		log.Printf("DelegationSyncSetup: Fetching the private DNSSEC key for %s in prep for signing KEY RRset", zd.ZoneName)
+		//			dak, err := kdb.GetDnssecActiveKeys(zd.ZoneName)
+		//			if err != nil {
+		//				log.Printf("DelegationSyncher: Error from kdb.GetDnssecActiveKeys(%s): %v. Parent sync via UPDATE not possible.", zd.ZoneName, err)
+		//				continue
+		//			}
+		rrset := apex.RRtypes[dns.TypeKEY]
+		_, err := zd.SignRRset(&rrset, zd.ZoneName, nil, false)
+		if err != nil {
+			log.Printf("Error signing %s KEY RRset: %v", zd.ZoneName, err)
+		} else {
+			apex.RRtypes[dns.TypeKEY] = rrset
+			log.Printf("Successfully signed %s KEY RRset", zd.ZoneName)
+		}
+	} else {
+		log.Printf("DelegationSyncSetup: Zone %s does not allow online signing, KEY RRset cannot be re-signed", zd.ZoneName)
+	}
+
+	// 4. There is a KEY RRset, we have tried to sign it if possible. But has it been uploaded to the parent?
+	// XXX: This is a bit of a hack, but we need to bootstrap the parent with the child's SIG(0) key. In the future
+	// we should keep state of whether successful key bootstrapping has been done or not in the keystore.
+	msg, err, ur := zd.BootstrapSig0KeyWithParent(alg)
+	if err != nil {
+		log.Printf("DelegationSyncSetup: Zone %s: Error from BootstrapSig0KeyWithParent(): %v.", zd.ZoneName, err)
+		for _, tes := range ur.TargetStatus {
+			log.Printf("DelegationSyncSetup: Zone %s: TargetUpdateStatus: %v", zd.ZoneName, tes)
+		}
+		return err
+	}
+	log.Printf("DelegationSyncSetup: Zone %s: SIG(0) key bootstrap: %s", zd.ZoneName, msg)
 	return nil
 }
 

--- a/tdns/parseconfig.go
+++ b/tdns/parseconfig.go
@@ -315,7 +315,7 @@ func ParseZones(conf *Config, zrch chan ZoneRefresher, reload bool) ([]string, e
 			log.Printf("ParseZones: zone %s: DNSSEC policy \"%s\" accepted", zname, zconf.DnssecPolicy)
 		}
 
-		log.Printf("ParseZones: zone %s incoming options: %v", zname, zconf.Options)
+		log.Printf("ParseZones: zone %s incoming options: %v", zname, zconf.OptionsStrs)
 		options := map[ZoneOption]bool{}
 		var cleanoptions []ZoneOption
 		for _, option := range zconf.OptionsStrs {
@@ -366,7 +366,13 @@ func ParseZones(conf *Config, zrch chan ZoneRefresher, reload bool) ([]string, e
 		}
 		zconf.Options = cleanoptions
 		zones[zname] = zconf
-		log.Printf("ParseZones: zone %s outgoing options: %+v", zname, options)
+		var outopts []string
+		for o, val := range options {
+			if val {
+				outopts = append(outopts, ZoneOptionToString[o])
+			}
+		}
+		log.Printf("ParseZones: zone %s outgoing options: %+v", zname, outopts)
 
 		log.Printf("ParseZones: zone %s: type: %s, store: %s, primary: %s, notify: %v, zonefile: %s",
 			zname, zconf.Type, zconf.Store, zconf.Primary, zconf.Notify, zconf.Zonefile)
@@ -425,7 +431,6 @@ func ParseZones(conf *Config, zrch chan ZoneRefresher, reload bool) ([]string, e
 				RRtypes: zonerrtypes,
 			},
 		}
-		log.Printf("ParseZones: zone %s outgoing options: %v", zname, options)
 		all_zones = append(all_zones, zname)
 
 		zrch <- ZoneRefresher{

--- a/tdns/refreshengine.go
+++ b/tdns/refreshengine.go
@@ -104,20 +104,20 @@ func RefreshEngine(conf *Config, stopch chan struct{}, appMode string) {
 					dp, _ := conf.Internal.DnssecPolicies[zr.DnssecPolicy]
 					msc, _ := conf.MultiSigner[zr.MultiSigner]
 					zd := &ZoneData{
-						ZoneName:         zone,
-						ZoneStore:        zr.ZoneStore,
-						Logger:           log.Default(),
-						Upstream:         zr.Primary,
-						Downstreams:      zr.Notify,
-						Zonefile:         zr.Zonefile,
-						ZoneType:         zr.ZoneType,
-						Options:          zr.Options,
-						UpdatePolicy:     zr.UpdatePolicy,
-						DnssecPolicy:     &dp,
-						MultiSigner:      &msc,
-						DelegationSyncCh: conf.Internal.DelegationSyncQ,
-						Data:             cmap.New[OwnerData](),
-						KeyDB:            conf.Internal.KeyDB,
+						ZoneName:        zone,
+						ZoneStore:       zr.ZoneStore,
+						Logger:          log.Default(),
+						Upstream:        zr.Primary,
+						Downstreams:     zr.Notify,
+						Zonefile:        zr.Zonefile,
+						ZoneType:        zr.ZoneType,
+						Options:         zr.Options,
+						UpdatePolicy:    zr.UpdatePolicy,
+						DnssecPolicy:    &dp,
+						MultiSigner:     &msc,
+						DelegationSyncQ: conf.Internal.DelegationSyncQ,
+						Data:            cmap.New[OwnerData](),
+						KeyDB:           conf.Internal.KeyDB,
 					}
 
 					updated, err = zd.Refresh(Globals.Verbose, Globals.Debug, zr.Force)
@@ -164,7 +164,7 @@ func RefreshEngine(conf *Config, stopch chan struct{}, appMode string) {
 
 					// This is a new zone being added to the server. Let's see if the zone
 					// config should cause any specific changes to the zone data to be made.
-					err = zd.SetupZoneSync()
+					err = zd.SetupZoneSync(conf.Internal.DelegationSyncQ)
 					if err != nil {
 						log.Printf("Error from SetupZoneSync(%s): %v", zone, err)
 					}

--- a/tdns/structs.go
+++ b/tdns/structs.go
@@ -60,29 +60,29 @@ type ZoneData struct {
 	OwnerIndex cmap.ConcurrentMap[string, int]
 	ApexLen    int
 	//	RRs            RRArray
-	Data             cmap.ConcurrentMap[string, OwnerData]
-	Ready            bool   // true if zd.Data has been populated (from file or upstream)
-	XfrType          string // axfr | ixfr
-	Logger           *log.Logger
-	ZoneFile         string
-	IncomingSerial   uint32 // SOA serial that we got from upstream
-	CurrentSerial    uint32 // SOA serial after local bumping
-	Verbose          bool
-	Debug            bool
-	IxfrChain        []Ixfr
-	Upstream         string   // primary from where zone is xfrred
-	Downstreams      []string // secondaries that we notify
-	Zonefile         string
-	DelegationSyncCh chan DelegationSyncRequest
-	Parent           string   // name of parentzone (if filled in)
-	ParentNS         []string // names of parent nameservers
-	ParentServers    []string // addresses of parent nameservers
-	Children         map[string]*ChildDelegationData
-	Options          map[ZoneOption]bool
-	UpdatePolicy     UpdatePolicy
-	DnssecPolicy     *DnssecPolicy
-	MultiSigner      *MultiSignerConf
-	KeyDB            *KeyDB
+	Data            cmap.ConcurrentMap[string, OwnerData]
+	Ready           bool   // true if zd.Data has been populated (from file or upstream)
+	XfrType         string // axfr | ixfr
+	Logger          *log.Logger
+	ZoneFile        string
+	IncomingSerial  uint32 // SOA serial that we got from upstream
+	CurrentSerial   uint32 // SOA serial after local bumping
+	Verbose         bool
+	Debug           bool
+	IxfrChain       []Ixfr
+	Upstream        string   // primary from where zone is xfrred
+	Downstreams     []string // secondaries that we notify
+	Zonefile        string
+	DelegationSyncQ chan DelegationSyncRequest
+	Parent          string   // name of parentzone (if filled in)
+	ParentNS        []string // names of parent nameservers
+	ParentServers   []string // addresses of parent nameservers
+	Children        map[string]*ChildDelegationData
+	Options         map[ZoneOption]bool
+	UpdatePolicy    UpdatePolicy
+	DnssecPolicy    *DnssecPolicy
+	MultiSigner     *MultiSignerConf
+	KeyDB           *KeyDB
 }
 
 // ZoneConf represents the external config for a zone; it contains no zone data

--- a/tdns/zone_updater.go
+++ b/tdns/zone_updater.go
@@ -108,8 +108,8 @@ func (kdb *KeyDB) ZoneUpdaterEngine(stopchan chan struct{}) error {
 						log.Printf("ZoneUpdater: dss.InSync: %t", dss.InSync)
 
 						if zd.Options[OptDelSyncChild] && !dss.InSync {
-							log.Printf("ZoneUpdater: Zone %s has delegation sync enabled and is out of sync. Sending SYNC-DELEGATION request. len(zd.DelegationSyncCh): %d", zd.ZoneName, len(zd.DelegationSyncCh))
-							zd.DelegationSyncCh <- DelegationSyncRequest{
+							log.Printf("ZoneUpdater: Zone %s has delegation sync enabled and is out of sync. Sending SYNC-DELEGATION request. len(zd.DelegationSyncQ): %d", zd.ZoneName, len(zd.DelegationSyncQ))
+							zd.DelegationSyncQ <- DelegationSyncRequest{
 								Command:    "SYNC-DELEGATION",
 								ZoneName:   zd.ZoneName,
 								ZoneData:   zd,


### PR DESCRIPTION
The DelegationSyncher() is responsible for preparing zones with the delegation-sync-child option for delegation synching with the parent. In the UPDATE case that involves generating a SIG(0) keypair, publishing a KEY RR with the pub key and sending an initial self-signed ADD of the same key to the parent.

This PR changes the DelegationSyncher() behaviour from checking all known zones only once, on startup, to instead check zones when told to over the channel it receives requests via. This enables the RefreshEngine() to send new zones (added via "tdns-cli config reload-zones") to be checked.