### PR TITLE
Gossip protocol, multi-provider authorization, and Operations migration

### DIFF
--- a/docs/2026-03-21-transport-extraction-analysis.md
+++ b/docs/2026-03-21-transport-extraction-analysis.md
@@ -1,0 +1,559 @@
+# Transport Extraction Analysis: Three-Repo Architecture
+
+Date: 2026-03-21
+Status: AGREED — ready for detailed planning
+
+## Goal
+
+Split the tdns v2 monolith into three repos with a clear
+dependency chain, keeping each focused on a single concern:
+
+```
+tdns-mp  →  tdns-transport  →  tdns
+ (apps)     (communication)    (pure DNS)
+
+any-app  →  tdns-transport  →  tdns
+```
+
+Two major drivers for this split:
+
+**1. Navigability and change safety.** The v2 codebase is
+approaching the point where it is difficult to navigate
+and all changes become increasingly risky. The monolith
+has ~190 .go files with deep cross-cutting concerns.
+Splitting reduces the cognitive load per repo and makes
+each change's blast radius smaller and more predictable.
+
+**2. Reusability of the transport layer.** The CHUNK/JOSE framework and the DNS
+message router are general-purpose infrastructure for
+secure, reliable communication over DNS. They should be
+usable by any application — not just multi-provider DNS.
+
+The first concrete non-MP consumers are **KDC/KRS** (Key
+Distribution Center / Key Receiver Service) for DNSSEC
+private key distribution. They already use CHUNKs for
+payload delivery but currently use HPKE inside CHUNK
+rather than JOSE. They have nothing to do with
+multi-provider — no SDE, no gossip, no combiner, no
+agent coordination. They just need the transport
+framework for secure message delivery over DNS.
+
+After extraction, KDC/KRS would import tdns + tdns-transport
+and get CHUNK transport + JOSE crypto without pulling in
+any multi-provider machinery. This is the validation case
+for the architecture.
+
+Other future consumers:
+- Management/control plane applications
+- Any app needing authenticated, encrypted messaging
+  between distributed components over DNS
+
+By isolating tdns-transport as its own repo, any app can
+import it alongside tdns without pulling in the entire
+multi-provider stack (SDE, combiner logic, gossip, etc.).
+
+## The Three Repos
+
+### tdns — Pure DNS Library
+
+DNS protocol implementation. Zones, queries, signing,
+refresh, UPDATE/NOTIFY, caches. No knowledge of
+multi-provider or agent-to-agent communication.
+
+### tdns-transport — Communication Layer
+
+General-purpose infrastructure for secure, reliable
+communication over DNS. The CHUNK/JOSE framework, DNS
+message router, transport abstractions, peer management,
+and crypto middleware. Knows how to send/receive messages
+between endpoints but has no opinion about what the
+messages mean or what to do with the data.
+
+This is a **reusable library** — any application can import
+it to get authenticated, encrypted, reliable messaging
+over DNS without taking a dependency on multi-provider
+logic. Imports tdns for DNS primitives only.
+
+### tdns-mp — Multi-Provider Applications
+
+The application layer. SDE, HsyncEngine, combiner/signer
+message handlers, agent discovery/authorization, role-specific
+wiring, CLI commands for agent/combiner/signer. Imports both
+tdns and tdns-transport.
+
+## What Goes Where
+
+### tdns (stays)
+
+**Zone management:**
+- Zone loading, parsing, serving
+- ZoneDataRepo (pure zone data storage)
+- Refresh engine
+- Query handlers (DefaultQueryHandler, etc.)
+- UPDATE/NOTIFY responders
+
+**DNSSEC:**
+- Signing, validation
+- Key management (non-transport)
+- DSYNC/delegation sync protocol basics
+
+**DNS types:**
+- All RR types including CHUNK, HSYNC3, HSYNCPARAM
+  (DNS wire format — must be parseable by any DNS library)
+- EDNS0 extensions
+- DNS client
+
+**Infrastructure:**
+- Config basics (non-MP parts of config.go)
+- CLI framework
+- Cache modules
+- Database layer (non-HSYNC tables)
+
+### tdns-transport (new repo)
+
+**Transport abstractions:**
+- `agent/transport/` — 18 files, entire package
+  - Transport interface (Hello, Beat, Sync, Confirm, etc.)
+  - DNSTransport implementation (NOTIFY+CHUNK)
+  - APITransport implementation (HTTPS REST)
+  - DNSMessageRouter + middleware chain
+  - Message handlers (HandleBeat, HandleSync, etc.)
+  - ChunkNotifyHandler
+  - PayloadCrypto (JWS/JWE)
+  - Peer + PeerRegistry
+
+**Distribution tracking:**
+- `distrib/` — 12 files, distribution manifest/tracking
+
+**Payload crypto:**
+- `crypto/` — 6 files, JWS/JWE encryption (not DNSSEC)
+- `hpke/` — 8 files, HPKE encryption (used by KDC/KRS)
+
+**Message types:**
+- AgentMsg constants (hello, beat, sync, update, etc.)
+- AgentHelloPost, AgentBeatPost, AgentMsgPost, etc.
+- PublishInstruction, RROperation
+- All message serialization structs
+- (Extracted from current core/messages.go)
+
+**Transport manager core:**
+- TransportManager struct + NewTransportManager
+- Reliable message queue
+- MsgQs channel struct definition
+
+### tdns-mp (new repo)
+
+**Sync engine:**
+- SynchedDataEngine (wraps tdns ZoneDataRepo, adds sync
+  state tracking, confirmation, remote agent tracking)
+- HsyncEngine (agent-side message consumer)
+- hsync_utils.go, hsync_beat.go, hsync_hello.go
+
+**Role-specific message handlers:**
+- CombinerMsgHandler (consumes MsgQs, calls
+  CombinerProcessUpdate)
+- SignerMsgHandler (consumes MsgQs, DNSKEY processing)
+
+**Agent coordination:**
+- agent_authorization.go (IsPeerAuthorized)
+- agent_discovery.go (DNS-based peer discovery)
+- gossip.go (GossipStateTable)
+- provider_groups.go (ProviderGroupManager)
+
+**Combiner/signer logic:**
+- combiner_msg_handler.go, combiner_peer.go,
+  combiner_chunk.go, combiner_utils.go
+- signer_msg_handler.go, signer_peer.go,
+  signer_transport.go
+- CombinerProcessUpdate, agent policy evaluation
+
+**Application wiring:**
+- StartAgent, StartCombiner, StartAuth (role init)
+- Multi-provider parts of main_initfuncs.go
+- Multi-provider parts of config.go / parseconfig.go
+
+**API handlers:**
+- apihandler_agent.go, apihandler_agent_router.go
+- apihandler_combiner.go
+
+**Database:**
+- db_hsync.go (HSYNC persistence)
+- db_combiner_publish_instructions.go
+- CombinerContributions tables
+
+**CLI commands:**
+- Agent/combiner/signer-specific CLI commands from v2/cli/
+- Agent debug commands (RFI, resync, etc.)
+
+**Application binaries:**
+- agentv2, combinerv2, authv2 main packages
+- (These currently live in tdns/cmdv2/ and would move)
+
+## Current Separation Quality
+
+The `agent/transport` package is already clean — zero
+references to `Conf` or globals, everything injected via
+interfaces and closures. This is the easiest part to extract.
+
+The SDE is the most coupled component but moves entirely
+to tdns-mp, avoiding the need to split it. It will import
+tdns for ZoneDataRepo and tdns-transport for message types.
+
+## Interface Boundaries
+
+### tdns exports (consumed by tdns-transport)
+
+- DNS RR types (dns.RR, CHUNK, HSYNC3, etc.)
+- Zone data types (RRset, zone name types)
+- DNS client for transport operations
+- EDNS0 option types
+
+### tdns-transport exports (consumed by tdns-mp and any app)
+
+- Transport interface + implementations
+- DNSMessageRouter + middleware pipeline
+- PeerRegistry + Peer state machine
+- MessageContext for handler functions
+- ReliableMessageQueue
+- MsgQs channel struct
+- Message type constants and structs
+- Distribution tracking
+- PayloadCrypto (JWS/JWE)
+- ChunkNotifyHandler
+
+Any application can register its own message types and
+handlers with the router. The middleware pipeline (auth,
+crypto, stats, logging) works regardless of message
+semantics. An app needs only to:
+1. Import tdns-transport
+2. Create a DNSMessageRouter
+3. Register handlers for its own message types
+4. Plug in crypto keys and peer authorization logic
+
+### tdns-mp exports (consumed by application binaries)
+
+- StartAgent(), StartCombiner(), StartAuth()
+- CLI command registration
+- Config types for multi-provider settings
+
+## File-by-File Assignment
+
+### Files staying in tdns
+
+Core DNS:
+- zone_*.go (zone loading, parsing)
+- defaultqueryhandlers.go, updateresponder.go,
+  notifyresponder.go
+- sign.go, resigner.go, dnssec_validate.go
+- refreshengine.go, structs.go
+- dnslookup.go, zone_utils.go
+- cache/*.go, edns0/*.go, hpke/*.go
+
+Core types:
+- core/rr_*.go (all RR types including CHUNK, HSYNC3)
+- core/core_structs.go, core/rrset_utils.go
+- core/chunk_utilities.go, core/notify_helpers.go
+- core/dnsclient.go, core/transport.go
+- core/concurrent_map.go, core/miek_utils.go
+
+Config (DNS parts):
+- Parts of config.go not related to MP
+- Parts of parseconfig.go not related to MP
+
+### Files moving to tdns-transport
+
+Transport package (move as-is):
+- agent/transport/transport.go
+- agent/transport/api.go
+- agent/transport/dns.go
+- agent/transport/dns_message_router.go
+- agent/transport/router_init.go
+- agent/transport/handlers.go
+- agent/transport/handler.go
+- agent/transport/chunk_notify_handler.go
+- agent/transport/crypto.go
+- agent/transport/crypto_middleware.go
+- agent/transport/stats_middleware.go
+- agent/transport/peer.go
+- agent/transport/log.go
+- agent/transport/doc.go
+- agent/transport/init.go
+- agent/transport/*_test.go
+
+Sub-packages (move as-is):
+- distrib/*.go (12 files)
+- crypto/*.go (6 files, JWS/JWE only)
+
+From v2 root:
+- reliable_message_queue.go
+
+From core (extract):
+- Message types from core/messages.go
+- core/confirmation.go (ConfirmationAccumulator)
+
+### Files moving to tdns-mp
+
+SDE + sync engine:
+- syncheddataengine.go
+- hsyncengine.go
+- hsync_transport.go
+- hsync_utils.go
+- hsync_beat.go
+- hsync_hello.go
+
+Role handlers:
+- combiner_msg_handler.go
+- combiner_peer.go
+- combiner_chunk.go
+- combiner_utils.go
+- signer_msg_handler.go
+- signer_peer.go
+- signer_transport.go
+
+Agent coordination:
+- agent_authorization.go
+- agent_discovery.go
+- agent_utils.go
+- agent_policy.go
+- agent_structs.go (AgentRegistry, etc.)
+- gossip.go
+- provider_groups.go
+
+Database:
+- db_hsync.go
+- db_combiner_publish_instructions.go
+
+API handlers:
+- apihandler_agent.go
+- apihandler_agent_router.go
+- apihandler_combiner.go
+
+Config (MP parts):
+- MultiProviderConf, MsgQs from config.go
+- MP-related parts of parseconfig.go
+- MP-related parts of main_initfuncs.go
+
+CLI commands (from v2/cli/):
+- agent_*_cmds.go
+- combiner_*_cmds.go
+- signer_*_cmds.go
+- MP-specific debug commands
+
+Application binaries:
+- cmdv2/agentv2/
+- cmdv2/combinerv2/
+- cmdv2/authv2/
+
+## Risks and Considerations
+
+1. **Three repos = more build complexity.** Coordinating
+   versions across three go.mod files. Mitigated by go.mod
+   replace directives during development.
+
+2. **config.go split.** Currently one large file with both
+   DNS and MP config. Must be cleanly divided. MsgQs and
+   MultiProviderConf move to tdns-mp (or tdns-transport
+   for MsgQs).
+
+3. **main_initfuncs.go split.** Role initialization mixes
+   DNS setup (zone loading, query handler registration)
+   with MP setup (transport manager, peer registration).
+   Must be split into DNS init (tdns) + MP init (tdns-mp).
+
+4. **CLI command split.** v2/cli/ has ~100 files mixing DNS
+   and MP commands. Need to identify which are pure DNS
+   (zone, rrset, debug) vs MP (agent, combiner, signer,
+   resync, peer, gossip).
+
+5. **CHUNK RR stays in tdns** even though only transport
+   uses it. It's a DNS wire format type — any DNS library
+   should parse it.
+
+6. **No external consumers currently.** All transport usage
+   is internal. cmdv2/ binaries use Config API, never import
+   transport directly. Full freedom to restructure.
+
+7. **core/messages.go extraction.** This file mixes DNS
+   message types with transport message types. Need careful
+   separation — transport structs to tdns-transport, DNS
+   types stay in tdns/core.
+
+## Implementation Order
+
+### Phase 1: tdns-transport extraction
+
+Lowest risk, cleanest boundaries:
+1. Create tdns-transport repo
+2. Move agent/transport/, distrib/, crypto/ as-is
+3. Extract message types from core/messages.go
+4. Move reliable_message_queue.go
+5. Update import paths, verify build
+
+### Phase 2: tdns-mp extraction
+
+Higher complexity, requires config split:
+1. Create tdns-mp repo
+2. Move SDE, HsyncEngine, message handlers
+3. Move agent coordination (gossip, provider groups, etc.)
+4. Split config.go and main_initfuncs.go
+5. Move role-specific CLI commands
+6. Move application binaries (cmdv2/agent, combiner, auth)
+7. Update import paths, verify build
+
+### Phase 3: Cleanup
+
+1. Remove dead imports from tdns
+2. Verify tdns builds and works standalone (IMR, dog, etc.)
+3. Verify tdns-transport builds with only tdns dependency
+4. Verify tdns-mp builds with both dependencies
+5. Update all design docs
+
+## Complexity Analysis (Rough Estimate)
+
+### Overall assessment: MEDIUM-HIGH
+
+The extraction is doable but not trivial. The main
+complexity is not in the transport layer itself (which is
+already clean) but in the **integration plumbing** —
+Config.Internal, main_initfuncs.go, and the ZoneData
+struct that spans all three concerns.
+
+### What's clean (low effort)
+
+**agent/transport/ package** — already self-contained,
+zero imports of tdns root, only imports core/ for message
+types. Can move to tdns-transport almost as-is. Same for
+distrib/ and crypto/ (JWS/JWE).
+
+**core/messages.go** — pure structs with json tags.
+Zero coupling to transport or MP infrastructure. Trivial
+to extract into tdns-transport.
+
+**CLI commands** — clearly split: ~33 files pure DNS,
+~18 files MP-specific (agent_*, combiner_*, hsync_*,
+distrib_*). The MP commands move to tdns-mp.
+
+### What's tangled (high effort)
+
+**Config.Internal** (~50 fields, 15 MP-specific mixed
+with ~35 DNS fields). This is the main coupling point.
+MsgQs, TransportManager, AgentRegistry, CombinerState,
+DistributionCache, LeaderElectionManager all live here
+alongside RefreshZoneCh, QueryHandlers, KeyDB, etc.
+
+Prerequisite: split InternalConf into InternalDnsConf
+(stays in tdns) and InternalMpConf (moves to tdns-mp).
+~300 lines of refactoring + updating all access sites.
+
+**main_initfuncs.go** — MainInit() mixes DNS setup
+(zone parsing, channel creation, KeyDB) with MP setup
+(TransportManager, PayloadCrypto, peer registration)
+sequentially. StartAgent/StartCombiner/StartAuth are
+role-specific but each mixes DNS init with MP init.
+
+Need to split into: DNS init (tdns) called first, then
+MP init (tdns-mp) layered on top.
+
+**ZoneData struct** (in structs.go) — has fields for
+all roles: AgentContributions, PersistContributions,
+OnFirstLoad callbacks, LeaderElectionManager ref. These
+are MP concerns embedded in a DNS data structure.
+
+**SDE** — syncheddataengine.go has zero transport imports
+(good!) but uses MsgQs channels via parameter injection
+and has one hard reference to
+TransportManager.EnqueueForSpecificAgent(). Need a small
+interface abstraction (MessageEnqueuer) to decouple.
+
+### Concrete numbers
+
+| What | Count |
+|---|---|
+| Total .go files in v2/ | ~190 |
+| Files moving to tdns-transport | ~35 |
+| Files moving to tdns-mp | ~55 |
+| Files staying in tdns | ~100 |
+| Files importing agent/transport | 35 |
+| Files referencing TransportManager | 28 |
+| Files referencing MsgQs | ~4 |
+| Config.Internal MP fields | ~15 |
+| Config.Internal DNS fields | ~35 |
+| CLI files (DNS) | ~33 |
+| CLI files (MP) | ~18 |
+
+### Effort estimate by phase
+
+**Phase 0: Prerequisite refactoring** — 1 week
+- Split Config.Internal into DNS vs MP structs
+- Extract ZoneData MP fields into separate struct
+- Define interface abstractions (MessageEnqueuer, etc.)
+- All within current single repo, no extraction yet
+
+**Phase 1: tdns-transport extraction** — 1-2 weeks
+- Move agent/transport/, distrib/, crypto/
+- Extract message types from core/messages.go
+- Move reliable_message_queue.go
+- Update import paths across all three repos
+- Verify build
+
+**Phase 2: tdns-mp extraction** — 2-3 weeks
+- Move SDE, HsyncEngine, message handlers
+- Move agent coordination (gossip, provider groups)
+- Split main_initfuncs.go into DNS init + MP init
+- Move role-specific CLI commands
+- Move application binaries (agentv2, combinerv2, authv2)
+- Move API handlers for agent/combiner
+- Move db_hsync and combiner persistence
+- Update import paths, verify build
+
+**Phase 3: Cleanup and verification** — 1 week
+- Verify tdns builds standalone (IMR, dog, CLI tools)
+- Verify tdns-transport builds with only tdns dependency
+- Verify tdns-mp builds with both dependencies
+- Verify non-MP apps can use tdns-transport independently
+- Update design docs, remove dead code
+
+**Total estimated effort: 5-7 weeks**
+
+### Risk factors that could increase effort
+
+1. **Hidden coupling** — grep found 35 files importing
+   agent/transport. Some may have subtle dependencies
+   not yet identified.
+
+2. **Circular type references** — if types in tdns
+   reference types that move to tdns-transport or
+   tdns-mp, need careful interface extraction.
+
+3. **Test coverage** — tests may assume single-repo
+   structure. Integration tests especially may need
+   rework.
+
+4. **go.mod coordination** — three repos means version
+   management. During development, replace directives
+   help but add friction.
+
+### Risk factors that reduce effort
+
+1. **No external consumers** — all transport usage is
+   internal. No backwards compatibility concerns.
+
+2. **Dependency injection already in place** — transport
+   package already uses interfaces and closures, not
+   globals.
+
+3. **Clean message types** — core/messages.go is pure
+   structs, trivial to relocate.
+
+4. **CLI commands clearly separated** — agent/combiner
+   commands are in their own files, not mixed with DNS
+   commands.
+
+## Next Steps
+
+1. Create Linear project for tracking
+2. Begin Phase 0 (prerequisite refactoring within
+   current repo)
+3. Phase 1 (tdns-transport extraction)
+4. Phase 2 (tdns-mp extraction)
+5. Phase 3 (cleanup)

--- a/docs/2026-03-22-dns-chat-design-sketch.md
+++ b/docs/2026-03-22-dns-chat-design-sketch.md
@@ -1,0 +1,377 @@
+# DNS-Based Secure Messaging: Design Sketch
+
+Date: 2026-03-22
+Status: IDEA — creative exploration, not committed work
+
+## Purpose
+
+A DNS-based secure messaging application built on top of
+tdns-transport. Demonstrates that the CHUNK/JOSE transport
+framework is general-purpose — not just for DNS operations.
+
+Messages are distributed through a network of DNS servers,
+signed with JWKs published in DNS, and delivered to
+recipients via gossip-like propagation.
+
+## Architecture Overview
+
+```
+Sender                                      Receiver
+  |                                            |
+  |  CHUNK message (signed, encrypted)         |
+  |  to any server in the mesh                 |
+  v                                            |
+Server A  --gossip-->  Server B  --gossip-->  Server C
+                                               |
+                                               |  message delivered
+                                               |  (poll or push)
+                                               v
+                                            Receiver
+```
+
+## Identity Model: Member Zones
+
+Identity is DNS-native. No separate PKI.
+
+A **member zone** is a DNS zone that contains JWK records
+for its members. Example:
+
+```
+chat.example.com.
+  alice.chat.example.com.  JWK  { "kty": "EC", ... }
+  bob.chat.example.com.    JWK  { "kty": "EC", ... }
+```
+
+- A user's identity is their DNS name
+- Their public key is their JWK record
+- Anyone can look up a user's key via DNS
+- Multiple member zones = federation (users in different
+  zones can message each other)
+- The zone operator controls membership (add/remove JWKs)
+
+**Verification**: when a server receives a message, it
+looks up the sender's JWK in DNS and verifies the
+signature. Unsigned or unverifiable messages are dropped.
+
+## Message Format
+
+```json
+{
+   "id": "uuid-v4",
+   "from": "alice.chat.example.com.",
+   "to": "bob.chat.example.com.",
+   "timestamp": "2026-03-22T14:30:00Z",
+   "ttl": 3600,
+   "content": "encrypted-payload",
+   "signature": "JWS-signature-over-all-above"
+}
+```
+
+- **id**: UUID, unique per message, used for confirmation
+  and deduplication
+- **from**: sender's DNS identity (FQDN)
+- **to**: recipient's DNS identity (FQDN)
+- **ttl**: seconds until message expires, server drops
+  undelivered messages after TTL
+- **content**: encrypted with recipient's public JWK
+  (only recipient can read it)
+- **signature**: sender signs the entire message with
+  their private JWK (servers verify sender identity)
+
+## Message Propagation
+
+Messages propagate through the server mesh using a
+gossip-like protocol, similar to the existing beat/gossip
+mechanism in tdns-transport.
+
+### Routing
+
+Servers don't need full routing tables. Simple approach:
+
+1. Server receives message for recipient X
+2. If X is connected to this server → deliver
+3. If not → propagate to all peers (with dedup via
+   message UUID)
+
+More sophisticated routing (if needed later):
+- Servers track which peers have which connected users
+- Gossip this information in beats
+- Route directly to the right peer
+
+### Deduplication
+
+Each server maintains a seen-message cache (UUID →
+timestamp). Messages already seen are dropped. Cache
+entries expire after message TTL.
+
+### Confirmation Flow
+
+```
+Recipient's server  →  propagate back through mesh  →
+  Sender's server  →  Sender
+
+Confirmation message:
+{
+   "type": "confirm",
+   "message_id": "uuid-of-original",
+   "status": "delivered"
+}
+```
+
+Once all servers see the confirmation, they drop the
+message from their propagation queue. This is the same
+reliable delivery pattern as multi-provider CONFIRM.
+
+## Message Delivery to Recipients
+
+### How Telegram et al. do it
+
+All major messaging platforms (Telegram, Signal,
+WhatsApp) use **persistent full-duplex connections**
+(TCP or WebSocket). The server pushes messages over
+the existing connection. When the app is backgrounded,
+they fall back to OS push notifications (APNs/FCM)
+to wake the app.
+
+### Our constraints
+
+DNS is request-response, not persistent. We don't have
+WebSockets or long-lived TCP connections in the DNS
+model. Our options:
+
+### Option 1: Long-poll (RECOMMENDED for initial impl)
+
+Recipient sends a DNS query to their server. Server
+holds the query open until either:
+- A message arrives → respond with the message
+- Timeout (e.g. 30s) → respond with empty, client
+  immediately re-polls
+
+This is identical to Telegram's Bot API `getUpdates`
+mechanism. It works through NATs, is simple to
+implement, and gives near-real-time delivery (~0-30s
+latency depending on timing).
+
+**Implementation**: new DNS query type where qname
+encodes the recipient identity. Server matches against
+pending messages. Response carries CHUNK payload with
+the message(s).
+
+### Option 2: Push via NOTIFY
+
+If the recipient runs a daemon (is a server, or runs
+a lightweight receiver), the server sends a NOTIFY
+with the message as a CHUNK payload. Same mechanism
+as multi-provider CONFIRM.
+
+Better latency (instant), but requires recipient
+reachability. Does not work through NATs.
+
+### Option 3: Hybrid (RECOMMENDED for production)
+
+Recipient declares its delivery preference:
+- **poll**: "I will poll you" (NAT-friendly, default)
+- **push**: "Send me NOTIFYs at this address"
+  (low latency, requires reachability)
+
+Stored as a DNS record or communicated at registration.
+Server uses the appropriate mechanism per recipient.
+
+## Group Messaging
+
+Member zones naturally define groups. Two models:
+
+**Zone-as-group**: send a message with `"to":
+"chat.example.com."` (the zone apex). Server delivers
+to all members of that zone. Simple, works with
+existing infrastructure.
+
+**Explicit groups**: a TXT or custom record at a name
+within the zone lists group members. Messages to that
+name go to listed members only.
+
+## Server Requirements
+
+A chat server is a tdns-transport application that:
+
+1. Imports tdns + tdns-transport
+2. Registers message handlers for: send, poll, confirm
+3. Participates in server mesh via existing peer
+   discovery (HSYNC3 or configured peers)
+4. Maintains a message queue per connected user
+5. Propagates messages to peers via gossip
+6. Verifies sender JWK signatures on receipt
+7. Encrypts stored messages with recipient's JWK
+
+Estimated implementation size: modest. Most of the
+heavy lifting (CHUNK transport, JOSE crypto, peer
+management, gossip) is already in tdns-transport.
+
+## Security Properties
+
+- **End-to-end encrypted**: content encrypted with
+  recipient's JWK, only recipient can decrypt
+- **Sender authenticated**: JWK signature verified by
+  every server in the chain
+- **No server-side plaintext**: servers route encrypted
+  blobs, cannot read content
+- **Ephemeral**: messages expire after TTL, no
+  permanent storage
+- **Identity via DNS**: no separate account system, no
+  passwords, identity = DNS name + published JWK
+- **Federation via DNS**: cross-zone messaging works
+  because JWK lookup is just a DNS query
+
+## Comparison to Existing Systems
+
+| | Signal | Telegram | DNS Chat |
+|---|---|---|---|
+| Identity | Phone number | Phone number | DNS name |
+| PKI | Signal servers | Telegram servers | DNS (JWK records) |
+| Transport | WebSocket | MTProto/TCP | DNS CHUNK/JOSE |
+| Delivery | Push (persistent conn) | Push (persistent conn) | Poll or push (DNS) |
+| E2E encryption | Yes (Signal Protocol) | Optional (MTProto) | Yes (JWK/JOSE) |
+| Server sees content | No | Yes (non-secret chats) | No |
+| Federation | No | No | Yes (cross-zone) |
+| Persistence | Store-and-forward | Cloud storage | Ephemeral (TTL) |
+
+## Name Suggestions
+
+- **murmur** — messages propagate like murmurs through
+  the network of servers
+- **dnschat** — straightforward
+- **whisper** — encrypted, ephemeral messaging
+- **relay** — messages relayed through DNS mesh
+
+## Mobile App: The Killer Demo
+
+The most compelling demonstration would be a **mobile
+phone app**. Infrastructure-to-infrastructure messaging
+is useful but invisible. A phone app makes it tangible.
+
+### Transport: DNS-over-TCP as Persistent Connection
+
+We already use TCP for DNS. A long-lived TCP connection
+between the phone app and its "home" nameserver is
+essentially the same architecture as Signal (WebSocket)
+or WhatsApp (TCP/XMPP) — just speaking DNS on the wire.
+
+RFC 7766 encourages TCP connection reuse and imposes
+no protocol-level maximum timeout. We control both
+client and server, so we set whatever timeout we want.
+
+```
+Phone App  ----TCP (long-lived)---->  Home Server
+                                        |
+                                      mesh gossip
+                                        |
+               Other Servers  <-------->+
+```
+
+### Connection Lifecycle
+
+1. **Connect**: app opens TCP to home server, sends
+   HELLO with identity + JWK signature
+2. **Idle**: connection stays open. Server pushes
+   incoming messages as NOTIFY+CHUNK down the TCP
+   connection. App sends messages as NOTIFY+CHUNK up.
+3. **Ping**: periodic keepalive (existing ping mechanism)
+   to detect dead connections and keep NAT mappings alive
+4. **Disconnect**: OS kills connection (background,
+   sleep, network switch). Server queues messages.
+5. **Reconnect**: app reconnects, sends "catch-up" query
+   ("give me everything since timestamp X"). Server
+   drains queue, then resumes push mode.
+
+### Comparison to Signal/Telegram Architecture
+
+| | Signal | Telegram | DNS Chat Mobile |
+|---|---|---|---|
+| Wire protocol | WebSocket | MTProto/TCP | DNS/TCP |
+| Connection | Persistent WS | Persistent TCP | Persistent TCP |
+| Push mechanism | Server writes to WS | Server writes to TCP | Server sends NOTIFY+CHUNK |
+| Catch-up | Reconnect + drain | Reconnect + resend unACKed | Reconnect + poll since timestamp |
+| Background wake | APNs/FCM | APNs/FCM | APNs/FCM (future, optional) |
+
+The architecture is essentially identical. The difference
+is that our wire protocol is DNS, which means:
+- Every message is a valid DNS transaction
+- Existing DNS infrastructure (firewalls, monitoring)
+  sees normal DNS traffic
+- No new ports, no new protocols to whitelist
+
+### Mobile OS Constraints
+
+- **iOS**: background TCP connections are killed after
+  ~30 seconds of inactivity. Must use periodic keepalive
+  or accept reconnect-and-drain model. APNs integration
+  needed for production use.
+- **Android**: more lenient with background connections
+  but battery optimization may kill them. FCM integration
+  for reliable background delivery.
+- **Both**: foreground use with persistent TCP works fine.
+  Background delivery is the hard part, same as for
+  every other messaging app.
+
+### MVP Scope
+
+A proof-of-concept mobile app needs:
+1. TCP connection management (connect, keepalive,
+   reconnect)
+2. Send message (NOTIFY+CHUNK to home server)
+3. Receive message (server pushes NOTIFY+CHUNK)
+4. Catch-up on reconnect (poll since last seen timestamp)
+5. Simple UI: contact list (from member zone), message
+   thread, send box
+
+Does NOT need for MVP:
+- APNs/FCM integration (foreground-only is fine)
+- Group chat (1:1 is enough to demonstrate)
+- File transfer
+- Read receipts
+
+### Technology
+
+- **iOS**: Swift, using Network.framework for TCP
+- **Android**: Kotlin, using java.nio or Netty for TCP
+- **Cross-platform**: Flutter or React Native with a
+  native TCP module
+- **DNS parsing**: minimal — only needs to construct
+  and parse NOTIFY+CHUNK messages, not a full resolver
+
+## Open Questions
+
+1. Should servers store messages for offline recipients
+   or only deliver to currently-connected users?
+   (Store-and-forward up to TTL seems right.)
+
+2. Maximum message size? CHUNK can handle large payloads
+   but chat messages should be small. Cap at 4KB? 16KB?
+
+3. Should read receipts be a thing? (Easy to add as
+   another confirmation type, but privacy implications.)
+
+4. File/image transfer? Could work via CHUNK but feels
+   like scope creep for a proof-of-concept.
+
+5. Key rotation? User publishes new JWK, old one removed.
+   In-flight messages encrypted with old key can't be
+   decrypted. Need a transition period with both keys?
+
+## Value as a Framework Demonstration
+
+This app exercises every layer of tdns-transport:
+
+- **CHUNK transport**: message payloads
+- **JOSE crypto**: signing + encryption
+- **Message routing**: custom message types (send,
+  poll, confirm)
+- **Peer management**: server mesh discovery
+- **Gossip propagation**: message distribution
+- **Confirmation semantics**: delivery confirmation
+- **DNS identity**: JWK lookup for sender verification
+
+It proves the framework handles a domain completely
+unrelated to DNS operations, which is the strongest
+possible argument for tdns-transport as a general-
+purpose communication layer.

--- a/docs/2026-03-22-transport-api-design-investigation.md
+++ b/docs/2026-03-22-transport-api-design-investigation.md
@@ -1,0 +1,197 @@
+# Transport API Design Investigation
+
+Date: 2026-03-22
+Status: RESEARCH ONLY — no code changes until after repo split
+
+## Purpose
+
+Before extracting tdns-transport as a reusable library,
+investigate how its public API should look. Two areas
+need comparison with established patterns in the TLD
+registry / REST API space.
+
+## (A) Confirmation Model: Two-Step Confirm vs Alternatives
+
+### What we have now
+
+Immediate ACK ("PENDING") followed by async CONFIRM
+NOTIFY with the actual result. This is a push-based
+callback over DNS:
+
+```
+Agent → Combiner:  UPDATE message
+Combiner → Agent:  immediate "PENDING" ACK
+  (combiner processes async)
+Combiner → Agent:  CONFIRM NOTIFY with result
+```
+
+### Patterns used elsewhere
+
+**1. Webhook / callback registration**
+Client registers a callback URL. Server POSTs result
+when ready. Used by: Stripe, GitHub, many payment APIs.
+
+- Pro: clean async, client controls where results go
+- Con: client must be reachable, URL management overhead
+- Our equivalent: we push via DNS NOTIFY, which is
+  essentially a DNS-native webhook
+
+**2. Polling with location header**
+Server returns `202 Accepted` + a status URL. Client
+polls until result appears. Used by: Azure ARM, AWS
+CloudFormation, ICANN CZDS.
+
+- Pro: simple, client-driven, no callback infra needed
+- Con: chatty, latency = poll interval, wasted requests
+- Our equivalent: RFI mechanism (agent can ask combiner
+  "what happened to my update?") but not currently used
+  as a polling pattern
+
+**3. Long-poll / SSE / WebSocket**
+Hold connection open until result arrives. Used by:
+Cloudflare API for deployments, various real-time APIs.
+
+- Pro: low latency, no polling waste
+- Con: connection management, timeout handling, not
+  natural for DNS
+
+**4. EPP (Extensible Provisioning Protocol)**
+Used by domain registries (Verisign, etc.). Synchronous
+request-response over persistent TCP. Slow operations
+return a "pending" response code (1001) and the result
+arrives later via EPP poll messages.
+
+- Pro: well-proven in domain industry
+- Con: requires persistent connection, poll-based
+- Our equivalent: very similar! We return PENDING and
+  push the result, which is arguably better than EPP's
+  poll model
+
+**5. RDAP + REST registrar APIs**
+Newer registry APIs. Mostly synchronous. Some operations
+(transfers, disputes) use status polling.
+
+### Assessment
+
+Our current model (immediate PENDING + async CONFIRM
+push) is actually well-designed for the DNS context:
+
+- No polling overhead
+- No persistent connection required
+- Push-based, so low latency
+- Natural fit for NOTIFY mechanism
+
+**Key limitation of our push model:** it requires both
+sides to be reachable. This is fine for DNS nameservers
+(they must be reachable by definition) but would not
+work for clients behind NATs. The poll model's main
+advantage is that it works through NATs — the client
+initiates all connections, server never needs to reach
+back.
+
+For tdns-transport as a general-purpose library, this
+matters: not all future consumers will be nameservers.
+A KRS behind a NAT can send requests to a KDC but
+can't receive unsolicited NOTIFY pushes. Supporting
+both push (current) and poll (fallback for NAT'd
+clients) may be needed.
+
+**Possible improvements to investigate:**
+- Support both push and poll confirmation models, with
+  the client choosing based on its reachability
+- Should the PENDING ACK carry an estimated completion
+  time? (REST APIs sometimes include Retry-After)
+- Should there be a timeout/expiry on pending operations?
+  (What if CONFIRM never arrives?)
+- Should there be an explicit "cancel" mechanism?
+- Should the client be able to register interest in
+  specific notification types? (subscription model)
+
+## (B) Message Type Model: Domain Verbs vs CRUD Semantics
+
+### What we have now
+
+Domain-specific message types:
+- hello, beat, sync, update, rfi, ping
+- keystate, edits, config, audit, status-update
+
+These are verbs specific to the multi-provider domain.
+
+### REST CRUD model
+
+Generic operations on resources:
+- GET (read), POST (create), PUT (replace),
+  PATCH (modify), DELETE (remove)
+
+Applied to our domain:
+- `GET zone/data` ≈ rfi edits, rfi keystate
+- `POST zone/update` ≈ update (new contribution)
+- `PATCH zone/records` ≈ ClassINET add / ClassNONE delete
+- `DELETE zone/records` ≈ ClassANY remove
+
+### Hybrid model (verbs + resources)
+
+Keep some domain verbs but make the framework generic:
+- Transport layer defines: MessageType (string) +
+  Resource (string) + Operation (enum: query/mutate/notify)
+- Apps register handlers for (MessageType, Resource) pairs
+- Framework handles routing, confirmation, retry
+
+Example registrations:
+- MP app: ("update", "zone/*") → HandleUpdate
+- KDC app: ("distribute", "key/*") → HandleKeyDistribution
+- Any app: ("ping", "*") → HandlePing
+
+### Assessment
+
+For tdns-transport as a reusable library, the message
+type system should be:
+
+1. **Generic at the framework level** — MessageType is
+   just a string, apps define their own types
+2. **Typed at the app level** — each app has its own
+   constants and handler registrations
+3. **Common infrastructure messages built-in** — ping,
+   hello, beat could be provided by the framework since
+   peer liveness is a transport concern
+
+This is essentially what we have now in the router
+(handlers register for MessageType strings) but the
+built-in message types are MP-specific. The change
+would be:
+- Framework provides: ping, hello (peer introduction)
+- Framework defines: MessageType registration API
+- Apps provide: everything domain-specific
+
+### Questions to resolve
+
+1. Should beat/heartbeat be a framework feature or
+   app-level? (Argument for framework: peer liveness
+   is transport-level. Argument against: beat payload
+   carries gossip, which is MP-specific.)
+
+2. Should confirmation semantics be built into the
+   framework? (Probably yes — reliable delivery is a
+   transport concern, not app-specific.)
+
+3. Should the framework enforce request-response
+   pairing or allow fire-and-forget? (Both — let the
+   app choose per message type.)
+
+4. How much of the peer state machine (NEEDED → KNOWN
+   → INTRODUCING → OPERATIONAL) is generic vs
+   MP-specific?
+
+## Relationship to Repo Split
+
+These design questions inform how tdns-transport's
+public API should look, but **no code changes should
+happen until after the repo split**. The split should
+proceed with the current message type model. API
+redesign is a separate effort that happens after
+tdns-transport exists as its own repo.
+
+Priority order:
+1. Fix current brokenness
+2. Repo split (current API preserved)
+3. API redesign within tdns-transport (this doc)

--- a/docs/2026-03-23-option-handler-registration.md
+++ b/docs/2026-03-23-option-handler-registration.md
@@ -1,7 +1,7 @@
 # Option Handler Registration for Zone Config
 
 **Date:** 2026-03-23
-**Status:** Plan
+**Status:** Implemented
 
 ## Problem
 

--- a/docs/2026-03-23-option-handler-registration.md
+++ b/docs/2026-03-23-option-handler-registration.md
@@ -1,0 +1,319 @@
+# Option Handler Registration for Zone Config
+
+**Date:** 2026-03-23
+**Status:** Plan
+
+## Problem
+
+The SDE startup hydration loop iterates `Zones.IterBuffered()`
+and checks `zd.Options[OptMultiProvider]`. But for secondary
+zones, the RefreshEngine may not have processed the zone yet,
+so the option is not set on the ZoneData stub. This causes a
+race condition where some MP zones are skipped during hydration.
+
+Fixing this by copying options onto stubs earlier would
+increase coupling between zone parsing (future tdns repo) and
+MP logic (future tdns-mp repo), working against the planned
+three-repo split.
+
+## Solution: Option Handler Registration
+
+Extend the zone config parsing to support registered
+callbacks for specific zone options. When the parser
+encounters a zone option, it calls any registered handler
+for that option. This allows tdns-mp to react to
+`multi-provider` at parse time without tdns knowing anything
+about MP logic.
+
+This follows the same pattern as:
+- OnFirstLoad callbacks (zone loading events)
+- DNSMessageRouter handlers (message type events)
+- Query handler registration (query events)
+
+## Design
+
+### Registry
+
+A global registry of option handlers, keyed by ZoneOption:
+
+```go
+// In tdns (e.g., parseconfig.go or a new file option_handlers.go)
+
+type ZoneOptionHandler func(zname string, zconf ZoneConf,
+    options map[ZoneOption]bool)
+
+var optionHandlers = make(map[ZoneOption][]ZoneOptionHandler)
+
+func RegisterZoneOptionHandler(opt ZoneOption,
+    handler ZoneOptionHandler) {
+    optionHandlers[opt] = append(optionHandlers[opt], handler)
+}
+```
+
+Multiple handlers can be registered for the same option
+(append, not replace). Handlers are called synchronously
+during ParseZones, in registration order.
+
+### Call Site
+
+In ParseZones, after options are parsed for a zone but
+before the ZoneRefresher is sent to RefreshZoneCh:
+
+```go
+// After parseZoneOptions returns 'options' for zname:
+for opt, val := range options {
+    if val {
+        if handlers, ok := optionHandlers[opt]; ok {
+            for _, handler := range handlers {
+                handler(zname, zconf, options)
+            }
+        }
+    }
+}
+```
+
+This fires synchronously during ParseZones. All registered
+handlers complete before the next zone is parsed. No race
+with RefreshEngine.
+
+### ZoneConf Parameter
+
+The handler receives the full ZoneConf (zone name, type,
+primary, zonefile, options, etc.) so it can make decisions
+based on the zone's configuration. This is read-only --
+handlers should not modify the ZoneConf.
+
+### tdns-mp Registration
+
+In tdns-mp's init code (before ParseZones is called), the
+MP layer registers its handler:
+
+```go
+// In tdns-mp init (e.g., main_initfuncs.go StartAgent)
+RegisterZoneOptionHandler(OptMultiProvider,
+    func(zname string, zconf ZoneConf,
+        options map[ZoneOption]bool) {
+        // Add to the list of zones needing SDE hydration
+        mpZoneList = append(mpZoneList, zname)
+    })
+```
+
+The `mpZoneList` is then consumed by the SDE hydration
+loop instead of `Zones.IterBuffered()`.
+
+## Implementation Plan
+
+### Phase 1: Option Handler Registry
+
+**Goal:** Create the registry mechanism in tdns.
+
+**Changes:**
+
+1. **New file `option_handlers.go`** (in v2/):
+   - `ZoneOptionHandler` type
+   - `optionHandlers` map
+   - `RegisterZoneOptionHandler()` function
+   - Keep it minimal -- just the registry and call mechanism
+
+2. **parseconfig.go**: After `parseZoneOptions()` returns
+   and after the zone stub is created/retrieved, iterate
+   the parsed options and invoke registered handlers.
+   Insert the handler invocation loop before the
+   OnFirstLoad callback setup (the handler fires once per
+   config parse, not once per zone load).
+
+**Files:** v2/option_handlers.go (new), v2/parseconfig.go
+
+### Phase 2: MP Zone List via Handler
+
+**Goal:** tdns-mp registers a handler that collects MP zone
+names. SDE hydration uses this list.
+
+**Changes:**
+
+1. **main_initfuncs.go**: In StartAgent (and StartCombiner,
+   StartAuth), before ParseZones is called, register a
+   handler for OptMultiProvider that appends the zone name
+   to a list stored in `conf.Internal`.
+
+   But note: ParseZones is called inside MainInit which
+   runs before StartAgent. So the handler must be
+   registered BEFORE MainInit calls ParseZones. This means
+   registration happens in the role-specific setup that
+   runs before MainInit, or in a pre-parse hook.
+
+   Alternative: register the handler at package init time
+   using a well-known variable, or register it in the
+   early part of MainInit before the ParseZones call.
+
+2. **config.go**: Add `MPZoneNames []string` to
+   InternalConf (or a new MPConf struct). The handler
+   populates this list.
+
+3. **syncheddataengine.go**: Change the hydration loop
+   from:
+   ```go
+   for item := range Zones.IterBuffered() {
+       if !zd.Options[OptMultiProvider] { continue }
+   ```
+   to:
+   ```go
+   for _, zname := range conf.Internal.MPZoneNames {
+       zd, ok := Zones.Get(zname)
+       if !ok { continue }
+   ```
+
+   The zone stub IS in the Zones map (ParseZones creates
+   it). It just might not have Options set yet. But we
+   don't check Options anymore -- we trust the list.
+
+**Files:** v2/main_initfuncs.go, v2/config.go,
+v2/syncheddataengine.go
+
+### Phase 3: Verify and Clean Up
+
+**Goal:** Ensure the hydration works for all MP zones and
+the old code path is removed.
+
+**Changes:**
+
+1. Remove the `zd.Options[OptMultiProvider]` check from
+   the hydration loop (replaced by list iteration).
+
+2. Add logging: log the MP zone list after ParseZones
+   completes, before hydration starts. This makes it
+   easy to verify all zones were registered.
+
+3. Test with 4+ MP zones on agent.alpha to confirm all
+   are hydrated on restart.
+
+**Files:** v2/syncheddataengine.go
+
+## Registration Timing
+
+The critical question is: when is the handler registered
+relative to when ParseZones runs?
+
+Current startup sequence in MainInit:
+```
+1. Basic config loading (viper)
+2. ParseZones(ctx, false)  -- line 234
+3. Role-specific setup (StartAgent/StartCombiner/etc.)
+4. Engine goroutines launched
+```
+
+The handler must be registered BEFORE step 2. Options:
+
+**(a) Register in MainInit before ParseZones:**
+Insert handler registration between steps 1 and 2.
+MainInit already knows the role from config. Simple.
+
+**(b) Register in package init():**
+The handler function would append to a package-level
+slice. Less explicit but guaranteed to run before
+ParseZones.
+
+**(c) Register via a pre-parse callback on Config:**
+Config gets a `PreParseHooks []func()` that MainInit
+calls before ParseZones. Role-specific setup registers
+the hook.
+
+**Recommended: (a).** It's explicit, the code is already
+in MainInit, and the role is known. No new abstraction
+needed for the registration timing.
+
+```go
+// In MainInit, before ParseZones:
+var mpZoneNames []string
+RegisterZoneOptionHandler(OptMultiProvider,
+    func(zname string, zconf ZoneConf,
+        options map[ZoneOption]bool) {
+        mpZoneNames = append(mpZoneNames, zname)
+    })
+
+all_zones, err := conf.ParseZones(ctx, false)
+
+// Store for later use by SDE:
+conf.Internal.MPZoneNames = mpZoneNames
+```
+
+## Unknown Option Detection
+
+With static option handling, ParseZones knows every valid
+option and warns about unknown ones. With dynamic handler
+registration, ParseZones no longer has complete knowledge
+-- some options are handled by registered callbacks from
+other packages.
+
+To preserve the ability to detect faulty configs, the
+option processing must track which options were "claimed"
+(either handled locally by ParseZones or by a registered
+handler). Any option that is neither locally handled nor
+has a registered handler is reported as unknown.
+
+Implementation:
+
+```go
+// In the option processing loop:
+for opt, val := range options {
+    if !val { continue }
+    handled := false
+
+    // Check if locally handled (existing switch cases)
+    if isLocallyHandledOption(opt) {
+        handled = true
+    }
+
+    // Check if a handler is registered
+    if handlers, ok := optionHandlers[opt]; ok && len(handlers) > 0 {
+        for _, handler := range handlers {
+            handler(zname, zconf, options)
+        }
+        handled = true
+    }
+
+    if !handled {
+        lg.Warn("unknown zone option with no handler",
+            "zone", zname, "option", ZoneOptionToString[opt])
+    }
+}
+```
+
+This ensures that:
+- Options handled by tdns (ParseZones switch) are fine
+- Options handled by tdns-mp (registered handlers) are fine
+- Options with neither are flagged as likely config errors
+
+The `isLocallyHandledOption` check can be a simple set of
+the options that ParseZones processes directly (the ones in
+its switch statement). Everything else must have a handler.
+
+## Future Extensions
+
+The option handler pattern is general-purpose. Other uses:
+
+- **delegation-sync-child**: Register a handler that sets
+  up delegation sync infrastructure per zone at parse time.
+- **catalog-zone**: Register a handler that initializes
+  catalog zone processing.
+- **online-signing**: Register a handler that validates
+  DNSSEC policy availability at parse time.
+
+Each of these currently has ad-hoc code scattered through
+parseconfig.go and main_initfuncs.go. Option handlers
+would consolidate them and make the extension points
+explicit.
+
+## Relationship to Three-Repo Split
+
+This design keeps the dependency direction clean:
+
+- **tdns** defines `RegisterZoneOptionHandler` and calls
+  handlers during ParseZones
+- **tdns-mp** calls `RegisterZoneOptionHandler` at init
+  time to register its MP handler
+- **tdns** has no import of tdns-mp; the coupling is via
+  the handler registry (inversion of control)
+
+The handler registry stays in tdns. The handler
+implementations move to tdns-mp. No circular dependencies.

--- a/docs/2026-03-23-unsigned-zone-dnskey-suppression.md
+++ b/docs/2026-03-23-unsigned-zone-dnskey-suppression.md
@@ -1,7 +1,7 @@
 # Unsigned Zone DNSKEY Suppression + KEYSTATE Timeout Fix
 
 **Date:** 2026-03-23
-**Status:** Plan (approved)
+**Status:** Implemented (KEYSTATE timeout still under investigation)
 
 ## Problem 1: DNSKEY Noise in Unsigned Zones
 

--- a/docs/2026-03-23-unsigned-zone-dnskey-suppression.md
+++ b/docs/2026-03-23-unsigned-zone-dnskey-suppression.md
@@ -1,0 +1,93 @@
+# Unsigned Zone DNSKEY Suppression
+
+**Date:** 2026-03-23
+**Status:** Plan
+
+## Problem
+
+Zones with no `signers=` key in HSYNCPARAM (unsigned zones)
+are still getting DNSKEYs generated, distributed between
+agents, and published by combiners. This is wrong -- DNSKEYs
+in an unsigned zone are meaningless noise.
+
+Example: ardbeg.whisky.dnslab has `nsmgmt="agent"` but no
+signers. Both alpha and delta generate keypairs, exchange
+them via SYNC, and publish them via their combiners.
+
+## Three-Layer Fix
+
+### Layer 1: Signer -- Don't Generate Keys for Unsigned Zones
+
+The signer generates keypairs based on DNSSEC policy and
+`OptInlineSigning`. With the "no signing without
+authorization" fix, `OptInlineSigning` is NOT set for zones
+with no signers. But key generation may be triggered by
+other paths:
+
+- DNSSEC policy evaluation during zone load
+- KeyStateWorker periodic checks
+- KEYSTATE inventory requests from agent
+
+**Fix:** All key generation paths must check whether the
+zone has signers authorized. If `analyzeHsyncSigners`
+returns `weShouldSign=false` AND `zoneSigned=false`, no
+keys should be generated.
+
+Also check: does the signer's KEYSTATE response include
+keys for unsigned zones? If so, the agent receives them
+and distributes.
+
+### Layer 2: Agent -- Don't Distribute DNSKEYs for Unsigned Zones
+
+The agent receives KEYSTATE from the signer and feeds
+local DNSKEYs into the SDE via `LocalDnskeysFromKeystate`.
+The SDE then distributes them to remote agents and the
+combiner.
+
+**Fix:** `LocalDnskeysFromKeystate` should check the
+HSYNCPARAM: if no signers are listed, return early without
+feeding any keys into the SDE.
+
+Also: the DNSKEY SYNC from remote agents (carrying their
+foreign keys) should be accepted into the SDE (for
+awareness) but NOT forwarded to the combiner for unsigned
+zones. This is already handled by the `OptMPDisallowEdits`
+guard for non-signing providers, but for unsigned zones
+(NO provider is a signer) there's no specific guard yet.
+
+### Layer 3: Combiner -- Reject DNSKEY Operations for Unsigned Zones
+
+Last line of defense. The combiner's
+`combinerProcessOperations` should check the HSYNCPARAM:
+if no signers are listed, reject DNSKEY operations.
+
+**Fix:** In the operation processing loop, when the RR
+type is DNSKEY, check the zone's HSYNCPARAM. If signers
+is empty, reject with reason "DNSKEY not allowed in
+unsigned zone".
+
+## Implementation Order
+
+Layer 1 (signer) stops the problem at the source.
+Layer 2 (agent) prevents distribution even if keys exist.
+Layer 3 (combiner) prevents publication as last defense.
+
+All three should be implemented together for correctness.
+
+## Related Issue: KEYSTATE Timeouts
+
+Separate from the DNSKEY suppression, there are frequent
+KEYSTATE exchange failures:
+
+```
+WARNING: KEYSTATE exchange FAILED: timeout waiting for
+signer response (15s)
+```
+
+This needs investigation:
+- Is the signer overloaded?
+- Is the KEYSTATE request not reaching the signer?
+- Is the response being consumed by the wrong handler?
+- Is there a channel contention issue (single-slot
+  response channel)?
+- Does it correlate with specific zones or all zones?

--- a/docs/2026-03-23-unsigned-zone-dnskey-suppression.md
+++ b/docs/2026-03-23-unsigned-zone-dnskey-suppression.md
@@ -1,93 +1,112 @@
-# Unsigned Zone DNSKEY Suppression
+# Unsigned Zone DNSKEY Suppression + KEYSTATE Timeout Fix
 
 **Date:** 2026-03-23
-**Status:** Plan
+**Status:** Plan (approved)
 
-## Problem
+## Problem 1: DNSKEY Noise in Unsigned Zones
 
 Zones with no `signers=` key in HSYNCPARAM (unsigned zones)
-are still getting DNSKEYs generated, distributed between
-agents, and published by combiners. This is wrong -- DNSKEYs
-in an unsigned zone are meaningless noise.
+are still getting DNSKEYs distributed between agents and
+published by combiners. DNSKEYs in an unsigned zone are
+meaningless noise.
 
 Example: ardbeg.whisky.dnslab has `nsmgmt="agent"` but no
-signers. Both alpha and delta generate keypairs, exchange
-them via SYNC, and publish them via their combiners.
+signers. Both alpha and delta distribute keypairs and
+publish them via their combiners.
 
-## Three-Layer Fix
+## Problem 2: KEYSTATE Exchange Timeouts
 
-### Layer 1: Signer -- Don't Generate Keys for Unsigned Zones
+Frequent "timeout waiting for signer response (15s)"
+warnings. Root cause: the `keystateRfiChan` in
+TransportManager is zone-agnostic. When zone A is waiting
+for a KEYSTATE response and zone B's proactive KEYSTATE
+arrives, it gets routed to zone A's dedicated channel.
+Zone A rejects it (wrong zone) and times out.
 
-The signer generates keypairs based on DNSSEC policy and
-`OptInlineSigning`. With the "no signing without
-authorization" fix, `OptInlineSigning` is NOT set for zones
-with no signers. But key generation may be triggered by
-other paths:
+## Part A: KEYSTATE Timeout Fix
 
-- DNSSEC policy evaluation during zone load
-- KeyStateWorker periodic checks
-- KEYSTATE inventory requests from agent
+### Root Cause
 
-**Fix:** All key generation paths must check whether the
-zone has signers authorized. If `analyzeHsyncSigners`
-returns `weShouldSign=false` AND `zoneSigned=false`, no
-keys should be generated.
+`routeKeystateMessage()` in `hsync_transport.go` routes
+all inventory messages to `keystateRfiChan` when set,
+without checking the zone name.
 
-Also check: does the signer's KEYSTATE response include
-keys for unsigned zones? If so, the agent receives them
-and distributes.
+### Fix
 
-### Layer 2: Agent -- Don't Distribute DNSKEYs for Unsigned Zones
+Store the expected zone name alongside the channel pointer.
+In `routeKeystateMessage`, check zone match before routing
+to the dedicated channel. Mismatches fall through to the
+shared `KeystateInventory` channel (proactive handler).
 
-The agent receives KEYSTATE from the signer and feeds
-local DNSKEYs into the SDE via `LocalDnskeysFromKeystate`.
-The SDE then distributes them to remote agents and the
-combiner.
+**Files:** hsync_transport.go (~15 lines), hsync_utils.go
+(~5 lines)
 
-**Fix:** `LocalDnskeysFromKeystate` should check the
-HSYNCPARAM: if no signers are listed, return early without
-feeding any keys into the SDE.
+## Part B: DNSKEY Suppression
 
-Also: the DNSKEY SYNC from remote agents (carrying their
-foreign keys) should be accepted into the SDE (for
-awareness) but NOT forwarded to the combiner for unsigned
-zones. This is already handled by the `OptMPDisallowEdits`
-guard for non-signing providers, but for unsigned zones
-(NO provider is a signer) there's no specific guard yet.
+### Current Guards
 
-### Layer 3: Combiner -- Reject DNSKEY Operations for Unsigned Zones
+Key generation at the signer is already guarded:
+`OptInlineSigning` is not set for unsigned zones, so
+`key_state_worker.go` skips generation. **No fix needed
+at signer key generation.**
 
-Last line of defense. The combiner's
-`combinerProcessOperations` should check the HSYNCPARAM:
-if no signers are listed, reject DNSKEY operations.
+### Fix 1: Signer KEYSTATE Inventory Response
 
-**Fix:** In the operation processing loop, when the RR
-type is DNSKEY, check the zone's HSYNCPARAM. If signers
-is empty, reject with reason "DNSKEY not allowed in
-unsigned zone".
+**File:** signer_msg_handler.go
+
+Before calling `GetKeyInventory`, check if we are a signer
+for this zone (`zd.MPdata.WeAreSigner`). If not (whether
+the zone is unsigned or signed by others), send empty
+inventory. The check is "are WE a signer" not "does the
+zone HAVE signers".
+
+### Fix 2: Agent LocalDnskeysFromKeystate
+
+**File:** hsync_utils.go
+
+Add guard at function entry: if zone is unsigned
+(`!zd.MPdata.ZoneSigned`), return early without feeding
+any keys into the SDE.
+
+### Fix 3: Agent SYNC-DNSKEY-RRSET Handler
+
+**File:** hsyncengine.go
+
+Add check before feeding DNSKEY changes to SDE: if zone
+is unsigned, skip the sync.
+
+### Fix 4: Agent Proactive KEYSTATE Handler
+
+**File:** hsyncengine.go
+
+Add check before triggering DNSKEY distribution after
+proactive inventory: if zone is unsigned, skip.
+
+### Fix 5: Combiner DNSKEY Rejection (Defense-in-Depth)
+
+**File:** combiner_chunk.go
+
+In the operation processing loop, reject DNSKEY operations
+for zones where HSYNCPARAM has no signers.
 
 ## Implementation Order
 
-Layer 1 (signer) stops the problem at the source.
-Layer 2 (agent) prevents distribution even if keys exist.
-Layer 3 (combiner) prevents publication as last defense.
+1. Part A (KEYSTATE timeout) -- fixes frequent warnings
+2. Part B fixes 2+4 (agent guards) -- stops distribution
+3. Part B fix 1 (signer guard) -- stops at source
+4. Part B fix 3 (agent SYNC handler) -- covers remote path
+5. Part B fix 5 (combiner guard) -- defense-in-depth
 
-All three should be implemented together for correctness.
+## Verification
 
-## Related Issue: KEYSTATE Timeouts
+### KEYSTATE timeout
+- Restart agent with 4+ MP zones
+- No "timeout waiting for signer response" in logs
+- All zones show successful KEYSTATE exchange
 
-Separate from the DNSKEY suppression, there are frequent
-KEYSTATE exchange failures:
-
-```
-WARNING: KEYSTATE exchange FAILED: timeout waiting for
-signer response (15s)
-```
-
-This needs investigation:
-- Is the signer overloaded?
-- Is the KEYSTATE request not reaching the signer?
-- Is the response being consumed by the wrong handler?
-- Is there a channel contention issue (single-slot
-  response channel)?
-- Does it correlate with specific zones or all zones?
+### DNSKEY suppression
+- ardbeg.whisky.dnslab (unsigned): no DNSKEYs in zone
+  transfer, no DNSKEY entries in SDE
+- Signed zones (caol-ila, whisky): DNSKEYs still work
+- addrr/delrr: still works for signed zones
+- Key rollover: still works for signed zones

--- a/guide/README.md
+++ b/guide/README.md
@@ -27,6 +27,11 @@ servers for multi-provider DNSSEC coordination.
   -- Delegation sync, DNS transport signaling, experimental
   record types, multi-signer DNSSEC.
 
+- [MP Change Tracking Semantics](mp-change-tracking-semantics.md)
+  -- Design decisions for how multi-provider changes are
+  tracked, confirmed, and routed. Corner cases for
+  non-signing providers.
+
 - Future Work (coming soon)
   -- IXFR support, API transport for agent-agent comms,
   TSIG authentication, HPKE encryption.

--- a/guide/mp-change-tracking-semantics.md
+++ b/guide/mp-change-tracking-semantics.md
@@ -1,0 +1,126 @@
+# Semantics of Multi-Provider Change Tracking
+
+This document captures design decisions and corner cases for
+how multi-provider zone changes are tracked, confirmed, and
+routed between agents, combiners, and signers.
+
+## Principles
+
+1. **Agents accept all valid data from peers.** The SDE
+   (Synched Data Engine) stores data from all providers
+   regardless of whether the local provider will act on it.
+   SDEs should be as synchronized as possible across all
+   providers in a group.
+
+2. **Only the combiner decides what to apply.** The combiner
+   enforces policy (signing authorization, protected
+   namespaces, RR type restrictions). An agent does not
+   second-guess the combiner's policy -- it forwards data
+   and lets the combiner accept or reject.
+
+3. **Rejection means combiner rejection.** A REJECTED
+   confirmation from an agent means the local combiner
+   rejected the data based on policy the agent may not be
+   aware of. It does NOT mean the agent refused to store
+   the data.
+
+4. **Non-forwarding is not rejection.** When an agent
+   accepts data into its SDE but does not forward to its
+   combiner (e.g., because OptMPDisallowEdits is set),
+   the agent sends ACCEPTED -- not REJECTED -- back to the
+   originator. The data was successfully delivered to the
+   agent. The internal decision not to forward is
+   transparent to the sender.
+
+5. **The sender sends to all providers; the receiver
+   decides.** The sender does not filter recipients based
+   on signing status or other provider-specific state.
+   The receiver knows its own state and acts accordingly.
+
+## Corner Cases
+
+### Non-Signing Provider Receives DNSKEY SYNC
+
+**Scenario:** signer.alpha sends DNSKEYs to agent.echo
+via agent-to-agent SYNC. Echo is a provider for the zone
+but not a signer (HSYNCPARAM signers= does not include
+echo).
+
+**Behavior:**
+- agent.echo accepts the DNSKEYs into its SDE (principle 1)
+- agent.echo does NOT forward to combiner.echo because
+  OptMPDisallowEdits is set (echo is not a signer)
+- agent.echo sends ACCEPTED back to agent.alpha
+  (principle 4)
+
+**Why not REJECTED:** signer.alpha tracks DNSKEY
+propagation and blocks key rollover until all agents
+confirm. If echo rejects, alpha's key rollover is blocked
+by a provider that has no role in the signing process.
+The DNSKEYs reach echo's zone via zone transfer (from
+alpha's signer), not via combiner edits.
+
+**Why not filter at sender:** Alpha could in theory skip
+sending to non-signers. But:
+- Echo's SDE benefits from having the data (awareness,
+  consistency checking, gossip)
+- The sender should not need to understand each
+  receiver's internal state
+- The HSYNCPARAM signers list could change; echo might
+  become a signer later
+
+### Non-Signing Provider Receives NS SYNC
+
+**Scenario:** agent.alpha adds an NS record and sends
+SYNC to agent.echo. Echo is not a signer.
+
+**Behavior:**
+- agent.echo accepts the NS into its SDE
+- agent.echo does NOT forward to combiner.echo
+- agent.echo sends ACCEPTED back to agent.alpha
+
+The NS reaches echo's zone via zone transfer from
+alpha's signer (which serves the signed zone including
+the new NS). Echo's combiner is not involved.
+
+### Non-Signing Provider Local addrr/delrr
+
+**Scenario:** Operator runs `agent zone addrr` on echo
+for a zone where echo is not a signer.
+
+**Behavior:**
+- The add-rr API endpoint checks OptMPDisallowEdits
+- Returns an immediate error: "zone is signed but this
+  provider is not a signer; modifications not allowed"
+- No data enters the SDE or reaches the combiner
+
+**Why reject at the API level:** This is a local command,
+not a peer SYNC. The operator needs immediate feedback
+that the operation is not possible. Silently accepting
+would be confusing.
+
+### Combiner Receives Update for Non-Signing Zone
+
+**Scenario:** Despite agent-side guards, an UPDATE reaches
+combiner.echo for a zone where echo is not a signer
+(e.g., from an older agent version or a race condition).
+
+**Behavior:**
+- Combiner checks MP authorization (checkMPauthorization)
+- Rejects with per-record RejectedItems
+- Sends CONFIRM with status=FAILED back to the agent
+- Records the rejection in the combiner's rejected edits
+  audit trail
+
+This is the last line of defense. The combiner always
+enforces its own policy regardless of what the agent did.
+
+## Option Summary
+
+| Option | Meaning | Set By |
+|--------|---------|--------|
+| allow-edits | Combiner may edit this zone | populateMPdata (provider + signer) |
+| mp-disallow-edits | Zone is signed, we are not a signer | populateMPdata (provider, not signer) |
+| mp-not-listed-error | We are not listed as a provider at all | populateMPdata (guard 3 failure) |
+| multi-signer | Multiple providers sign this zone | populateMPdata (otherSigners > 0) |
+| inline-signing | Signer should sign this zone | populateMPdata (WeAreSigner) |

--- a/v2/agent_utils.go
+++ b/v2/agent_utils.go
@@ -21,6 +21,10 @@ import (
 
 var lgAgent = Logger("agent")
 
+// discoveryFailureFlushThreshold is the number of consecutive discovery
+// failures before flushing the IMR cache for the agent's domain.
+const discoveryFailureFlushThreshold = 3
+
 func (ar *AgentRegistry) AddZoneToAgent(identity AgentId, zone ZoneName) {
 	agent, exists := ar.S.Get(identity)
 	if !exists {
@@ -628,7 +632,7 @@ func (ar *AgentRegistry) attemptDiscovery(agent *Agent, imr *Imr, discoverAPI, d
 		agent.ApiDetails.LatestErrorTime = time.Now()
 		agent.mu.Unlock()
 
-		if failures >= 3 && imr.Cache != nil {
+		if failures >= discoveryFailureFlushThreshold && imr.Cache != nil {
 			identity := string(agent.Identity)
 			removed, err := imr.Cache.FlushDomain(identity, false)
 			if err == nil && removed > 0 {

--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -104,9 +104,20 @@ type ZoneResponse struct {
 	Zone     string
 	Names    []string
 	Zones    map[string]ZoneConf
+	MPZones  map[string]MPZoneInfo `json:"mp_zones,omitempty"`
 	Msg      string
 	Error    bool
 	ErrorMsg string
+}
+
+// MPZoneInfo carries multi-provider zone details for the mplist command.
+type MPZoneInfo struct {
+	Providers  []string     `json:"providers"`
+	Signers    []string     `json:"signers"`
+	NSmgmt     string       `json:"nsmgmt"`
+	ParentSync string       `json:"parentsync"`
+	Suffix     string       `json:"suffix,omitempty"`
+	Options    []ZoneOption `json:"options"`
 }
 type ZoneDsyncPost struct {
 	Command   string // status | bootstrap | ...

--- a/v2/apihandler_agent.go
+++ b/v2/apihandler_agent.go
@@ -276,12 +276,18 @@ func (conf *Config) APIagent(refreshZoneCh chan<- ZoneRefresher, kdb *KeyDB) fun
 			}
 
 			isAdd := amp.Command == "add-rr"
+			apex := dns.Fqdn(string(amp.Zone))
 			var parsedRRs []dns.RR
 			for _, rrStr := range amp.RRs {
 				rr, err := dns.NewRR(rrStr)
 				if err != nil {
 					resp.Error = true
 					resp.ErrorMsg = fmt.Sprintf("failed to parse RR %q: %v", rrStr, err)
+					return
+				}
+				if dns.Fqdn(rr.Header().Name) != apex {
+					resp.Error = true
+					resp.ErrorMsg = fmt.Sprintf("record owner %q is not the zone apex %q", rr.Header().Name, apex)
 					return
 				}
 				if !AllowedLocalRRtypes[rr.Header().Rrtype] {
@@ -346,13 +352,26 @@ func (conf *Config) APIagent(refreshZoneCh chan<- ZoneRefresher, kdb *KeyDB) fun
 				}
 			}
 			cresp := make(chan *AgentMsgResponse, 1)
-			conf.Internal.MsgQs.SynchedDataUpdate <- &SynchedDataUpdate{
+			select {
+			case conf.Internal.MsgQs.SynchedDataUpdate <- &SynchedDataUpdate{
 				Zone:       amp.Zone,
 				AgentId:    AgentId(conf.MultiProvider.Identity),
 				UpdateType: "local",
 				Update:     zu,
 				Force:      force,
 				Response:   cresp,
+			}:
+				// enqueued successfully
+			case <-r.Context().Done():
+				resp.Error = true
+				resp.ErrorMsg = "request cancelled"
+				resp.Status = "fail"
+				return
+			case <-time.After(2 * time.Second):
+				resp.Error = true
+				resp.ErrorMsg = "SynchedDataUpdate queue full, try again later"
+				resp.Status = "fail"
+				return
 			}
 
 			select {
@@ -626,7 +645,7 @@ func (conf *Config) APIagent(refreshZoneCh chan<- ZoneRefresher, kdb *KeyDB) fun
 			resp.Identity = AgentId(conf.MultiProvider.Identity)
 
 		case "refresh-keys":
-			zd.RequestAndWaitForKeyInventory()
+			zd.RequestAndWaitForKeyInventory(context.Background())
 			if !zd.GetKeystateOK() {
 				resp.Error = true
 				resp.ErrorMsg = fmt.Sprintf("KEYSTATE exchange failed for zone %s: %s", amp.Zone, zd.GetKeystateError())

--- a/v2/apihandler_agent.go
+++ b/v2/apihandler_agent.go
@@ -262,6 +262,118 @@ func (conf *Config) APIagent(refreshZoneCh chan<- ZoneRefresher, kdb *KeyDB) fun
 				resp.ErrorMsg = "No response from CommandHandler after 10 seconds, state unknown"
 			}
 
+		case "add-rr", "del-rr":
+			// Add or delete an RR: store locally + sync to peers + send to combiner
+			if len(amp.RRs) == 0 {
+				resp.Error = true
+				resp.ErrorMsg = "at least one RR is required"
+				return
+			}
+			if zd != nil && zd.Options[OptMPDisallowEdits] {
+				resp.Error = true
+				resp.ErrorMsg = fmt.Sprintf("zone %s is signed but this provider is not a signer; modifications not allowed", amp.Zone)
+				return
+			}
+
+			isAdd := amp.Command == "add-rr"
+			var parsedRRs []dns.RR
+			for _, rrStr := range amp.RRs {
+				rr, err := dns.NewRR(rrStr)
+				if err != nil {
+					resp.Error = true
+					resp.ErrorMsg = fmt.Sprintf("failed to parse RR %q: %v", rrStr, err)
+					return
+				}
+				if !AllowedLocalRRtypes[rr.Header().Rrtype] {
+					resp.Error = true
+					resp.ErrorMsg = fmt.Sprintf("RR type %s is not allowed", dns.TypeToString[rr.Header().Rrtype])
+					return
+				}
+				if isAdd {
+					rr.Header().Class = dns.ClassINET
+				} else {
+					rr.Header().Class = dns.ClassNONE
+				}
+				parsedRRs = append(parsedRRs, rr)
+			}
+
+			zu := &ZoneUpdate{
+				Zone:    amp.Zone,
+				AgentId: AgentId(conf.MultiProvider.Identity),
+				RRs:     parsedRRs,
+				RRsets:  make(map[uint16]core.RRset),
+			}
+
+			opStr := "add"
+			if !isAdd {
+				opStr = "delete"
+			}
+			opsMap := make(map[uint16][]string)
+			for _, rr := range parsedRRs {
+				rrtype := rr.Header().Rrtype
+				rrset, exists := zu.RRsets[rrtype]
+				if !exists {
+					rrset = core.RRset{
+						Name:   rr.Header().Name,
+						Class:  rr.Header().Class,
+						RRtype: rrtype,
+					}
+				}
+				rrset.RRs = append(rrset.RRs, rr)
+				zu.RRsets[rrtype] = rrset
+				inetRR := dns.Copy(rr)
+				inetRR.Header().Class = dns.ClassINET
+				opsMap[rrtype] = append(opsMap[rrtype], inetRR.String())
+			}
+			for rrtype, records := range opsMap {
+				zu.Operations = append(zu.Operations, core.RROperation{
+					Operation: opStr,
+					RRtype:    dns.TypeToString[rrtype],
+					Records:   records,
+				})
+			}
+
+			action := "Adding"
+			if !isAdd {
+				action = "Removing"
+			}
+			lgApi.Info("RR operation", "cmd", amp.Command, "action", action, "count", len(parsedRRs), "zone", amp.Zone)
+
+			force := false
+			if amp.Data != nil {
+				if f, ok := amp.Data["force"].(bool); ok {
+					force = f
+				}
+			}
+			cresp := make(chan *AgentMsgResponse, 1)
+			conf.Internal.MsgQs.SynchedDataUpdate <- &SynchedDataUpdate{
+				Zone:       amp.Zone,
+				AgentId:    AgentId(conf.MultiProvider.Identity),
+				UpdateType: "local",
+				Update:     zu,
+				Force:      force,
+				Response:   cresp,
+			}
+
+			select {
+			case r := <-cresp:
+				if r.Error {
+					resp.Error = true
+					resp.ErrorMsg = r.ErrorMsg
+					resp.Msg = fmt.Sprintf("%s RR(s) failed: %s", amp.Command, r.ErrorMsg)
+				} else {
+					resp.Msg = fmt.Sprintf("%s %d RR(s) for zone %q", action, len(parsedRRs), amp.Zone)
+					if r.Msg != "" {
+						resp.Msg += " - " + r.Msg
+					}
+				}
+				resp.Status = "ok"
+			case <-time.After(5 * time.Second):
+				resp.Error = true
+				resp.ErrorMsg = "timeout waiting for SynchedDataEngine response"
+				resp.Status = "timeout"
+			}
+
 		case "hsync-zonestatus":
 			// Get the apex owner object
 			owner, err := zd.GetOwner(zd.ZoneName)
@@ -1299,139 +1411,6 @@ func (conf *Config) APIagentDebug() func(w http.ResponseWriter, r *http.Request)
 			}
 			resp.Msg = fmt.Sprintf("Combiner data retrieved for %d zone(s)", len(combinerData))
 			resp.Status = "ok"
-
-		case "add-rr", "del-rr":
-			// Add or delete an RR of any allowed type: store locally + sync to peers + send to combiner
-			if amp.Zone == "" {
-				resp.Error = true
-				resp.ErrorMsg = "zone is required"
-				return
-			}
-			if len(amp.RRs) == 0 {
-				resp.Error = true
-				resp.ErrorMsg = "at least one RR is required"
-				return
-			}
-
-			// Reject edits for non-signing providers
-			if zd, ok := Zones.Get(string(amp.Zone)); ok && zd.Options[OptMPDisallowEdits] {
-				resp.Error = true
-				resp.ErrorMsg = fmt.Sprintf("zone %s is signed but this provider is not a signer; modifications not allowed", amp.Zone)
-				return
-			}
-
-			isAdd := amp.Command == "add-rr"
-
-			// Parse and validate the RRs (must be an allowed type at the zone apex)
-			var parsedRRs []dns.RR
-			for _, rrStr := range amp.RRs {
-				rr, err := dns.NewRR(rrStr)
-				if err != nil {
-					resp.Error = true
-					resp.ErrorMsg = fmt.Sprintf("failed to parse RR %q: %v", rrStr, err)
-					return
-				}
-				if !AllowedLocalRRtypes[rr.Header().Rrtype] {
-					resp.Error = true
-					resp.ErrorMsg = fmt.Sprintf("RR type %s is not allowed", dns.TypeToString[rr.Header().Rrtype])
-					return
-				}
-				if isAdd {
-					rr.Header().Class = dns.ClassINET
-				} else {
-					rr.Header().Class = dns.ClassNONE
-				}
-				parsedRRs = append(parsedRRs, rr)
-			}
-
-			// Create the ZoneUpdate with RRs, RRsets, and Operations
-			zu := &ZoneUpdate{
-				Zone:    amp.Zone,
-				AgentId: AgentId(conf.MultiProvider.Identity),
-				RRs:     parsedRRs,
-				RRsets:  make(map[uint16]core.RRset),
-			}
-
-			// Populate RRsets (needed by ProcessUpdate) and Operations (for wire transport)
-			opStr := "add"
-			if !isAdd {
-				opStr = "delete"
-			}
-			opsMap := make(map[uint16][]string)
-			for _, rr := range parsedRRs {
-				rrtype := rr.Header().Rrtype
-				rrset, exists := zu.RRsets[rrtype]
-				if !exists {
-					rrset = core.RRset{
-						Name:   rr.Header().Name,
-						Class:  rr.Header().Class,
-						RRtype: rrtype,
-					}
-				}
-				rrset.RRs = append(rrset.RRs, rr)
-				zu.RRsets[rrtype] = rrset
-				// For Operations, use ClassINET string representation
-				inetRR := dns.Copy(rr)
-				inetRR.Header().Class = dns.ClassINET
-				opsMap[rrtype] = append(opsMap[rrtype], inetRR.String())
-			}
-			for rrtype, records := range opsMap {
-				zu.Operations = append(zu.Operations, core.RROperation{
-					Operation: opStr,
-					RRtype:    dns.TypeToString[rrtype],
-					Records:   records,
-				})
-			}
-
-			action := "Adding"
-			if !isAdd {
-				action = "Removing"
-			}
-			// Collect RR type names for logging
-			rrtypeNames := make(map[string]bool)
-			for _, rr := range parsedRRs {
-				rrtypeNames[dns.TypeToString[rr.Header().Rrtype]] = true
-			}
-			var typeList []string
-			for name := range rrtypeNames {
-				typeList = append(typeList, name)
-			}
-			lgApi.Info("RR operation", "cmd", amp.Command, "action", action, "count", len(parsedRRs), "types", strings.Join(typeList, ", "), "zone", amp.Zone)
-
-			force := false
-			if amp.Data != nil {
-				if f, ok := amp.Data["force"].(bool); ok {
-					force = f
-				}
-			}
-			cresp := make(chan *AgentMsgResponse, 1)
-			conf.Internal.MsgQs.SynchedDataUpdate <- &SynchedDataUpdate{
-				Zone:       amp.Zone,
-				AgentId:    AgentId(conf.MultiProvider.Identity),
-				UpdateType: "local",
-				Update:     zu,
-				Force:      force,
-				Response:   cresp,
-			}
-
-			select {
-			case r := <-cresp:
-				if r.Error {
-					resp.Error = true
-					resp.ErrorMsg = r.ErrorMsg
-					resp.Msg = fmt.Sprintf("%s RR(s) failed: %s", amp.Command, r.ErrorMsg)
-				} else {
-					resp.Msg = fmt.Sprintf("%s %d RR(s) for zone %q", action, len(parsedRRs), amp.Zone)
-					if r.Msg != "" {
-						resp.Msg += " - " + r.Msg
-					}
-				}
-				resp.Status = "ok"
-			case <-time.After(5 * time.Second):
-				resp.Error = true
-				resp.ErrorMsg = "timeout waiting for SynchedDataEngine response"
-				resp.Status = "timeout"
-			}
 
 		case "send-sync-to":
 			// Send a real SYNC to a remote agent

--- a/v2/apihandler_agent.go
+++ b/v2/apihandler_agent.go
@@ -388,6 +388,10 @@ func (conf *Config) APIagent(refreshZoneCh chan<- ZoneRefresher, kdb *KeyDB) fun
 					}
 					resp.Status = "ok"
 				}
+			case <-r.Context().Done():
+				resp.Error = true
+				resp.ErrorMsg = "request cancelled"
+				resp.Status = "fail"
 			case <-time.After(5 * time.Second):
 				resp.Error = true
 				resp.ErrorMsg = "timeout waiting for SynchedDataEngine response"
@@ -645,7 +649,7 @@ func (conf *Config) APIagent(refreshZoneCh chan<- ZoneRefresher, kdb *KeyDB) fun
 			resp.Identity = AgentId(conf.MultiProvider.Identity)
 
 		case "refresh-keys":
-			zd.RequestAndWaitForKeyInventory(context.Background())
+			zd.RequestAndWaitForKeyInventory(r.Context())
 			if !zd.GetKeystateOK() {
 				resp.Error = true
 				resp.ErrorMsg = fmt.Sprintf("KEYSTATE exchange failed for zone %s: %s", amp.Zone, zd.GetKeystateError())

--- a/v2/apihandler_agent.go
+++ b/v2/apihandler_agent.go
@@ -361,13 +361,14 @@ func (conf *Config) APIagent(refreshZoneCh chan<- ZoneRefresher, kdb *KeyDB) fun
 					resp.Error = true
 					resp.ErrorMsg = r.ErrorMsg
 					resp.Msg = fmt.Sprintf("%s RR(s) failed: %s", amp.Command, r.ErrorMsg)
+					resp.Status = "fail"
 				} else {
 					resp.Msg = fmt.Sprintf("%s %d RR(s) for zone %q", action, len(parsedRRs), amp.Zone)
 					if r.Msg != "" {
 						resp.Msg += " - " + r.Msg
 					}
+					resp.Status = "ok"
 				}
-				resp.Status = "ok"
 			case <-time.After(5 * time.Second):
 				resp.Error = true
 				resp.ErrorMsg = "timeout waiting for SynchedDataEngine response"

--- a/v2/apihandler_combiner.go
+++ b/v2/apihandler_combiner.go
@@ -299,6 +299,7 @@ func APIcombinerEdits(conf *Config) func(w http.ResponseWriter, r *http.Request)
 			}
 			// Build agent -> rrtype -> []rr from AgentContributions
 			current := make(map[string]map[string][]string)
+			zd.mu.Lock()
 			if zd.AgentContributions != nil {
 				for agentID, ownerMap := range zd.AgentContributions {
 					for _, rrtypeMap := range ownerMap {
@@ -314,6 +315,7 @@ func APIcombinerEdits(conf *Config) func(w http.ResponseWriter, r *http.Request)
 					}
 				}
 			}
+			zd.mu.Unlock()
 			resp.Current = current
 			totalRRs := 0
 			for _, rrtypeMap := range current {

--- a/v2/apihandler_combiner.go
+++ b/v2/apihandler_combiner.go
@@ -384,15 +384,15 @@ func APIcombinerEdits(conf *Config) func(w http.ResponseWriter, r *http.Request)
 					if zd, ok := Zones.Get(zone); ok {
 						zd.mu.Lock()
 						zd.AgentContributions = nil
-						zd.mu.Unlock()
 						zd.rebuildCombinerData()
+						zd.mu.Unlock()
 					}
 				} else {
 					for _, zd := range Zones.Items() {
 						zd.mu.Lock()
 						zd.AgentContributions = nil
-						zd.mu.Unlock()
 						zd.rebuildCombinerData()
+						zd.mu.Unlock()
 					}
 				}
 			}

--- a/v2/apihandler_combiner.go
+++ b/v2/apihandler_combiner.go
@@ -378,21 +378,21 @@ func APIcombinerEdits(conf *Config) func(w http.ResponseWriter, r *http.Request)
 					errs = append(errs, fmt.Errorf("contributions: %w", err))
 				} else {
 					parts = append(parts, fmt.Sprintf("%d contributions", n))
-				}
-				// Also clear in-memory AgentContributions and rebuild CombinerData
-				if zone != "" {
-					if zd, ok := Zones.Get(zone); ok {
-						zd.mu.Lock()
-						zd.AgentContributions = nil
-						zd.rebuildCombinerData()
-						zd.mu.Unlock()
-					}
-				} else {
-					for _, zd := range Zones.Items() {
-						zd.mu.Lock()
-						zd.AgentContributions = nil
-						zd.rebuildCombinerData()
-						zd.mu.Unlock()
+					// Clear in-memory AgentContributions only on DB success
+					if zone != "" {
+						if zd, ok := Zones.Get(zone); ok {
+							zd.mu.Lock()
+							zd.AgentContributions = nil
+							zd.rebuildCombinerData()
+							zd.mu.Unlock()
+						}
+					} else {
+						for _, zd := range Zones.Items() {
+							zd.mu.Lock()
+							zd.AgentContributions = nil
+							zd.rebuildCombinerData()
+							zd.mu.Unlock()
+						}
 					}
 				}
 			}

--- a/v2/apihandler_combiner.go
+++ b/v2/apihandler_combiner.go
@@ -291,8 +291,13 @@ func APIcombinerEdits(conf *Config) func(w http.ResponseWriter, r *http.Request)
 
 		case "list-current":
 			zone := dns.Fqdn(cp.Zone)
-			zd, _ := Zones.Get(zone)
-			// Build agent → rrtype → []rr from AgentContributions
+			zd, ok := Zones.Get(zone)
+			if !ok || zd == nil {
+				resp.Error = true
+				resp.ErrorMsg = fmt.Sprintf("zone %s not found", zone)
+				return
+			}
+			// Build agent -> rrtype -> []rr from AgentContributions
 			current := make(map[string]map[string][]string)
 			if zd.AgentContributions != nil {
 				for agentID, ownerMap := range zd.AgentContributions {

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
+	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
 )
 
@@ -41,12 +43,12 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 		}()
 
 		zd, exist := Zones.Get(zp.Zone)
-		if !exist && zp.Command != "list-zones" {
+		if !exist && zp.Command != "list-zones" && zp.Command != "list-mp-zones" {
 			resp.Error = true
 			resp.ErrorMsg = fmt.Sprintf("Zone %s is unknown", zp.Zone)
 			return
 		}
-		if zd == nil && zp.Command != "list-zones" {
+		if zd == nil && zp.Command != "list-zones" && zp.Command != "list-mp-zones" {
 			resp.Error = true
 			resp.ErrorMsg = fmt.Sprintf("Zone %s: zone data is nil", zp.Zone)
 			return
@@ -182,6 +184,80 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 				zones[zname] = zconf
 			}
 			resp.Zones = zones
+
+		case "list-mp-zones":
+			mpZones := map[string]MPZoneInfo{}
+			for item := range Zones.IterBuffered() {
+				zname := item.Key
+				zd := item.Val
+				if !zd.Options[OptMultiProvider] {
+					continue
+				}
+
+				info := MPZoneInfo{}
+
+				// Collect options
+				for opt, val := range zd.Options {
+					if val {
+						info.Options = append(info.Options, opt)
+					}
+				}
+
+				// Extract HSYNCPARAM and HSYNC3 data from zone apex
+				apex, err := zd.GetOwner(zd.ZoneName)
+				if err == nil && apex != nil {
+					// HSYNC3: provider labels
+					hsync3RRset, exists := apex.RRtypes.Get(core.TypeHSYNC3)
+					if exists {
+						for _, rr := range hsync3RRset.RRs {
+							if prr, ok := rr.(*dns.PrivateRR); ok {
+								if h3, ok := prr.Data.(*core.HSYNC3); ok {
+									info.Providers = append(info.Providers, strings.TrimSuffix(h3.Label, "."))
+								}
+							}
+						}
+					}
+
+					// HSYNCPARAM: nsmgmt, parentsync, signers, suffix
+					hsyncparamRRset, exists := apex.RRtypes.Get(core.TypeHSYNCPARAM)
+					if exists && len(hsyncparamRRset.RRs) > 0 {
+						if prr, ok := hsyncparamRRset.RRs[0].(*dns.PrivateRR); ok {
+							if hp, ok := prr.Data.(*core.HSYNCPARAM); ok {
+								switch hp.GetNSmgmt() {
+								case core.HsyncNSmgmtAGENT:
+									info.NSmgmt = "agent"
+								default:
+									info.NSmgmt = "owner"
+								}
+								switch hp.GetParentSync() {
+								case core.HsyncParentSyncAgent:
+									info.ParentSync = "agent"
+								default:
+									info.ParentSync = "owner"
+								}
+								info.Signers = hp.GetSigners()
+								info.Suffix = hp.GetSuffix()
+							}
+						}
+					}
+				}
+
+				if info.NSmgmt == "" {
+					info.NSmgmt = "owner"
+				}
+				if info.ParentSync == "" {
+					info.ParentSync = "owner"
+				}
+				if info.Signers == nil {
+					info.Signers = []string{}
+				}
+				if info.Providers == nil {
+					info.Providers = []string{}
+				}
+
+				mpZones[zname] = info
+			}
+			resp.MPZones = mpZones
 
 		default:
 			resp.ErrorMsg = fmt.Sprintf("Unknown zone command: %s", zp.Command)

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -196,10 +196,19 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 
 				info := MPZoneInfo{}
 
-				// Collect options
+				// Collect options from both zd.Options and zd.MPdata.Options
+				seen := make(map[ZoneOption]bool)
 				for opt, val := range zd.Options {
 					if val {
 						info.Options = append(info.Options, opt)
+						seen[opt] = true
+					}
+				}
+				if zd.MPdata != nil {
+					for opt, val := range zd.MPdata.Options {
+						if val && !seen[opt] {
+							info.Options = append(info.Options, opt)
+						}
 					}
 				}
 

--- a/v2/cli/agent_cmds.go
+++ b/v2/cli/agent_cmds.go
@@ -382,7 +382,7 @@ func VerifyAndSendLocalDNSRecord(zonename, dnsRecord, cmd string) error {
 
 	amr, err := SendAgentMgmtCmd(&tdns.AgentMgmtPost{
 		Command: apiCmd,
-		Zone:    tdns.ZoneName(dns.Fqdn(tdns.Globals.Zonename)),
+		Zone:    tdns.ZoneName(dns.Fqdn(zonename)),
 		RRs:     []string{rr.String()},
 	}, "local")
 

--- a/v2/cli/agent_cmds.go
+++ b/v2/cli/agent_cmds.go
@@ -99,20 +99,6 @@ var agentLocalZoneDataRemoveRRCmd = &cobra.Command{
 	},
 }
 
-var agentLocalZoneDataRemoveRRsetCmd = &cobra.Command{
-	Use:   "remove-rrset",
-	Short: "Remove a local DNS RRset for an existing zone",
-	Run: func(cmd *cobra.Command, args []string) {
-		PrepArgs("zonename")
-
-		err := VerifyAndSendLocalDNSRecord(tdns.Globals.Zonename, dnsRecord, "remove-rrset")
-		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
-		}
-	},
-}
-
 var agentDiscoverCmd = &cobra.Command{
 	Use:   "discover <agent-identity>",
 	Short: "Trigger DNS discovery for a remote agent",
@@ -332,7 +318,6 @@ func init() {
 	agentLocalCmd.AddCommand(agentLocalZoneDataCmd)
 	agentLocalZoneDataCmd.AddCommand(agentLocalZoneDataAddRRCmd)
 	agentLocalZoneDataCmd.AddCommand(agentLocalZoneDataRemoveRRCmd)
-	agentLocalZoneDataCmd.AddCommand(agentLocalZoneDataRemoveRRsetCmd)
 
 	// agentLocalZoneDataCmd.PersistentFlags().StringVarP(&localRRtype, "rrtype", "R", "", "RR type to add")
 	agentLocalZoneDataCmd.PersistentFlags().StringVarP(&dnsRecord, "RR", "", "", "DNS record to add")
@@ -370,14 +355,12 @@ func SendAgentMgmtCmd(req *tdns.AgentMgmtPost, prefix string) (*tdns.AgentMgmtRe
 }
 
 func VerifyAndSendLocalDNSRecord(zonename, dnsRecord, cmd string) error {
-	var rr dns.RR
-	var err error
-
 	if dnsRecord == "" {
 		return fmt.Errorf("error: DNS record is required")
 	}
 
-	if rr, err = dns.NewRR(dnsRecord); err != nil {
+	rr, err := dns.NewRR(dnsRecord)
+	if err != nil {
 		return fmt.Errorf("error: invalid DNS record (did not parse): %v", err)
 	}
 
@@ -386,36 +369,21 @@ func VerifyAndSendLocalDNSRecord(zonename, dnsRecord, cmd string) error {
 			rr.Header().Name, zonename)
 	}
 
-	switch rr.(type) {
-	// let's only support NS, DNSKEY and KEYfor now
-	case *dns.NS, *dns.DNSKEY, *dns.KEY:
-		// all good
-	default:
-		return fmt.Errorf("invalid RR type: %s (only NS, DNSKEY and KEY allowed)", dns.TypeToString[rr.Header().Rrtype])
-	}
-
+	// Map CLI command to API command
+	var apiCmd string
 	switch cmd {
 	case "add-rr":
-		// This is a normal add RR, signaled by the CLASS=IN
-		rr.Header().Class = dns.ClassINET
+		apiCmd = "add-rr"
 	case "remove-rr":
-		// This is a delete RR, signaled by the CLASS=NONE
-		rr.Header().Class = dns.ClassNONE
-	case "remove-rrset":
-		// This is a delete RRset, signaled by the CLASS=ANY
-		rr.Header().Class = dns.ClassANY
+		apiCmd = "del-rr"
 	default:
 		return fmt.Errorf("invalid command: %s", cmd)
 	}
 
-	rrs := []string{rr.String()}
-
 	amr, err := SendAgentMgmtCmd(&tdns.AgentMgmtPost{
-		Command: "update-local-zonedata",
-		RRType:  rr.Header().Rrtype,
-		Zone:    tdns.ZoneName(tdns.Globals.Zonename),
-		AgentId: tdns.AgentId(myIdentity),
-		RRs:     rrs,
+		Command: apiCmd,
+		Zone:    tdns.ZoneName(dns.Fqdn(tdns.Globals.Zonename)),
+		RRs:     []string{rr.String()},
 	}, "local")
 
 	if err != nil {

--- a/v2/cli/agent_zone_cmds.go
+++ b/v2/cli/agent_zone_cmds.go
@@ -58,6 +58,28 @@ var agentZoneListCmd = &cobra.Command{
 	},
 }
 
+var agentZoneMPListCmd = &cobra.Command{
+	Use:   "mplist",
+	Short: "List multi-provider zones with HSYNCPARAM details",
+	Run: func(cmd *cobra.Command, args []string) {
+		prefixcmd, _ := getCommandContext("zone")
+		api, err := getApiClient(prefixcmd, true)
+		if err != nil {
+			log.Fatalf("Error getting API client for %s: %v", prefixcmd, err)
+		}
+
+		cr, err := SendZoneCommand(api, tdns.ZonePost{
+			Command: "list-mp-zones",
+		})
+		if err != nil {
+			fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+			os.Exit(1)
+		}
+
+		ListMPZones(cr)
+	},
+}
+
 var agentZoneReloadCmd = &cobra.Command{
 	Use:   "reload",
 	Short: "Request re-loading a zone",
@@ -502,7 +524,7 @@ func init() {
 	AgentCmd.AddCommand(AgentZoneCmd)
 
 	// Zone subcommands relevant to the agent
-	AgentZoneCmd.AddCommand(agentZoneListCmd, agentZoneReloadCmd, agentZoneWriteCmd)
+	AgentZoneCmd.AddCommand(agentZoneListCmd, agentZoneMPListCmd, agentZoneReloadCmd, agentZoneWriteCmd)
 	AgentZoneCmd.AddCommand(agentZoneUpdateCmd, agentZoneReadFakeCmd)
 	AgentZoneCmd.AddCommand(agentZoneDsyncCmd)
 

--- a/v2/cli/agent_zone_cmds.go
+++ b/v2/cli/agent_zone_cmds.go
@@ -384,7 +384,7 @@ Examples:
 			log.Fatalf("Error getting API client: %v", err)
 		}
 
-		_, buf, err := api.RequestNG("POST", "/agent/debug", req, true)
+		_, buf, err := api.RequestNG("POST", "/agent", req, true)
 		if err != nil {
 			log.Fatalf("API request failed: %v", err)
 		}
@@ -458,7 +458,7 @@ Examples:
 			log.Fatalf("Error getting API client: %v", err)
 		}
 
-		_, buf, err := api.RequestNG("POST", "/agent/debug", req, true)
+		_, buf, err := api.RequestNG("POST", "/agent", req, true)
 		if err != nil {
 			log.Fatalf("API request failed: %v", err)
 		}

--- a/v2/cli/combiner_edits_cmds.go
+++ b/v2/cli/combiner_edits_cmds.go
@@ -56,6 +56,28 @@ var combinerZoneListCmd = &cobra.Command{
 	},
 }
 
+var combinerZoneMPListCmd = &cobra.Command{
+	Use:   "mplist",
+	Short: "List multi-provider zones with HSYNCPARAM details",
+	Run: func(cmd *cobra.Command, args []string) {
+		prefixcmd, _ := getCommandContext("zone")
+		api, err := getApiClient(prefixcmd, true)
+		if err != nil {
+			log.Fatalf("Error getting API client for %s: %v", prefixcmd, err)
+		}
+
+		cr, err := SendZoneCommand(api, tdns.ZonePost{
+			Command: "list-mp-zones",
+		})
+		if err != nil {
+			fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+			log.Fatalf("Error: %v", err)
+		}
+
+		ListMPZones(cr)
+	},
+}
+
 var combinerZoneEditsCmd = &cobra.Command{
 	Use:   "edits",
 	Short: "Manage pending, approved and rejected edits",
@@ -447,7 +469,7 @@ var combinerZoneBumpCmd = &cobra.Command{
 
 func init() {
 	CombinerCmd.AddCommand(combinerZoneCmd)
-	combinerZoneCmd.AddCommand(combinerZoneListCmd)
+	combinerZoneCmd.AddCommand(combinerZoneListCmd, combinerZoneMPListCmd)
 	combinerZoneCmd.AddCommand(combinerZoneBumpCmd)
 	combinerZoneCmd.AddCommand(combinerZoneReloadCmd)
 	combinerZoneCmd.AddCommand(combinerZoneEditsCmd)

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -412,7 +412,10 @@ func ListMPZones(cr tdns.ZoneResponse) {
 		return
 	}
 
-	out := []string{"Zone|Providers|Signers|NSmgmt|ParentSync|Options"}
+	var out []string
+	if tdns.Globals.ShowHeaders {
+		out = append(out, "Zone|Providers|Signers|NSmgmt|ParentSync|Suffix|Options")
+	}
 
 	var znames []string
 	for zname := range cr.MPZones {
@@ -433,8 +436,8 @@ func ListMPZones(cr tdns.ZoneResponse) {
 		}
 		sort.Strings(opts)
 		optStr := "[" + strings.Join(opts, " ") + "]"
-		out = append(out, fmt.Sprintf("%s|%s|%s|%s|%s|%s",
-			zname, providers, signers, info.NSmgmt, info.ParentSync, optStr))
+		out = append(out, fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
+			zname, providers, signers, info.NSmgmt, info.ParentSync, info.Suffix, optStr))
 	}
 
 	fmt.Println(columnize.SimpleFormat(out))

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strings"
 
 	tdns "github.com/johanix/tdns/v2"
 	"github.com/miekg/dns"
@@ -266,6 +267,28 @@ var zoneListCmd = &cobra.Command{
 	},
 }
 
+var zoneMPListCmd = &cobra.Command{
+	Use:   "mplist",
+	Short: "List multi-provider zones with HSYNCPARAM details",
+	Run: func(cmd *cobra.Command, args []string) {
+		prefixcmd, _ := getCommandContext("zone")
+		api, err := getApiClient(prefixcmd, true)
+		if err != nil {
+			log.Fatalf("Error getting API client for %s: %v", prefixcmd, err)
+		}
+
+		cr, err := SendZoneCommand(api, tdns.ZonePost{
+			Command: "list-mp-zones",
+		})
+		if err != nil {
+			fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+			os.Exit(1)
+		}
+
+		ListMPZones(cr)
+	},
+}
+
 var zoneSerialBumpCmd = &cobra.Command{
 	Use:   "bump",
 	Short: "Bump SOA serial and epoch (if any) in tdns-auth version of zone",
@@ -294,7 +317,7 @@ var zoneSerialBumpCmd = &cobra.Command{
 }
 
 func init() {
-	ZoneCmd.AddCommand(zoneListCmd, zoneNsecCmd, zoneSignCmd, zoneReloadCmd, zoneSerialBumpCmd)
+	ZoneCmd.AddCommand(zoneListCmd, zoneMPListCmd, zoneNsecCmd, zoneSignCmd, zoneReloadCmd, zoneSerialBumpCmd)
 	ZoneCmd.AddCommand(zoneWriteCmd, zoneFreezeCmd, zoneThawCmd)
 
 	zoneNsecCmd.AddCommand(zoneNsecGenerateCmd, zoneNsecShowCmd)
@@ -380,6 +403,41 @@ func ListZones(cr tdns.ZoneResponse) {
 	})
 	out = append(out, zoneLines...)
 	fmt.Printf("%s\n", columnize.SimpleFormat(out))
+}
+
+// ListMPZones displays multi-provider zone details in tabular format.
+func ListMPZones(cr tdns.ZoneResponse) {
+	if len(cr.MPZones) == 0 {
+		fmt.Println("No multi-provider zones configured")
+		return
+	}
+
+	out := []string{"Zone|Providers|Signers|NSmgmt|ParentSync|Options"}
+
+	var znames []string
+	for zname := range cr.MPZones {
+		znames = append(znames, zname)
+	}
+	sort.Strings(znames)
+
+	for _, zname := range znames {
+		info := cr.MPZones[zname]
+		providers := strings.Join(info.Providers, ",")
+		signers := strings.Join(info.Signers, ",")
+		if signers == "" {
+			signers = "(none)"
+		}
+		opts := []string{}
+		for _, opt := range info.Options {
+			opts = append(opts, tdns.ZoneOptionToString[opt])
+		}
+		sort.Strings(opts)
+		optStr := "[" + strings.Join(opts, " ") + "]"
+		out = append(out, fmt.Sprintf("%s|%s|%s|%s|%s|%s",
+			zname, providers, signers, info.NSmgmt, info.ParentSync, optStr))
+	}
+
+	fmt.Println(columnize.SimpleFormat(out))
 }
 
 func VerboseListZone(cr tdns.ZoneResponse) {

--- a/v2/combiner_chunk.go
+++ b/v2/combiner_chunk.go
@@ -919,6 +919,26 @@ func combinerProcessOperations(req *CombinerSyncRequest, zd *ZoneData, zonename 
 			continue
 		}
 
+		// Defense-in-depth: reject DNSKEY operations for unsigned zones
+		if rrtype == dns.TypeDNSKEY && !isProvider {
+			apex, err := zd.GetOwner(zd.ZoneName)
+			if err == nil && apex != nil {
+				if hpRRset, exists := apex.RRtypes.Get(core.TypeHSYNCPARAM); exists && len(hpRRset.RRs) > 0 {
+					if prr, ok := hpRRset.RRs[0].(*dns.PrivateRR); ok {
+						if hp, ok := prr.Data.(*core.HSYNCPARAM); ok && len(hp.GetSigners()) == 0 {
+							for _, rec := range op.Records {
+								rejectedItems = append(rejectedItems, RejectedItem{
+									Record: rec,
+									Reason: "DNSKEY not allowed in unsigned zone (no signers in HSYNCPARAM)",
+								})
+							}
+							continue
+						}
+					}
+				}
+			}
+		}
+
 		// Parse and validate all RRs in this operation
 		var parsedRRs []dns.RR
 		parseOk := true

--- a/v2/combiner_chunk.go
+++ b/v2/combiner_chunk.go
@@ -265,12 +265,12 @@ func checkMPauthorization(zd *ZoneData) error {
 			return fmt.Errorf("zone %q: contributions rejected — zone has OptMultiProvider set but the zone owner has not published HSYNC3+HSYNCPARAM records (zone is not declared as multi-provider by its owner)", zd.ZoneName)
 		}
 		ourIdentities := ourHsyncIdentities()
-		matched, ourLabel, _ := zd.matchHsyncProvider(ourIdentities)
+		matched, _, _ := zd.matchHsyncProvider(ourIdentities)
 		if !matched {
 			return fmt.Errorf("zone %q: contributions rejected — none of our agent identities %v match any HSYNC3 provider record in the zone (we are not a recognized provider for this zone)", zd.ZoneName, ourIdentities)
 		}
 		// Must be guard 4: we are a provider but not a signer
-		return fmt.Errorf("zone %q: contributions rejected — we are provider %q but the zone is signed and our label is not listed in HSYNCPARAM signers (we are not authorized to sign this zone)", zd.ZoneName, ourLabel)
+		return fmt.Errorf("zone %q: rejected (mp-disallow-edits: zone is signed, we are not a signer)", zd.ZoneName)
 	}
 	return nil
 }
@@ -412,7 +412,7 @@ func combinerNotifyDelegationChange(tm *TransportManager, senderID, zonename str
 				Class:  dns.ClassINET,
 				Ttl:    120,
 			}
-			_, _, csyncChanged, err := zd.ReplaceCombinerDataByRRtype("combiner", zonename, dns.TypeCSYNC, []dns.RR{csync})
+			_, _, csyncChanged, err := zd.ReplaceCombinerDataByRRtype(tm.LocalID, zonename, dns.TypeCSYNC, []dns.RR{csync})
 			if err != nil {
 				lgCombiner.Error("combinerNotifyDelegationChange: CSYNC replace failed", "zone", zonename, "err", err)
 			} else {
@@ -426,7 +426,7 @@ func combinerNotifyDelegationChange(tm *TransportManager, senderID, zonename str
 		if err != nil {
 			lgCombiner.Error("combinerNotifyDelegationChange: CDS synthesis failed", "zone", zonename, "err", err)
 		} else if len(cdsRRs) > 0 {
-			_, _, cdsChanged, err := zd.ReplaceCombinerDataByRRtype("combiner", zonename, dns.TypeCDS, cdsRRs)
+			_, _, cdsChanged, err := zd.ReplaceCombinerDataByRRtype(tm.LocalID, zonename, dns.TypeCDS, cdsRRs)
 			if err != nil {
 				lgCombiner.Error("combinerNotifyDelegationChange: CDS replace failed", "zone", zonename, "err", err)
 			} else {

--- a/v2/combiner_msg_handler.go
+++ b/v2/combiner_msg_handler.go
@@ -355,9 +355,16 @@ func sendEditsToAgent(conf *Config, tm *TransportManager, agentID string, zone s
 		return
 	}
 
-	// Extract all agents' contributions
+	// Copy AgentContributions under lock, then convert outside the lock
+	zd.mu.Lock()
+	contribsCopy := make(map[string]map[string]map[uint16]core.RRset, len(zd.AgentContributions))
+	for aid, ownerMap := range zd.AgentContributions {
+		contribsCopy[aid] = ownerMap
+	}
+	zd.mu.Unlock()
+
 	agentRecords := make(map[string]map[string][]string)
-	for aid, contributions := range zd.AgentContributions {
+	for aid, contributions := range contribsCopy {
 		recs := contributionsToRecords(contributions)
 		if len(recs) > 0 {
 			agentRecords[aid] = recs

--- a/v2/combiner_utils.go
+++ b/v2/combiner_utils.go
@@ -178,6 +178,9 @@ func (zd *ZoneData) mergeWithUpstream(owner string, rrtype uint16, agentRRset co
 // and vice versa. The per-agent storage in AgentContributions already provides
 // structural isolation; policy enforcement needs to happen at the RR level.
 func (zd *ZoneData) AddCombinerData(senderID string, data map[string][]core.RRset) (bool, error) {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+
 	if zd.CombinerData == nil {
 		zd.CombinerData = core.NewCmap[OwnerData]()
 	}
@@ -614,6 +617,9 @@ func (zd *ZoneData) RemoveCombinerDataByRRtype(senderID string, owner string, rr
 // added and removed RR strings, plus whether any change occurred.
 // Used for "replace" operation semantics at the combiner level.
 func (zd *ZoneData) ReplaceCombinerDataByRRtype(senderID, owner string, rrtype uint16, newRRs []dns.RR) (applied []string, removed []string, changed bool, err error) {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+
 	if senderID == "" {
 		senderID = "local"
 	}

--- a/v2/combiner_utils.go
+++ b/v2/combiner_utils.go
@@ -912,6 +912,7 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 		parts = append(parts, fmt.Sprintf("loaded contributions from %d agent(s)", len(zoneContribs)))
 	} else {
 		zd.AgentContributions = make(map[string]map[string]map[uint16]core.RRset)
+		zd.rebuildCombinerData()
 		parts = append(parts, "no contributions in snapshot")
 	}
 
@@ -943,8 +944,12 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 						rr.Header().Name = ownerName
 						parsedRRs = append(parsedRRs, rr)
 					}
-					zd.replaceCombinerDataByRRtypeLocked(senderID, ownerName, dns.TypeKEY, parsedRRs)
-					keyCount++
+					_, _, changed, replErr := zd.replaceCombinerDataByRRtypeLocked(senderID, ownerName, dns.TypeKEY, parsedRRs)
+					if replErr != nil {
+						lgCombiner.Warn("reapply: failed to replace _signal KEY", "sender", senderID, "owner", ownerName, "err", replErr)
+					} else if changed {
+						keyCount++
+					}
 				}
 			}
 		}
@@ -973,8 +978,12 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 					}
 					parsedRRs = append(parsedRRs, rr)
 				}
-				zd.replaceCombinerDataByRRtypeLocked(senderID, zone, dns.TypeKEY, parsedRRs)
-				parts = append(parts, fmt.Sprintf("applied at-apex KEY from %s", senderID))
+				_, _, changed, replErr := zd.replaceCombinerDataByRRtypeLocked(senderID, zone, dns.TypeKEY, parsedRRs)
+				if replErr != nil {
+					lgCombiner.Warn("reapply: failed to replace at-apex KEY", "sender", senderID, "err", replErr)
+				} else if changed {
+					parts = append(parts, fmt.Sprintf("applied at-apex KEY from %s", senderID))
+				}
 			}
 		}
 	}

--- a/v2/combiner_utils.go
+++ b/v2/combiner_utils.go
@@ -447,6 +447,9 @@ func (zd *ZoneData) GetCombinerDataNG() map[string][]RRsetString {
 // Returns the list of RR strings that were actually removed. If an RR was already
 // absent, it is not included in the returned list (true no-op detection).
 func (zd *ZoneData) RemoveCombinerDataNG(senderID string, data map[string][]string) ([]string, error) {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+
 	if zd.AgentContributions == nil {
 		return nil, nil
 	}
@@ -547,6 +550,9 @@ func (zd *ZoneData) RemoveCombinerDataNG(senderID string, data map[string][]stri
 // for a specific owner. Used for ClassANY delete semantics.
 // Returns the list of RR strings that were removed.
 func (zd *ZoneData) RemoveCombinerDataByRRtype(senderID string, owner string, rrtype uint16) ([]string, error) {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+
 	if senderID == "" {
 		senderID = "local"
 	}
@@ -620,6 +626,10 @@ func (zd *ZoneData) ReplaceCombinerDataByRRtype(senderID, owner string, rrtype u
 	zd.mu.Lock()
 	defer zd.mu.Unlock()
 
+	return zd.replaceCombinerDataByRRtypeLocked(senderID, owner, rrtype, newRRs)
+}
+
+func (zd *ZoneData) replaceCombinerDataByRRtypeLocked(senderID, owner string, rrtype uint16, newRRs []dns.RR) (applied []string, removed []string, changed bool, err error) {
 	if senderID == "" {
 		senderID = "local"
 	}
@@ -892,19 +902,16 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 		return "", fmt.Errorf("failed to load contributions: %w", err)
 	}
 
+	zd.mu.Lock()
 	if zoneContribs, ok := allContribs[zone]; ok {
-		zd.mu.Lock()
 		zd.AgentContributions = make(map[string]map[string]map[uint16]core.RRset)
 		for senderID, ownerMap := range zoneContribs {
 			zd.AgentContributions[senderID] = ownerMap
 		}
-		zd.mu.Unlock()
 		zd.rebuildCombinerData()
 		parts = append(parts, fmt.Sprintf("loaded contributions from %d agent(s)", len(zoneContribs)))
 	} else {
-		zd.mu.Lock()
 		zd.AgentContributions = make(map[string]map[string]map[uint16]core.RRset)
-		zd.mu.Unlock()
 		parts = append(parts, "no contributions in snapshot")
 	}
 
@@ -912,6 +919,7 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 	if isProvider {
 		allInstr, err := kdb.LoadAllPublishInstructions()
 		if err != nil {
+			zd.mu.Unlock()
 			return "", fmt.Errorf("failed to load publish instructions: %w", err)
 		}
 		keyCount := 0
@@ -935,7 +943,7 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 						rr.Header().Name = ownerName
 						parsedRRs = append(parsedRRs, rr)
 					}
-					zd.ReplaceCombinerDataByRRtype(senderID, ownerName, dns.TypeKEY, parsedRRs)
+					zd.replaceCombinerDataByRRtypeLocked(senderID, ownerName, dns.TypeKEY, parsedRRs)
 					keyCount++
 				}
 			}
@@ -949,6 +957,7 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 	if !isProvider {
 		allInstr, err := kdb.LoadAllPublishInstructions()
 		if err != nil {
+			zd.mu.Unlock()
 			return "", fmt.Errorf("failed to load publish instructions: %w", err)
 		}
 		if senders, ok := allInstr[zone]; ok {
@@ -964,11 +973,12 @@ func combinerReapplyContributions(zone string, kdb *KeyDB) (string, error) {
 					}
 					parsedRRs = append(parsedRRs, rr)
 				}
-				zd.ReplaceCombinerDataByRRtype(senderID, zone, dns.TypeKEY, parsedRRs)
+				zd.replaceCombinerDataByRRtypeLocked(senderID, zone, dns.TypeKEY, parsedRRs)
 				parts = append(parts, fmt.Sprintf("applied at-apex KEY from %s", senderID))
 			}
 		}
 	}
+	zd.mu.Unlock()
 
 	// 4. Apply to zone data.
 	modified, err := zd.CombineWithLocalChanges()

--- a/v2/config.go
+++ b/v2/config.go
@@ -523,6 +523,7 @@ type InternalConf struct {
 	TransportManager      *TransportManager      // Multi-transport (API + DNS) for agent/combiner/signer; nil if transport not initialized
 	LeaderElectionManager *LeaderElectionManager // Per-zone leader election for delegation sync; nil if not agent
 	ChunkPayloadStore     ChunkPayloadStore      // Optional: for query-mode CHUNK (agent); keyed by qname; set when agent chunk_mode is "query"
+	MPZoneNames           []string               // Zone names with OptMultiProvider, collected at parse time for SDE hydration
 	DistributionCache     *DistributionCache     // In-memory cache of distributions (agent/combiner)
 }
 

--- a/v2/config.go
+++ b/v2/config.go
@@ -635,6 +635,7 @@ func (conf *Config) ReloadZoneConfig(ctx context.Context) (string, error) {
 	prezones := Zones.Keys()
 	lgConfig.Info("ReloadZones: zones prior to reloading", "zones", prezones)
 	// XXX: This is wrong. We must get the zones config file from outside (to enamble things like MUSIC to use a different config file)
+	conf.Internal.MPZoneNames = nil             // reset before re-collection by option handler
 	zonelist, err := conf.ParseZones(ctx, true) // true: reload, not initial parsing
 	if err != nil {
 		lgConfig.Error("ReloadZoneConfig: error parsing zones", "err", err)

--- a/v2/hsync_transport.go
+++ b/v2/hsync_transport.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/johanix/tdns/v2/agent/transport"
@@ -35,14 +34,6 @@ func generatePingNonce() string {
 		panic(fmt.Sprintf("failed to generate random bytes for ping nonce: %v", err))
 	}
 	return hex.EncodeToString(b)
-}
-
-// keystateRfiStateT pairs a zone name with a response channel so that
-// routeKeystateMessage can route solicited inventory responses to the
-// correct requester without zone mismatches.
-type keystateRfiStateT struct {
-	Zone string
-	Chan chan *KeystateInventoryMsg
 }
 
 // TransportManager manages multiple transports for agent communication.
@@ -105,11 +96,30 @@ type TransportManager struct {
 	// Uses a closure because ImrEngine starts asynchronously after TM creation.
 	getImrEngine func() *Imr
 
-	// keystateRfiState is set by RequestAndWaitForKeyInventory to receive the
-	// solicited inventory response for a specific zone. routeKeystateMessage
-	// checks the zone name before routing here; mismatches fall through to
-	// the shared KeystateInventory channel.
-	keystateRfiState atomic.Pointer[keystateRfiStateT]
+	keystateRfiMu    sync.Mutex
+	keystateRfiState map[string]chan *KeystateInventoryMsg // key: zone name
+}
+
+func (tm *TransportManager) setKeystateRfi(zone string, ch chan *KeystateInventoryMsg) {
+	tm.keystateRfiMu.Lock()
+	defer tm.keystateRfiMu.Unlock()
+	if tm.keystateRfiState == nil {
+		tm.keystateRfiState = make(map[string]chan *KeystateInventoryMsg)
+	}
+	tm.keystateRfiState[zone] = ch
+}
+
+func (tm *TransportManager) deleteKeystateRfi(zone string) {
+	tm.keystateRfiMu.Lock()
+	defer tm.keystateRfiMu.Unlock()
+	delete(tm.keystateRfiState, zone)
+}
+
+func (tm *TransportManager) getKeystateRfi(zone string) (chan *KeystateInventoryMsg, bool) {
+	tm.keystateRfiMu.Lock()
+	defer tm.keystateRfiMu.Unlock()
+	ch, ok := tm.keystateRfiState[zone]
+	return ch, ok
 }
 
 // TransportManagerConfig holds configuration for creating a TransportManager.
@@ -888,9 +898,9 @@ func (tm *TransportManager) routeKeystateMessage(msg *transport.IncomingMessage)
 
 	// If there's a pending RFI request waiting for this zone's inventory,
 	// route there. Zone mismatches fall through to the shared channel.
-	if state := tm.keystateRfiState.Load(); state != nil && state.Zone == payload.Zone {
+	if ch, ok := tm.getKeystateRfi(payload.Zone); ok {
 		select {
-		case state.Chan <- inventoryMsg:
+		case ch <- inventoryMsg:
 			lgTransport.Info("routed KEYSTATE inventory to RFI requester", "sender", senderID, "zone", payload.Zone, "keys", len(items))
 		default:
 			lgTransport.Warn("keystateRfiChan full, dropping inventory", "sender", senderID)

--- a/v2/hsync_transport.go
+++ b/v2/hsync_transport.go
@@ -37,6 +37,14 @@ func generatePingNonce() string {
 	return hex.EncodeToString(b)
 }
 
+// keystateRfiStateT pairs a zone name with a response channel so that
+// routeKeystateMessage can route solicited inventory responses to the
+// correct requester without zone mismatches.
+type keystateRfiStateT struct {
+	Zone string
+	Chan chan *KeystateInventoryMsg
+}
+
 // TransportManager manages multiple transports for agent communication.
 type TransportManager struct {
 	// APITransport is the HTTPS-based transport
@@ -97,11 +105,11 @@ type TransportManager struct {
 	// Uses a closure because ImrEngine starts asynchronously after TM creation.
 	getImrEngine func() *Imr
 
-	// keystateRfiChan is set by RequestAndWaitForKeyInventory to receive the
-	// solicited inventory response. When non-nil, routeKeystateMessage routes
-	// inventory messages here instead of msgQs.KeystateInventory, preventing
-	// the HsyncEngine from stealing the response.
-	keystateRfiChan atomic.Pointer[chan *KeystateInventoryMsg]
+	// keystateRfiState is set by RequestAndWaitForKeyInventory to receive the
+	// solicited inventory response for a specific zone. routeKeystateMessage
+	// checks the zone name before routing here; mismatches fall through to
+	// the shared KeystateInventory channel.
+	keystateRfiState atomic.Pointer[keystateRfiStateT]
 }
 
 // TransportManagerConfig holds configuration for creating a TransportManager.
@@ -878,11 +886,11 @@ func (tm *TransportManager) routeKeystateMessage(msg *transport.IncomingMessage)
 		Inventory: items,
 	}
 
-	// If there's a pending RFI request waiting for this inventory, route there
-	// instead of the shared KeystateInventory channel (which HsyncEngine also reads).
-	if rfiChanPtr := tm.keystateRfiChan.Load(); rfiChanPtr != nil {
+	// If there's a pending RFI request waiting for this zone's inventory,
+	// route there. Zone mismatches fall through to the shared channel.
+	if state := tm.keystateRfiState.Load(); state != nil && state.Zone == payload.Zone {
 		select {
-		case *rfiChanPtr <- inventoryMsg:
+		case state.Chan <- inventoryMsg:
 			lgTransport.Info("routed KEYSTATE inventory to RFI requester", "sender", senderID, "zone", payload.Zone, "keys", len(items))
 		default:
 			lgTransport.Warn("keystateRfiChan full, dropping inventory", "sender", senderID)

--- a/v2/hsync_utils.go
+++ b/v2/hsync_utils.go
@@ -5,6 +5,7 @@
 package tdns
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -273,7 +274,7 @@ func filterLocalDNSKEYs(rrset *core.RRset, remoteKeyTags map[uint16]bool) []dns.
 // Sets zd.KeystateOK/KeystateError/KeystateTime to reflect success or failure.
 // KEYSTATE failure is an error condition — the agent depends on KEYSTATE for
 // DNSKEY classification and must not guess when it's unavailable.
-func (zd *ZoneData) RequestAndWaitForKeyInventory() {
+func (zd *ZoneData) RequestAndWaitForKeyInventory(ctx context.Context) {
 	zd.SetKeystateTime(time.Now())
 
 	tm := Conf.Internal.TransportManager
@@ -341,6 +342,12 @@ func (zd *ZoneData) RequestAndWaitForKeyInventory() {
 		zd.Logger.Printf("RequestAndWaitForKeyInventory: zone %s: received %d-key inventory from signer, %d foreign → %d RemoteDNSKEYs",
 			zd.ZoneName, len(inv.Inventory), len(foreignKeyTags), len(remoteDNSKEYs))
 
+	case <-ctx.Done():
+		zd.SetKeystateOK(false)
+		zd.SetKeystateError("cancelled")
+		zd.Logger.Printf("RequestAndWaitForKeyInventory: zone %s: cancelled", zd.ZoneName)
+		zd.SetRemoteDNSKEYs(nil)
+
 	case <-timeout.C:
 		zd.SetKeystateOK(false)
 		zd.SetKeystateError("timeout waiting for signer response (15s)")
@@ -354,7 +361,7 @@ func (zd *ZoneData) RequestAndWaitForKeyInventory() {
 // as confirmed data (the combiner already has them).
 //
 // Modeled on RequestAndWaitForKeyInventory.
-func (zd *ZoneData) RequestAndWaitForEdits() {
+func (zd *ZoneData) RequestAndWaitForEdits(ctx context.Context) {
 	tm := Conf.Internal.TransportManager
 	if tm == nil {
 		zd.Logger.Printf("RequestAndWaitForEdits: zone %s: no TransportManager available", zd.ZoneName)
@@ -398,6 +405,9 @@ func (zd *ZoneData) RequestAndWaitForEdits() {
 
 		// Apply to SDE with per-agent attribution
 		zd.applyEditsToSDE(resp.AgentRecords)
+
+	case <-ctx.Done():
+		zd.Logger.Printf("RequestAndWaitForEdits: zone %s: cancelled", zd.ZoneName)
 
 	case <-timeout.C:
 		zd.Logger.Printf("RequestAndWaitForEdits: zone %s: timeout waiting for combiner EDITS response (15s)", zd.ZoneName)

--- a/v2/hsync_utils.go
+++ b/v2/hsync_utils.go
@@ -161,8 +161,18 @@ func (zd *ZoneData) LocalDnskeysChanged(newzd *ZoneData) (bool, *DnskeyStatus, e
 // Returns (changed, status, error). If KEYSTATE is unavailable (LastKeyInventory == nil),
 // returns (false, nil, nil) — caller should suppress SYNC-DNSKEY-RRSET.
 func (zd *ZoneData) LocalDnskeysFromKeystate() (bool, *DnskeyStatus, error) {
-	// Don't process DNSKEYs for unsigned zones
+	// Don't process DNSKEYs for unsigned zones, but clean up any
+	// previously published keys on transition to unsigned.
 	if zd.MPdata != nil && !zd.MPdata.ZoneSigned {
+		if len(zd.LocalDNSKEYs) > 0 {
+			ds := &DnskeyStatus{
+				Time:         time.Now(),
+				ZoneName:     zd.ZoneName,
+				LocalRemoves: zd.LocalDNSKEYs,
+			}
+			zd.LocalDNSKEYs = nil
+			return true, ds, nil
+		}
 		return false, nil, nil
 	}
 
@@ -280,11 +290,8 @@ func (zd *ZoneData) RequestAndWaitForKeyInventory() {
 	// Include the zone name so routeKeystateMessage only routes
 	// matching responses here (prevents cross-zone interference).
 	rfiChan := make(chan *KeystateInventoryMsg, 1)
-	tm.keystateRfiState.Store(&keystateRfiStateT{
-		Zone: zd.ZoneName,
-		Chan: rfiChan,
-	})
-	defer tm.keystateRfiState.Store(nil)
+	tm.setKeystateRfi(zd.ZoneName, rfiChan)
+	defer tm.deleteKeystateRfi(zd.ZoneName)
 
 	// Send RFI KEYSTATE to signer
 	if err := tm.sendRfiToSigner(zd.ZoneName, "KEYSTATE"); err != nil {

--- a/v2/hsync_utils.go
+++ b/v2/hsync_utils.go
@@ -161,6 +161,11 @@ func (zd *ZoneData) LocalDnskeysChanged(newzd *ZoneData) (bool, *DnskeyStatus, e
 // Returns (changed, status, error). If KEYSTATE is unavailable (LastKeyInventory == nil),
 // returns (false, nil, nil) — caller should suppress SYNC-DNSKEY-RRSET.
 func (zd *ZoneData) LocalDnskeysFromKeystate() (bool, *DnskeyStatus, error) {
+	// Don't process DNSKEYs for unsigned zones
+	if zd.MPdata != nil && !zd.MPdata.ZoneSigned {
+		return false, nil, nil
+	}
+
 	inv := zd.GetLastKeyInventory()
 	if inv == nil {
 		zd.Logger.Printf("LocalDnskeysFromKeystate: zone %s: no KEYSTATE inventory available", zd.ZoneName)
@@ -272,9 +277,14 @@ func (zd *ZoneData) RequestAndWaitForKeyInventory() {
 
 	// Use a dedicated channel for this solicited RFI response so the
 	// HsyncEngine's proactive-inventory consumer doesn't steal it.
+	// Include the zone name so routeKeystateMessage only routes
+	// matching responses here (prevents cross-zone interference).
 	rfiChan := make(chan *KeystateInventoryMsg, 1)
-	tm.keystateRfiChan.Store(&rfiChan)
-	defer tm.keystateRfiChan.Store(nil)
+	tm.keystateRfiState.Store(&keystateRfiStateT{
+		Zone: zd.ZoneName,
+		Chan: rfiChan,
+	})
+	defer tm.keystateRfiState.Store(nil)
 
 	// Send RFI KEYSTATE to signer
 	if err := tm.sendRfiToSigner(zd.ZoneName, "KEYSTATE"); err != nil {

--- a/v2/hsync_utils.go
+++ b/v2/hsync_utils.go
@@ -810,12 +810,25 @@ func (zd *ZoneData) populateMPdata() {
 	zd.Options[OptMPDisallowEdits] = false
 	zd.Options[OptAllowEdits] = true
 
+	// Preserve any existing MPdata.Options (set at parse time),
+	// create the map if needed.
+	var mpOpts map[ZoneOption]bool
+	if zd.MPdata != nil && zd.MPdata.Options != nil {
+		mpOpts = zd.MPdata.Options
+	} else {
+		mpOpts = make(map[ZoneOption]bool)
+	}
+	mpOpts[OptMultiProvider] = true
+	mpOpts[OptMPDisallowEdits] = zoneSigned && !weShouldSign
+	mpOpts[OptMultiSigner] = weShouldSign && otherSigners > 0
+
 	zd.MPdata = &MPdata{
 		WeAreProvider: true,
 		OurLabel:      ourLabel,
 		WeAreSigner:   weShouldSign,
 		OtherSigners:  otherSigners,
 		ZoneSigned:    zoneSigned,
+		Options:       mpOpts,
 	}
 	zd.Logger.Printf("populateMPdata: zone %s: provider=%q signer=%v otherSigners=%d zoneSigned=%v",
 		zd.ZoneName, ourLabel, weShouldSign, otherSigners, zoneSigned)

--- a/v2/hsyncengine.go
+++ b/v2/hsyncengine.go
@@ -315,6 +315,12 @@ func (ar *AgentRegistry) SyncRequestHandler(ourId AgentId, req SyncRequest, sync
 	case "SYNC-DNSKEY-RRSET":
 		lgEngine.Info("DNSKEY RRset changed", "zone", req.ZoneName)
 
+		// Don't distribute DNSKEYs for unsigned zones
+		if zd, exists := Zones.Get(string(req.ZoneName)); exists && zd.MPdata != nil && !zd.MPdata.ZoneSigned {
+			lgEngine.Debug("skipping DNSKEY sync for unsigned zone", "zone", req.ZoneName)
+			break
+		}
+
 		if req.DnskeyStatus == nil {
 			lgEngine.Warn("SYNC-DNSKEY-RRSET but no DnskeyStatus, ignoring", "zone", req.ZoneName)
 			break

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -233,21 +233,21 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	// Register option handler for multi-provider zones. This fires
 	// during ParseZones for each zone with OptMultiProvider, collecting
 	// zone names for SDE hydration. Must be registered before ParseZones.
-	var mpZoneNames []string
+	// The handler writes to conf.Internal.MPZoneNames directly; callers
+	// must reset it to nil before each ParseZones call.
 	RegisterZoneOptionHandler(OptMultiProvider, func(zname string, options map[ZoneOption]bool) {
-		mpZoneNames = append(mpZoneNames, zname)
+		conf.Internal.MPZoneNames = append(conf.Internal.MPZoneNames, zname)
 	})
 
 	// Parse all configured zones
+	conf.Internal.MPZoneNames = nil
 	all_zones, err := conf.ParseZones(ctx, false) // false = initial load, not reload
 	if err != nil {
 		return fmt.Errorf("error parsing zones: %v", err)
 	}
 	// Provide the complete zone list to engines that need cross-zone post-initialization
 	conf.Internal.AllZones = all_zones
-	// Store MP zone list (collected by the handler above during ParseZones)
-	conf.Internal.MPZoneNames = mpZoneNames
-	lgConfig.Info("multi-provider zones from config", "count", len(mpZoneNames), "zones", mpZoneNames)
+	lgConfig.Info("multi-provider zones from config", "count", len(conf.Internal.MPZoneNames), "zones", conf.Internal.MPZoneNames)
 	// Load dynamic zones from dynamic config file (if configured and included)
 	// This must happen after ParseZones so that main config zones take precedence
 	if conf.DynamicZones.ConfigFile != "" {

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -230,6 +230,14 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	// if Globals.Debug {
 	//	log.Printf("*** MainInit: 5 ***")
 	// }
+	// Register option handler for multi-provider zones. This fires
+	// during ParseZones for each zone with OptMultiProvider, collecting
+	// zone names for SDE hydration. Must be registered before ParseZones.
+	var mpZoneNames []string
+	RegisterZoneOptionHandler(OptMultiProvider, func(zname string, options map[ZoneOption]bool) {
+		mpZoneNames = append(mpZoneNames, zname)
+	})
+
 	// Parse all configured zones
 	all_zones, err := conf.ParseZones(ctx, false) // false = initial load, not reload
 	if err != nil {
@@ -237,6 +245,9 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	}
 	// Provide the complete zone list to engines that need cross-zone post-initialization
 	conf.Internal.AllZones = all_zones
+	// Store MP zone list (collected by the handler above during ParseZones)
+	conf.Internal.MPZoneNames = mpZoneNames
+	lgConfig.Info("multi-provider zones from config", "count", len(mpZoneNames), "zones", mpZoneNames)
 	// Load dynamic zones from dynamic config file (if configured and included)
 	// This must happen after ParseZones so that main config zones take precedence
 	if conf.DynamicZones.ConfigFile != "" {

--- a/v2/option_handlers.go
+++ b/v2/option_handlers.go
@@ -3,6 +3,8 @@
  */
 package tdns
 
+import "sync"
+
 // ZoneOptionHandler is a callback invoked during ParseZones when a
 // zone has a specific option set. Handlers are registered before
 // ParseZones runs and fire synchronously during parsing.
@@ -12,12 +14,17 @@ package tdns
 //   - options: all parsed options for this zone (read-only)
 type ZoneOptionHandler func(zname string, options map[ZoneOption]bool)
 
-var optionHandlers = make(map[ZoneOption][]ZoneOptionHandler)
+var (
+	optionHandlersMu sync.Mutex
+	optionHandlers   = make(map[ZoneOption][]ZoneOptionHandler)
+)
 
 // RegisterZoneOptionHandler registers a callback for a zone option.
 // Multiple handlers can be registered for the same option.
 // Handlers fire synchronously during ParseZones, in registration order.
 func RegisterZoneOptionHandler(opt ZoneOption, handler ZoneOptionHandler) {
+	optionHandlersMu.Lock()
+	defer optionHandlersMu.Unlock()
 	optionHandlers[opt] = append(optionHandlers[opt], handler)
 }
 
@@ -25,6 +32,8 @@ func RegisterZoneOptionHandler(opt ZoneOption, handler ZoneOptionHandler) {
 // zone's options. Returns the set of options that were handled by
 // at least one registered handler (used for unknown-option detection).
 func invokeOptionHandlers(zname string, options map[ZoneOption]bool) map[ZoneOption]bool {
+	optionHandlersMu.Lock()
+	defer optionHandlersMu.Unlock()
 	handled := make(map[ZoneOption]bool)
 	for opt, val := range options {
 		if !val {

--- a/v2/option_handlers.go
+++ b/v2/option_handlers.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ */
+package tdns
+
+// ZoneOptionHandler is a callback invoked during ParseZones when a
+// zone has a specific option set. Handlers are registered before
+// ParseZones runs and fire synchronously during parsing.
+//
+// Parameters:
+//   - zname: the FQDN zone name
+//   - options: all parsed options for this zone (read-only)
+type ZoneOptionHandler func(zname string, options map[ZoneOption]bool)
+
+var optionHandlers = make(map[ZoneOption][]ZoneOptionHandler)
+
+// RegisterZoneOptionHandler registers a callback for a zone option.
+// Multiple handlers can be registered for the same option.
+// Handlers fire synchronously during ParseZones, in registration order.
+func RegisterZoneOptionHandler(opt ZoneOption, handler ZoneOptionHandler) {
+	optionHandlers[opt] = append(optionHandlers[opt], handler)
+}
+
+// invokeOptionHandlers calls all registered handlers for the given
+// zone's options. Returns the set of options that were handled by
+// at least one registered handler (used for unknown-option detection).
+func invokeOptionHandlers(zname string, options map[ZoneOption]bool) map[ZoneOption]bool {
+	handled := make(map[ZoneOption]bool)
+	for opt, val := range options {
+		if !val {
+			continue
+		}
+		if handlers, ok := optionHandlers[opt]; ok && len(handlers) > 0 {
+			for _, handler := range handlers {
+				handler(zname, options)
+			}
+			handled[opt] = true
+		}
+	}
+	return handled
+}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -680,6 +680,32 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, erro
 			Zones.Set(zname, zdp)
 		}
 
+		// Apply static options to the stub immediately so they
+		// are available before the RefreshEngine processes the
+		// zone. Then invoke registered option handlers.
+		if zdp.Options == nil {
+			zdp.Options = make(map[ZoneOption]bool)
+		}
+		for opt, val := range options {
+			zdp.Options[opt] = val
+		}
+
+		// For MP zones, ensure MPdata exists with Options so that
+		// MP-specific options can be set at parse time.
+		if options[OptMultiProvider] {
+			if zdp.MPdata == nil {
+				zdp.MPdata = &MPdata{
+					Options: make(map[ZoneOption]bool),
+				}
+			}
+			if zdp.MPdata.Options == nil {
+				zdp.MPdata.Options = make(map[ZoneOption]bool)
+			}
+			zdp.MPdata.Options[OptMultiProvider] = true
+		}
+
+		invokeOptionHandlers(zname, options)
+
 		if zdp.FirstZoneLoad {
 			lgConfig.Info("considering OnFirstLoad callbacks", "zone", zname,
 				"online-signing", options[OptOnlineSigning],

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -680,29 +680,41 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, erro
 			Zones.Set(zname, zdp)
 		}
 
-		// Apply static options to the stub immediately so they
-		// are available before the RefreshEngine processes the
-		// zone. Then invoke registered option handlers.
-		if zdp.Options == nil {
-			zdp.Options = make(map[ZoneOption]bool)
+		// Apply static options via copy-on-write to avoid racing with
+		// concurrent readers of zdp.Options / zdp.MPdata.Options.
+		newOpts := make(map[ZoneOption]bool)
+		for opt, val := range zdp.Options {
+			newOpts[opt] = val
 		}
 		for opt, val := range options {
-			zdp.Options[opt] = val
+			newOpts[opt] = val
 		}
 
-		// For MP zones, ensure MPdata exists with Options so that
-		// MP-specific options can be set at parse time.
+		var newMPdata *MPdata
 		if options[OptMultiProvider] {
-			if zdp.MPdata == nil {
-				zdp.MPdata = &MPdata{
-					Options: make(map[ZoneOption]bool),
+			if zdp.MPdata != nil {
+				// Copy existing MPdata, build new Options map
+				cp := *zdp.MPdata
+				newMPdata = &cp
+				mpOpts := make(map[ZoneOption]bool)
+				for opt, val := range cp.Options {
+					mpOpts[opt] = val
+				}
+				mpOpts[OptMultiProvider] = true
+				newMPdata.Options = mpOpts
+			} else {
+				newMPdata = &MPdata{
+					Options: map[ZoneOption]bool{OptMultiProvider: true},
 				}
 			}
-			if zdp.MPdata.Options == nil {
-				zdp.MPdata.Options = make(map[ZoneOption]bool)
-			}
-			zdp.MPdata.Options[OptMultiProvider] = true
 		}
+
+		zdp.mu.Lock()
+		zdp.Options = newOpts
+		if newMPdata != nil {
+			zdp.MPdata = newMPdata
+		}
+		zdp.mu.Unlock()
 
 		invokeOptionHandlers(zname, options)
 

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -682,10 +682,9 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, erro
 
 		// Apply static options via copy-on-write to avoid racing with
 		// concurrent readers of zdp.Options / zdp.MPdata.Options.
-		newOpts := make(map[ZoneOption]bool)
-		for opt, val := range zdp.Options {
-			newOpts[opt] = val
-		}
+		// Build from fresh parsed options only; on reload this clears
+		// options that were removed from the config file.
+		newOpts := make(map[ZoneOption]bool, len(options))
 		for opt, val := range options {
 			newOpts[opt] = val
 		}
@@ -693,15 +692,10 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, erro
 		var newMPdata *MPdata
 		if options[OptMultiProvider] {
 			if zdp.MPdata != nil {
-				// Copy existing MPdata, build new Options map
+				// Copy existing MPdata, build fresh MP Options map
 				cp := *zdp.MPdata
 				newMPdata = &cp
-				mpOpts := make(map[ZoneOption]bool)
-				for opt, val := range cp.Options {
-					mpOpts[opt] = val
-				}
-				mpOpts[OptMultiProvider] = true
-				newMPdata.Options = mpOpts
+				newMPdata.Options = map[ZoneOption]bool{OptMultiProvider: true}
 			} else {
 				newMPdata = &MPdata{
 					Options: map[ZoneOption]bool{OptMultiProvider: true},
@@ -713,6 +707,8 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, erro
 		zdp.Options = newOpts
 		if newMPdata != nil {
 			zdp.MPdata = newMPdata
+		} else if !options[OptMultiProvider] {
+			zdp.MPdata = nil
 		}
 		zdp.mu.Unlock()
 

--- a/v2/provider_groups.go
+++ b/v2/provider_groups.go
@@ -89,7 +89,7 @@ func (pgm *ProviderGroupManager) RecomputeGroups() {
 			continue
 		}
 		apex, err := zd.GetOwner(zd.ZoneName)
-		if err != nil {
+		if err != nil || apex == nil {
 			lgProviderGroup.Warn("skipping zone due to apex lookup failure", "zone", zd.ZoneName, "err", err)
 			continue
 		}

--- a/v2/provider_groups.go
+++ b/v2/provider_groups.go
@@ -15,6 +15,8 @@ import (
 	"github.com/miekg/dns"
 )
 
+var lgProviderGroup = Logger("provider-group")
+
 // ProviderGroup represents a set of providers that together serve a group of zones.
 // The group is identified by a hash of the sorted member identities.
 type ProviderGroup struct {
@@ -88,6 +90,7 @@ func (pgm *ProviderGroupManager) RecomputeGroups() {
 		}
 		apex, err := zd.GetOwner(zd.ZoneName)
 		if err != nil {
+			lgProviderGroup.Warn("skipping zone due to apex lookup failure", "zone", zd.ZoneName, "err", err)
 			continue
 		}
 

--- a/v2/scanner.go
+++ b/v2/scanner.go
@@ -142,30 +142,36 @@ func ScannerEngine(ctx context.Context, conf *Config) error {
 		var actions []dns.RR
 		// DS changes (from CDS scan)
 		for _, rr := range resp.DSAdds {
-			rr.Header().Class = dns.ClassINET
-			actions = append(actions, rr)
+			cp := dns.Copy(rr)
+			cp.Header().Class = dns.ClassINET
+			actions = append(actions, cp)
 		}
 		for _, rr := range resp.DSRemoves {
-			rr.Header().Class = dns.ClassNONE
-			actions = append(actions, rr)
+			cp := dns.Copy(rr)
+			cp.Header().Class = dns.ClassNONE
+			actions = append(actions, cp)
 		}
 		// NS changes (from CSYNC scan)
 		for _, rr := range resp.NSAdds {
-			rr.Header().Class = dns.ClassINET
-			actions = append(actions, rr)
+			cp := dns.Copy(rr)
+			cp.Header().Class = dns.ClassINET
+			actions = append(actions, cp)
 		}
 		for _, rr := range resp.NSRemoves {
-			rr.Header().Class = dns.ClassNONE
-			actions = append(actions, rr)
+			cp := dns.Copy(rr)
+			cp.Header().Class = dns.ClassNONE
+			actions = append(actions, cp)
 		}
 		// Glue changes (from CSYNC scan)
 		for _, rr := range resp.GlueAdds {
-			rr.Header().Class = dns.ClassINET
-			actions = append(actions, rr)
+			cp := dns.Copy(rr)
+			cp.Header().Class = dns.ClassINET
+			actions = append(actions, cp)
 		}
 		for _, rr := range resp.GlueRemoves {
-			rr.Header().Class = dns.ClassNONE
-			actions = append(actions, rr)
+			cp := dns.Copy(rr)
+			cp.Header().Class = dns.ClassNONE
+			actions = append(actions, cp)
 		}
 
 		// Determine update type from which fields are populated
@@ -1285,7 +1291,9 @@ func (scanner *Scanner) queryCDSAtSignalingNames(ctx context.Context, childZone 
 	}
 
 	if queriedNS == 0 {
-		return nil, fmt.Errorf("no out-of-bailiwick NS found for %s", childZone)
+		// All NS are in-bailiwick -- return nil to let caller fall back to direct/apex path
+		scanLog.Printf("queryCDSAtSignalingNames: %s: no out-of-bailiwick NS, falling back", childZone)
+		return nil, nil
 	}
 
 	// Verify all signaling responses agree with each other

--- a/v2/scanner.go
+++ b/v2/scanner.go
@@ -1149,8 +1149,10 @@ func (scanner *Scanner) ProcessCDSNotify(ctx context.Context, tuple ScanTuple, p
 			return
 		}
 		scanLog.Printf("ProcessCDSNotify: %s: RFC 9615 signaling verification passed", childZone)
-		// Use signaling-verified CDS
-		cdsRRset = sigCDS
+		// Use signaling-verified CDS (nil means all NS were in-bailiwick, keep original cdsRRset)
+		if sigCDS != nil {
+			cdsRRset = sigCDS
+		}
 	} else if requireValidation {
 		if scanner.HasOption("at-apex") && bootstrapping {
 			// RFC 8078 opportunistic onboarding: bootstrapping with

--- a/v2/signer_msg_handler.go
+++ b/v2/signer_msg_handler.go
@@ -175,10 +175,17 @@ func sendKeystateInventoryToAgent(conf *Config, tm *TransportManager, agentID st
 		return fmt.Errorf("KeyDB not available")
 	}
 
-	// Query all keys for this zone
-	items, err := kdb.GetKeyInventory(zone)
-	if err != nil {
-		return fmt.Errorf("GetKeyInventory failed: %w", err)
+	// Only include keys if we are a signer for this zone.
+	// Non-signers send empty inventory so the agent gets a response.
+	var items []KeyInventoryItem
+	if zd, ok := Zones.Get(zone); ok && zd.MPdata != nil && !zd.MPdata.WeAreSigner {
+		lgSigner.Debug("not a signer for zone, sending empty inventory", "zone", zone)
+	} else {
+		var err error
+		items, err = kdb.GetKeyInventory(zone)
+		if err != nil {
+			return fmt.Errorf("GetKeyInventory failed: %w", err)
+		}
 	}
 
 	lgSigner.Debug("KeyDB inventory queried", "zone", zone, "keys", len(items))

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -62,11 +62,12 @@ const (
 // is not set, or the zone owner hasn't declared it via HSYNC3+HSYNCPARAM, or we are
 // not a listed provider). Populated during zone refresh by populateMPdata().
 type MPdata struct {
-	WeAreProvider bool   // At least one of our agent identities matches an HSYNC3 Identity
-	OurLabel      string // Our provider label from the matching HSYNC3 record
-	WeAreSigner   bool   // Our label appears in HSYNCPARAM signers (or zone is unsigned)
-	OtherSigners  int    // Count of other signers in HSYNCPARAM
-	ZoneSigned    bool   // HSYNCPARAM signers= is non-empty (zone uses multi-signer)
+	WeAreProvider bool                // At least one of our agent identities matches an HSYNC3 Identity
+	OurLabel      string              // Our provider label from the matching HSYNC3 record
+	WeAreSigner   bool                // Our label appears in HSYNCPARAM signers (or zone is unsigned)
+	OtherSigners  int                 // Count of other signers in HSYNCPARAM
+	ZoneSigned    bool                // HSYNCPARAM signers= is non-empty (zone uses multi-signer)
+	Options       map[ZoneOption]bool // MP-specific options (future: migrate from zd.Options)
 }
 
 type ZoneData struct {

--- a/v2/syncheddataengine.go
+++ b/v2/syncheddataengine.go
@@ -322,43 +322,40 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 	conf.Internal.ZoneDataRepo = zdr
 
 	// Hydrate SDE for each multi-provider zone. Per zone, sequentially:
-	// 1. RFI EDITS → combiner: all agents' contributions (baseline)
-	// 2. RFI KEYSTATE → signer: DNSKEY inventory (local vs foreign keys)
-	// Phase 3 (RFI SYNC → remote agents) is added later.
+	// 1. RFI EDITS -> combiner: all agents' contributions (baseline)
+	// 2. RFI KEYSTATE -> signer: DNSKEY inventory (local vs foreign keys)
 	//
-	// Both EDITS and KEYSTATE use single-slot response channels, so requests
-	// must be synchronous per zone. See DNS-154 for refactoring this.
+	// Uses conf.Internal.MPZoneNames (collected at parse time) instead of
+	// scanning Zones.IterBuffered() -- avoids race with RefreshEngine.
 	tm := conf.Internal.TransportManager
 	hasCombiner := tm != nil && tm.combinerID != ""
 	hasSigner := tm != nil && tm.signerID != ""
 
 	if hasCombiner || hasSigner {
-		for item := range Zones.IterBuffered() {
-			zd := item.Val
-			if !zd.Options[OptMultiProvider] {
+		lgEngine.Info("startup hydration: MP zones to hydrate", "count", len(conf.Internal.MPZoneNames), "zones", conf.Internal.MPZoneNames)
+		for _, zname := range conf.Internal.MPZoneNames {
+			zd, ok := Zones.Get(zname)
+			if !ok || zd == nil {
+				lgEngine.Warn("startup hydration: zone not in Zones map, skipping", "zone", zname)
 				continue
 			}
 			if hasCombiner {
-				lgEngine.Info("startup hydration: requesting edits from combiner", "zone", item.Key)
+				lgEngine.Info("startup hydration: requesting edits from combiner", "zone", zname)
 				zd.RequestAndWaitForEdits()
 			}
 			if hasSigner {
-				lgEngine.Info("startup hydration: requesting key inventory from signer", "zone", item.Key)
+				lgEngine.Info("startup hydration: requesting key inventory from signer", "zone", zname)
 				zd.RequestAndWaitForKeyInventory()
 
-				// Extract local DNSKEYs from the inventory and add to SDE.
-				// RequestAndWaitForKeyInventory sets RemoteDNSKEYs (foreign)
-				// and stores the inventory, but doesn't populate local DNSKEYs
-				// in the SDE.
 				changed, ds, err := zd.LocalDnskeysFromKeystate()
 				if err != nil {
-					lgEngine.Error("startup hydration: LocalDnskeysFromKeystate failed", "zone", item.Key, "err", err)
+					lgEngine.Error("startup hydration: LocalDnskeysFromKeystate failed", "zone", zname, "err", err)
 				} else if changed && ds != nil {
 					localAgentID := AgentId(conf.MultiProvider.Identity)
 					for _, rr := range ds.CurrentLocalKeys {
-						zdr.AddConfirmedRR(ZoneName(item.Key), localAgentID, rr)
+						zdr.AddConfirmedRR(ZoneName(zname), localAgentID, rr)
 					}
-					lgEngine.Info("startup hydration: added local DNSKEYs to SDE", "zone", item.Key, "keys", len(ds.CurrentLocalKeys))
+					lgEngine.Info("startup hydration: added local DNSKEYs to SDE", "zone", zname, "keys", len(ds.CurrentLocalKeys))
 				}
 			}
 		}
@@ -541,16 +538,26 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 						if remoteSkipCombiner {
 							lgEngine.Info("remote update accepted locally, not forwarding to combiner (mp-disallow-edits)", "zone", synchedDataUpdate.Zone)
 							resp.Msg = "Remote update accepted locally (not forwarded to combiner: zone signed, not a signer)"
-							// Send ACCEPTED confirmation to originator. The data is in
-							// our SDE; we just don't forward to our combiner because
-							// we're not a signer. The sender should not be blocked.
+							// Send ACCEPTED confirmation with applied records to
+							// originator. The data is in our SDE; we just don't
+							// forward to our combiner. The sender should not be blocked.
 							if synchedDataUpdate.OriginatingDistID != "" && msgQs.OnRemoteConfirmationReady != nil {
+								var appliedRecords []string
+								if synchedDataUpdate.Update != nil {
+									for _, op := range synchedDataUpdate.Update.Operations {
+										appliedRecords = append(appliedRecords, op.Records...)
+									}
+								}
+								lgEngine.Info("sending immediate ACCEPTED for non-signing zone",
+									"zone", synchedDataUpdate.Zone, "agent", synchedDataUpdate.AgentId,
+									"records", len(appliedRecords), "originDistID", synchedDataUpdate.OriginatingDistID)
 								msgQs.OnRemoteConfirmationReady(&RemoteConfirmationDetail{
 									OriginatingDistID: synchedDataUpdate.OriginatingDistID,
 									OriginatingSender: string(synchedDataUpdate.AgentId),
 									Zone:              synchedDataUpdate.Zone,
-									Status:            "accepted",
+									Status:            "ok",
 									Message:           "accepted into SDE (not forwarded to combiner: not a signer)",
+									AppliedRecords:    appliedRecords,
 								})
 							}
 						} else {

--- a/v2/syncheddataengine.go
+++ b/v2/syncheddataengine.go
@@ -343,11 +343,11 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 			}
 			if hasCombiner {
 				lgEngine.Info("startup hydration: requesting edits from combiner", "zone", zname)
-				zd.RequestAndWaitForEdits()
+				zd.RequestAndWaitForEdits(ctx)
 			}
 			if hasSigner {
 				lgEngine.Info("startup hydration: requesting key inventory from signer", "zone", zname)
-				zd.RequestAndWaitForKeyInventory()
+				zd.RequestAndWaitForKeyInventory(ctx)
 
 				changed, ds, err := zd.LocalDnskeysFromKeystate()
 				if err != nil {

--- a/v2/syncheddataengine.go
+++ b/v2/syncheddataengine.go
@@ -331,37 +331,42 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 	hasCombiner := tm != nil && tm.combinerID != ""
 	hasSigner := tm != nil && tm.signerID != ""
 
-	if hasCombiner || hasSigner {
-		lgEngine.Info("startup hydration: MP zones to hydrate", "count", len(conf.Internal.MPZoneNames), "zones", conf.Internal.MPZoneNames)
-		for _, zname := range conf.Internal.MPZoneNames {
-			zd, ok := Zones.Get(zname)
-			if !ok || zd == nil {
-				lgEngine.Warn("startup hydration: zone not in Zones map, skipping", "zone", zname)
-				continue
-			}
-			if hasCombiner {
-				lgEngine.Info("startup hydration: requesting edits from combiner", "zone", zname)
-				zd.RequestAndWaitForEdits()
-			}
-			if hasSigner {
-				lgEngine.Info("startup hydration: requesting key inventory from signer", "zone", zname)
-				zd.RequestAndWaitForKeyInventory()
+	lgEngine.Info("SynchedDataEngine started")
 
-				changed, ds, err := zd.LocalDnskeysFromKeystate()
-				if err != nil {
-					lgEngine.Error("startup hydration: LocalDnskeysFromKeystate failed", "zone", zname, "err", err)
-				} else if changed && ds != nil {
-					localAgentID := AgentId(conf.MultiProvider.Identity)
-					for _, rr := range ds.CurrentLocalKeys {
-						zdr.AddConfirmedRR(ZoneName(zname), localAgentID, rr)
+	// Run hydration in background so the main select loop is immediately
+	// responsive to commands (zone edits list, etc.).
+	if hasCombiner || hasSigner {
+		go func() {
+			lgEngine.Info("startup hydration: MP zones to hydrate", "count", len(conf.Internal.MPZoneNames), "zones", conf.Internal.MPZoneNames)
+			for _, zname := range conf.Internal.MPZoneNames {
+				zd, ok := Zones.Get(zname)
+				if !ok || zd == nil {
+					lgEngine.Warn("startup hydration: zone not in Zones map, skipping", "zone", zname)
+					continue
+				}
+				if hasCombiner {
+					lgEngine.Info("startup hydration: requesting edits from combiner", "zone", zname)
+					zd.RequestAndWaitForEdits()
+				}
+				if hasSigner {
+					lgEngine.Info("startup hydration: requesting key inventory from signer", "zone", zname)
+					zd.RequestAndWaitForKeyInventory()
+
+					changed, ds, err := zd.LocalDnskeysFromKeystate()
+					if err != nil {
+						lgEngine.Error("startup hydration: LocalDnskeysFromKeystate failed", "zone", zname, "err", err)
+					} else if changed && ds != nil {
+						localAgentID := AgentId(conf.MultiProvider.Identity)
+						for _, rr := range ds.CurrentLocalKeys {
+							zdr.AddConfirmedRR(ZoneName(zname), localAgentID, rr)
+						}
+						lgEngine.Info("startup hydration: added local DNSKEYs to SDE", "zone", zname, "keys", len(ds.CurrentLocalKeys))
 					}
-					lgEngine.Info("startup hydration: added local DNSKEYs to SDE", "zone", zname, "keys", len(ds.CurrentLocalKeys))
 				}
 			}
-		}
+			lgEngine.Info("startup hydration complete")
+		}()
 	}
-
-	lgEngine.Info("SynchedDataEngine started")
 
 	// Periodic eviction of stale tracking entries (terminal states older than 1 hour).
 	trackingEvictTicker := time.NewTicker(5 * time.Minute)

--- a/v2/syncheddataengine.go
+++ b/v2/syncheddataengine.go
@@ -553,6 +553,23 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 											appliedRecords = append(appliedRecords, op.Records...)
 										}
 									}
+									// Fallback: if Operations was empty, extract from RRsets/RRs
+									if len(appliedRecords) == 0 && len(removedRecords) == 0 {
+										for _, rrset := range synchedDataUpdate.Update.RRsets {
+											for _, rr := range rrset.RRs {
+												appliedRecords = append(appliedRecords, rr.String())
+											}
+										}
+										for _, rr := range synchedDataUpdate.Update.RRs {
+											if rr.Header().Class == dns.ClassNONE {
+												cp := dns.Copy(rr)
+												cp.Header().Class = dns.ClassINET
+												removedRecords = append(removedRecords, cp.String())
+											} else {
+												appliedRecords = append(appliedRecords, rr.String())
+											}
+										}
+									}
 								}
 								lgEngine.Info("sending immediate ACCEPTED for non-signing zone",
 									"zone", synchedDataUpdate.Zone, "agent", synchedDataUpdate.AgentId,

--- a/v2/syncheddataengine.go
+++ b/v2/syncheddataengine.go
@@ -333,39 +333,35 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 
 	lgEngine.Info("SynchedDataEngine started")
 
-	// Run hydration in background so the main select loop is immediately
-	// responsive to commands (zone edits list, etc.).
 	if hasCombiner || hasSigner {
-		go func() {
-			lgEngine.Info("startup hydration: MP zones to hydrate", "count", len(conf.Internal.MPZoneNames), "zones", conf.Internal.MPZoneNames)
-			for _, zname := range conf.Internal.MPZoneNames {
-				zd, ok := Zones.Get(zname)
-				if !ok || zd == nil {
-					lgEngine.Warn("startup hydration: zone not in Zones map, skipping", "zone", zname)
-					continue
-				}
-				if hasCombiner {
-					lgEngine.Info("startup hydration: requesting edits from combiner", "zone", zname)
-					zd.RequestAndWaitForEdits()
-				}
-				if hasSigner {
-					lgEngine.Info("startup hydration: requesting key inventory from signer", "zone", zname)
-					zd.RequestAndWaitForKeyInventory()
+		lgEngine.Info("startup hydration: MP zones to hydrate", "count", len(conf.Internal.MPZoneNames), "zones", conf.Internal.MPZoneNames)
+		for _, zname := range conf.Internal.MPZoneNames {
+			zd, ok := Zones.Get(zname)
+			if !ok || zd == nil {
+				lgEngine.Warn("startup hydration: zone not in Zones map, skipping", "zone", zname)
+				continue
+			}
+			if hasCombiner {
+				lgEngine.Info("startup hydration: requesting edits from combiner", "zone", zname)
+				zd.RequestAndWaitForEdits()
+			}
+			if hasSigner {
+				lgEngine.Info("startup hydration: requesting key inventory from signer", "zone", zname)
+				zd.RequestAndWaitForKeyInventory()
 
-					changed, ds, err := zd.LocalDnskeysFromKeystate()
-					if err != nil {
-						lgEngine.Error("startup hydration: LocalDnskeysFromKeystate failed", "zone", zname, "err", err)
-					} else if changed && ds != nil {
-						localAgentID := AgentId(conf.MultiProvider.Identity)
-						for _, rr := range ds.CurrentLocalKeys {
-							zdr.AddConfirmedRR(ZoneName(zname), localAgentID, rr)
-						}
-						lgEngine.Info("startup hydration: added local DNSKEYs to SDE", "zone", zname, "keys", len(ds.CurrentLocalKeys))
+				changed, ds, err := zd.LocalDnskeysFromKeystate()
+				if err != nil {
+					lgEngine.Error("startup hydration: LocalDnskeysFromKeystate failed", "zone", zname, "err", err)
+				} else if changed && ds != nil {
+					localAgentID := AgentId(conf.MultiProvider.Identity)
+					for _, rr := range ds.CurrentLocalKeys {
+						zdr.AddConfirmedRR(ZoneName(zname), localAgentID, rr)
 					}
+					lgEngine.Info("startup hydration: added local DNSKEYs to SDE", "zone", zname, "keys", len(ds.CurrentLocalKeys))
 				}
 			}
-			lgEngine.Info("startup hydration complete")
-		}()
+		}
+		lgEngine.Info("startup hydration complete")
 	}
 
 	// Periodic eviction of stale tracking entries (terminal states older than 1 hour).
@@ -548,14 +544,19 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 							// forward to our combiner. The sender should not be blocked.
 							if synchedDataUpdate.OriginatingDistID != "" && msgQs.OnRemoteConfirmationReady != nil {
 								var appliedRecords []string
+								var removedRecords []string
 								if synchedDataUpdate.Update != nil {
 									for _, op := range synchedDataUpdate.Update.Operations {
-										appliedRecords = append(appliedRecords, op.Records...)
+										if op.Operation == "delete" {
+											removedRecords = append(removedRecords, op.Records...)
+										} else {
+											appliedRecords = append(appliedRecords, op.Records...)
+										}
 									}
 								}
 								lgEngine.Info("sending immediate ACCEPTED for non-signing zone",
 									"zone", synchedDataUpdate.Zone, "agent", synchedDataUpdate.AgentId,
-									"records", len(appliedRecords), "originDistID", synchedDataUpdate.OriginatingDistID)
+									"records", len(appliedRecords), "removed", len(removedRecords), "originDistID", synchedDataUpdate.OriginatingDistID)
 								msgQs.OnRemoteConfirmationReady(&RemoteConfirmationDetail{
 									OriginatingDistID: synchedDataUpdate.OriginatingDistID,
 									OriginatingSender: string(synchedDataUpdate.AgentId),
@@ -563,6 +564,7 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 									Status:            "ok",
 									Message:           "accepted into SDE (not forwarded to combiner: not a signer)",
 									AppliedRecords:    appliedRecords,
+									RemovedRecords:    removedRecords,
 								})
 							}
 						} else {

--- a/v2/syncheddataengine.go
+++ b/v2/syncheddataengine.go
@@ -539,17 +539,18 @@ func (conf *Config) SynchedDataEngine(ctx context.Context, msgQs *MsgQs) {
 						}
 
 						if remoteSkipCombiner {
-							lgEngine.Info("remote update applied but not forwarding to combiner (mp-disallow-edits)", "zone", synchedDataUpdate.Zone)
-							resp.Msg = "Remote update applied locally (not forwarded to combiner: zone signed, not a signer)"
-							// Send terminal REJECTED confirmation to originator so it
-							// doesn't wait forever for a combiner confirmation.
+							lgEngine.Info("remote update accepted locally, not forwarding to combiner (mp-disallow-edits)", "zone", synchedDataUpdate.Zone)
+							resp.Msg = "Remote update accepted locally (not forwarded to combiner: zone signed, not a signer)"
+							// Send ACCEPTED confirmation to originator. The data is in
+							// our SDE; we just don't forward to our combiner because
+							// we're not a signer. The sender should not be blocked.
 							if synchedDataUpdate.OriginatingDistID != "" && msgQs.OnRemoteConfirmationReady != nil {
 								msgQs.OnRemoteConfirmationReady(&RemoteConfirmationDetail{
 									OriginatingDistID: synchedDataUpdate.OriginatingDistID,
 									OriginatingSender: string(synchedDataUpdate.AgentId),
 									Zone:              synchedDataUpdate.Zone,
-									Status:            "rejected",
-									Message:           "zone is signed but this provider is not a signer; edits not forwarded to combiner",
+									Status:            "accepted",
+									Message:           "accepted into SDE (not forwarded to combiner: not a signer)",
 								})
 							}
 						} else {

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -198,7 +198,7 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 		if keyschanged && zd.Options[OptMultiProvider] {
 			if Globals.App.Type == AppTypeAgent {
 				// KEYSTATE is the sole source of truth for local vs foreign DNSKEYs.
-				zd.RequestAndWaitForKeyInventory()
+				zd.RequestAndWaitForKeyInventory(context.Background())
 				_, dskeyStatus, err = zd.LocalDnskeysFromKeystate()
 				if err != nil {
 					lg.Error("LocalDnskeysFromKeystate failed", "zone", zd.ZoneName, "err", err)
@@ -382,7 +382,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 			if Globals.App.Type == AppTypeAgent {
 				// KEYSTATE is the sole source of truth for local vs foreign DNSKEYs.
 				// Request inventory from signer, then derive local keys from it.
-				zd.RequestAndWaitForKeyInventory()
+				zd.RequestAndWaitForKeyInventory(context.Background())
 				_, dskeyStatusUpstream, err = zd.LocalDnskeysFromKeystate()
 				if err != nil {
 					lg.Error("LocalDnskeysFromKeystate failed", "zone", zd.ZoneName, "err", err)


### PR DESCRIPTION
## Summary

Major multi-provider infrastructure improvements: provider group
gossip protocol, non-signing provider gates, legacy Records removal,
DNSKEY suppression for unsigned zones, and comprehensive documentation.

## Provider Group Gossip Protocol (DNS-155 through DNS-160)

- Provider group computation from HSYNC3 identity sets
- NxN gossip state matrix exchanged bidirectionally on BEAT
  heartbeats via CHUNK EDNS(0)
- Mutual OPERATIONAL detection with group callbacks
- Per-group leader elections (single-initiator, 3-phase
  CALL/VOTE/CONFIRM, gossip propagation)
- Discovery restricted to locally supported transports

## Multi-Provider Authorization

- HSYNC3 identity check before setting dynamic zone options
- mp-not-listed-error warning for non-provider zones
- mp-disallow-edits for non-signing providers (zone signed
  by others)
- No-default-signing: empty signers= means no authorization
- Combiner REJECT confirmation with per-record details
- Agent rejects addrr/delrr for non-signing zones
- Non-signing agent accepts SYNCs (for SDE awareness) but
  sends ACCEPTED, not REJECTED, to avoid blocking sender
- Option handler registration for zone config parsing

## Operations Migration

- Remove 5 legacy Records-based debug CLI commands
- Stop populating Records in SYNC/UPDATE transport
- Remove legacy Records fallback from combiner and agent
- Move add-rr/del-rr to management API (was debug)

## DNSKEY Suppression for Unsigned Zones

- Signer sends empty KEYSTATE inventory when not a signer
- Agent skips DNSKEY distribution for unsigned zones
- Combiner rejects DNSKEY ops for unsigned zones
- KEYSTATE timeout fix: zone-qualified RFI channel routing

## Other Improvements

- Rename allow-combine to allow-edits
- HSYNCPARAM suffix key for provider NS namespace
- Zone mplist command (all roles)
- Non-blocking SDE startup hydration
- Combiner uses configured identity (not hardcoded "combiner")
- Deep-copy for gossip state and provider group getters
- Hash collision prevention in provider group computation

## Documentation

- guide/ hierarchy: quickstart, advanced topics, special
  features, application docs
- MP change tracking semantics doc
- Planning doc audit with open-items tracker
- Non-signing provider gates plan

## Parent Sync & Delegation

- CDS/CSYNC NOTIFY scan pipeline
- CSYNC scanner (RFC 7477)
- Combiner-driven parent sync
- SIG(0) KEY publication via combiner
- Code review fixes (rounds 2-8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "zone mplist" CLI/API and MPZones output to list multi-provider zones with providers, signers, management flags and options.

* **Bug Fixes**
  * Stricter zone-existence checks for list/edit operations.
  * Skip DNSKEY sync for unsigned multi-provider zones.
  * Avoid mutating shared DNS records and fixed discovery failure flush timing.

* **Improvements**
  * Full add/delete RR edit flow via main agent API and consistent CLI routing.
  * Per-zone key-inventory handling, option handler hooks, MP zone hydration, and safer concurrency for combiner/state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->