### PR TITLE
cli/configure: reusable bootstrap-configurator library

### DIFF
--- a/v2/cli/configure/diff.go
+++ b/v2/cli/configure/diff.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Bootstrap-configure library: diff preview + top-level confirmation.
+ *
+ * Substitution templates produce deterministic output where most
+ * lines are stable and only a handful differ per re-run. That
+ * makes a simple positional line-diff adequate.
+ *
+ * The confirmation gate here is a single top-level yes/no for
+ * all files. Per-file confirmation belongs to the live-server
+ * gate in ping.go.
+ */
+package configure
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// FileChange is one pending rewrite. If OldTxt is empty the file
+// does not exist yet; the diff preview treats the whole NewTxt
+// as added.
+type FileChange struct {
+	Path   string
+	OldTxt string
+	NewTxt string
+}
+
+// Changed reports whether content is going to move.
+func (c FileChange) Changed() bool { return c.OldTxt != c.NewTxt }
+
+// PreviewDiff writes a human-readable diff for c to w.
+func PreviewDiff(w io.Writer, c FileChange) {
+	if c.OldTxt == "" {
+		fmt.Fprintf(w, "\n--- %s (new file, %d lines) ---\n", c.Path, lineCount(c.NewTxt))
+		for _, line := range splitLines(c.NewTxt) {
+			fmt.Fprintf(w, "+ %s\n", line)
+		}
+		return
+	}
+
+	oldLines := splitLines(c.OldTxt)
+	newLines := splitLines(c.NewTxt)
+	fmt.Fprintf(w, "\n--- %s ---\n", c.Path)
+
+	n := len(oldLines)
+	if len(newLines) > n {
+		n = len(newLines)
+	}
+	for i := 0; i < n; i++ {
+		var o, ne string
+		if i < len(oldLines) {
+			o = oldLines[i]
+		}
+		if i < len(newLines) {
+			ne = newLines[i]
+		}
+		switch {
+		case i >= len(oldLines):
+			fmt.Fprintf(w, "+ %s\n", ne)
+		case i >= len(newLines):
+			fmt.Fprintf(w, "- %s\n", o)
+		case o == ne:
+			fmt.Fprintf(w, "  %s\n", o)
+		default:
+			fmt.Fprintf(w, "- %s\n", o)
+			fmt.Fprintf(w, "+ %s\n", ne)
+		}
+	}
+}
+
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.TrimSuffix(s, "\n")
+	return strings.Split(s, "\n")
+}
+
+func lineCount(s string) int { return len(splitLines(s)) }
+
+// confirmApply shows all pending changes and asks for a single
+// top-level yes/no. Returns true iff the user typed "yes"
+// (case-insensitive, exact).
+func confirmApply(w io.Writer, in *bufio.Reader, changes []FileChange) bool {
+	pending := make([]FileChange, 0, len(changes))
+	for _, c := range changes {
+		if c.Changed() {
+			pending = append(pending, c)
+		}
+	}
+	if len(pending) == 0 {
+		fmt.Fprintln(w, "\nNo changes to apply.")
+		return false
+	}
+	for _, c := range pending {
+		PreviewDiff(w, c)
+	}
+	fmt.Fprintf(w, "\nApply %d file change(s)? Type 'yes' to confirm: ", len(pending))
+	line, err := in.ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	return strings.TrimSpace(line) == "yes"
+}
+
+// applyChanges writes each pending change using atomicWrite.
+// Returns the list of backup paths created (for reporting).
+func applyChanges(w io.Writer, changes []FileChange) ([]string, error) {
+	var backups []string
+	for _, c := range changes {
+		if !c.Changed() {
+			continue
+		}
+		bak, err := atomicWrite(c.Path, c.NewTxt)
+		if err != nil {
+			return backups, err
+		}
+		if bak != "" {
+			fmt.Fprintf(w, "  wrote %s (backup: %s)\n", c.Path, bak)
+			backups = append(backups, bak)
+		} else {
+			fmt.Fprintf(w, "  wrote %s (new)\n", c.Path)
+		}
+	}
+	return backups, nil
+}

--- a/v2/cli/configure/diff.go
+++ b/v2/cli/configure/diff.go
@@ -104,11 +104,29 @@ func confirmApply(w io.Writer, in *bufio.Reader, changes []FileChange) bool {
 	if err != nil && line == "" {
 		return false
 	}
+	// Deliberately case-sensitive. A typed-confirmation gate is
+	// meant to force intentionality; "YES" is the kind of thing a
+	// shell autocomplete or paste buffer can produce by accident,
+	// so we require the exact lowercase literal.
 	return strings.TrimSpace(line) == "yes"
 }
 
 // applyChanges writes each pending change using atomicWrite.
 // Returns the list of backup paths created (for reporting).
+//
+// No rollback on partial failure. atomicWrite is atomic per file
+// (rename(2)), but this function walks the slice sequentially —
+// if the 3rd of 4 writes fails, the first two are already on
+// disk. We deliberately do not try to undo them, because:
+//
+//   - The user has seen the full diff and confirmed the intent.
+//   - Backups of every replaced file are still on disk (.bak.<ts>).
+//   - Automatic rollback would have to handle the case where a
+//     restore itself fails, giving worse failure modes than "stop
+//     and let the operator look at the backups."
+//
+// Callers should report the returned error and point at the
+// backup paths for recovery.
 func applyChanges(w io.Writer, changes []FileChange) ([]string, error) {
 	var backups []string
 	for _, c := range changes {

--- a/v2/cli/configure/generate.go
+++ b/v2/cli/configure/generate.go
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Bootstrap-configure library: generation of missing material.
+ *
+ * Apps invoke these from their GenerateMissingMaterial callback
+ * in the Spec. Generation is reuse-by-default: if the target
+ * file already exists, the function is a no-op. Rotation is out
+ * of scope for this library.
+ *
+ *   - EnsureApiKey     — in-memory random string, caller persists.
+ *   - EnsureJoseKeypair — writes priv + pub to disk.
+ *   - EnsureTLSCert    — self-signed via openssl.
+ */
+package configure
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/johanix/tdns-transport/v2/crypto"
+	_ "github.com/johanix/tdns-transport/v2/crypto/jose"
+)
+
+// GenerateApiKey returns a hex-encoded 32-byte random key.
+func GenerateApiKey() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("crypto/rand: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// EnsureApiKey returns `current` if non-empty, else a freshly
+// generated key. The caller is responsible for persisting the
+// returned value into the rendered config.
+func EnsureApiKey(current string) (string, error) {
+	if current != "" {
+		return current, nil
+	}
+	return GenerateApiKey()
+}
+
+// EnsureJoseKeypair generates a JOSE keypair at privPath (and a
+// matching pubPath derived by substituting ".priv." → ".pub.")
+// if privPath does not already exist. Returns the pub path, the
+// KeyID for display, and a bool indicating whether generation
+// actually ran.
+func EnsureJoseKeypair(privPath string) (pubPath, keyID string, generated bool, err error) {
+	pubPath = DerivePubPath(privPath)
+
+	if _, statErr := os.Stat(privPath); statErr == nil {
+		return pubPath, "", false, nil
+	} else if !os.IsNotExist(statErr) {
+		return "", "", false, fmt.Errorf("stat %s: %w", privPath, statErr)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(privPath), 0o700); err != nil {
+		return "", "", false, fmt.Errorf("mkdir %s: %w", filepath.Dir(privPath), err)
+	}
+
+	backend, err := crypto.GetBackend("jose")
+	if err != nil {
+		return "", "", false, fmt.Errorf("jose backend: %w", err)
+	}
+	priv, pub, err := backend.GenerateKeypair()
+	if err != nil {
+		return "", "", false, fmt.Errorf("generate jose keypair: %w", err)
+	}
+	privBytes, err := backend.SerializePrivateKey(priv)
+	if err != nil {
+		return "", "", false, fmt.Errorf("serialize priv: %w", err)
+	}
+	pubBytes, err := backend.SerializePublicKey(pub)
+	if err != nil {
+		return "", "", false, fmt.Errorf("serialize pub: %w", err)
+	}
+	defer zero(privBytes)
+
+	keyID = joseKeyID(pubBytes)
+
+	privPretty, err := prettyJSON(privBytes)
+	if err != nil {
+		return "", "", false, err
+	}
+	defer zero(privPretty)
+	pubPretty, err := prettyJSON(pubBytes)
+	if err != nil {
+		return "", "", false, err
+	}
+
+	header := fmt.Sprintf(`# JOSE Private Key
+# KeyID: %s
+# Config: long_term_jose_priv_key: %s
+# WARNING: This is a PRIVATE KEY. Keep it secret.
+#
+`, keyID, privPath)
+	content := []byte(header + string(privPretty) + "\n")
+	defer zero(content)
+
+	f, err := os.OpenFile(privPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", "", false, fmt.Errorf("create %s: %w", privPath, err)
+	}
+	if _, err := f.Write(content); err != nil {
+		f.Close()
+		return "", "", false, fmt.Errorf("write %s: %w", privPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return "", "", false, fmt.Errorf("close %s: %w", privPath, err)
+	}
+
+	if err := os.WriteFile(pubPath, append(pubPretty, '\n'), 0o644); err != nil {
+		return "", "", false, fmt.Errorf("write %s: %w", pubPath, err)
+	}
+	return pubPath, keyID, true, nil
+}
+
+// DerivePubPath turns "…/foo.jose.priv.json" into
+// "…/foo.jose.pub.json". If ".priv." is absent the path is
+// returned with ".pub" inserted before the extension.
+func DerivePubPath(priv string) string {
+	if strings.Contains(priv, ".priv.") {
+		return strings.Replace(priv, ".priv.", ".pub.", 1)
+	}
+	ext := filepath.Ext(priv)
+	return strings.TrimSuffix(priv, ext) + ".pub" + ext
+}
+
+func joseKeyID(pubBytes []byte) string {
+	const n = 8
+	if len(pubBytes) < n {
+		return "jose_" + hex.EncodeToString(pubBytes)
+	}
+	h := hex.EncodeToString(pubBytes)
+	if len(h) < n {
+		return "jose_" + h
+	}
+	return "jose_" + h[:n]
+}
+
+func prettyJSON(raw []byte) ([]byte, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil, fmt.Errorf("parse JSON: %w", err)
+	}
+	return json.MarshalIndent(v, "", "  ")
+}
+
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// EnsureTLSCert writes a self-signed cert + key to certPath /
+// keyPath if certPath does not already exist.
+//
+// SAN = DNS:<cn>, DNS:localhost, IP:<listenIP>, IP:127.0.0.1
+// (deduped). CN is the identity with trailing dot stripped.
+//
+// Requires `openssl` on PATH. Non-interactive.
+func EnsureTLSCert(certPath, keyPath, identity, listenHostPort string) (generated bool, err error) {
+	if _, statErr := os.Stat(certPath); statErr == nil {
+		return false, nil
+	} else if !os.IsNotExist(statErr) {
+		return false, fmt.Errorf("stat %s: %w", certPath, statErr)
+	}
+
+	if _, err := exec.LookPath("openssl"); err != nil {
+		return false, fmt.Errorf("openssl not found on PATH: %w", err)
+	}
+
+	cn := strings.TrimSuffix(identity, ".")
+	if cn == "" {
+		return false, fmt.Errorf("identity is required for cert CN")
+	}
+
+	host, _, splitErr := net.SplitHostPort(listenHostPort)
+	if splitErr != nil {
+		host = ""
+	}
+
+	dnsNames := dedup([]string{cn, "localhost"})
+	ips := dedup(trimEmpty([]string{host, "127.0.0.1"}))
+	san := buildSAN(dnsNames, ips)
+
+	for _, p := range []string{certPath, keyPath} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(p), err)
+		}
+	}
+
+	tmp, err := os.CreateTemp("", "openssl-san-*.cnf")
+	if err != nil {
+		return false, fmt.Errorf("tempfile: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	cnf := fmt.Sprintf(`[ req ]
+default_bits       = 2048
+distinguished_name = req_distinguished_name
+req_extensions     = v3_req
+x509_extensions    = v3_req
+prompt             = no
+
+[ req_distinguished_name ]
+CN = %s
+
+[ v3_req ]
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = %s
+`, cn, san)
+
+	if _, err := tmp.WriteString(cnf); err != nil {
+		tmp.Close()
+		return false, fmt.Errorf("write openssl cnf: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return false, fmt.Errorf("close openssl cnf: %w", err)
+	}
+
+	cmd := exec.Command(
+		"openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+		"-keyout", keyPath,
+		"-out", certPath,
+		"-days", "3650",
+		"-config", tmpName,
+	)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("openssl req: %w", err)
+	}
+	if err := os.Chmod(keyPath, 0o600); err != nil {
+		return false, fmt.Errorf("chmod %s: %w", keyPath, err)
+	}
+	return true, nil
+}
+
+func buildSAN(dns, ips []string) string {
+	var parts []string
+	for _, n := range dns {
+		parts = append(parts, "DNS:"+n)
+	}
+	for _, ip := range ips {
+		parts = append(parts, "IP:"+ip)
+	}
+	return strings.Join(parts, ",")
+}
+
+func dedup(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func trimEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if strings.TrimSpace(s) != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/v2/cli/configure/generate.go
+++ b/v2/cli/configure/generate.go
@@ -56,10 +56,26 @@ func EnsureApiKey(current string) (string, error) {
 func EnsureJoseKeypair(privPath string) (pubPath, keyID string, generated bool, err error) {
 	pubPath = DerivePubPath(privPath)
 
-	if _, statErr := os.Stat(privPath); statErr == nil {
+	privExists, err := fileExists(privPath)
+	if err != nil {
+		return "", "", false, fmt.Errorf("stat %s: %w", privPath, err)
+	}
+	pubExists, err := fileExists(pubPath)
+	if err != nil {
+		return "", "", false, fmt.Errorf("stat %s: %w", pubPath, err)
+	}
+	switch {
+	case privExists && pubExists:
 		return pubPath, "", false, nil
-	} else if !os.IsNotExist(statErr) {
-		return "", "", false, fmt.Errorf("stat %s: %w", privPath, statErr)
+	case privExists && !pubExists:
+		// Orphaned priv from a previous partial failure. Refuse to
+		// silently proceed — the caller should either delete the
+		// priv to force regeneration or recover the pub manually
+		// from the priv (we don't do that here to avoid touching
+		// an existing private key).
+		return "", "", false, fmt.Errorf("%s exists but matching pub %s is missing; remove priv to regenerate, or restore pub from backup", privPath, pubPath)
+	case !privExists && pubExists:
+		return "", "", false, fmt.Errorf("%s exists but matching priv %s is missing; remove pub to regenerate", pubPath, privPath)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(privPath), 0o700); err != nil {
@@ -118,9 +134,27 @@ func EnsureJoseKeypair(privPath string) (pubPath, keyID string, generated bool, 
 	}
 
 	if err := os.WriteFile(pubPath, append(pubPretty, '\n'), 0o644); err != nil {
+		// Best-effort cleanup of the orphan priv so a retry can
+		// generate both. We prefer this to leaving a half-written
+		// pair that would fail the priv/pub consistency check.
+		_ = os.Remove(privPath)
 		return "", "", false, fmt.Errorf("write %s: %w", pubPath, err)
 	}
 	return pubPath, keyID, true, nil
+}
+
+// fileExists reports whether a path points to a regular file.
+// (Does not distinguish files from directories; the configurator
+// paths are always file paths.)
+func fileExists(p string) (bool, error) {
+	_, err := os.Stat(p)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 // DerivePubPath turns "…/foo.jose.priv.json" into
@@ -168,10 +202,21 @@ func zero(b []byte) {
 //
 // Requires `openssl` on PATH. Non-interactive.
 func EnsureTLSCert(certPath, keyPath, identity, listenHostPort string) (generated bool, err error) {
-	if _, statErr := os.Stat(certPath); statErr == nil {
+	certExists, err := fileExists(certPath)
+	if err != nil {
+		return false, fmt.Errorf("stat %s: %w", certPath, err)
+	}
+	keyExists, err := fileExists(keyPath)
+	if err != nil {
+		return false, fmt.Errorf("stat %s: %w", keyPath, err)
+	}
+	switch {
+	case certExists && keyExists:
 		return false, nil
-	} else if !os.IsNotExist(statErr) {
-		return false, fmt.Errorf("stat %s: %w", certPath, statErr)
+	case certExists && !keyExists:
+		return false, fmt.Errorf("%s exists but matching key %s is missing; refusing to overwrite", certPath, keyPath)
+	case !certExists && keyExists:
+		return false, fmt.Errorf("%s exists but matching cert %s is missing; refusing to overwrite", keyPath, certPath)
 	}
 
 	if _, err := exec.LookPath("openssl"); err != nil {
@@ -188,9 +233,16 @@ func EnsureTLSCert(certPath, keyPath, identity, listenHostPort string) (generate
 		host = ""
 	}
 
-	dnsNames := dedup([]string{cn, "localhost"})
-	ips := dedup(trimEmpty([]string{host, "127.0.0.1"}))
-	san := buildSAN(dnsNames, ips)
+	dnsNames := []string{cn, "localhost"}
+	ips := []string{"127.0.0.1"}
+	if host != "" {
+		if net.ParseIP(host) != nil {
+			ips = append(ips, host)
+		} else {
+			dnsNames = append(dnsNames, host)
+		}
+	}
+	san := buildSAN(dedup(dnsNames), dedup(ips))
 
 	for _, p := range []string{certPath, keyPath} {
 		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
@@ -273,12 +325,3 @@ func dedup(in []string) []string {
 	return out
 }
 
-func trimEmpty(in []string) []string {
-	out := make([]string, 0, len(in))
-	for _, s := range in {
-		if strings.TrimSpace(s) != "" {
-			out = append(out, s)
-		}
-	}
-	return out
-}

--- a/v2/cli/configure/io.go
+++ b/v2/cli/configure/io.go
@@ -99,6 +99,14 @@ func atomicWrite(path, content string) (backup string, err error) {
 	}
 
 	if err = os.Rename(tmpName, path); err != nil {
+		// Best-effort restore of the original file so a failed
+		// write does not leave the path empty.
+		if backup != "" {
+			if restoreErr := os.Rename(backup, path); restoreErr != nil {
+				return backup, fmt.Errorf("rename %s → %s: %w (also failed to restore from %s: %v)", tmpName, path, err, backup, restoreErr)
+			}
+			backup = ""
+		}
 		return backup, fmt.Errorf("rename %s → %s: %w", tmpName, path, err)
 	}
 	return backup, nil

--- a/v2/cli/configure/io.go
+++ b/v2/cli/configure/io.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Bootstrap-configure library: file I/O primitives.
+ *
+ * Atomic write with unconditional timestamped backup of any
+ * existing file. Called from the orchestrator only after the
+ * user has confirmed a previewed diff.
+ *
+ * App-level code generally does not call AtomicWrite directly —
+ * the orchestrator in run.go does — but ReadFileIfExists and
+ * ValidateYAML are useful primitives for apps that need to parse
+ * existing configs to seed their interview.
+ */
+package configure
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReadFileIfExists returns the file contents, or ("", nil) if
+// the path does not exist. Other errors are returned as-is.
+func ReadFileIfExists(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	return string(data), nil
+}
+
+// ValidateYAML returns nil if the content parses as a YAML
+// document. Used as a sanity gate before any atomic write.
+func ValidateYAML(content string) error {
+	var any interface{}
+	return yaml.Unmarshal([]byte(content), &any)
+}
+
+// backupPath returns the timestamped backup path for a given
+// config file. Format: foo.yaml.bak.2026-04-21T14-03-22.
+func backupPath(path string, now time.Time) string {
+	stamp := now.UTC().Format("2006-01-02T15-04-05")
+	return path + ".bak." + stamp
+}
+
+// atomicWrite validates `content` as YAML, writes it to a
+// tempfile in the same directory, then renames into place.
+//
+// If `path` already exists it is renamed to a timestamped backup
+// first. Returns the backup path (empty if no prior file).
+func atomicWrite(path, content string) (backup string, err error) {
+	if parseErr := ValidateYAML(content); parseErr != nil {
+		return "", fmt.Errorf("refuse to write invalid YAML to %s: %w", path, parseErr)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("create tempfile in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err = tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("write tempfile: %w", err)
+	}
+	if err = tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("chmod tempfile: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		return "", fmt.Errorf("close tempfile: %w", err)
+	}
+
+	if _, statErr := os.Stat(path); statErr == nil {
+		backup = backupPath(path, time.Now())
+		if err = os.Rename(path, backup); err != nil {
+			return "", fmt.Errorf("backup %s → %s: %w", path, backup, err)
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return "", fmt.Errorf("stat %s: %w", path, statErr)
+	}
+
+	if err = os.Rename(tmpName, path); err != nil {
+		return backup, fmt.Errorf("rename %s → %s: %w", tmpName, path, err)
+	}
+	return backup, nil
+}

--- a/v2/cli/configure/ping.go
+++ b/v2/cli/configure/ping.go
@@ -36,6 +36,15 @@ type LiveTarget struct {
 // isAlive returns true if the API at t.BaseURL accepts a ping
 // signed with t.APIKey. All errors (connection refused, timeout,
 // auth failure) are treated as "not alive".
+//
+// Uses "insecure" TLS on purpose: in a bootstrap context the
+// server's cert is commonly self-signed (this very tool may have
+// generated it on a prior run) and we have no trust store yet.
+// The goal here is a liveness probe, not authentication — a
+// responsive apikey-accepting HTTPS endpoint is all we need to
+// gate the rewrite. Switching this to verified TLS would require
+// the operator to thread a rootCA path through config bootstrap,
+// which defeats the purpose of an interactive bootstrap tool.
 func (t LiveTarget) isAlive() bool {
 	if !t.HasConfig || t.BaseURL == "" || t.APIKey == "" {
 		return false

--- a/v2/cli/configure/ping.go
+++ b/v2/cli/configure/ping.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Bootstrap-configure library: live-server gate.
+ *
+ * Before overwriting a running server's config, probe its API
+ * using the *existing* credentials (the new apikey is not yet
+ * accepted by the running server). A responsive server requires
+ * a typed confirmation string per role, e.g.
+ * `yes, reconfigure mpagent`.
+ *
+ * Refusing any gate aborts the entire write. This library does
+ * not support partial apply of coordinated configs.
+ */
+package configure
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+// LiveTarget is the per-role input the gate needs. The app
+// builds these from its parsed *existing* config.
+type LiveTarget struct {
+	Role      string // short label for messages, e.g. "mpagent"
+	Path      string // config path this target corresponds to
+	BaseURL   string // https://host:port/api/v1
+	APIKey    string
+	HasConfig bool // false if no existing config file was found
+}
+
+// isAlive returns true if the API at t.BaseURL accepts a ping
+// signed with t.APIKey. All errors (connection refused, timeout,
+// auth failure) are treated as "not alive".
+func (t LiveTarget) isAlive() bool {
+	if !t.HasConfig || t.BaseURL == "" || t.APIKey == "" {
+		return false
+	}
+	c := tdns.NewClient(t.Role, t.BaseURL, t.APIKey, "X-API-Key", "insecure")
+	if c == nil {
+		return false
+	}
+	_, err := c.SendPing(1, false)
+	return err == nil
+}
+
+// gateLiveServers probes each target whose config is about to
+// change and, for every live one, requires a typed confirmation.
+// Returns nil iff the gate clears. A non-nil error means the user
+// refused or input was interrupted — abort the write.
+func gateLiveServers(
+	w io.Writer,
+	in *bufio.Reader,
+	targets []LiveTarget,
+	changes []FileChange,
+) error {
+	changing := make(map[string]bool, len(changes))
+	for _, c := range changes {
+		if c.Changed() {
+			changing[c.Path] = true
+		}
+	}
+
+	fmt.Fprintln(w, "\nProbing live servers…")
+	var live []LiveTarget
+	for _, t := range targets {
+		if !changing[t.Path] {
+			continue
+		}
+		if t.isAlive() {
+			fmt.Fprintf(w, "  %s: LIVE (existing config responds to ping)\n", t.Role)
+			live = append(live, t)
+		} else {
+			fmt.Fprintf(w, "  %s: quiet\n", t.Role)
+		}
+	}
+	if len(live) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(w, "\nOne or more target servers are currently running.")
+	fmt.Fprintln(w, "Rewriting their configs will not affect the running")
+	fmt.Fprintln(w, "daemon until it is restarted, but a mismatched apikey")
+	fmt.Fprintln(w, "or identity can surprise operators who restart later.")
+	fmt.Fprintln(w, "Confirm each live server explicitly.")
+
+	for _, t := range live {
+		want := "yes, reconfigure " + t.Role
+		fmt.Fprintf(w, "\n  type exactly '%s' to proceed: ", want)
+		line, err := in.ReadString('\n')
+		if err != nil && line == "" {
+			return fmt.Errorf("aborted: input closed during live-server gate")
+		}
+		if strings.TrimRight(line, "\r\n") != want {
+			return fmt.Errorf("aborted: confirmation string mismatch for %s", t.Role)
+		}
+	}
+	return nil
+}

--- a/v2/cli/configure/prompt.go
+++ b/v2/cli/configure/prompt.go
@@ -12,7 +12,9 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -117,14 +119,22 @@ func AbsDir(s string) error {
 	return nil
 }
 
-// HostPort requires "host:port".
+// HostPort requires "host:port" and rejects out-of-range ports.
+// Accepts IPv6 literals in [::1]:853 form via net.SplitHostPort.
 func HostPort(s string) error {
 	if err := NonEmpty("host:port")(s); err != nil {
 		return err
 	}
-	parts := strings.Split(s, ":")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return fmt.Errorf("expected host:port")
+	host, port, err := net.SplitHostPort(s)
+	if err != nil {
+		return fmt.Errorf("expected host:port: %w", err)
+	}
+	if host == "" {
+		return fmt.Errorf("expected host:port (empty host)")
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil || n < 1 || n > 65535 {
+		return fmt.Errorf("invalid port %q (must be 1–65535)", port)
 	}
 	return nil
 }

--- a/v2/cli/configure/prompt.go
+++ b/v2/cli/configure/prompt.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Bootstrap-configure library: interactive prompt primitives.
+ *
+ * Apps use these to build their role-specific interview flow.
+ * Stdin-based; for empty-input behaviour see Ask.
+ */
+package configure
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// Validator returns nil on valid input, or an error describing
+// what is wrong. The prompter will re-prompt on error.
+type Validator func(string) error
+
+// Prompter is a thin wrapper around bufio.Reader / io.Writer so
+// tests can stub stdin/stdout. Construct with NewPrompter (which
+// binds to os.Stdin / os.Stdout) or build a struct literal for
+// tests.
+type Prompter struct {
+	In  *bufio.Reader
+	Out io.Writer
+}
+
+// NewPrompter returns a Prompter bound to os.Stdin / os.Stdout.
+func NewPrompter() *Prompter {
+	return &Prompter{In: bufio.NewReader(os.Stdin), Out: os.Stdout}
+}
+
+// Ask shows `label`, pre-filled with `dflt`. Empty input accepts
+// the default. The validator runs on the effective value;
+// failure re-prompts.
+func (p *Prompter) Ask(label, dflt string, v Validator) string {
+	for {
+		if dflt != "" {
+			fmt.Fprintf(p.Out, "%s [%s]: ", label, dflt)
+		} else {
+			fmt.Fprintf(p.Out, "%s: ", label)
+		}
+		line, err := p.In.ReadString('\n')
+		if err != nil && line == "" {
+			return ""
+		}
+		val := strings.TrimSpace(line)
+		if val == "" {
+			val = dflt
+		}
+		if v != nil {
+			if vErr := v(val); vErr != nil {
+				fmt.Fprintf(p.Out, "  invalid: %v\n", vErr)
+				continue
+			}
+		}
+		return val
+	}
+}
+
+// AskIdentity accepts a bare name, canonicalises it via
+// dns.Fqdn, echoes the canonical form, and returns it.
+func (p *Prompter) AskIdentity(label, dflt string) string {
+	raw := p.Ask(label, dflt, NonEmpty("identity"))
+	fq := dns.Fqdn(strings.TrimSpace(raw))
+	if fq != raw {
+		fmt.Fprintf(p.Out, "  using %s\n", fq)
+	}
+	return fq
+}
+
+// AskYesNo prompts [Y/n] / [y/N]. Empty input returns
+// `defaultYes`. Any non-"n"-starting answer counts as yes.
+func (p *Prompter) AskYesNo(label string, defaultYes bool) bool {
+	tag := "[Y/n]"
+	if !defaultYes {
+		tag = "[y/N]"
+	}
+	fmt.Fprintf(p.Out, "%s %s: ", label, tag)
+	line, err := p.In.ReadString('\n')
+	if err != nil && line == "" {
+		return defaultYes
+	}
+	ans := strings.ToLower(strings.TrimSpace(line))
+	if ans == "" {
+		return defaultYes
+	}
+	return ans[0] != 'n'
+}
+
+// --- Standard validators ---
+
+// NonEmpty rejects blank input, labelling errors with `field`.
+func NonEmpty(field string) Validator {
+	return func(s string) error {
+		if strings.TrimSpace(s) == "" {
+			return fmt.Errorf("%s is required", field)
+		}
+		return nil
+	}
+}
+
+// AbsDir requires an absolute path.
+func AbsDir(s string) error {
+	if err := NonEmpty("directory")(s); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(s, "/") {
+		return fmt.Errorf("must be an absolute path")
+	}
+	return nil
+}
+
+// HostPort requires "host:port".
+func HostPort(s string) error {
+	if err := NonEmpty("host:port")(s); err != nil {
+		return err
+	}
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("expected host:port")
+	}
+	return nil
+}
+
+// OrDefault returns cur if non-empty, else dflt.
+func OrDefault(cur, dflt string) string {
+	if cur == "" {
+		return dflt
+	}
+	return cur
+}

--- a/v2/cli/configure/run.go
+++ b/v2/cli/configure/run.go
@@ -100,10 +100,14 @@ func run(spec Spec, w io.Writer, in *bufio.Reader) error {
 
 	changes := make([]FileChange, 0, len(spec.Paths))
 	for _, path := range spec.Paths {
+		newTxt, ok := rendered[path]
+		if !ok {
+			return fmt.Errorf("RenderAll did not produce content for %s; a missing-key here would silently clobber the existing file with empty YAML", path)
+		}
 		changes = append(changes, FileChange{
 			Path:   path,
 			OldTxt: existing[path],
-			NewTxt: rendered[path],
+			NewTxt: newTxt,
 		})
 	}
 

--- a/v2/cli/configure/run.go
+++ b/v2/cli/configure/run.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Bootstrap-configure library: orchestrator.
+ *
+ * Apps populate a Spec and call Run. The library handles:
+ *
+ *   1. read existing configs (Spec.ReadExisting)
+ *   2. interview (Spec.RunInterview, using the Prompter)
+ *   3. render templates (Spec.RenderAll)
+ *   4. diff preview + top-level confirmation
+ *   5. live-server gate (Spec.LiveTargets)
+ *   6. generation of missing material (Spec.GenerateMaterial)
+ *   7. atomic write + backup of every changed file
+ *
+ * State is passed opaquely as `any` — the app owns the shape.
+ * The library never inspects it.
+ */
+package configure
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Spec describes one app's configure flow. All callbacks receive
+// the app-owned state (from ReadExisting, then through Interview).
+type Spec struct {
+	// Paths is the ordered list of files the flow owns. Iteration
+	// order is deterministic for diff output; the first entry
+	// usually matches the "primary" role.
+	Paths []string
+
+	// ReadExisting is called once at the start to seed the
+	// interview with defaults from any existing config files.
+	ReadExisting func() (state any, err error)
+
+	// RunInterview drives the prompts. The returned state is
+	// passed forward to the render/generate hooks.
+	RunInterview func(p *Prompter, seed any) (any, error)
+
+	// RenderAll returns rendered content keyed by Path.
+	RenderAll func(state any) (map[string]string, error)
+
+	// LiveTargets returns the ping-gate inputs for each role whose
+	// config is about to change. Apps that don't want a gate can
+	// return nil.
+	LiveTargets func(state any) []LiveTarget
+
+	// GenerateMaterial runs after the top-level confirm and the
+	// live-server gate but before the atomic write. Apps call the
+	// EnsureXxx helpers here to create missing JOSE keys, TLS
+	// certs, etc. Existing files must be left untouched.
+	GenerateMaterial func(state any) error
+}
+
+// Run drives the full bootstrap flow.
+func Run(spec Spec) error {
+	return run(spec, os.Stdout, bufio.NewReader(os.Stdin))
+}
+
+// run is the testable body of Run — takes explicit io/reader.
+func run(spec Spec, w io.Writer, in *bufio.Reader) error {
+	if err := validateSpec(spec); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w, "Reading any existing configuration…")
+	existing := make(map[string]string, len(spec.Paths))
+	for _, p := range spec.Paths {
+		content, err := ReadFileIfExists(p)
+		if err != nil {
+			return err
+		}
+		existing[p] = content
+		if content == "" {
+			fmt.Fprintf(w, "  %s: (not present)\n", p)
+		} else {
+			fmt.Fprintf(w, "  %s: %d bytes\n", p, len(content))
+		}
+	}
+
+	seed, err := spec.ReadExisting()
+	if err != nil {
+		return fmt.Errorf("read existing: %w", err)
+	}
+
+	p := &Prompter{In: in, Out: w}
+	state, err := spec.RunInterview(p, seed)
+	if err != nil {
+		return fmt.Errorf("interview: %w", err)
+	}
+
+	rendered, err := spec.RenderAll(state)
+	if err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+
+	changes := make([]FileChange, 0, len(spec.Paths))
+	for _, path := range spec.Paths {
+		changes = append(changes, FileChange{
+			Path:   path,
+			OldTxt: existing[path],
+			NewTxt: rendered[path],
+		})
+	}
+
+	if !confirmApply(w, in, changes) {
+		fmt.Fprintln(w, "\nAborted. No files changed.")
+		return nil
+	}
+
+	if spec.LiveTargets != nil {
+		if err := gateLiveServers(w, in, spec.LiveTargets(state), changes); err != nil {
+			fmt.Fprintln(w, "\n"+err.Error())
+			return nil
+		}
+	}
+
+	if spec.GenerateMaterial != nil {
+		if err := spec.GenerateMaterial(state); err != nil {
+			return fmt.Errorf("generate material: %w", err)
+		}
+	}
+
+	if _, err := applyChanges(w, changes); err != nil {
+		return fmt.Errorf("apply: %w", err)
+	}
+	fmt.Fprintln(w, "\nDone.")
+	return nil
+}
+
+func validateSpec(s Spec) error {
+	if len(s.Paths) == 0 {
+		return fmt.Errorf("configure.Run: Spec.Paths is empty")
+	}
+	if s.ReadExisting == nil {
+		return fmt.Errorf("configure.Run: Spec.ReadExisting is nil")
+	}
+	if s.RunInterview == nil {
+		return fmt.Errorf("configure.Run: Spec.RunInterview is nil")
+	}
+	if s.RenderAll == nil {
+		return fmt.Errorf("configure.Run: Spec.RenderAll is nil")
+	}
+	return nil
+}


### PR DESCRIPTION
Lifted from the mpcli configure subcommand. Contains the plumbing that has no role knowledge (prompt primitives, diff preview + top-level confirmation, atomic write with timestamped backup, YAML validation, API-key / JOSE-keypair / TLS-cert generation, live-server ping gate) plus an orchestrator (Run + Spec) that drives the standard flow.

Apps populate a Spec with callbacks (ReadExisting, RunInterview, RenderAll, LiveTargets, GenerateMaterial) and call configure.Run. State is passed opaquely as `any`; the library never inspects it.

Target consumers: tdns-mp/cmd/mpcli (first), plus tdns-cli and the kdc/krs/edgesigner CLIs to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Interactive configuration workflow with diff preview before applying changes
- Validation gate that checks live servers before modifying configurations
- Automatic generation of API keys, TLS certificates, and keypairs
- Atomic file operations with timestamped backups
- Interactive CLI prompts with input validation for configuration values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->