### PR TITLE
Cherry-pick non-PQC CLI improvements from mldsa44-sig0-fork

### DIFF
--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -142,6 +142,7 @@ type ConfigResponse struct {
 	ApiServer       ApiServerConf
 	Identities      []string
 	CombinerOptions map[CombinerOption]bool
+	DBFile          string
 	Msg             string
 	Error           bool
 	ErrorMsg        string

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -14,6 +14,7 @@ import (
 	cache "github.com/johanix/tdns/v2/cache"
 	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
+	"github.com/spf13/viper"
 )
 
 func (kdb *KeyDB) APIkeystore(conf *Config) func(w http.ResponseWriter, r *http.Request) {
@@ -267,6 +268,7 @@ func APIconfig(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 			resp.DnsEngine = conf.DnsEngine
 			resp.ApiServer = conf.ApiServer
 			resp.Identities = conf.Service.Identities
+			resp.DBFile = viper.GetString("db.file")
 			if conf.MultiProvider != nil {
 				resp.CombinerOptions = conf.MultiProvider.CombinerOptions
 			}

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -14,7 +14,6 @@ import (
 	cache "github.com/johanix/tdns/v2/cache"
 	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
-	"github.com/spf13/viper"
 )
 
 func (kdb *KeyDB) APIkeystore(conf *Config) func(w http.ResponseWriter, r *http.Request) {
@@ -268,7 +267,7 @@ func APIconfig(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 			resp.DnsEngine = conf.DnsEngine
 			resp.ApiServer = conf.ApiServer
 			resp.Identities = conf.Service.Identities
-			resp.DBFile = viper.GetString("db.file")
+			resp.DBFile = conf.Db.File
 			if conf.MultiProvider != nil {
 				resp.CombinerOptions = conf.MultiProvider.CombinerOptions
 			}

--- a/v2/childsync_utils.go
+++ b/v2/childsync_utils.go
@@ -56,12 +56,25 @@ func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, UpdateResul
 	var edeCode uint16
 	var edeMessage string
 
+	// If the packed message exceeds the EDNS UDP buffer we advertise
+	// (1232), use TCP. dns.Exchange is hardcoded UDP and does not fall
+	// back on truncation, so a too-large UPDATE just times out — common
+	// with ML-DSA-44 SIG(0), where the signature alone is ~2.4 KB.
+	const udpSafeLimit = 1232
+	useTCP := msg.Len() > udpSafeLimit
+	client := &dns.Client{}
+	if useTCP {
+		client.Net = "tcp"
+	}
+
 	for _, dst := range addrs {
-		lgDns.Debug("sending DNS UPDATE", "zone", zonename, "dst", dst)
+		lgDns.Debug("sending DNS UPDATE", "zone", zonename, "dst", dst,
+			"net", map[bool]string{true: "tcp", false: "udp"}[useTCP],
+			"size", msg.Len())
 
 		lgDns.Debug("sending update message", "msg", msg.String())
 
-		res, err := dns.Exchange(msg, dst)
+		res, _, err := client.Exchange(msg, dst)
 		if err != nil {
 			lgDns.Warn("error from dns.Exchange, trying next address", "dst", dst, "err", err)
 			ur.TargetStatus[dst] = TargetUpdateStatus{

--- a/v2/childsync_utils.go
+++ b/v2/childsync_utils.go
@@ -56,11 +56,16 @@ func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, UpdateResul
 	var edeCode uint16
 	var edeMessage string
 
-	// If the packed message exceeds the EDNS UDP buffer we advertise
-	// (1232), use TCP. dns.Exchange is hardcoded UDP and does not fall
-	// back on truncation, so a too-large UPDATE just times out — common
-	// with ML-DSA-44 SIG(0), where the signature alone is ~2.4 KB.
-	const udpSafeLimit = 1232
+	// If the packed message exceeds the EDNS UDP buffer advertised on
+	// the message's OPT RR, use TCP. dns.Exchange is hardcoded UDP and
+	// does not fall back on truncation, so a too-large UPDATE just
+	// times out — common with ML-DSA-44 SIG(0), where the signature
+	// alone is ~2.4 KB. Fall back to 1232 (EDNS "safe" default) if the
+	// caller didn't attach an OPT.
+	udpSafeLimit := 1232
+	if opt := msg.IsEdns0(); opt != nil {
+		udpSafeLimit = int(opt.UDPSize())
+	}
 	useTCP := msg.Len() > udpSafeLimit
 	client := &dns.Client{}
 	if useTCP {

--- a/v2/cli/agent_zone_cmds.go
+++ b/v2/cli/agent_zone_cmds.go
@@ -455,8 +455,10 @@ func init() {
 	// 20260415 johani: agentZoneDelRRCmd.Flags().StringVarP(&agentZoneRR, "rr", "", "", "DNS record to delete")
 	// 20260415 johani: agentZoneDelRRCmd.Flags().Bool("force", false, "Bypass dedup check and always send transaction")
 
-	agentZoneDsyncRollKeyCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519", "Algorithm to use for the new SIG(0) key")
-	agentZoneDsyncBootstrapCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519", "Algorithm to use for the new SIG(0) key")
+	agentZoneDsyncRollKeyCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519",
+		sig0AlgorithmsHelp("Algorithm for the new SIG(0) key"))
+	agentZoneDsyncBootstrapCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519",
+		sig0AlgorithmsHelp("Algorithm for the new SIG(0) key"))
 	agentZoneDsyncRollKeyCmd.PersistentFlags().StringVarP(&agentRollaction, "rollaction", "r", "complete", "[debug] Phase of the rollover to perform: complete, add, remove, update-local")
 	agentZoneDsyncRollKeyCmd.PersistentFlags().MarkHidden("rollaction")
 }

--- a/v2/cli/agent_zone_cmds.go
+++ b/v2/cli/agent_zone_cmds.go
@@ -441,6 +441,7 @@ func init() {
 	// Update subcommands
 	agentZoneUpdateCmd.AddCommand(agentZoneUpdateCreateCmd)
 	agentZoneUpdateCreateCmd.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to update")
+	AttachUpdateCreateFlags(agentZoneUpdateCreateCmd)
 
 	// Flags
 	AgentZoneCmd.PersistentFlags().BoolVarP(&force, "force", "F", false, "force operation")

--- a/v2/cli/algorithms.go
+++ b/v2/cli/algorithms.go
@@ -13,13 +13,10 @@ var SupportedSig0Algorithms = []string{
 	"ECDSAP256SHA256",
 	"ECDSAP384SHA384",
 	"ED25519",
-	"MLDSA44",
 }
 
 // SupportedDnssecAlgorithms lists the DNSSEC algorithm names tdns
-// accepts for zone signing (RRSIG). MLDSA44 is deliberately omitted:
-// it is supported only for SIG(0) transaction signatures, not zone
-// signing.
+// accepts for zone signing (RRSIG).
 var SupportedDnssecAlgorithms = []string{
 	"RSASHA256",
 	"RSASHA512",

--- a/v2/cli/algorithms.go
+++ b/v2/cli/algorithms.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package cli
+
+import "strings"
+
+// SupportedSig0Algorithms lists the DNSSEC algorithm names tdns
+// accepts for SIG(0) key generation and transaction signing.
+var SupportedSig0Algorithms = []string{
+	"RSASHA256",
+	"RSASHA512",
+	"ECDSAP256SHA256",
+	"ECDSAP384SHA384",
+	"ED25519",
+	"MLDSA44",
+}
+
+// SupportedDnssecAlgorithms lists the DNSSEC algorithm names tdns
+// accepts for zone signing (RRSIG). MLDSA44 is deliberately omitted:
+// it is supported only for SIG(0) transaction signatures, not zone
+// signing.
+var SupportedDnssecAlgorithms = []string{
+	"RSASHA256",
+	"RSASHA512",
+	"ECDSAP256SHA256",
+	"ECDSAP384SHA384",
+	"ED25519",
+}
+
+func sig0AlgorithmsHelp(prefix string) string {
+	return prefix + ". Supported: " + strings.Join(SupportedSig0Algorithms, ", ")
+}
+
+func dnssecAlgorithmsHelp(prefix string) string {
+	return prefix + ". Supported: " + strings.Join(SupportedDnssecAlgorithms, ", ")
+}

--- a/v2/cli/config_cmds.go
+++ b/v2/cli/config_cmds.go
@@ -159,6 +159,11 @@ var configStatusCmd = &cobra.Command{
 			} else {
 				fmt.Printf("ApiServer: api key is not set\n")
 			}
+			if resp.DBFile != "" {
+				fmt.Printf("DB: %s\n", resp.DBFile)
+			} else {
+				fmt.Printf("DB: not configured\n")
+			}
 		}
 
 		if resp.Msg != "" {

--- a/v2/cli/debug_cmds.go
+++ b/v2/cli/debug_cmds.go
@@ -240,7 +240,8 @@ func init() {
 	DebugCmd.PersistentFlags().StringVarP(&debugQtype, "qtype", "", "", "qtype of rrset to examine")
 
 	defalg := viper.GetString("delegationsync.child.update.keygen.algorithm")
-	debugSig0Cmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", defalg, "algorithm to use for SIG(0)")
+	debugSig0Cmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", defalg,
+		sig0AlgorithmsHelp("Algorithm to use for SIG(0)"))
 	debugSig0Cmd.PersistentFlags().StringVarP(&tdns.Globals.Rrtype, "rrtype", "r", "", "rrtype to use for SIG(0)")
 }
 

--- a/v2/cli/keystore_cmds.go
+++ b/v2/cli/keystore_cmds.go
@@ -415,6 +415,13 @@ func writeSig0ExportFiles(sk tdns.Sig0Key, outdir string) error {
 	base := fmt.Sprintf("K%s+%03d+%05d", sk.Name, algNum, sk.Keyid)
 	privPath := filepath.Join(outdir, base+".private")
 	keyPath := filepath.Join(outdir, base+".key")
+	for _, p := range []string{privPath, keyPath} {
+		if _, err := os.Stat(p); err == nil {
+			return fmt.Errorf("refusing to overwrite existing file %s (move or delete it first)", p)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat %s: %v", p, err)
+		}
+	}
 	if err := os.WriteFile(privPath, []byte(sk.PrivateKey), 0600); err != nil {
 		return fmt.Errorf("write %s: %v", privPath, err)
 	}

--- a/v2/cli/keystore_cmds.go
+++ b/v2/cli/keystore_cmds.go
@@ -241,7 +241,8 @@ func init() {
 	keystoreSig0SetStateCmd.Flags().IntVarP(&keyid, "keyid", "", 0, "Key ID of key to delete")
 	keystoreSig0SetStateCmd.Flags().StringVarP(&NewState, "state", "", "", "New state of key (created|published|active|retired)")
 	keystoreSig0GenerateCmd.Flags().StringVarP(&NewState, "state", "", "", "Inital key state (created|published|active|retired)")
-	keystoreSig0GenerateCmd.Flags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519", "Algorithm to use for key generation (default: ED25519)")
+	keystoreSig0GenerateCmd.Flags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519",
+		sig0AlgorithmsHelp("Algorithm to use for SIG(0) key generation"))
 	keystoreSig0GenerateCmd.MarkFlagRequired("state")
 
 	keystoreSig0ExportCmd.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone the key belongs to")
@@ -263,7 +264,8 @@ func init() {
 	keystoreDnssecSetStateCmd.Flags().StringVarP(&NewState, "state", "", "", "New statei of key")
 	keystoreDnssecGenerateCmd.Flags().StringVarP(&keytype, "keytype", "", "", "Key type to generate (KSK|ZSK|CSK)")
 	keystoreDnssecGenerateCmd.Flags().StringVarP(&NewState, "state", "", "", "Inital key state (created|published|active|retired)")
-	keystoreDnssecGenerateCmd.Flags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519", "Algorithm to use for key generation (default: ED25519)")
+	keystoreDnssecGenerateCmd.Flags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519",
+		dnssecAlgorithmsHelp("Algorithm to use for DNSSEC key generation"))
 	keystoreDnssecGenerateCmd.MarkFlagRequired("keytype")
 	keystoreDnssecGenerateCmd.MarkFlagRequired("state")
 	// keystoreDnssecGenerateCmd.MarkFlagRequired("algorithm") // XXX: marking it as required defeats the default value

--- a/v2/cli/keystore_cmds.go
+++ b/v2/cli/keystore_cmds.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,7 +21,7 @@ import (
 
 // var filename string
 var keyid int
-var NewState, filename, keytype string
+var NewState, filename, keytype, outdir string
 
 var KeystoreCmd = &cobra.Command{
 	Use:   "keystore",
@@ -75,6 +76,19 @@ var keystoreSig0ListCmd = &cobra.Command{
 	Short: "List all SIG(0) key pairs in the keystore",
 	Run: func(cmd *cobra.Command, args []string) {
 		Sig0KeyMgmt("list")
+	},
+}
+
+var keystoreSig0ExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export a SIG(0) key pair from the keystore as BIND-style .private/.key files",
+	Long: `Write the SIG(0) key pair for (zone, keyid) to two files in BIND filename
+convention: K<zone>+<alg-num>+<keyid>.private (PKCS#8 PEM) and .key (zone-file
+KEY RR). The resulting pair is directly consumable by commands accepting
+--key <basename.private>.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		PrepArgs("zonename", "keyid")
+		Sig0KeyMgmt("export")
 	},
 }
 
@@ -210,7 +224,7 @@ func init() {
 	KeystoreCmd.AddCommand(keystoreSig0Cmd, keystoreDnssecCmd)
 
 	keystoreSig0Cmd.AddCommand(keystoreSig0AddCmd, keystoreSig0ImportCmd, keystoreSig0GenerateCmd)
-	keystoreSig0Cmd.AddCommand(keystoreSig0ListCmd, keystoreSig0DeleteCmd, keystoreSig0SetStateCmd)
+	keystoreSig0Cmd.AddCommand(keystoreSig0ListCmd, keystoreSig0ExportCmd, keystoreSig0DeleteCmd, keystoreSig0SetStateCmd)
 
 	keystoreDnssecCmd.AddCommand(keystoreDnssecAddCmd, keystoreDnssecImportCmd, keystoreDnssecGenerateCmd)
 	keystoreDnssecCmd.AddCommand(keystoreDnssecListCmd, keystoreDnssecDeleteCmd, keystoreDnssecSetStateCmd, keystoreDnssecGenDSCmd, keystoreDnssecRolloverCmd, keystoreDnssecClearCmd)
@@ -229,6 +243,12 @@ func init() {
 	keystoreSig0GenerateCmd.Flags().StringVarP(&NewState, "state", "", "", "Inital key state (created|published|active|retired)")
 	keystoreSig0GenerateCmd.Flags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519", "Algorithm to use for key generation (default: ED25519)")
 	keystoreSig0GenerateCmd.MarkFlagRequired("state")
+
+	keystoreSig0ExportCmd.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone the key belongs to")
+	keystoreSig0ExportCmd.Flags().IntVarP(&keyid, "keyid", "", 0, "Key ID of key to export")
+	keystoreSig0ExportCmd.Flags().StringVarP(&outdir, "outdir", "o", ".", "Directory to write .private and .key files to")
+	keystoreSig0ExportCmd.MarkFlagRequired("zone")
+	keystoreSig0ExportCmd.MarkFlagRequired("keyid")
 
 	keystoreDnssecAddCmd.Flags().StringVarP(&filename, "file", "f", "", "Name of file containing either pub or priv SIG(0) data")
 	keystoreDnssecAddCmd.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to add DNSSEC key for")
@@ -310,7 +330,7 @@ func Sig0KeyMgmt(cmd string) {
 		data.Algorithm = dns.StringToAlgorithm[tdns.Globals.Algorithm]
 		data.State = NewState
 
-	case "delete", "setstate":
+	case "delete", "setstate", "export":
 		data.Keyid = uint16(keyid)
 		data.Zone = tdns.Globals.Zonename
 		data.Keyname = tdns.Globals.Zonename
@@ -362,7 +382,50 @@ func Sig0KeyMgmt(cmd string) {
 		if tr.Msg != "" {
 			fmt.Printf("%s\n", tr.Msg)
 		}
+
+	case "export":
+		if len(tr.Sig0keys) == 0 {
+			fmt.Printf("No key returned for zone %s keyid %d\n",
+				tdns.Globals.Zonename, keyid)
+			os.Exit(1)
+		}
+		for _, v := range tr.Sig0keys {
+			if err := writeSig0ExportFiles(v, outdir); err != nil {
+				fmt.Printf("Error writing key files: %v\n", err)
+				os.Exit(1)
+			}
+		}
+		if tr.Msg != "" {
+			fmt.Printf("%s\n", tr.Msg)
+		}
 	}
+}
+
+// writeSig0ExportFiles writes a SIG(0) key pair to two BIND-style files
+// in outdir: K<zone>+<alg>+<keyid>.private (PKCS#8 PEM as stored in the
+// keystore) and .key (zone-file KEY RR text). The resulting basename is
+// directly consumable by tdns.ReadPrivateKey.
+func writeSig0ExportFiles(sk tdns.Sig0Key, outdir string) error {
+	algNum, ok := dns.StringToAlgorithm[strings.ToUpper(sk.Algorithm)]
+	if !ok {
+		return fmt.Errorf("unknown algorithm %q in exported key", sk.Algorithm)
+	}
+	base := fmt.Sprintf("K%s+%03d+%05d", sk.Name, algNum, sk.Keyid)
+	privPath := filepath.Join(outdir, base+".private")
+	keyPath := filepath.Join(outdir, base+".key")
+	if err := os.WriteFile(privPath, []byte(sk.PrivateKey), 0600); err != nil {
+		return fmt.Errorf("write %s: %v", privPath, err)
+	}
+	keyRR := sk.Keystr
+	if !strings.HasSuffix(keyRR, "\n") {
+		keyRR += "\n"
+	}
+	if err := os.WriteFile(keyPath, []byte(keyRR), 0644); err != nil {
+		return fmt.Errorf("write %s: %v", keyPath, err)
+	}
+	fmt.Printf("Wrote %s\n", privPath)
+	fmt.Printf("Wrote %s\n", keyPath)
+	return nil
 }
 
 func DnssecKeyMgmt(cmd string) {

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -79,23 +79,37 @@ The zone to update is mandatory to specify on the command line with the --zone f
 	},
 }
 
-// init registers update-related Cobra subcommands and binds their command-line flags.
-// It wires the child, zone, and top-level update create commands and defines flags for
-// zone, parent, signer, server, and keyfile.
+// AttachUpdateCreateFlags adds the three flags common to every
+// "update create" entry point — --signer, --server, --key — to cmd,
+// bound to the package-level vars CreateUpdate reads. Use this from
+// every leaf create command (including cross-package ones in
+// tdns-mp/v2/cli) so the signer name, target server, and keyfile can
+// always be overridden from the CLI.
+func AttachUpdateCreateFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&signer, "signer", "", "",
+		"Name of signer (key used to sign the update; defaults to --zone)")
+	cmd.Flags().StringVarP(&server, "server", "S", "",
+		"Server to send the update to (addr:port)")
+	cmd.Flags().StringVarP(&keyfile, "key", "K", "",
+		"SIG(0) keyfile to use for signing (.private/.key basename)")
+}
+
+// init registers update-related Cobra subcommands and binds their
+// command-line flags.
 func init() {
 	ChildCmd.AddCommand(childUpdateCmd)
 	childUpdateCmd.AddCommand(childUpdateCreateCmd)
 	childUpdateCreateCmd.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to update")
 	childUpdateCreateCmd.Flags().StringVarP(&tdns.Globals.ParentZone, "parent", "P", "", "Parent zone to send update to")
+	AttachUpdateCreateFlags(childUpdateCreateCmd)
 
 	ZoneCmd.AddCommand(zoneUpdateCmd)
 	zoneUpdateCmd.AddCommand(zoneUpdateCreateCmd)
 	zoneUpdateCreateCmd.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to update")
+	AttachUpdateCreateFlags(zoneUpdateCreateCmd)
 
 	UpdateCmd.AddCommand(updateCreateCmd)
-	updateCreateCmd.Flags().StringVarP(&signer, "signer", "", "", "Name of signer (i.e. key used to sign update)")
-	updateCreateCmd.Flags().StringVarP(&server, "server", "S", "", "Server to send update to (in addr:port format)")
-	updateCreateCmd.Flags().StringVarP(&keyfile, "key", "K", "", "SIG(0) keyfile to use for signing the update")
+	AttachUpdateCreateFlags(updateCreateCmd)
 }
 
 // CreateUpdate starts an interactive CLI for composing, signing, and sending DNS UPDATEs.
@@ -133,20 +147,22 @@ func CreateUpdate(updateType string) {
 
 	if keyfile != "" {
 		pkc, err := tdns.ReadPrivateKey(keyfile)
-		if err != nil {
+		switch {
+		case err != nil:
 			fmt.Printf("Error reading SIG(0) key file '%s': %v\n", keyfile, err)
-			signing = true
-		}
-		if pkc.KeyType != dns.TypeKEY {
-			fmt.Printf("Keyfile did not contain a SIG(0) key\n")
-			signing = true
-		}
-		if signing {
-			fmt.Printf("Using keyfile %s\n", keyfile)
+		case pkc == nil:
+			fmt.Printf("Keyfile '%s' yielded no key\n", keyfile)
+		case pkc.KeyType != dns.TypeKEY:
+			fmt.Printf("Keyfile '%s' did not contain a SIG(0) key\n", keyfile)
+		default:
+			fmt.Printf("Using keyfile %s (signer=%s, keyid=%d)\n",
+				keyfile, pkc.KeyRR.Header().Name, pkc.KeyRR.KeyTag())
 			sak = &tdns.Sig0ActiveKeys{
 				Keys: []*tdns.PrivateKeyCache{pkc},
 			}
-		} else {
+			signing = true
+		}
+		if !signing {
 			fmt.Printf("Warning: no SIG(0) signing of update messages possible.\n")
 		}
 	} else {

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -382,6 +382,7 @@ cmdloop:
 			for {
 				rrstr = tdns.TtyQuestion("Record", "", false)
 				if rrstr == "" {
+					fmt.Println("[empty input, end of replacement additions]")
 					break
 				}
 				if strings.ToUpper(rrstr) == "QUIT" {

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -201,7 +201,13 @@ func CreateUpdate(updateType string) {
 			return nil, fmt.Errorf("error creating update: %v", err)
 		}
 		if len(delRRsets) > 0 {
+			// §2.5.2 deletes must precede adds in the Update section,
+			// otherwise the receiver applies them last and wipes the
+			// records we just inserted (RFC 2136 processes in order).
+			saved := updateMsg.Ns
+			updateMsg.Ns = nil
 			updateMsg.RemoveRRset(delRRsets)
+			updateMsg.Ns = append(updateMsg.Ns, saved...)
 		}
 
 		if keyfile != "" {
@@ -398,7 +404,10 @@ cmdloop:
 					continue
 				}
 				if len(delRRsets) > 0 {
+					saved := preview.Ns
+					preview.Ns = nil
 					preview.RemoveRRset(delRRsets)
+					preview.Ns = append(preview.Ns, saved...)
 					fmt.Printf("With DEL-RRSET attached:\n%s\n", preview.String())
 				}
 				tdns.Globals.Debug = false

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -346,6 +346,10 @@ cmdloop:
 			// like "foo.bar. IN NS" — first token is owner, scan the
 			// rest for a type, skip class/TTL tokens.
 			fields := strings.Fields(input)
+			if len(fields) == 0 {
+				fmt.Println("No owner name provided")
+				continue
+			}
 			owner := dns.Fqdn(fields[0])
 			var rrtype uint16
 			for _, tok := range fields[1:] {

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -130,10 +130,42 @@ func CreateUpdate(updateType string) {
 		os.Exit(1)
 	}
 
-	var adds, removes, delRRsets []dns.RR
+	// Single ordered list of update actions. RFC 2136 processes the
+	// Update section in order on the receiver, so we must preserve the
+	// exact entry sequence — separate add/del/del-rrset slices would
+	// reshuffle them.
+	type updateAction struct {
+		op string // "add" | "del" | "del-rrset"
+		rr dns.RR
+	}
+	var actions []updateAction
 
 	var ttl int = 60
 	var op, rrstr, port string
+
+	// buildUpdate assembles a *dns.Msg from the ordered actions list
+	// using the library helpers (Insert/Remove/RemoveRRset) one record
+	// at a time, so each one gets the correct class/rdata treatment
+	// without losing entry order.
+	buildUpdate := func() (*dns.Msg, error) {
+		if zone == "" || zone == "." {
+			return nil, fmt.Errorf("zone not set")
+		}
+		m := new(dns.Msg)
+		m.SetUpdate(zone)
+		for _, a := range actions {
+			switch a.op {
+			case "add":
+				m.Insert([]dns.RR{a.rr})
+			case "del":
+				m.Remove([]dns.RR{a.rr})
+			case "del-rrset":
+				m.RemoveRRset([]dns.RR{a.rr})
+			}
+		}
+		m.SetEdns0(1232, true)
+		return m, nil
+	}
 
 	zone = dns.Fqdn(tdns.Globals.Zonename)
 	if signer == "" {
@@ -191,23 +223,14 @@ func CreateUpdate(updateType string) {
 			fmt.Println("Target zone not set, please set it first")
 			return nil, fmt.Errorf("target zone not set")
 		}
-		if len(adds) == 0 && len(removes) == 0 && len(delRRsets) == 0 {
+		if len(actions) == 0 {
 			fmt.Println("No records to send, please add or delete some records first")
 			return nil, fmt.Errorf("no records to send")
 		}
-		updateMsg, err := tdns.CreateUpdate(zone, adds, removes)
+		updateMsg, err := buildUpdate()
 		if err != nil {
 			fmt.Printf("Error creating update: %v\n", err)
 			return nil, fmt.Errorf("error creating update: %v", err)
-		}
-		if len(delRRsets) > 0 {
-			// §2.5.2 deletes must precede adds in the Update section,
-			// otherwise the receiver applies them last and wipes the
-			// records we just inserted (RFC 2136 processes in order).
-			saved := updateMsg.Ns
-			updateMsg.Ns = nil
-			updateMsg.RemoveRRset(delRRsets)
-			updateMsg.Ns = append(updateMsg.Ns, saved...)
 		}
 
 		if keyfile != "" {
@@ -296,30 +319,17 @@ cmdloop:
 				rr.Header().Ttl = uint32(ttl)
 			}
 
-			if op == "add" {
-				duplicate := false
-				for _, arr := range adds {
-					if dns.IsDuplicate(rr, arr) {
-						fmt.Printf("Record already added: %s\n", rrstr)
-						duplicate = true
-						break
-					}
+			wantOp := op // "add" or "del"
+			duplicate := false
+			for _, a := range actions {
+				if a.op == wantOp && dns.IsDuplicate(rr, a.rr) {
+					fmt.Printf("Record already %sed: %s\n", wantOp, rrstr)
+					duplicate = true
+					break
 				}
-				if !duplicate {
-					adds = append(adds, rr)
-				}
-			} else {
-				duplicate := false
-				for _, rrr := range removes {
-					if dns.IsDuplicate(rr, rrr) {
-						fmt.Printf("Record already removed: %s\n", rrstr)
-						duplicate = true
-						break
-					}
-				}
-				if !duplicate {
-					removes = append(removes, rr)
-				}
+			}
+			if !duplicate {
+				actions = append(actions, updateAction{op: wantOp, rr: rr})
 			}
 
 		case "replace":
@@ -354,10 +364,13 @@ cmdloop:
 				rrtype = t
 			}
 
-			// Queue the §2.5.2 delete-RRset. Only Name+Rrtype are read by
-			// m.RemoveRRset — it emits a CLASS ANY / empty-rdata record.
-			delRRsets = append(delRRsets,
-				&dns.ANY{Hdr: dns.RR_Header{Name: owner, Rrtype: rrtype}})
+			// Queue the §2.5.2 delete-RRset first, then the replacement
+			// adds, in entry order. m.RemoveRRset only reads Name+Rrtype
+			// from the placeholder.
+			actions = append(actions, updateAction{
+				op: "del-rrset",
+				rr: &dns.ANY{Hdr: dns.RR_Header{Name: owner, Rrtype: rrtype}},
+			})
 			fmt.Printf("Queued DEL-RRSET for %s %s\n",
 				owner, dns.TypeToString[rrtype])
 
@@ -387,7 +400,7 @@ cmdloop:
 				if ttl > 0 {
 					rr.Header().Ttl = uint32(ttl)
 				}
-				adds = append(adds, rr)
+				actions = append(actions, updateAction{op: "add", rr: rr})
 			}
 
 		case "show":
@@ -397,34 +410,26 @@ cmdloop:
 			}
 			if msg == nil {
 				var out = []string{"Operation|Record"}
-				for _, rr := range adds {
-					out = append(out, fmt.Sprintf("ADD|%s", rr.String()))
-				}
-				for _, rr := range removes {
-					out = append(out, fmt.Sprintf("DEL|%s", rr.String()))
-				}
-				for _, rr := range delRRsets {
-					h := rr.Header()
-					out = append(out, fmt.Sprintf("DEL-RRSET|%s %s",
-						h.Name, dns.TypeToString[h.Rrtype]))
+				for _, a := range actions {
+					switch a.op {
+					case "add":
+						out = append(out, fmt.Sprintf("ADD|%s", a.rr.String()))
+					case "del":
+						out = append(out, fmt.Sprintf("DEL|%s", a.rr.String()))
+					case "del-rrset":
+						h := a.rr.Header()
+						out = append(out, fmt.Sprintf("DEL-RRSET|%s %s",
+							h.Name, dns.TypeToString[h.Rrtype]))
+					}
 				}
 				fmt.Println(columnize.SimpleFormat(out))
 
-				tdns.Globals.Debug = true
-				preview, err := tdns.CreateUpdate(zone, adds, removes)
+				preview, err := buildUpdate()
 				if err != nil {
 					fmt.Printf("Error creating update: %v\n", err)
-					tdns.Globals.Debug = false
 					continue
 				}
-				if len(delRRsets) > 0 {
-					saved := preview.Ns
-					preview.Ns = nil
-					preview.RemoveRRset(delRRsets)
-					preview.Ns = append(preview.Ns, saved...)
-					fmt.Printf("With DEL-RRSET attached:\n%s\n", preview.String())
-				}
-				tdns.Globals.Debug = false
+				fmt.Printf("Update message:\n%s\n", preview.String())
 			} else {
 				fmt.Printf("Update message:\n%s\n", msg.String())
 			}
@@ -476,9 +481,7 @@ cmdloop:
 			PrintUpdateResult(ur)
 			fmt.Printf("Update sent, rcode: %d (%s)\n", rcode, dns.RcodeToString[rcode])
 
-			adds = []dns.RR{}
-			removes = []dns.RR{}
-			delRRsets = []dns.RR{}
+			actions = nil
 			msg = nil
 			msgSigned = false
 		}

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -130,7 +130,7 @@ func CreateUpdate(updateType string) {
 		os.Exit(1)
 	}
 
-	var adds, removes []dns.RR
+	var adds, removes, delRRsets []dns.RR
 
 	var ttl int = 60
 	var op, rrstr, port string
@@ -177,7 +177,7 @@ func CreateUpdate(updateType string) {
 		fmt.Printf("Update will be sent to zone %s\n", zone)
 	}
 
-	var ops = []string{"zone", "add", "del", "show", "send", "sign", "set-ttl", "server", "quit"}
+	var ops = []string{"zone", "add", "del", "replace", "show", "send", "sign", "set-ttl", "server", "quit"}
 	fmt.Printf("Defined operations are: %v\n", ops)
 
 	var msgSigned bool = false
@@ -191,7 +191,7 @@ func CreateUpdate(updateType string) {
 			fmt.Println("Target zone not set, please set it first")
 			return nil, fmt.Errorf("target zone not set")
 		}
-		if len(adds) == 0 && len(removes) == 0 {
+		if len(adds) == 0 && len(removes) == 0 && len(delRRsets) == 0 {
 			fmt.Println("No records to send, please add or delete some records first")
 			return nil, fmt.Errorf("no records to send")
 		}
@@ -199,6 +199,9 @@ func CreateUpdate(updateType string) {
 		if err != nil {
 			fmt.Printf("Error creating update: %v\n", err)
 			return nil, fmt.Errorf("error creating update: %v", err)
+		}
+		if len(delRRsets) > 0 {
+			updateMsg.RemoveRRset(delRRsets)
 		}
 
 		if keyfile != "" {
@@ -313,6 +316,60 @@ cmdloop:
 				}
 			}
 
+		case "replace":
+			if zone == "." {
+				fmt.Println("Target zone not set, please set it first")
+				continue
+			}
+			owner := tdns.TtyQuestion("Owner name of RRset to replace", "", true)
+			if strings.ToUpper(owner) == "QUIT" {
+				break cmdloop
+			}
+			owner = dns.Fqdn(owner)
+
+			typestr := tdns.TtyQuestion("RR type", "A", true)
+			rrtype, ok := dns.StringToType[strings.ToUpper(typestr)]
+			if !ok {
+				fmt.Printf("Unknown RR type: %s\n", typestr)
+				continue
+			}
+
+			// Queue the §2.5.2 delete-RRset. Only Name+Rrtype are read by
+			// m.RemoveRRset — it emits a CLASS ANY / empty-rdata record.
+			delRRsets = append(delRRsets,
+				&dns.ANY{Hdr: dns.RR_Header{Name: owner, Rrtype: rrtype}})
+			fmt.Printf("Queued DEL-RRSET for %s %s\n",
+				owner, dns.TypeToString[rrtype])
+
+			fmt.Println("Enter replacement records (blank line to finish):")
+			for {
+				rrstr = tdns.TtyQuestion("Record", "", false)
+				if rrstr == "" {
+					break
+				}
+				if strings.ToUpper(rrstr) == "QUIT" {
+					break cmdloop
+				}
+				rr, err := dns.NewRR(rrstr)
+				if err != nil {
+					fmt.Printf("Error parsing RR: %v\n", err)
+					continue
+				}
+				if rr.Header().Name != owner {
+					fmt.Printf("Warning: record owner %q differs from RRset owner %q\n",
+						rr.Header().Name, owner)
+				}
+				if rr.Header().Rrtype != rrtype {
+					fmt.Printf("Warning: record type %s differs from RRset type %s\n",
+						dns.TypeToString[rr.Header().Rrtype],
+						dns.TypeToString[rrtype])
+				}
+				if ttl > 0 {
+					rr.Header().Ttl = uint32(ttl)
+				}
+				adds = append(adds, rr)
+			}
+
 		case "show":
 			if zone == "." {
 				fmt.Println("Target zone not set, please set it first")
@@ -326,13 +383,23 @@ cmdloop:
 				for _, rr := range removes {
 					out = append(out, fmt.Sprintf("DEL|%s", rr.String()))
 				}
+				for _, rr := range delRRsets {
+					h := rr.Header()
+					out = append(out, fmt.Sprintf("DEL-RRSET|%s %s",
+						h.Name, dns.TypeToString[h.Rrtype]))
+				}
 				fmt.Println(columnize.SimpleFormat(out))
 
 				tdns.Globals.Debug = true
-				_, err := tdns.CreateUpdate(zone, adds, removes)
+				preview, err := tdns.CreateUpdate(zone, adds, removes)
 				if err != nil {
 					fmt.Printf("Error creating update: %v\n", err)
+					tdns.Globals.Debug = false
 					continue
+				}
+				if len(delRRsets) > 0 {
+					preview.RemoveRRset(delRRsets)
+					fmt.Printf("With DEL-RRSET attached:\n%s\n", preview.String())
 				}
 				tdns.Globals.Debug = false
 			} else {
@@ -388,6 +455,7 @@ cmdloop:
 
 			adds = []dns.RR{}
 			removes = []dns.RR{}
+			delRRsets = []dns.RR{}
 			msg = nil
 			msgSigned = false
 		}

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -327,17 +327,31 @@ cmdloop:
 				fmt.Println("Target zone not set, please set it first")
 				continue
 			}
-			owner := tdns.TtyQuestion("Owner name of RRset to replace", "", true)
-			if strings.ToUpper(owner) == "QUIT" {
+			input := tdns.TtyQuestion("Owner name of RRset to replace (e.g. 'foo.bar. NS')", "", true)
+			if strings.ToUpper(input) == "QUIT" {
 				break cmdloop
 			}
-			owner = dns.Fqdn(owner)
 
-			typestr := tdns.TtyQuestion("RR type", "A", true)
-			rrtype, ok := dns.StringToType[strings.ToUpper(typestr)]
-			if !ok {
-				fmt.Printf("Unknown RR type: %s\n", typestr)
-				continue
+			// Accept either a bare owner name or an RR-style prefix
+			// like "foo.bar. IN NS" — first token is owner, scan the
+			// rest for a type, skip class/TTL tokens.
+			fields := strings.Fields(input)
+			owner := dns.Fqdn(fields[0])
+			var rrtype uint16
+			for _, tok := range fields[1:] {
+				if t, ok := dns.StringToType[strings.ToUpper(tok)]; ok {
+					rrtype = t
+					break
+				}
+			}
+			if rrtype == 0 {
+				typestr := tdns.TtyQuestion("RR type", "A", true)
+				t, ok := dns.StringToType[strings.ToUpper(typestr)]
+				if !ok {
+					fmt.Printf("Unknown RR type: %s\n", typestr)
+					continue
+				}
+				rrtype = t
 			}
 
 			// Queue the §2.5.2 delete-RRset. Only Name+Rrtype are read by

--- a/v2/cli/zone_dsync_cmds.go
+++ b/v2/cli/zone_dsync_cmds.go
@@ -172,8 +172,10 @@ func init() {
 	ZoneCmd.AddCommand(zoneDsyncCmd)
 	zoneDsyncCmd.AddCommand(zoneDsyncStatusCmd, zoneDsyncBootstrapCmd, zoneDsyncRollKeyCmd, zoneDsyncPublishCmd, zoneDsyncUnpublishCmd)
 
-	zoneDsyncRollKeyCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519", "Algorithm to use for the new SIG(0) key")
-	zoneDsyncBootstrapCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519", "Algorithm to use for the new SIG(0) key")
+	zoneDsyncRollKeyCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519",
+		sig0AlgorithmsHelp("Algorithm for the new SIG(0) key"))
+	zoneDsyncBootstrapCmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", "ED25519",
+		sig0AlgorithmsHelp("Algorithm for the new SIG(0) key"))
 	zoneDsyncRollKeyCmd.PersistentFlags().StringVarP(&rollaction, "rollaction", "r", "complete", "[debug] Phase of the rollover to perform: complete, add, remove, update-local")
 	zoneDsyncRollKeyCmd.PersistentFlags().MarkHidden("rollaction")
 }

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -182,6 +182,35 @@ SELECT zonename, state, keyid, algorithm, creator, privatekey, keyrr FROM Sig0Ke
 		txSuccess = true
 		return &resp, err
 
+	case "export":
+		const getOneSig0KeySql = `
+SELECT zonename, state, keyid, algorithm, creator, privatekey, keyrr FROM Sig0KeyStore WHERE zonename=? AND keyid=?`
+		row := tx.QueryRow(getOneSig0KeySql, kp.Zone, kp.Keyid)
+		var zonename, state, algorithm, creator, privatekey, keyrrstr string
+		var keyid int
+		err := row.Scan(&zonename, &state, &keyid, &algorithm, &creator, &privatekey, &keyrrstr)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				resp.Error = true
+				resp.ErrorMsg = fmt.Sprintf("SIG(0) key for zone %q keyid %d not found", kp.Zone, kp.Keyid)
+				return &resp, nil
+			}
+			return &resp, fmt.Errorf("error from row.Scan(): %v", err)
+		}
+		mapkey := fmt.Sprintf("%s::%d", zonename, keyid)
+		resp.Sig0keys = map[string]Sig0Key{
+			mapkey: {
+				Name:       zonename,
+				State:      state,
+				Keyid:      uint16(keyid),
+				Algorithm:  algorithm,
+				Creator:    creator,
+				PrivateKey: privatekey, // unredacted: export intentionally surfaces it
+				Keystr:     keyrrstr,
+			},
+		}
+		resp.Msg = fmt.Sprintf("Exported SIG(0) key %s keyid %d", zonename, keyid)
+
 	case "setstate":
 		res, err = tx.Exec(setStateSig0KeySql, kp.State, kp.Keyname, kp.Keyid)
 		if err != nil {

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -183,9 +183,7 @@ SELECT zonename, state, keyid, algorithm, creator, privatekey, keyrr FROM Sig0Ke
 		return &resp, err
 
 	case "export":
-		const getOneSig0KeySql = `
-SELECT zonename, state, keyid, algorithm, creator, privatekey, keyrr FROM Sig0KeyStore WHERE zonename=? AND keyid=?`
-		row := tx.QueryRow(getOneSig0KeySql, kp.Zone, kp.Keyid)
+		row := tx.QueryRow(getSig0KeySql, kp.Zone, kp.Keyid)
 		var zonename, state, algorithm, creator, privatekey, keyrrstr string
 		var keyid int
 		err := row.Scan(&zonename, &state, &keyid, &algorithm, &creator, &privatekey, &keyrrstr)

--- a/v2/tty_utils.go
+++ b/v2/tty_utils.go
@@ -25,8 +25,8 @@ func TtyQuestion(query, oldval string, force bool) string {
 		fmt.Printf("%s [%s]: ", query, oldval)
 		text, _ := reader.ReadString('\n')
 		if text == "\n" {
-			fmt.Printf("[empty response, keeping previous value]\n")
 			if oldval != "" {
+				fmt.Printf("[empty response, keeping previous value]\n")
 				return oldval // all ok
 			} else if force {
 				fmt.Printf("[error: previous value was empty string, not allowed]\n")


### PR DESCRIPTION
## Summary

Eight commits cherry-picked from \`mldsa44-sig0-fork\`, containing only the generic CLI improvements and one real bug fix. All PQC / ML-DSA-44 code, the \`johanix/dns\` fork pin, and the CIRCL dependency are deliberately held back.

**Contents:**
- \`update create\`: decouple signer identity from target zone; fix nil-panic on keyfile failures
- \`keystore sig0 export\` + surface \`db.file\` in \`config status -v\`
- Interactive \`update create\`: new 'replace' op (RFC 2136 §2.5.2), entry-order action tracking, fixes to DEL-RRSET ordering, \`owner [class] type\` input parsing
- Auto-switch to TCP for oversized DNS UPDATEs (fires on msg.Len() > advertised EDNS UDP size)
- Centralised \`SupportedSig0Algorithms\` / \`SupportedDnssecAlgorithms\` + \`--algorithm\` help-text integration (\`MLDSA44\` trimmed from the list — follow-up commit — since the fork/keystore support isn't on main)

**Companion PR:** johanix/tdns-mp#TBD (one-line wiring of \`AttachUpdateCreateFlags\` in \`agent zone update create\`).

## Test plan

- [x] \`cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make\` — builds clean
- [x] Companion tdns-mp branch builds clean against this branch
- [ ] Smoke-test \`update create\` interactive flow on NetBSD VM
- [ ] Smoke-test \`keystore sig0 export\` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SIG(0) key export command to export keys in BIND-compatible format.
  * Database file path now displayed in configuration responses.
  * New "replace" operation for interactive DNS updates.

* **Improvements**
  * Large DNS updates now automatically use TCP transport when needed.
  * Algorithm help text dynamically generated and more informative.
  * Enhanced error handling and logging for SIG(0) key operations.
  * Interactive update workflow now preserves exact entry sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->