### PR TITLE
cli: apiclient registry; drop tdns.Globals.Api (in tdns/v2/cli)

### DIFF
--- a/cmdv2/cliv2/root.go
+++ b/cmdv2/cliv2/root.go
@@ -120,91 +120,15 @@ func initConfig() {
 	}
 
 	cli.ValidateConfig(nil, cfgFileUsed) // will terminate on error
-	err := viper.Unmarshal(&cconf)
-	if err != nil {
-		// viper.Unmarshal failure means cconf is empty/invalid
-		// This will cause initApi() to run with empty cconf.ApiServers
-		// which leaves tdns.Globals.Api uninitialized
-		log.Fatalf("FATAL: viper.Unmarshal failed to parse config into cconf: %v\nThis would leave cconf.ApiServers empty and break initApi()/tdns.Globals.Api initialization", err)
+	if err := viper.Unmarshal(&cconf); err != nil {
+		log.Fatalf("FATAL: viper.Unmarshal failed to parse config: %v", err)
 	}
 }
 
-var cconf CliConf
-
-// var ApiClients = map[string]*tdns.ApiClient{}
-
-type CliConf struct {
-	ApiServers []ApiDetails
-	Keys	   tdns.KeyConf
-}
-
-type ApiDetails struct {
-	Name       string `validate:"required" yaml:"name"`
-	BaseURL    string `validate:"required" yaml:"baseurl"`
-	ApiKey     string `validate:"required" yaml:"apikey"`
-	AuthMethod string `validate:"required" yaml:"authmethod"`
-	RootCA     string `yaml:"rootca"`             // Optional: path to root CA cert, or "insecure" to skip verification
-	Command    string `yaml:"command,omitempty"`  // Optional: command to start the daemon (e.g., "/usr/local/libexec/tdns-auth")
-	ConfigFile string `yaml:"config_file,omitempty"` // Optional: path to server config (for keys generate/show)
-}
+var cconf cli.CliConf
 
 func initApi() {
-	if tdns.Globals.Debug {
-		fmt.Printf("initApi: setting up API clients for:")
-	}
-	for _, val := range cconf.ApiServers {
-		// Validate the conf for this apiserver
-		// Use configured RootCA, or default to "insecure" if not specified
-		rootCA := val.RootCA
-		if rootCA == "" {
-			rootCA = "insecure" // Default: skip TLS verification
-		}
-		
-		tmp := tdns.NewClient(val.Name, val.BaseURL, val.ApiKey, val.AuthMethod, rootCA)
-		if tmp == nil {
-			log.Fatalf("initApi: Failed to setup API client for %q (baseurl: %s, rootca: %s). Exiting.", val.Name, val.BaseURL, rootCA)
-		}
-		tdns.Globals.ApiClients[val.Name] = tmp
-		if tdns.Globals.Debug {
-			// fmt.Printf("API client for %q set up (baseurl: %q).\n", val.Name, tmp.BaseUrl)
-			fmt.Printf(" %s ", val.Name)
-		}
-	}
-	if tdns.Globals.Debug {
-		fmt.Printf("\n")
-	}
-
-	// Validate that "tdns-auth" API client exists before assigning to tdns.Globals.Api
-	// This prevents nil dereferences in downstream code that assumes Api is non-nil
-	authClient, exists := tdns.Globals.ApiClients["tdns-auth"]
-	if !exists || authClient == nil {
-		log.Fatalf("FATAL: No API server named 'tdns-auth' found in ApiServers configuration.\n" +
-			"tdns.Globals.Api requires a configured ApiServer with name: 'tdns-auth'\n" +
-			"Please add to your config:\n" +
-			"  api_servers:\n" +
-			"    - name: tdns-auth\n" +
-			"      baseurl: http://localhost:8080\n" +
-			"      apikey: your-api-key\n" +
-			"      authmethod: X-API-Key")
-	}
-
-	// for convenience we store the API client for "tdns-auth" in the old place also
-	tdns.Globals.Api = authClient
-
-//	numtsigs := len(cconf.Keys.Tsig)
-//	if numtsigs > 0 {
-//		tdns.Globals.TsigKeys = make(map[string]*tdns.TsigDetails, numtsigs)
-//		for _, val := range cconf.Keys.Tsig {
-//			tdns.Globals.TsigKeys[val.Name] = &tdns.TsigDetails{
-//								Name:		val.Name,
-//								Algorithm:	val.Algorithm,
-//								Secret:		val.Secret,
-//							  }
-//		}
-//	}
-
-	numtsigs, _ := tdns.ParseTsigKeys(&cconf.Keys)
-	if tdns.Globals.Debug {
-		fmt.Printf("Parsed %d TSIG keys\n", numtsigs)
+	if err := cli.InitApiClients(&cconf); err != nil {
+		log.Fatalf("FATAL: %v", err)
 	}
 }

--- a/cmdv2/cliv2/shared_cmds.go
+++ b/cmdv2/cliv2/shared_cmds.go
@@ -12,22 +12,21 @@ func init() {
 	rootCmd.AddCommand(cli.DbCmd)
 
 	// From ../tdns/cli/start_cmds.go:
-	// Root-level ping preserves the historic "server" default (tdns-auth client).
-	rootCmd.AddCommand(cli.NewPingCmd("server"))
+	// Root-level ping targets the auth daemon.
+	rootCmd.AddCommand(cli.NewPingCmd("auth"))
 
 	// From ../tdns/cli/report.go:
 	rootCmd.AddCommand(cli.ReportCmd)
 
-	rootCmd.AddCommand(cli.NewDaemonCmd("server"))
+	rootCmd.AddCommand(cli.NewDaemonCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewDaemonCmd("agent"))
 
 	// From ../tdns/cli/ddns_cmds.go:
 	rootCmd.AddCommand(cli.DdnsCmd, cli.DelCmd)
 
 	// From ../tdns/cli/debug_cmds.go:
-	rootCmd.AddCommand(cli.DebugCmd)
-	cli.AgentCmd.AddCommand(cli.DebugCmd)
-	//	cli.CombinerCmd.AddCommand(cli.DebugCmd)
+	rootCmd.AddCommand(cli.NewDebugCmd("auth"))
+	cli.AgentCmd.AddCommand(cli.NewDebugCmd("agent"))
 
 	// Keystore and truststore are under AuthCmd and AgentCmd
 	// (wired in cli/auth_cmds.go init). Agent also gets them:
@@ -38,7 +37,7 @@ func init() {
 	rootCmd.AddCommand(cli.DsyncDiscoveryCmd)
 
 	// From ../tdns/cli/config_cmds.go:
-	rootCmd.AddCommand(cli.NewConfigCmd("server"))
+	rootCmd.AddCommand(cli.NewConfigCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewConfigCmd("agent"))
 
 	// From ../tdns/cli/generate_cmds.go:
@@ -48,7 +47,7 @@ func init() {
 	rootCmd.AddCommand(cli.NotifyCmd)
 
 	// From ../tdns/cli/commands.go:
-	rootCmd.AddCommand(cli.StopCmd)
+	rootCmd.AddCommand(cli.NewStopCmd("auth"))
 
 	// From ../tdns/cli/combiner_cmds.go:
 	//	rootCmd.AddCommand(cli.CombinerCmd)

--- a/v2/cli/apiclient.go
+++ b/v2/cli/apiclient.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Johan Stenstam, johani@johani.org
+ *
+ * API client configuration, role → clientKey registry, and the
+ * shared InitApiClients helper used by each CLI binary's root.go.
+ */
+package cli
+
+import (
+	"fmt"
+	"log"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+// ApiDetails is one entry in the apiservers list of a CLI config file.
+type ApiDetails struct {
+	Name       string `validate:"required" yaml:"name"`
+	BaseURL    string `validate:"required" yaml:"baseurl"`
+	ApiKey     string `validate:"required" yaml:"apikey"`
+	AuthMethod string `validate:"required" yaml:"authmethod"`
+	RootCA     string `yaml:"rootca"`
+	Command    string `yaml:"command,omitempty"`
+	ConfigFile string `yaml:"config_file,omitempty"`
+}
+
+// CliConf is the parsed CLI config. Each CLI binary's root.go populates
+// one of these (currently via viper + Unmarshal) and hands it to
+// InitApiClients.
+type CliConf struct {
+	ApiServers []ApiDetails
+	Keys       tdns.KeyConf
+}
+
+// roleToClientKey maps Cobra-tree role names (e.g. "agent", "signer")
+// to the clientKey used to look up the ApiClient in
+// tdns.Globals.ApiClients (e.g. "tdns-agent", "tdns-mpsigner").
+//
+// Each CLI package owns the roles for the daemons it interacts with
+// and registers them via RegisterRole in its own init(). Downstream
+// packages (e.g. tdns-mp/v2/cli) can override entries set by upstream
+// packages; the per-binary effective map is the union of whichever
+// cli packages the binary imports.
+var roleToClientKey = map[string]string{}
+
+// RegisterRole associates role with clientKey. Later calls for the
+// same role override earlier ones — this is how tdns-mp overrides the
+// "agent" → "tdns-agent" default with "agent" → "tdns-mpagent".
+//
+// Safe only from init() (map is not concurrency-safe; init ordering
+// inside a package is deterministic, across imported packages it is
+// topological and thus deterministic for override purposes).
+func RegisterRole(role, clientKey string) {
+	roleToClientKey[role] = clientKey
+}
+
+func init() {
+	// tdns-owned roles. Downstream cli packages register their own
+	// daemons' roles (signer/combiner/agent→mpagent in tdns-mp,
+	// scanner in tdns-apps, kdc/krs in tdns-nm, …).
+	RegisterRole("auth", "tdns-auth")
+	RegisterRole("server", "tdns-auth") // root-level default
+	RegisterRole("imr", "tdns-imr")
+	RegisterRole("agent", "tdns-agent")
+}
+
+// apiConfig is the most recent CliConf passed to InitApiClients. Used
+// by getApiDetailsByClientKey to look up per-server config (command
+// path for "daemon start", config_file for "keys generate", etc.)
+// without reaching back into viper.
+var apiConfig *CliConf
+
+// InitApiClients creates a tdns.ApiClient for every entry in
+// c.ApiServers and stashes them in tdns.Globals.ApiClients. Also
+// parses TSIG keys from c.Keys and records c for later config
+// lookups.
+//
+// Unlike the previous per-binary implementations, this does *not*
+// require a client named "tdns-auth". tdns.Globals.Api is set from
+// the "tdns-auth" client only if one happens to be configured;
+// callers that still use Globals.Api directly will fail at use-time
+// if it's nil.
+func InitApiClients(c *CliConf) error {
+	if c == nil {
+		return fmt.Errorf("InitApiClients: nil CliConf")
+	}
+
+	if tdns.Globals.Debug {
+		fmt.Printf("InitApiClients: setting up API clients for:")
+	}
+	for _, val := range c.ApiServers {
+		rootCA := val.RootCA
+		if rootCA == "" {
+			rootCA = "insecure" // default: skip TLS verification
+		}
+		ac := tdns.NewClient(val.Name, val.BaseURL, val.ApiKey, val.AuthMethod, rootCA)
+		if ac == nil {
+			return fmt.Errorf("InitApiClients: failed to setup API client for %q (baseurl: %s, rootca: %s)",
+				val.Name, val.BaseURL, rootCA)
+		}
+		tdns.Globals.ApiClients[val.Name] = ac
+		if tdns.Globals.Debug {
+			fmt.Printf(" %s", val.Name)
+		}
+	}
+	if tdns.Globals.Debug {
+		fmt.Printf("\n")
+	}
+
+	// Legacy convenience: tdns.Globals.Api still used directly by some
+	// CLI handlers (commands.go, debug_cmds.go, ddns_cmds.go,
+	// zone_dsync_cmds.go — tracked for cleanup). Point it at the
+	// tdns-auth client when available; leave nil otherwise.
+	if authClient, ok := tdns.Globals.ApiClients["tdns-auth"]; ok {
+		tdns.Globals.Api = authClient
+	}
+
+	apiConfig = c
+
+	numtsigs, _ := tdns.ParseTsigKeys(&c.Keys)
+	if tdns.Globals.Debug {
+		fmt.Printf("Parsed %d TSIG keys\n", numtsigs)
+	}
+
+	return nil
+}
+
+// GetApiClient returns the configured ApiClient for the given role.
+// The role is resolved to a clientKey via the RegisterRole registry
+// and looked up in tdns.Globals.ApiClients. dieOnError controls
+// whether unknown/missing roles terminate the process.
+func GetApiClient(role string, dieOnError bool) (*tdns.ApiClient, error) {
+	clientKey := getClientKeyFromParent(role)
+	if clientKey == "" {
+		if dieOnError {
+			log.Fatalf("Unknown role: %s", role)
+		}
+		return nil, fmt.Errorf("unknown role: %s", role)
+	}
+
+	client := tdns.Globals.ApiClients[clientKey]
+	if client == nil {
+		if dieOnError {
+			keys := make([]string, 0, len(tdns.Globals.ApiClients))
+			for k := range tdns.Globals.ApiClients {
+				keys = append(keys, k)
+			}
+			log.Fatalf("No API client found for %s (have clients for: %v)", clientKey, keys)
+		}
+		return nil, fmt.Errorf("no API client found for %s", clientKey)
+	}
+
+	if tdns.Globals.Debug {
+		fmt.Printf("Using API client for %q:\nBaseUrl: %s\n", clientKey, client.BaseUrl)
+	}
+	return client, nil
+}
+
+func getClientKeyFromParent(role string) string {
+	return roleToClientKey[role]
+}
+
+// getApiDetailsByClientKey returns the ApiDetails entry whose Name
+// matches clientKey, or nil if no such entry exists. Data comes from
+// the CliConf handed to InitApiClients — no viper reach-through.
+func getApiDetailsByClientKey(clientKey string) *ApiDetails {
+	if apiConfig == nil {
+		return nil
+	}
+	for i := range apiConfig.ApiServers {
+		if apiConfig.ApiServers[i].Name == clientKey {
+			return &apiConfig.ApiServers[i]
+		}
+	}
+	return nil
+}

--- a/v2/cli/apiclient.go
+++ b/v2/cli/apiclient.go
@@ -59,7 +59,6 @@ func init() {
 	// daemons' roles (signer/combiner/agent→mpagent in tdns-mp,
 	// scanner in tdns-apps, kdc/krs in tdns-nm, …).
 	RegisterRole("auth", "tdns-auth")
-	RegisterRole("server", "tdns-auth") // root-level default
 	RegisterRole("imr", "tdns-imr")
 	RegisterRole("agent", "tdns-agent")
 }
@@ -76,10 +75,9 @@ var apiConfig *CliConf
 // lookups.
 //
 // Unlike the previous per-binary implementations, this does *not*
-// require a client named "tdns-auth". tdns.Globals.Api is set from
-// the "tdns-auth" client only if one happens to be configured;
-// callers that still use Globals.Api directly will fail at use-time
-// if it's nil.
+// require a client named "tdns-auth". Callers resolve their ApiClient
+// via GetApiClient(role, …) and get a use-time failure if the role
+// they need isn't configured.
 func InitApiClients(c *CliConf) error {
 	if c == nil {
 		return fmt.Errorf("InitApiClients: nil CliConf")
@@ -107,10 +105,11 @@ func InitApiClients(c *CliConf) error {
 		fmt.Printf("\n")
 	}
 
-	// Legacy convenience: tdns.Globals.Api still used directly by some
-	// CLI handlers (commands.go, debug_cmds.go, ddns_cmds.go,
-	// zone_dsync_cmds.go — tracked for cleanup). Point it at the
-	// tdns-auth client when available; leave nil otherwise.
+	// Shim: tdns.Globals.Api is still used by external packages
+	// (tdns-es, tdns-nm, tdns/music). Point it at the tdns-auth client
+	// when available so those keep working. Nothing inside tdns/v2/cli
+	// reads it any more; the shim can go away once the external
+	// consumers migrate to GetApiClient(role, …).
 	if authClient, ok := tdns.Globals.ApiClients["tdns-auth"]; ok {
 		tdns.Globals.Api = authClient
 	}

--- a/v2/cli/catalog_cmds.go
+++ b/v2/cli/catalog_cmds.go
@@ -40,8 +40,8 @@ var catalogCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -77,8 +77,8 @@ var catalogDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -120,8 +120,8 @@ var catalogZoneAddCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -159,8 +159,8 @@ var catalogZoneDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -197,8 +197,8 @@ var catalogZoneListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -271,8 +271,8 @@ var catalogGroupAddCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -309,8 +309,8 @@ var catalogGroupDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -347,8 +347,8 @@ var catalogGroupListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -398,8 +398,8 @@ var catalogZoneGroupAddCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -437,8 +437,8 @@ var catalogZoneGroupDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -575,8 +575,8 @@ var catalogNotifyAddCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -613,8 +613,8 @@ var catalogNotifyRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}
@@ -651,8 +651,8 @@ var catalogNotifyListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// CatalogCmd is only registered under rootCmd in cliv2 → role "server".
-		api, err := GetApiClient("server", true)
+		// CatalogCmd is only registered under rootCmd in cliv2 → role "auth".
+		api, err := GetApiClient("auth", true)
 		if err != nil {
 			log.Fatalf("Error getting API client: %v", err)
 		}

--- a/v2/cli/commands.go
+++ b/v2/cli/commands.go
@@ -17,51 +17,32 @@ var force bool
 var showError bool
 var errorTimeout string
 
-var StopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Send stop command to tdns-auth / tdns-agent",
-	Run: func(cmd *cobra.Command, args []string) {
-		SendCommand("stop", ".")
-	},
-}
-
 var showfile, shownotify, showprimary bool
 
-func init() {
-}
-
-func SendCommand(cmd, zone string) (string, error) {
-
-	data := tdns.CommandPost{
-		Command: cmd,
-		Zone:    zone,
+// NewStopCmd returns a fresh "stop" *cobra.Command bound to the given
+// role. Each attachment site must create its own command (root "server"
+// default in tdns-cli; signer / combiner / agent in mpcli).
+func NewStopCmd(role string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop",
+		Short: "Send stop command to the daemon",
+		Run: func(cmd *cobra.Command, args []string) {
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error getting API client: %v", err)
+			}
+			resp, err := SendCommandNG(api, tdns.CommandPost{
+				Command: "stop",
+				Zone:    ".",
+			})
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			if resp.Msg != "" {
+				fmt.Printf("%s\n", resp.Msg)
+			}
+		},
 	}
-
-	bytebuf := new(bytes.Buffer)
-	json.NewEncoder(bytebuf).Encode(data)
-
-	status, buf, err := tdns.Globals.Api.Post("/command", bytebuf.Bytes())
-	if err != nil {
-
-		return "", fmt.Errorf("error from api post: %v", err)
-	}
-	// Only print status if it's not 200 (success) - useful for debugging errors
-	if status != 200 && tdns.Globals.Verbose {
-		fmt.Printf("Status: %d\n", status)
-	}
-
-	var cr tdns.CommandResponse
-
-	err = json.Unmarshal(buf, &cr)
-	if err != nil {
-		return "", fmt.Errorf("error from unmarshal: %v", err)
-	}
-
-	if cr.Error {
-		return "", fmt.Errorf("error from %s: %s", cr.AppName, cr.ErrorMsg)
-	}
-
-	return cr.Msg, nil
 }
 
 func SendCommandNG(api *tdns.ApiClient, data tdns.CommandPost) (tdns.CommandResponse, error) {

--- a/v2/cli/daemon_cmds.go
+++ b/v2/cli/daemon_cmds.go
@@ -104,10 +104,8 @@ Right now this doesn't do much, but later on various services will be able to re
 				clientKey = "tdns-auth" // fallback for unknown roles
 			}
 			daemonCommand := ""
-			if apiDetails := getApiDetailsByClientKey(clientKey); apiDetails != nil {
-				if cmdStr, ok := apiDetails["command"].(string); ok && cmdStr != "" {
-					daemonCommand = cmdStr
-				}
+			if ad := getApiDetailsByClientKey(clientKey); ad != nil {
+				daemonCommand = ad.Command
 			}
 
 			// Extract flags to pass to daemon (--config, --debug, -v, etc.)
@@ -160,10 +158,8 @@ Right now this doesn't do much, but later on various services will be able to re
 				clientKey = "tdns-auth" // fallback for unknown roles
 			}
 			daemonCommand := ""
-			if apiDetails := getApiDetailsByClientKey(clientKey); apiDetails != nil {
-				if cmdStr, ok := apiDetails["command"].(string); ok && cmdStr != "" {
-					daemonCommand = cmdStr
-				}
+			if ad := getApiDetailsByClientKey(clientKey); ad != nil {
+				daemonCommand = ad.Command
 			}
 
 			// Fallback to viper for backward compatibility

--- a/v2/cli/ddns_cmds.go
+++ b/v2/cli/ddns_cmds.go
@@ -42,7 +42,11 @@ var delStatusCmd = &cobra.Command{
 			scheme = uint8(val)
 		}
 
-		dr, err := SendDelegationCmd(tdns.Globals.Api, tdns.DelegationPost{
+		api, err := GetApiClient("auth", true)
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+		dr, err := SendDelegationCmd(api, tdns.DelegationPost{
 			Command: "status",
 			Zone:    tdns.Globals.Zonename,
 		})
@@ -104,7 +108,11 @@ var delSyncCmd = &cobra.Command{
 			scheme = uint8(val)
 		}
 
-		dr, err := SendDelegationCmd(tdns.Globals.Api, tdns.DelegationPost{
+		api, err := GetApiClient("auth", true)
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+		dr, err := SendDelegationCmd(api, tdns.DelegationPost{
 			Command: "sync",
 			Scheme:  scheme,
 			Zone:    tdns.Globals.Zonename,
@@ -189,7 +197,11 @@ var delExportCmd = &cobra.Command{
 			scheme = uint8(val)
 		}
 
-		dr, err := SendDelegationCmd(tdns.Globals.Api, tdns.DelegationPost{
+		api, err := GetApiClient("auth", true)
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+		dr, err := SendDelegationCmd(api, tdns.DelegationPost{
 			Command: "export",
 			Zone:    tdns.Globals.Zonename,
 			Outfile: outfile,

--- a/v2/cli/debug_cmds.go
+++ b/v2/cli/debug_cmds.go
@@ -22,227 +22,248 @@ import (
 
 var debugQname, debugQtype string
 
-var DebugCmd = &cobra.Command{
-	Use:   "debug",
-	Short: "A brief description of your command",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("debug called")
-	},
-}
+// NewDebugCmd returns a fresh "debug" command tree bound to the given
+// role. Extras are attached as additional subcommands — used by tdns-mp
+// to inject DebugAgentCmd under the agent tree only.
+func NewDebugCmd(role string, extras ...*cobra.Command) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "debug",
+		Short: "Debug commands against the configured daemon",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("debug called")
+		},
+	}
+	c.PersistentFlags().StringVarP(&debugQname, "qname", "", "", "qname of rrset to examine")
+	c.PersistentFlags().StringVarP(&debugQtype, "qtype", "", "", "qtype of rrset to examine")
 
-var debugSig0Cmd = &cobra.Command{
-	Use:   "sig0",
-	Short: "A brief description of your command",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("debug sig0 called")
-	},
-}
+	// sig0 subtree — local crypto operations, no API calls, role-independent.
+	sig0 := &cobra.Command{
+		Use:   "sig0",
+		Short: "SIG(0) key helper commands (local)",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("debug sig0 called")
+		},
+	}
+	defalg := viper.GetString("delegationsync.child.update.keygen.algorithm")
+	sig0.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", defalg,
+		sig0AlgorithmsHelp("Algorithm to use for SIG(0)"))
+	sig0.PersistentFlags().StringVarP(&tdns.Globals.Rrtype, "rrtype", "r", "", "rrtype to use for SIG(0)")
 
-var debugSig0GenerateCmd = &cobra.Command{
-	Use: "generate",
+	sig0Generate := &cobra.Command{
+		Use: "generate",
+		Run: func(cmd *cobra.Command, args []string) {
+			PrepArgs("zonename")
+			PrepArgs("algorithm")
+			PrepArgs("rrtype")
 
-	Run: func(cmd *cobra.Command, args []string) {
-		PrepArgs("zonename")
-		PrepArgs("algorithm")
-		PrepArgs("rrtype")
+			kdb, err := tdns.NewKeyDB(viper.GetString("db.file"), false, nil)
+			if err != nil {
+				fmt.Printf("Error from NewKeyDB(): %v\n", err)
+				os.Exit(1)
+			}
 
-		kdb, err := tdns.NewKeyDB(viper.GetString("db.file"), false, nil)
-		if err != nil {
-			fmt.Printf("Error from NewKeyDB(): %v\n", err)
-			os.Exit(1)
-		}
+			rrtype := dns.StringToType[strings.ToUpper(tdns.Globals.Rrtype)]
+			algorithm := dns.StringToAlgorithm[strings.ToUpper(tdns.Globals.Algorithm)]
 
-		rrtype := dns.StringToType[strings.ToUpper(tdns.Globals.Rrtype)]
-		algorithm := dns.StringToAlgorithm[strings.ToUpper(tdns.Globals.Algorithm)]
+			fmt.Printf("Calling generate sig0 with zone: %s algorithm: %s rrtype: %s\n",
+				tdns.Globals.Zonename, tdns.Globals.Algorithm, tdns.Globals.Rrtype)
 
-		fmt.Printf("Calling generate sig0 with zone: %s algorithm: %s rrtype: %s\n",
-			tdns.Globals.Zonename, tdns.Globals.Algorithm, tdns.Globals.Rrtype)
+			pkc, msg, err := kdb.GenerateKeypair(tdns.Globals.Zonename, "tdns-cli", "active", rrtype, algorithm, "", nil)
+			if err != nil {
+				fmt.Printf("Error: %s\n", err)
+				os.Exit(1)
+			}
+			fmt.Printf("Generated keypair:\n* Private key: %s\n* Public key: %s\n* KeyID: %d\n", pkc.PrivateKey, pkc.KeyRR.String(), pkc.KeyId)
+			fmt.Printf("Message: %s\n", msg)
 
-		pkc, msg, err := kdb.GenerateKeypair(tdns.Globals.Zonename, "tdns-cli", "active", rrtype, algorithm, "", nil) // nil = no tx
-		if err != nil {
-			fmt.Printf("Error: %s\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("Generated keypair:\n* Private key: %s\n* Public key: %s\n* KeyID: %d\n", pkc.PrivateKey, pkc.KeyRR.String(), pkc.KeyId)
-		fmt.Printf("Message: %s\n", msg)
+			var rr dns.RR
+			rr = &pkc.KeyRR
+			if rrtype == dns.TypeDNSKEY {
+				rr = &pkc.DnskeyRR
+			}
+			fmt.Printf("Generated keypair:\n* Private key: %s\n* Public key: %s\n* KeyID: %d\n", pkc.PrivateKey, rr.String(), pkc.KeyId)
+		},
+	}
+	sig0.AddCommand(sig0Generate)
 
-		var rr dns.RR
-		rr = &pkc.KeyRR
-		if rrtype == dns.TypeDNSKEY {
-			rr = &pkc.DnskeyRR
-		}
-		fmt.Printf("Generated keypair:\n* Private key: %s\n* Public key: %s\n* KeyID: %d\n", pkc.PrivateKey, rr.String(), pkc.KeyId)
-	},
-}
+	// API-calling subtrees — each resolves its ApiClient via role.
 
-var debugRRsetCmd = &cobra.Command{
-	Use: "rrset",
+	rrset := &cobra.Command{
+		Use: "rrset",
+		Run: func(cmd *cobra.Command, args []string) {
+			if tdns.Globals.Zonename == "" {
+				fmt.Printf("Error: zone name not specified. Terminating.\n")
+				os.Exit(1)
+			}
+			if debugQname == "" {
+				fmt.Printf("Error: qname name not specified. Terminating.\n")
+				os.Exit(1)
+			}
+			if debugQtype == "" {
+				fmt.Printf("Error: qtype name not specified. Terminating.\n")
+				os.Exit(1)
+			}
+			qtype := dns.StringToType[strings.ToUpper(debugQtype)]
+			if qtype == 0 {
+				fmt.Printf("Error: unknown qtype: '%s'. Terminating.\n", debugQtype)
+				os.Exit(1)
+			}
 
-	Run: func(cmd *cobra.Command, args []string) {
-		if tdns.Globals.Zonename == "" {
-			fmt.Printf("Error: zone name not specified. Terminating.\n")
-			os.Exit(1)
-		}
-		if debugQname == "" {
-			fmt.Printf("Error: qname name not specified. Terminating.\n")
-			os.Exit(1)
-		}
-		if debugQtype == "" {
-			fmt.Printf("Error: qtype name not specified. Terminating.\n")
-			os.Exit(1)
-		}
-		qtype := dns.StringToType[strings.ToUpper(debugQtype)]
-		if qtype == 0 {
-			fmt.Printf("Error: unknown qtype: '%s'. Terminating.\n", debugQtype)
-			os.Exit(1)
-		}
-
-		dr := SendDebug(tdns.Globals.Api, tdns.DebugPost{
-			Command: "rrset",
-			Zone:    dns.Fqdn(tdns.Globals.Zonename),
-			Qname:   dns.Fqdn(debugQname),
-			Qtype:   qtype,
-		})
-		fmt.Printf("debug response: %v\n", dr)
-	},
-}
-
-var debugValidateRRsetCmd = &cobra.Command{
-	Use: "validate-rrset",
-
-	Run: func(cmd *cobra.Command, args []string) {
-		PrepArgs("childzone")
-		if debugQname == "" {
-			fmt.Printf("Error: qname name not specified. Terminating.\n")
-			os.Exit(1)
-		}
-		if debugQtype == "" {
-			fmt.Printf("Error: qtype name not specified. Terminating.\n")
-			os.Exit(1)
-		}
-		qtype := dns.StringToType[strings.ToUpper(debugQtype)]
-		if qtype == 0 {
-			fmt.Printf("Error: unknown qtype: '%s'. Terminating.\n", debugQtype)
-			os.Exit(1)
-		}
-
-		dr := SendDebug(tdns.Globals.Api, tdns.DebugPost{
-			Command: "validate-rrset",
-			Zone:    dns.Fqdn(tdns.Globals.Zonename),
-			Qname:   dns.Fqdn(debugQname),
-			Qtype:   qtype,
-		})
-
-		if dr.Msg != "" {
-			fmt.Printf("%s\n", dr.Msg)
-		}
-
-		if tdns.Globals.Debug {
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			dr := SendDebug(api, tdns.DebugPost{
+				Command: "rrset",
+				Zone:    dns.Fqdn(tdns.Globals.Zonename),
+				Qname:   dns.Fqdn(debugQname),
+				Qtype:   qtype,
+			})
 			fmt.Printf("debug response: %v\n", dr)
-		}
-	},
-}
+		},
+	}
 
-var debugLAVCmd = &cobra.Command{
-	Use:   "lav",
-	Short: "Lookup and validate a child RRset",
-	Run: func(cmd *cobra.Command, args []string) {
-		if debugQname == "" {
-			fmt.Printf("Error: qname name not specified. Terminating.\n")
-			os.Exit(1)
-		}
-		if debugQtype == "" {
-			fmt.Printf("Error: qtype name not specified. Terminating.\n")
-			os.Exit(1)
-		}
-		qtype := dns.StringToType[strings.ToUpper(debugQtype)]
-		if qtype == 0 {
-			fmt.Printf("Error: unknown qtype: '%s'. Terminating.\n", debugQtype)
-			os.Exit(1)
-		}
-
-		dr := SendDebug(tdns.Globals.Api, tdns.DebugPost{
-			Command: "lav",
-			Qname:   dns.Fqdn(debugQname),
-			Qtype:   qtype,
-			Verbose: true,
-		})
-		fmt.Printf("debug response: %v\n", dr)
-
-	},
-}
-var debugShowTACmd = &cobra.Command{
-	Use:   "show-ta",
-	Short: "List known DNSSEC trust anchors",
-	Run: func(cmd *cobra.Command, args []string) {
-
-		dr := SendDebug(tdns.Globals.Api, tdns.DebugPost{
-			Command: "show-ta",
-			Verbose: true,
-		})
-
-		var out = []string{"Type|Signer|KeyID|State|Record"}
-
-		if len(dr.TrustedDnskeys) > 0 {
-			fmt.Printf("Known DNSKEYs:\n")
-			for _, dk := range dr.TrustedDnskeys {
-				out = append(out, fmt.Sprintf("DNSKEY|%s|%d|%s|%.70s...",
-					dk.Name, dk.Keyid, cache.ValidationStateToString[dk.State], dk.Dnskey.String()))
+	validateRRset := &cobra.Command{
+		Use: "validate-rrset",
+		Run: func(cmd *cobra.Command, args []string) {
+			PrepArgs("childzone")
+			if debugQname == "" {
+				fmt.Printf("Error: qname name not specified. Terminating.\n")
+				os.Exit(1)
 			}
-		}
-		fmt.Printf("%s\n", columnize.SimpleFormat(out))
-
-		out = []string{"Type|Signer|KeyID|Trusted|Record"}
-		if len(dr.TrustedSig0keys) > 0 {
-			fmt.Printf("Known SIG(0) keys:\n")
-			for k, v := range dr.TrustedSig0keys {
-				tmp := strings.Split(k, "::")
-				out = append(out, fmt.Sprintf("KEY|%s|%s|%v|%.70s...\n",
-					tmp[0], tmp[1], v.Validated, v.Key.String()))
+			if debugQtype == "" {
+				fmt.Printf("Error: qtype name not specified. Terminating.\n")
+				os.Exit(1)
 			}
-		}
-		fmt.Printf("%s\n", columnize.SimpleFormat(out))
-	},
-}
+			qtype := dns.StringToType[strings.ToUpper(debugQtype)]
+			if qtype == 0 {
+				fmt.Printf("Error: unknown qtype: '%s'. Terminating.\n", debugQtype)
+				os.Exit(1)
+			}
 
-var debugShowRRsetCacheCmd = &cobra.Command{
-	Use:   "show-rrsetcache",
-	Short: "List cached RRsets",
-	Run: func(cmd *cobra.Command, args []string) {
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			dr := SendDebug(api, tdns.DebugPost{
+				Command: "validate-rrset",
+				Zone:    dns.Fqdn(tdns.Globals.Zonename),
+				Qname:   dns.Fqdn(debugQname),
+				Qtype:   qtype,
+			})
 
-		dr := SendDebug(tdns.Globals.Api, tdns.DebugPost{
-			Command: "show-rrsetcache",
-			Verbose: true,
-		})
+			if dr.Msg != "" {
+				fmt.Printf("%s\n", dr.Msg)
+			}
 
-		var out = []string{"Name|RRtype|Expire|Record"}
+			if tdns.Globals.Debug {
+				fmt.Printf("debug response: %v\n", dr)
+			}
+		},
+	}
 
-		if len(dr.TrustedDnskeys) > 0 {
-			fmt.Printf("Cached RRsets:\n")
-			for _, crrset := range dr.CachedRRsets {
-				for _, rr := range crrset.RRset.RRs {
-					out = append(out, fmt.Sprintf("%s|%s|%v|%v",
-						crrset.Name, dns.TypeToString[crrset.RRtype], time.Until(crrset.Expiration).Seconds(), rr.String()))
+	lav := &cobra.Command{
+		Use:   "lav",
+		Short: "Lookup and validate a child RRset",
+		Run: func(cmd *cobra.Command, args []string) {
+			if debugQname == "" {
+				fmt.Printf("Error: qname name not specified. Terminating.\n")
+				os.Exit(1)
+			}
+			if debugQtype == "" {
+				fmt.Printf("Error: qtype name not specified. Terminating.\n")
+				os.Exit(1)
+			}
+			qtype := dns.StringToType[strings.ToUpper(debugQtype)]
+			if qtype == 0 {
+				fmt.Printf("Error: unknown qtype: '%s'. Terminating.\n", debugQtype)
+				os.Exit(1)
+			}
+
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			dr := SendDebug(api, tdns.DebugPost{
+				Command: "lav",
+				Qname:   dns.Fqdn(debugQname),
+				Qtype:   qtype,
+				Verbose: true,
+			})
+			fmt.Printf("debug response: %v\n", dr)
+		},
+	}
+
+	showTA := &cobra.Command{
+		Use:   "show-ta",
+		Short: "List known DNSSEC trust anchors",
+		Run: func(cmd *cobra.Command, args []string) {
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			dr := SendDebug(api, tdns.DebugPost{
+				Command: "show-ta",
+				Verbose: true,
+			})
+
+			var out = []string{"Type|Signer|KeyID|State|Record"}
+
+			if len(dr.TrustedDnskeys) > 0 {
+				fmt.Printf("Known DNSKEYs:\n")
+				for _, dk := range dr.TrustedDnskeys {
+					out = append(out, fmt.Sprintf("DNSKEY|%s|%d|%s|%.70s...",
+						dk.Name, dk.Keyid, cache.ValidationStateToString[dk.State], dk.Dnskey.String()))
 				}
 			}
-		}
-		fmt.Printf("%s\n", columnize.SimpleFormat(out))
-	},
-}
+			fmt.Printf("%s\n", columnize.SimpleFormat(out))
 
-func init() {
-	DebugCmd.AddCommand(debugRRsetCmd, debugValidateRRsetCmd, debugLAVCmd, debugShowTACmd, debugShowRRsetCacheCmd)
+			out = []string{"Type|Signer|KeyID|Trusted|Record"}
+			if len(dr.TrustedSig0keys) > 0 {
+				fmt.Printf("Known SIG(0) keys:\n")
+				for k, v := range dr.TrustedSig0keys {
+					tmp := strings.Split(k, "::")
+					out = append(out, fmt.Sprintf("KEY|%s|%s|%v|%.70s...\n",
+						tmp[0], tmp[1], v.Validated, v.Key.String()))
+				}
+			}
+			fmt.Printf("%s\n", columnize.SimpleFormat(out))
+		},
+	}
 
-	DebugCmd.AddCommand(debugSig0Cmd)
-	debugSig0Cmd.AddCommand(debugSig0GenerateCmd)
+	showRRsetCache := &cobra.Command{
+		Use:   "show-rrsetcache",
+		Short: "List cached RRsets",
+		Run: func(cmd *cobra.Command, args []string) {
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			dr := SendDebug(api, tdns.DebugPost{
+				Command: "show-rrsetcache",
+				Verbose: true,
+			})
 
-	DebugCmd.PersistentFlags().StringVarP(&debugQname, "qname", "", "", "qname of rrset to examine")
-	DebugCmd.PersistentFlags().StringVarP(&debugQtype, "qtype", "", "", "qtype of rrset to examine")
+			var out = []string{"Name|RRtype|Expire|Record"}
 
-	defalg := viper.GetString("delegationsync.child.update.keygen.algorithm")
-	debugSig0Cmd.PersistentFlags().StringVarP(&tdns.Globals.Algorithm, "algorithm", "a", defalg,
-		sig0AlgorithmsHelp("Algorithm to use for SIG(0)"))
-	debugSig0Cmd.PersistentFlags().StringVarP(&tdns.Globals.Rrtype, "rrtype", "r", "", "rrtype to use for SIG(0)")
+			if len(dr.TrustedDnskeys) > 0 {
+				fmt.Printf("Cached RRsets:\n")
+				for _, crrset := range dr.CachedRRsets {
+					for _, rr := range crrset.RRset.RRs {
+						out = append(out, fmt.Sprintf("%s|%s|%v|%v",
+							crrset.Name, dns.TypeToString[crrset.RRtype], time.Until(crrset.Expiration).Seconds(), rr.String()))
+					}
+				}
+			}
+			fmt.Printf("%s\n", columnize.SimpleFormat(out))
+		},
+	}
+
+	c.AddCommand(rrset, validateRRset, lav, showTA, showRRsetCache, sig0)
+	for _, e := range extras {
+		c.AddCommand(e)
+	}
+	return c
 }
 
 func SendDebug(api *tdns.ApiClient, data tdns.DebugPost) tdns.DebugResponse {

--- a/v2/cli/jose_keys_cmds.go
+++ b/v2/cli/jose_keys_cmds.go
@@ -59,11 +59,8 @@ func runKeysCommand(role string, cmd *cobra.Command, subcommand string, args []s
 	serverConfigPath := keysServerConfig
 	if serverConfigPath == "" {
 		clientKey := getClientKeyFromParent(role)
-		details := getApiDetailsByClientKey(clientKey)
-		if details != nil {
-			if cf, ok := details["config_file"].(string); ok && cf != "" {
-				serverConfigPath = cf
-			}
+		if ad := getApiDetailsByClientKey(clientKey); ad != nil && ad.ConfigFile != "" {
+			serverConfigPath = ad.ConfigFile
 		}
 	}
 	if serverConfigPath == "" {

--- a/v2/cli/ping.go
+++ b/v2/cli/ping.go
@@ -12,94 +12,12 @@ import (
 
 	"github.com/johanix/tdns/v2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
-
-// getClientKeyFromParent maps a parent command name to its corresponding clientKey.
-// Returns empty string if parent is unknown.
-func getClientKeyFromParent(parent string) string {
-	switch parent {
-	case "auth", "server":
-		return "tdns-auth"
-	case "signer":
-		return "tdns-mpsigner"
-	case "combiner":
-		return "tdns-combiner"
-	case "msa":
-		return "tdns-msa"
-	case "agent":
-		return "tdns-agent"
-	case "auditor":
-		return "tdns-mpauditor"
-	case "scanner":
-		return "tdns-scanner"
-	case "imr":
-		return "tdns-imr"
-	case "kdc":
-		return "tdns-kdc"
-	case "krs":
-		return "tdns-krs"
-	default:
-		return ""
-	}
-}
-
-func GetApiClient(parent string, dieOnError bool) (*tdns.ApiClient, error) {
-	clientKey := getClientKeyFromParent(parent)
-	if clientKey == "" {
-		if dieOnError {
-			log.Fatalf("Unknown parent command: %s", parent)
-		}
-		return nil, fmt.Errorf("unknown parent command: %s", parent)
-	}
-
-	client := tdns.Globals.ApiClients[clientKey]
-	if client == nil {
-		if dieOnError {
-			keys := make([]string, 0, len(tdns.Globals.ApiClients))
-			for k := range tdns.Globals.ApiClients {
-				keys = append(keys, k)
-			}
-			log.Fatalf("No API client found for %s (have clients for: %v)", clientKey, keys)
-		}
-		return nil, fmt.Errorf("no API client found for %s", clientKey)
-	}
-
-	if tdns.Globals.Debug {
-		fmt.Printf("Using API client for %q:\nBaseUrl: %s\n", clientKey, client.BaseUrl)
-	}
-	return client, nil
-}
-
-// getApiDetailsByClientKey retrieves the ApiDetails configuration for a given clientKey
-// by looking it up in the CLI config via viper.
-func getApiDetailsByClientKey(clientKey string) map[string]interface{} {
-	apiservers := viper.Get("apiservers")
-	if apiservers == nil {
-		return nil
-	}
-
-	servers, ok := apiservers.([]interface{})
-	if !ok {
-		return nil
-	}
-
-	for _, server := range servers {
-		serverMap, ok := server.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if name, ok := serverMap["name"].(string); ok && name == clientKey {
-			return serverMap
-		}
-	}
-	return nil
-}
 
 // NewPingCmd returns a fresh ping *cobra.Command bound to the given role.
 // Each attachment site must create its own command (Cobra does not allow
-// the same *cobra.Command under multiple parents). The role string is the
-// key understood by GetApiClient / getClientKeyFromParent.
+// the same *cobra.Command under multiple parents). The role string is
+// the registry key from RegisterRole.
 func NewPingCmd(role string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "ping",

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -60,9 +60,10 @@ var updateCreateCmd = &cobra.Command{
 }
 
 // newZoneUpdateCmd returns a fresh "zone update create" subtree.
-// DNS UPDATE construction is role-independent (talks to tdns.Globals.Api
-// directly), so this is called unconditionally from NewZoneCmd for
-// every role.
+// DNS UPDATE construction is role-independent (the interactive CLI
+// sends UPDATEs directly to a target DNS server specified via --server
+// rather than through an ApiClient), so this is called unconditionally
+// from NewZoneCmd for every role.
 func newZoneUpdateCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "update",

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -103,7 +103,7 @@ func NewZoneCmd(role string, extras ...*cobra.Command) *cobra.Command {
 	c.AddCommand(list, nsec, sign, reload, bump, write, freeze, thaw)
 	// Role-independent extras attached to every zone tree. Each is built
 	// fresh so the command pointer is unique per NewZoneCmd invocation.
-	c.AddCommand(newZoneReadFakeCmd(), newZoneUpdateCmd(), newZoneDsyncCmd())
+	c.AddCommand(newZoneReadFakeCmd(), newZoneUpdateCmd(), newZoneDsyncCmd(role))
 	for _, e := range extras {
 		c.AddCommand(e)
 	}

--- a/v2/cli/zone_dsync_cmds.go
+++ b/v2/cli/zone_dsync_cmds.go
@@ -19,11 +19,10 @@ import (
 
 var rollaction string
 
-// newZoneDsyncCmd returns a fresh "dsync" subtree. DSYNC operations
-// talk to tdns.Globals.Api directly (not via GetApiClient), so they
-// are role-independent; the subtree is attached to every zone tree
-// via NewZoneCmd.
-func newZoneDsyncCmd() *cobra.Command {
+// newZoneDsyncCmd returns a fresh "dsync" subtree bound to the given
+// role. Each Run closure resolves its ApiClient via GetApiClient(role)
+// instead of bypassing to tdns.Globals.Api.
+func newZoneDsyncCmd(role string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "dsync",
 		Short: "Prefix command, not useable by itself",
@@ -35,7 +34,11 @@ func newZoneDsyncCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("zonename")
 
-			resp, err := SendDsyncCommand(tdns.Globals.Api, tdns.ZoneDsyncPost{
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			resp, err := SendDsyncCommand(api, tdns.ZoneDsyncPost{
 				Command: "status",
 				Zone:    dns.Fqdn(tdns.Globals.Zonename),
 			})
@@ -78,7 +81,11 @@ func newZoneDsyncCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("zonename", "algorithm")
 
-			resp, err := SendDsyncCommand(tdns.Globals.Api, tdns.ZoneDsyncPost{
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			resp, err := SendDsyncCommand(api, tdns.ZoneDsyncPost{
 				Command:   "bootstrap-sig0-key",
 				Zone:      dns.Fqdn(tdns.Globals.Zonename),
 				Algorithm: dns.StringToAlgorithm[tdns.Globals.Algorithm],
@@ -106,7 +113,11 @@ func newZoneDsyncCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("zonename", "algorithm", "rollaction")
 
-			resp, err := SendDsyncCommand(tdns.Globals.Api, tdns.ZoneDsyncPost{
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			resp, err := SendDsyncCommand(api, tdns.ZoneDsyncPost{
 				Command:   "roll-sig0-key",
 				Zone:      dns.Fqdn(tdns.Globals.Zonename),
 				Algorithm: dns.StringToAlgorithm[tdns.Globals.Algorithm],
@@ -137,7 +148,11 @@ func newZoneDsyncCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("zonename")
 
-			resp, err := SendDsyncCommand(tdns.Globals.Api, tdns.ZoneDsyncPost{
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			resp, err := SendDsyncCommand(api, tdns.ZoneDsyncPost{
 				Command: "publish-dsync-rrset",
 				Zone:    dns.Fqdn(tdns.Globals.Zonename),
 			})
@@ -161,7 +176,11 @@ func newZoneDsyncCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("zonename")
 
-			resp, err := SendDsyncCommand(tdns.Globals.Api, tdns.ZoneDsyncPost{
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			resp, err := SendDsyncCommand(api, tdns.ZoneDsyncPost{
 				Command: "unpublish-dsync-rrset",
 				Zone:    dns.Fqdn(tdns.Globals.Zonename),
 			})

--- a/v2/cli/zone_dsync_cmds.go
+++ b/v2/cli/zone_dsync_cmds.go
@@ -20,8 +20,7 @@ import (
 var rollaction string
 
 // newZoneDsyncCmd returns a fresh "dsync" subtree bound to the given
-// role. Each Run closure resolves its ApiClient via GetApiClient(role)
-// instead of bypassing to tdns.Globals.Api.
+// role. Each Run closure resolves its ApiClient via GetApiClient(role).
 func newZoneDsyncCmd(role string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "dsync",

--- a/v2/global.go
+++ b/v2/global.go
@@ -21,8 +21,17 @@ type GlobalStuff struct {
 	AgentId     AgentId
 	ParentZone  string
 	Sig0Keyfile string
+	// Api is the legacy single-ApiClient convenience slot. Nothing in
+	// tdns/v2 itself reads it any more; the tdns/v2/cli factories all
+	// resolve clients via cli.GetApiClient(role, …) against ApiClients
+	// below. The field is kept as a shim for external consumers that
+	// have not yet migrated:
+	//   - tdns-es/es/cli (es_cmds.go, cmd/es-cli/main.go)
+	//   - tdns-nm/cmd/{kdc-cli,krs-cli}/main.go, tdns-nm/tnm/cli
+	//   - tdns/music/ (music cli commands — legacy)
+	// Delete once those are converted to cli.GetApiClient.
 	Api         *ApiClient
-	ApiClients  map[string]*ApiClient // tdns-cli has multiple clients
+	ApiClients  map[string]*ApiClient
 	PingCount   int
 	Slurp       bool
 	Algorithm   string


### PR DESCRIPTION
Second layer on top of the Cobra role refactor. Separates api-client
plumbing from `ping.go`, lifts the role → clientKey mapping out of a
hardcoded switch into a registry each cli package populates, and
eliminates direct `tdns.Globals.Api` use inside `tdns/v2/cli`.

## Summary

- **New `tdns/v2/cli/apiclient.go`** houses `GetApiClient`, the role
  registry (`RegisterRole`), `getApiDetailsByClientKey`, the
  `ApiDetails` / `CliConf` types lifted from each binary's root.go, and
  a shared `InitApiClients` that replaces the ~30-line duplicated
  `initApi()` blocks in `cliv2/root.go` and `mpcli/root.go`.

- **Role registry, no central switch.** `tdns/v2/cli` registers only
  the roles for daemons it owns: `auth`, `imr`, `agent`. Downstream
  cli packages register their own in `init()` — tdns-mp adds signer /
  combiner (and overrides agent → `tdns-mpagent`) via a new
  `tdns-mp/v2/cli/roles.go`. Last write wins so mpcli can shadow the
  tdns default for `agent`.

- **No more hardcoded `tdns-auth` requirement.** Both `initApi()`
  implementations used to `log.Fatalf` if no `tdns-auth` client was
  configured — a copy-paste artifact that made mpcli refuse to start
  without an irrelevant auth entry. Dropped.

- **Viper reach-through gone from `getApiDetailsByClientKey`.** The
  data it looks up (`command`, `config_file`) is already parsed into
  `CliConf.ApiServers` during `initConfig`; `getApiDetailsByClientKey`
  now walks that slice and returns `*ApiDetails`. Callers in
  `daemon_cmds.go` / `jose_keys_cmds.go` do direct struct-field access
  instead of `map[string]interface{}` casts.

- **`tdns.Globals.Api` eliminated inside `tdns/v2/cli`.** All ApiClient
  resolution now goes through `GetApiClient(role, …)`:
    - `commands.go` → `NewStopCmd(role)` factory; legacy `SendCommand`
      helper inlined into the factory and deleted.
    - `debug_cmds.go` → `NewDebugCmd(role, extras…)` factory; five
      API-calling subtrees now resolve via `GetApiClient(role)`. The
      `sig0` subtree (local crypto, no API) lives in the factory for
      uniqueness per attachment. `DebugAgentCmd` (tdns-mp) moves to
      the `extras` slot on the agent tree only.
    - `ddns_cmds.go` — 3 sites hardcoded to `auth` (single-parent).
    - `zone_dsync_cmds.go` — the 5 dsync subcommands now take role and
      call `GetApiClient(role)`.

- **`\"server\"` role alias removed.** There's no `server` daemon;
  root-level commands now bind `auth` directly in
  `cliv2/shared_cmds.go` (`NewPingCmd(\"auth\")`, `NewDaemonCmd(\"auth\")`,
  `NewDebugCmd(\"auth\")`, `NewConfigCmd(\"auth\")`, `NewStopCmd(\"auth\")`).
  `catalog_cmds.go`'s 13 hardcoded `\"server\"` sites updated to `\"auth\"`.

- **`tdns.Globals.Api` field kept as a shim.** `v2/global.go` now
  documents the three external consumers that still read the field
  (tdns-es, tdns-nm, tdns/music). Delete once those migrate.

## Test plan

- [ ] `cd tdns/cmdv2 && make` — binaries compile (verified locally).
- [ ] Smoke-test `tdns-cliv2` root-level commands (`ping`, `config
  status`, `stop`, `daemon status`, `keystore sig0 list`) target
  the auth daemon as before.
- [ ] Smoke-test `tdns-cliv2 agent …` paths target tdns-agent.
- [ ] Smoke-test `tdns-mpcli {signer,combiner,agent} …` paths now
  report the correct `tdns-mp<role>` API client in debug output.
  (Requires the paired tdns-mp PR.)
- [ ] Spot-check that external consumers (tdns-es, tdns-nm) still
  compile against the v2 module — field still present but flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)