### PR TITLE
fix(v2/scanner): guard nil *Imr in queryAllNSAndCompare

### DIFF
--- a/v2/scanner.go
+++ b/v2/scanner.go
@@ -467,6 +467,15 @@ func (imr *Imr) findEnclosingZoneNS(ctx context.Context, qname string, lg *log.L
 // compares the responses, and returns a representative RRset and whether all NS were in sync.
 // Returns: (responseRRset, allInSync, error)
 func (scanner *Scanner) queryAllNSAndCompare(ctx context.Context, qname string, qtype uint16, nsRRset *core.RRset, imr *Imr, lg *log.Logger) (*core.RRset, bool, error) {
+	// IMR may be disabled or the generalized-NOTIFY path may have
+	// reached the scanner before the IMR singleton was initialized;
+	// without this guard the subsequent imr.ImrQuery(...) call
+	// dereferences a nil *Imr and panics the tdns-authv2 process
+	// from inside a server handler goroutine, killing the daemon on
+	// otherwise-accepted NOTIFY(CDS/CSYNC) traffic.
+	if imr == nil {
+		return nil, false, fmt.Errorf("queryAllNSAndCompare: IMR is not initialized; cannot compare child NS data")
+	}
 	// Extract nameserver names from NS RRset
 	var nsNames []string
 	for _, rr := range nsRRset.RRs {


### PR DESCRIPTION
Fixes johanix/tdns#199.

`queryAllNSAndCompare` derefs its `imr *Imr` parameter directly without a nil check. When tdns-authv2 accepts a generalized `NOTIFY(CDS/CSYNC)` for a delegated child with IMR disabled, or before the IMR singleton has been initialized, the subsequent `imr.ImrQuery` call panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
(*Imr).ImrQuery(0x0, ...)
scanner.go:494 -> imrengine.go:318
```

…inside a server handler goroutine, killing the daemon on an otherwise-accepted NOTIFY.

## Fix

Return a descriptive error when `imr == nil` so the server still replies `NOERROR` at the NOTIFY layer but aborts the scanner path cleanly.

`gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added initialization validation to return error messages instead of allowing unsafe operations with missing required components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->