### PR TITLE
imr: make InitImrEngine idempotent

### DIFF
--- a/v2/imrengine.go
+++ b/v2/imrengine.go
@@ -67,6 +67,14 @@ type ImrResponse struct {
 // StartEngine("ImrEngine", ...). Apps that don't need early availability can
 // just call ImrEngine() which calls InitImrEngine() internally if needed.
 //
+// Idempotent: if conf.Internal.ImrEngine is already set, returns nil without
+// touching any state. The IMR is a process singleton by intent — its priming
+// cache, root hints, and validation state are expensive to construct and
+// would diverge between two instances. The guard at the top of this function
+// makes that singleton property hold by construction, regardless of which
+// application initialises the IMR or in what order. First-init wins; the
+// `quiet` parameter on subsequent calls is ignored.
+//
 // IMPORTANT: tdns-mp depends on this split. The mpagent calls InitImrEngine()
 // synchronously at startup so that conf.Internal.ImrEngine is guaranteed
 // non-nil before transport bridges and agent registries are created. Without
@@ -74,6 +82,13 @@ type ImrResponse struct {
 // calls panic. Do not fold InitImrEngine back into ImrEngine without updating
 // tdns-mp/v2/start_agent.go.
 func (conf *Config) InitImrEngine(quiet bool) error {
+	// Idempotency guard: IMR is a process singleton. Subsequent calls are
+	// no-ops; first-init wins.
+	if conf.Internal.ImrEngine != nil {
+		lgImr.Debug("InitImrEngine: already initialized, returning existing instance")
+		return nil
+	}
+
 	// 1. Create the cache
 	rrcache := cache.NewRRsetCache(log.Default(), conf.Imr.Verbose, conf.Imr.Debug)
 	rrcache.Quiet = quiet


### PR DESCRIPTION
## Summary

- Add a two-line idempotency guard at the top of `InitImrEngine` so subsequent calls are no-ops instead of destructive overwrites.
- The IMR is a process singleton by intent — its priming cache, root hints, and validation state are expensive to construct and would diverge between two instances.
- First-init wins; the `quiet` parameter on subsequent calls is ignored.

Previously, calling `InitImrEngine` twice silently allocated a fresh `RRsetCache` and a fresh `Imr`, overwriting both `conf.Internal.ImrEngine` and `Globals.ImrEngine`; any embedding wrapper or stale pointer that still referenced the first instance kept using the dead cache. The guard makes the singleton property hold by construction rather than by careful caller discipline.

## Why now

This is **Bite 0** of the transport-refactor early-bites plan documented in `tdns-mp/docs/2026-04-25-transport-refactor-early-bites.md`. It is the prerequisite for Bite 6 (move IMR lookup helpers into `tdns-transport`), where the embedded `*tdns.Imr` in any `transport.Imr` wrapper must reliably point to the same shared instance regardless of which application initialised it.

It is also the **only** change to the base `tdns/` repo across the entire early-bites plan; all other bites land in `tdns-mp/` and `tdns-transport/`.

## Test plan

- [ ] Build tdns / tdns-mp on the build server (this is a 2-line additive guard; no functional change for any current caller that already calls `InitImrEngine` exactly once)
- [ ] Smoke-test mpagent startup to confirm IMR initialises as before
- [ ] Confirm idempotency by manually invoking `InitImrEngine` twice in a test/REPL and verifying the second call is a no-op (optional — the guard is small enough to inspect by reading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine initialization now safely handles multiple calls without rebuilding internal caches and priming systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->