### PR TITLE
rollover: fast first-poll after UPDATE + DS-pending labels + check-interval warning

### DIFF
--- a/v2/apihandler_rollover.go
+++ b/v2/apihandler_rollover.go
@@ -43,7 +43,20 @@ func APIRolloverStatus(conf *Config) func(w http.ResponseWriter, r *http.Request
 			pol = zd.DnssecPolicy
 		}
 
-		out, err := ComputeRolloverStatus(kdb, zone, pol, time.Now())
+		// Surface the kasp.check_interval / attempt-timeout invariant
+		// in every status response. Uses the parsed kasp.check_interval
+		// the same way KeyStateWorker does at startup.
+		var checkInterval time.Duration
+		if conf.Kasp.CheckInterval != "" {
+			if d, err := time.ParseDuration(conf.Kasp.CheckInterval); err == nil && d > 0 {
+				checkInterval = d
+			}
+		}
+		if checkInterval == 0 {
+			checkInterval = time.Minute // defaultCheckInterval
+		}
+
+		out, err := ComputeRolloverStatus(kdb, zone, pol, checkInterval, time.Now())
 		if err != nil {
 			lgApi.Warn("rollover/status: ComputeRolloverStatus failed", "zone", zone, "err", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -645,7 +645,12 @@ func fetchRolloverStatusOffline(z string) *tdns.RolloverStatus {
 		cliFatalf("error: %v", err)
 	}
 	defer kdb.DB.Close()
-	s, err := tdns.ComputeRolloverStatus(kdb, z, pol, time.Now())
+	// Offline path: the daemon isn't running, so we can't query its
+	// kasp.check_interval. Pass 0, which suppresses the warning —
+	// surfacing it requires daemon-runtime context, and the operator
+	// running offline-mode is doing postmortem analysis where the
+	// warning would be noise.
+	s, err := tdns.ComputeRolloverStatus(kdb, z, pol, 0, time.Now())
 	if err != nil {
 		cliFatalf("error: %v", err)
 	}
@@ -825,6 +830,9 @@ func printStateNotes(s *tdns.RolloverStatus, verbose bool) {
 		if s.Headline == "SOFTFAIL" {
 			fmt.Printf("                    use 'auto-rollover unstick --zone %s' to skip the wait and probe now\n", s.Zone)
 		}
+	}
+	for _, w := range s.Warnings {
+		fmt.Printf("  WARNING:          %s\n", w)
 	}
 	if s.LastSoftfailCat != "" || s.LastSoftfailDetail != "" {
 		if s.LastSoftfailCat != "" {

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -231,6 +231,7 @@ func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *I
 			return err
 		}
 		lgSigner.Info("rollover: DS UPDATE accepted, arming observe", "zone", zone, "first_poll_at", nextPoll.Format(time.RFC3339))
+		scheduleFastObservePoll(ctx, conf, kdb, imr, zd, propagationDelay, initial)
 	case rolloverPhasePendingParentObserve:
 		agent := pol.Rollover.ParentAgent
 		if agent == "" {
@@ -423,6 +424,7 @@ func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *I
 		_ = setObserveSchedule(kdb, zone, now, nextPoll, int(initial.Seconds()))
 		_ = setNextPushAt(kdb, zone, nextPush)
 		lgSigner.Info("rollover: softfail probe accepted, observing", "zone", zone, "first_poll_at", nextPoll.Format(time.RFC3339), "next_probe_at", nextPush.Format(time.RFC3339))
+		scheduleFastObservePoll(ctx, conf, kdb, imr, zd, propagationDelay, initial)
 	case rolloverPhasePendingChildWithdraw:
 		// §8.8: wait effective_margin = max(policy.clamping.margin,
 		// max_observed_ttl) from each retired SEP key's retired_at, then
@@ -580,6 +582,44 @@ WHERE zone = ?`, zone); err != nil {
 	}
 	commit = true
 	return advanced, nil
+}
+
+// scheduleFastObservePoll spawns a one-shot goroutine that fires the
+// observe-phase poll exactly initial-wait after a successful UPDATE,
+// independent of the worker tick cadence. Without this, the first
+// parent-DS query is gated on the next KeyStateWorker tick, which can
+// be up to kasp.check_interval seconds away — and if that exceeds
+// attempt-timeout (= ds-publish-delay × 1.2 by default), the engine
+// declares the attempt timed out before any poll has ever fired.
+//
+// The goroutine waits initial-wait seconds, then re-runs
+// RolloverAutomatedTick for the same zone. RolloverAutomatedTick
+// acquires the per-zone lock internally, so concurrent tick + fast-poll
+// serialize cleanly. Daemon shutdown via ctx.Done() aborts the goroutine.
+//
+// Restart safety: if the daemon restarts while the goroutine is
+// sleeping, the goroutine is gone but the DB state still carries
+// observe_started_at + observe_next_poll_at. The next worker tick
+// after restart picks up where this left off (at the cost of being
+// bounded by check_interval — same as the pre-fix behavior). No state
+// is lost; just slower recovery.
+func scheduleFastObservePoll(ctx context.Context, conf *Config, kdb *KeyDB, imr *Imr, zd *ZoneData, propagationDelay, initial time.Duration) {
+	if initial <= 0 {
+		initial = defaultConfirmInitialWait
+	}
+	zone := zd.ZoneName
+	go func() {
+		timer := time.NewTimer(initial)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		if err := RolloverAutomatedTick(ctx, conf, kdb, imr, zd, propagationDelay, time.Now()); err != nil {
+			lgSigner.Debug("rollover: fast-poll tick error", "zone", zone, "err", err)
+		}
+	}()
 }
 
 // recordObserveTimeout stamps a per-key last_rollover_error on every

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -82,6 +82,13 @@ type RolloverStatus struct {
 
 	// Policy summary. Verbose mode shows this; compact mode hides it.
 	Policy *PolicySummary `json:"policy,omitempty"`
+
+	// Warnings carry runtime configuration concerns the engine wants
+	// to surface to the operator on every status query — currently
+	// the kasp.check_interval / attempt-timeout coupling check, but
+	// designed to grow as more cross-config invariants are caught.
+	// Empty slice means no warnings; rendered below the hint line.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // DSRange is an inclusive integer [low, high] rollover_index interval

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -19,7 +19,15 @@ import (
 // pol may be nil for zones that don't have a DNSSEC policy attached;
 // the function still returns a valid struct (Headline=OK, no policy
 // summary, no derived timing fields).
-func ComputeRolloverStatus(kdb *KeyDB, zone string, pol *DnssecPolicy, now time.Time) (*RolloverStatus, error) {
+//
+// checkInterval is kasp.check_interval (0 means "unknown / not
+// applicable"). Used purely to populate the Warnings field by
+// re-running the same kasp.check_interval / attempt-timeout
+// invariant check that key_state_worker logs at startup. Surfacing
+// it on every status query catches the case where the operator
+// edited the YAML but didn't restart, or where rollover-driven
+// behaviour has drifted from initial configuration.
+func ComputeRolloverStatus(kdb *KeyDB, zone string, pol *DnssecPolicy, checkInterval time.Duration, now time.Time) (*RolloverStatus, error) {
 	zone = dns.Fqdn(strings.TrimSpace(zone))
 	if zone == "." || zone == "" {
 		return nil, fmt.Errorf("ComputeRolloverStatus: empty zone")
@@ -58,7 +66,65 @@ func ComputeRolloverStatus(kdb *KeyDB, zone string, pol *DnssecPolicy, now time.
 		return nil, fmt.Errorf("ComputeRolloverStatus: %w", err)
 	}
 
+	applyInFlightPublicationLabels(out)
+	populateRolloverWarnings(out, pol, checkInterval)
+
 	return out, nil
+}
+
+// applyInFlightPublicationLabels overrides the Published column for
+// SEP keys that are mid-publication: the engine has submitted DS for
+// them to the parent (so they appear in SubmittedKeyIDs) but has not
+// yet confirmed publication (not in ConfirmedKeyIDs). Without this,
+// such keys display "none" — matching their local state but not the
+// engine's intent or the parent's actual DS RRset, which the operator
+// can verify via dig.
+//
+// Status remains advisory: a key labeled "DS pending" might already
+// be at the parent (engine just hasn't polled yet) or might be still
+// in flight. The "DS confirmed" line and last-poll timestamp give the
+// operator the freshness context to disambiguate.
+func applyInFlightPublicationLabels(out *RolloverStatus) {
+	if len(out.SubmittedKeyIDs) == 0 {
+		return
+	}
+	confirmed := make(map[uint16]bool, len(out.ConfirmedKeyIDs))
+	for _, k := range out.ConfirmedKeyIDs {
+		confirmed[k] = true
+	}
+	submitted := make(map[uint16]bool, len(out.SubmittedKeyIDs))
+	for _, k := range out.SubmittedKeyIDs {
+		submitted[k] = true
+	}
+	for i := range out.KSKs {
+		k := &out.KSKs[i]
+		if k.State != DnskeyStateCreated {
+			continue
+		}
+		if submitted[k.KeyID] && !confirmed[k.KeyID] {
+			k.Published = "DS pending"
+		}
+	}
+}
+
+// populateRolloverWarnings re-runs the cross-config invariant check
+// that key_state_worker.go logs once at daemon startup, surfacing it
+// on every status query. The most operationally consequential one
+// today: kasp.check_interval must be < attempt-timeout / 2, otherwise
+// observe-poll cadence is starved and rollover attempts deterministically
+// time out before any poll fires.
+func populateRolloverWarnings(out *RolloverStatus, pol *DnssecPolicy, checkInterval time.Duration) {
+	if pol == nil || checkInterval <= 0 {
+		return
+	}
+	if pol.Rollover.Method != RolloverMethodMultiDS && pol.Rollover.Method != RolloverMethodDoubleSignature {
+		return
+	}
+	if pol.Rollover.ConfirmTimeout > 0 && pol.Rollover.ConfirmTimeout < 2*checkInterval {
+		out.Warnings = append(out.Warnings,
+			fmt.Sprintf("kasp.check_interval (%s) is too coarse for attempt-timeout (%s); observe polling will be starved — lower kasp.check_interval to < attempt-timeout/2 or raise rollover.ds-publish-delay",
+				checkInterval, pol.Rollover.ConfirmTimeout))
+	}
 }
 
 func populateDSKeyidsForStatus(kdb *KeyDB, zone string, out *RolloverStatus) error {


### PR DESCRIPTION
## Summary

Three related fixes for testbed observations where:
- (a) The engine deterministically times out attempts when `kasp.check_interval > attempt-timeout/2` because the first observe-poll only fires on the next worker tick, not after `confirm_initial_wait`.
- (b) `auto-rollover status` displays stale DS-confirmed information that disagrees with what `dig` sees at the parent.

### Fix 1 — Fast first-poll after UPDATE
`scheduleFastObservePoll` spawns a one-shot goroutine that fires `confirm_initial_wait` (default 2s) after UPDATE, calling `RolloverAutomatedTick` directly. The per-zone lock serializes against concurrent worker ticks; `ctx.Done()` aborts on daemon shutdown. Wired into both UPDATE-success paths (initial push + softfail probe).

### Fix 2 — DS-pending label
SEP keys in `state=created` whose `KeyID` is in `SubmittedKeyIDs` but not `ConfirmedKeyIDs` now display as `DS pending` instead of `none` in the status table.

### Fix 3 — In-band kasp.check_interval warning
`RolloverStatus.Warnings []string` carries the same invariant the startup logger checks. Renders below the hint line as `WARNING: ...`.

## Test plan

- [ ] Run `auto-rollover status` on the testbed before this lands, observe stale `DS confirmed` and `published: none` for in-flight keys.
- [ ] Apply, observe `published: DS pending` for in-flight SEP keys.
- [ ] If `kasp.check_interval > attempt-timeout/2` config remains, observe the `WARNING` line appearing on every status call.
- [ ] After fixing the kasp.check_interval misconfiguration on the testbed, observe rollovers no longer time out (Fix 1 effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rollover status responses now include operator-visible warnings for configuration concerns.
  * Fast observe-phase polling automatically triggered after DS updates and softfail acceptance, reducing rollover transition delays.

* **Improvements**
  * SEP keys awaiting DS publication are now labeled as "DS pending" for clarity.
  * Configuration validation warnings alert operators when check intervals may impact rollover timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->