### PR TITLE
rollover: NOTIFY(CDS) push path with parallel dispatch

### DIFF
--- a/docs/2026-04-29-rollover-overhaul.md
+++ b/docs/2026-04-29-rollover-overhaul.md
@@ -1120,3 +1120,15 @@ phases 1-10 and 11. Each phase one or two commits.
 
 When complete, merge `rollover-overhaul` to `fast-roller-1`,
 then cherry-pick the merged sequence onto `fast-roller-mldsa44`.
+
+## Follow-up: NOTIFY-scheme push path
+
+The work in this document is UPDATE-only on the child side. The
+follow-up at [`2026-04-30-rollover-notify-scheme.md`](2026-04-30-rollover-notify-scheme.md)
+adds NOTIFY(CDS) as a second DS-push path with parallel dispatch
+under the new `auto` policy default. That work also splits the
+`child-config` category into `:waiting-for-parent` (1h-capped
+softfail, never hardfails) and `:local-error` (existing softfail
+path), and adds parent-side EDE attachment for NOTIFY rejections
+mirroring this document's Phase 11. Phase 9 of that work
+(tick-handler test harness) is deferred to a separate PR.

--- a/docs/2026-04-30-rollover-notify-scheme.md
+++ b/docs/2026-04-30-rollover-notify-scheme.md
@@ -2,8 +2,10 @@
 
 Author: Johan / Claude
 Date: 2026-04-30
-Status: planning — no code yet
-Branch: TBD (off `rollover-overhaul` once that lands)
+Status: implemented (phases 1–8, 10) on branch `rollover-notify-scheme`;
+        phase 9 (tick-handler test harness) deferred to separate PR;
+        phase 1a (tdns-mp wiring) deferred per original scope.
+Branch: `rollover-notify-scheme` (off `main` at bf01076a — PR #208 merge)
 
 Follow-up to the rollover overhaul (`2026-04-29-rollover-overhaul.md`).
 That work fixed the softfail state machine, parent-side EDE, and the
@@ -11,6 +13,75 @@ CLI-via-API rewrite. It did not touch one cross-cutting limitation:
 the rollover engine pushes DS via DNS UPDATE only. Parents that
 advertise the NOTIFY scheme in DSYNC are unreachable for automated
 KSK rollover.
+
+## Implementation status (2026-05-01)
+
+Phases 1–8 and Phase 10 (this section) are implemented on branch
+`rollover-notify-scheme`. Phases 9 (tick-handler test harness) and
+1a (tdns-mp KeyStateWorker wiring) are deferred to separate PRs.
+
+**Divergences from this design**, recorded for the next reader:
+
+1. **Phase 1 — `RolloverEngineDeps.Conf` retained.** The doc's
+   "no globals" goal targets the implicit dependencies of the
+   push path itself (Imr, DnssecPolicies, lock acquirer, logger).
+   Several existing helpers called from inside the tick
+   (`AtomicRollover`, `triggerResign`, `completeRolloverWithdraw`,
+   `scheduleFastObservePoll`) take `*Config` directly today and
+   were not in scope for Phase 1. `RolloverEngineDeps` therefore
+   carries a passthrough `Conf *Config`. tdns-mp will pass
+   `*tdns.Config` through this field unchanged. Refactoring those
+   helpers off `*Config` is independent follow-up work.
+
+2. **Phase 1 — `InternalUpdateQ` field type.** Doc said
+   `chan *ZoneUpdate`; codebase uses `chan UpdateRequest` (the
+   `kdb.UpdateQ` type). Implementation followed the codebase.
+
+3. **Phase 1 — third `PushWholeDSRRset` call site.** The CLI
+   `auto-rollover ds-push --offline` command at
+   `cli/ksk_rollover_cli.go:194` was a third caller of
+   `PushWholeDSRRset` not enumerated in the doc. Updated to
+   construct `RolloverEngineDeps` and call
+   `PushDSRRsetForRollover` (which falls through to the
+   single-scheme UPDATE path when no policy is attached).
+
+4. **Phase 4 — publish-and-sign is best-effort, not transactional.**
+   The doc Step 3 specifies `(publish CDS, sign CDS RRset, re-sign
+   apex NSEC)` as a single transaction with explicit rollback on
+   sign failure. The codebase's existing CDS-publish primitive
+   (`PublishCdsRRs` in `ops_cds.go`) is asynchronous fire-and-forget
+   via `kdb.UpdateQ`; sign and NSEC re-sign happen in the resigner
+   pipeline downstream, not synchronously with the publish. Adding
+   the synchronous transaction would require widening the publish
+   API across the codebase (`PublishCdsRRs`, `PublishCsyncRR`, …)
+   — out of scope for this branch. `pushDSRRsetViaNotify` uses the
+   same async-queue shape with a 5s send-side timeout to detect
+   immediate queue-full failures. The rollback path is therefore
+   unreachable in this design; revisit when the publish/sign sync
+   refactor happens.
+
+5. **Phase 5 — Trigger 3 (terminal hardfail) is a no-op hook.**
+   The post-overhaul state machine has no terminal-hardfail state;
+   softfail mode probes indefinitely with category-driven backoff
+   instead. The cleanup helper (`cleanupCdsAfterHardfail` in
+   `ksk_rollover_cds_cleanup.go`) exists with `//nolint:unused`
+   so a future commit that introduces terminal hardfail can call
+   it without re-discovering the cleanup logic. Triggers 1 and 2
+   are fully wired.
+
+6. **Phase 9 deferred.** The tick-handler test harness was the
+   largest single phase by far. Per the user's authorization
+   rules, deferred to a separate PR. The harness has reuse value
+   beyond NOTIFY support; building it as standalone test
+   infrastructure makes more sense than bundling it into the
+   feature branch. Pure-helper unit tests for
+   `decideRolloverSchemes` (22 cases) and `waitingForParentDelay`
+   (5 cases) cover the high-value decision logic in this branch.
+
+7. **Phase 1a deferred (per original scope).** Wiring tdns-mp's
+   `KeyStateWorker` to invoke the rollover push was explicitly
+   out of scope for this branch. The Phase 1 extraction makes
+   Phase 1a a small follow-up.
 
 > **Phase numbering note.** Phase numbers in this document (1–9) are
 > local to this work. References to "Phase 11" or "Phase 12" are to

--- a/guide/rapid-key-rollover.md
+++ b/guide/rapid-key-rollover.md
@@ -401,6 +401,7 @@ level of the daemon config):
 | `rollover.ds-publish-delay` | no | `5m` | Parent's expected DS publication latency |
 | `rollover.max-attempts-before-backoff` | no | `5` | Softfail threshold |
 | `rollover.softfail-delay` | no | derived (≥ 1h, ≥ ds-publish-delay) | Long-term-mode probe interval |
+| `rollover.dsync-scheme-preference` | no | `auto` | DSYNC scheme to use for DS push (see §6.4) |
 | `rollover.confirm-initial-wait` | no | `2s` | First-poll delay after UPDATE |
 | `rollover.confirm-poll-max` | no | derived (clamped 30s..5m) | Maximum DS-poll cadence |
 | `rollover.confirm-timeout` | no | derived (`ds-publish-delay × 1.2`) | Per-attempt observation budget |
@@ -453,7 +454,52 @@ delay)`) from this, so getting it roughly right matters more
 than getting it exactly right.
 
 
-### 6.3 The `clamping` choice
+### 6.3 The `rollover.dsync-scheme-preference` choice
+
+This knob controls which DSYNC scheme(s) the rollover engine
+uses to push the DS update to the parent. The parent advertises
+its supported schemes via DSYNC RRs at `_dsync.<parent>`; this
+knob decides what to do when the parent advertises more than
+one, or when the operator wants to pin a specific scheme.
+
+| Value | Both adv. | One adv. | Neither |
+|-------|-----------|----------|---------|
+| `auto` (default) | parallel UPDATE + NOTIFY | the advertised one | wait |
+| `prefer-update` | UPDATE only | the advertised one | wait |
+| `prefer-notify` | NOTIFY only | the advertised one | wait |
+| `force-update` | UPDATE only | UPDATE only or wait | wait |
+| `force-notify` | NOTIFY only | NOTIFY only or wait | wait |
+
+"wait" = `child-config:waiting-for-parent` softfail, capped at
+1h backoff, never hardfails, auto-recovers when DSYNC reappears.
+
+`auto` is the right default for almost every operator: when the
+parent advertises both UPDATE and NOTIFY for CDS, the engine
+sends both in parallel. Either path NOERROR is enough to enter
+the observe phase. The cost is one extra UDP NOTIFY per attempt
+on a parent that advertises both; the benefit is that an
+"advertised but broken" scheme on one path doesn't block the
+rollover when the other works.
+
+`prefer-*` values give explicit single-scheme behaviour on a
+both-advertising parent — useful for log hygiene or when
+debugging one path. `force-*` values are for testbeds and
+adversarial-testing: if the parent doesn't advertise the
+forced scheme, the engine refuses to fall through to the other
+one (you asked for `force`, you got `force`).
+
+NOTIFY async-rejection asymmetry: parent-side ProcessCDSNotify
+runs *after* the NOTIFY ACK is sent. CDS validation failures,
+RFC 9615 signaling check failures, and RFC 8078 bootstrap
+policy refusals at the parent therefore surface as
+`parent-publish-failure` from the child's POV — not as
+`parent-rejected`, even when the underlying cause is a
+parent-side rejection. To diagnose, consult the parent-side
+scanner logs. (UPDATE pushes are synchronous and do surface
+parent rejections as `parent-rejected` with EDE detail.)
+
+
+### 6.4 The `clamping` choice
 
 When clamping is enabled, the engine progressively lowers TTLs
 near a scheduled rollover so that cached data flushes faster as
@@ -551,15 +597,21 @@ The engine does *not* handle automatically:
 
 ## 9. When something goes wrong
 
-The four failure categories the engine recognizes:
+The failure categories the engine recognizes:
 
-- **child-config**: something on your side is wrong (sign
-  failure, no DS to publish, parent zone not resolvable).
-  Operator must fix; the engine will retry indefinitely with a
-  capped backoff if the failure is "no usable scheme advertised
-  at parent" (this auto-recovers when the parent comes back).
-  Other child-config flavours go to hardfail after
-  `max-attempts-before-backoff` consecutive failures.
+- **child-config:waiting-for-parent**: the parent advertises no
+  DSYNC scheme this rollover policy can use (either no DSYNC at
+  all, or `force-*` policy and the forced scheme isn't
+  advertised). The engine halts but probes forever with backoff
+  capped at 1h, never increments the hardfail counter, and
+  auto-recovers when the parent restores DSYNC advertisement.
+  No operator action required on the child side.
+
+- **child-config:local-error**: something on your side is wrong
+  (no SIG(0) key, no DS to publish, parent zone not resolvable,
+  CDS publish-and-sign queue failure). Goes to softfail after
+  `max-attempts-before-backoff` consecutive failures. Operator
+  intervention typically required.
 
 - **transport**: network-level failure to reach the parent
   (timeout, connection refused). The engine retries.
@@ -567,11 +619,17 @@ The four failure categories the engine recognizes:
 - **parent-rejected**: the parent acknowledged the request but
   responded with REFUSED, NOTAUTH, FORMERR, or SERVFAIL. The
   daemon's logs include EDE codes when the parent supplies them
-  — these are the most operationally-actionable errors.
+  — these are the most operationally-actionable errors. For
+  NOTIFY pushes, the new `EDENotifyDsyncSchemeNotAdvertised`
+  EDE catches misconfigured children on the very first push.
 
 - **parent-publish-failure**: the parent acknowledged but the
   DS RRset never appeared in the parent zone. The engine
-  retries.
+  retries. NOTE: on a NOTIFY-advertising parent, async CDS
+  validation failures inside the parent's scanner surface here
+  rather than as parent-rejected (NOTIFY ACK is sent before the
+  scan runs). Consult the parent-side scanner logs to
+  disambiguate parent-internal causes.
 
 For investigations, start by reading the daemon logs and the
 output of `auto-rollover status`. The status output identifies
@@ -588,8 +646,8 @@ happened. The `last_softfail_*` fields tell you when and why.
   bookkeeping.
 - **NOTIFY-scheme push path:** the design at
   `tdns/docs/2026-04-30-rollover-notify-scheme.md` documents
-  the upcoming work for parents that advertise NOTIFY-based
-  DSYNC instead of UPDATE-based DSYNC.
+  the parallel UPDATE+NOTIFY DS-push model and the
+  `dsync-scheme-preference` knob (§6.3 above).
 - **Multi-provider DNSSEC:** see the tdns-mp guide
   (`tdns-mp/guide/`) for KSK rollover in multi-provider
   deployments. The single-provider guidance here applies; the

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -768,7 +768,11 @@ func printStateTable(s *tdns.RolloverStatus) {
 		}
 	}
 	if s.LastUpdate != "" {
-		left = append(left, kv{"last UPDATE:", formatRolloverTime(s.LastUpdate)})
+		v := formatRolloverTime(s.LastUpdate)
+		if s.LastAttemptScheme != "" {
+			v = fmt.Sprintf("%s via %s", v, s.LastAttemptScheme)
+		}
+		left = append(left, kv{"last push:", v})
 	}
 	if s.ExpectedBy != "" {
 		left = append(left, kv{"expected by:", formatRolloverTime(s.ExpectedBy)})

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -191,7 +191,14 @@ Use --dry-run to print the DS set and UPDATE without sending.`,
 				return
 			}
 
-			res, err := tdns.PushWholeDSRRset(ctx, zd, kdb, imr)
+			deps := tdns.RolloverEngineDeps{
+				Conf:   &Conf,
+				KDB:    kdb,
+				Zone:   zd,
+				Imr:    imr,
+				Policy: zd.DnssecPolicy,
+			}
+			res, err := tdns.PushDSRRsetForRollover(ctx, deps)
 			if err != nil {
 				log.Fatalf("ds-push: %v", err)
 			}

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -130,12 +130,19 @@ func newKeystoreDnssecDsPushCmd(_ string) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "ds-push",
-		Short: "Compute DS RRset from keystore and push whole RRset to parent via SIG(0) UPDATE",
+		Short: "Compute DS RRset from keystore and push to parent (UPDATE-only in this offline mode)",
 		Long: `Loads tdns config (same as other CLI commands using -c), opens the local keystore DB,
-resolves parent + DSYNC UPDATE target, builds a whole-DS replacement UPDATE, signs with the
-zone's active SIG(0) key, and sends it. Requires imrengine in config.
+and pushes the whole DS RRset to the parent. Requires imrengine in config.
 
-Use --dry-run to print the DS set and UPDATE without sending.`,
+Offline mode: this CLI invocation builds a stub *ZoneData with no rollover policy
+attached, so PushDSRRsetForRollover falls through to the legacy single-scheme
+UPDATE path (whole-DS replacement, signed with the zone's active SIG(0) key).
+The auto / prefer-* / force-* dsync-scheme-preference values are honored only
+inside the daemon's rollover engine, where the policy is loaded from
+dnssecpolicies. To exercise NOTIFY pushes, run the daemon and let
+RolloverAutomatedTick drive the push.
+
+Use --dry-run to print the DS set and the UPDATE without sending.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs(cmd, "zonename")
 			ctx := context.Background()

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -787,11 +787,49 @@ func printStateTable(s *tdns.RolloverStatus) {
 	if s.AttemptTimeout != "" {
 		left = append(left, kv{"attempt timeout:", formatRolloverTime(s.AttemptTimeout)})
 	}
-	if s.Submitted != nil {
-		left = append(left, kv{"DS submitted:", dashKeyidsBracket(formatKeyidBracketList(s.SubmittedKeyIDs))})
+	// Per-scheme lines: separate "DS UPDATE" (the UPDATE-pushed DS
+	// RRset claim) from "CDS published" (the CDS RRset on the child
+	// apex via NOTIFY) from "DS observed" (what the engine has seen
+	// at the parent). Each line is conditional:
+	//   - DS UPDATE: rendered when Submitted is set AND the most
+	//     recent push attempt used UPDATE (LastAttemptScheme contains
+	//     "UPDATE").
+	//   - CDS published: rendered ONLY when CdsPublished is set —
+	//     which itself requires both engine ownership (RolloverZoneState
+	//     last_published_cds_index_*) AND apex CDS RRset present.
+	//     If the engine claims CDS but the apex is empty, this line
+	//     is suppressed so operators don't mis-read "CDS published"
+	//     when nothing is on the wire.
+	//   - DS observed: rendered when Confirmed is set. Renamed from
+	//     "DS confirmed:" — "observed" matches the parent-poll
+	//     terminology used elsewhere in status.
+	updateUsed := strings.Contains(s.LastAttemptScheme, "UPDATE")
+	if s.Submitted != nil && updateUsed {
+		v := dashKeyidsBracket(formatKeyidBracketList(s.SubmittedKeyIDs))
+		if s.LastUpdate != "" {
+			v = fmt.Sprintf("%s sent %s", v, formatRolloverTime(s.LastUpdate))
+		}
+		left = append(left, kv{"DS UPDATE:", v})
+	} else if s.Submitted != nil {
+		// Fallback: no scheme info recorded but we have a submitted
+		// range from a pre-NOTIFY-scheme rollover. Render the legacy
+		// line shape so existing testbeds don't lose status info.
+		left = append(left, kv{"DS UPDATE:", dashKeyidsBracket(formatKeyidBracketList(s.SubmittedKeyIDs))})
+	}
+	if s.CdsPublished != nil {
+		v := dashKeyidsBracket(formatKeyidBracketList(s.CdsPublishedKeyIDs))
+		v = fmt.Sprintf("%s NOTIFY(CDS)", v)
+		if s.LastUpdate != "" {
+			v = fmt.Sprintf("%s sent %s", v, formatRolloverTime(s.LastUpdate))
+		}
+		left = append(left, kv{"CDS published:", v})
 	}
 	if s.Confirmed != nil {
-		left = append(left, kv{"DS confirmed:", dashKeyidsBracket(formatKeyidBracketList(s.ConfirmedKeyIDs))})
+		v := dashKeyidsBracket(formatKeyidBracketList(s.ConfirmedKeyIDs))
+		if s.LastSuccess != "" {
+			v = fmt.Sprintf("%s observed %s", v, formatRolloverTime(s.LastSuccess))
+		}
+		left = append(left, kv{"DS observed:", v})
 	}
 
 	// Right column: timing config + history & polling.

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -787,22 +787,21 @@ func printStateTable(s *tdns.RolloverStatus) {
 	if s.AttemptTimeout != "" {
 		left = append(left, kv{"attempt timeout:", formatRolloverTime(s.AttemptTimeout)})
 	}
-	// Per-scheme lines: separate "DS UPDATE" (the UPDATE-pushed DS
-	// RRset claim) from "CDS published" (the CDS RRset on the child
-	// apex via NOTIFY) from "DS observed" (what the engine has seen
-	// at the parent). Each line is conditional:
+	// Per-scheme lines:
 	//   - DS UPDATE: rendered when Submitted is set AND the most
 	//     recent push attempt used UPDATE (LastAttemptScheme contains
-	//     "UPDATE").
-	//   - CDS published: rendered ONLY when CdsPublished is set —
-	//     which itself requires both engine ownership (RolloverZoneState
-	//     last_published_cds_index_*) AND apex CDS RRset present.
-	//     If the engine claims CDS but the apex is empty, this line
-	//     is suppressed so operators don't mis-read "CDS published"
-	//     when nothing is on the wire.
-	//   - DS observed: rendered when Confirmed is set. Renamed from
-	//     "DS confirmed:" — "observed" matches the parent-poll
-	//     terminology used elsewhere in status.
+	//     "UPDATE"). Timestamp is the dispatcher's send time
+	//     (LastUpdate = last_attempt_started_at; parallel dispatch
+	//     fires both legs from the same instant, so a per-scheme
+	//     send timestamp is artificial).
+	//   - CDS published: rendered when the engine has ever
+	//     successfully published CDS via NOTIFY (sparse
+	//     RolloverCdsPublication row). Survives Trigger-1 cleanup;
+	//     it's a historical fact, not a current-state claim.
+	//   - DS observed: rendered when ObservedKeyIDs is set —
+	//     i.e. the engine has done at least one parent-agent poll
+	//     that returned a usable answer. Reflects the latest poll's
+	//     answer, not the latest confirmed match.
 	updateUsed := strings.Contains(s.LastAttemptScheme, "UPDATE")
 	if s.Submitted != nil && updateUsed {
 		v := dashKeyidsBracket(formatKeyidBracketList(s.SubmittedKeyIDs))
@@ -816,31 +815,34 @@ func printStateTable(s *tdns.RolloverStatus) {
 		// line shape so existing testbeds don't lose status info.
 		left = append(left, kv{"DS UPDATE:", dashKeyidsBracket(formatKeyidBracketList(s.SubmittedKeyIDs))})
 	}
-	if s.CdsPublished != nil {
-		v := dashKeyidsBracket(formatKeyidBracketList(s.CdsPublishedKeyIDs))
-		v = fmt.Sprintf("%s NOTIFY(CDS)", v)
-		if s.LastUpdate != "" {
-			v = fmt.Sprintf("%s sent %s", v, formatRolloverTime(s.LastUpdate))
+	if len(s.CdsPublishedKeyIDs) > 0 {
+		v := formatKeyidBracketList(s.CdsPublishedKeyIDs)
+		if s.CdsPublishedAt != "" {
+			v = fmt.Sprintf("%s sent %s", v, formatRolloverTime(s.CdsPublishedAt))
 		}
 		left = append(left, kv{"CDS published:", v})
 	}
-	if s.Confirmed != nil {
-		v := dashKeyidsBracket(formatKeyidBracketList(s.ConfirmedKeyIDs))
-		if s.LastSuccess != "" {
-			v = fmt.Sprintf("%s observed %s", v, formatRolloverTime(s.LastSuccess))
+	if len(s.ObservedKeyIDs) > 0 {
+		v := formatKeyidBracketList(s.ObservedKeyIDs)
+		if s.ObservedAt != "" {
+			v = fmt.Sprintf("%s observed %s", v, formatRolloverTime(s.ObservedAt))
 		}
 		left = append(left, kv{"DS observed:", v})
+	} else if s.Confirmed != nil {
+		// Pre-existing-row fallback: zone has confirmed history but
+		// no last_ds_observed_keyids column populated yet (e.g. row
+		// from a daemon that pre-dates this commit). Show what we
+		// have so the line doesn't disappear post-upgrade.
+		left = append(left, kv{"DS observed:", dashKeyidsBracket(formatKeyidBracketList(s.ConfirmedKeyIDs))})
 	}
 
-	// Right column: timing config + history & polling.
+	// Right column: timing config + scheduling. Dropped:
+	//   - "last success" — same instant as DS observed <time> when
+	//     populated; redundant.
+	//   - "last poll"    — same instant as DS observed <time> by
+	//     construction (every poll updates last_ds_observed_*).
 	if s.Policy != nil && s.Policy.DsPublishDelay != "" {
 		right = append(right, kv{"ds-publish-delay:", s.Policy.DsPublishDelay})
-	}
-	if s.LastSuccess != "" {
-		right = append(right, kv{"last success:", formatRolloverTime(s.LastSuccess)})
-	}
-	if s.LastPoll != "" {
-		right = append(right, kv{"last poll:", formatRolloverTime(s.LastPoll)})
 	}
 	if s.NextPoll != "" {
 		right = append(right, kv{"next poll:", formatRolloverTime(s.NextPoll)})

--- a/v2/db.go
+++ b/v2/db.go
@@ -133,6 +133,15 @@ func dbMigrateSchema(db *sql.DB) {
 		{"RolloverZoneState", "last_success_at", "ALTER TABLE RolloverZoneState ADD COLUMN last_success_at TEXT"},
 		{"RolloverZoneState", "last_attempt_started_at", "ALTER TABLE RolloverZoneState ADD COLUMN last_attempt_started_at TEXT"},
 		{"RolloverZoneState", "last_poll_at", "ALTER TABLE RolloverZoneState ADD COLUMN last_poll_at TEXT"},
+		// Rollover NOTIFY-scheme phase 2: scheme + CDS-cleanup ownership.
+		// last_attempt_scheme is diagnostic-only ("UPDATE", "NOTIFY", or
+		// "UPDATE,NOTIFY" when a parallel send had at least one wire-level
+		// NOERROR). last_published_cds_index_low/high are engine-functional:
+		// a non-NULL pair asserts ownership of the current child-apex CDS
+		// RRset for cleanup-time comparison.
+		{"RolloverZoneState", "last_attempt_scheme", "ALTER TABLE RolloverZoneState ADD COLUMN last_attempt_scheme TEXT"},
+		{"RolloverZoneState", "last_published_cds_index_low", "ALTER TABLE RolloverZoneState ADD COLUMN last_published_cds_index_low INTEGER"},
+		{"RolloverZoneState", "last_published_cds_index_high", "ALTER TABLE RolloverZoneState ADD COLUMN last_published_cds_index_high INTEGER"},
 	}
 
 	for _, m := range migrations {

--- a/v2/db.go
+++ b/v2/db.go
@@ -142,6 +142,16 @@ func dbMigrateSchema(db *sql.DB) {
 		{"RolloverZoneState", "last_attempt_scheme", "ALTER TABLE RolloverZoneState ADD COLUMN last_attempt_scheme TEXT"},
 		{"RolloverZoneState", "last_published_cds_index_low", "ALTER TABLE RolloverZoneState ADD COLUMN last_published_cds_index_low INTEGER"},
 		{"RolloverZoneState", "last_published_cds_index_high", "ALTER TABLE RolloverZoneState ADD COLUMN last_published_cds_index_high INTEGER"},
+		// Last-observed DS RRset from the parent-agent poll. Stored as
+		// CSV-of-keyids (NOT a rollover_index range) so a polled answer
+		// can include keyids that have no RolloverKeyState row (parent
+		// has stale DS for a key the child has already removed, for
+		// example). Updated on every successful poll regardless of
+		// whether the polled set matches the engine's expected set;
+		// the operator's "DS observed" status line shows the latest
+		// poll rather than the latest confirmed match.
+		{"RolloverZoneState", "last_ds_observed_keyids", "ALTER TABLE RolloverZoneState ADD COLUMN last_ds_observed_keyids TEXT"},
+		{"RolloverZoneState", "last_ds_observed_at", "ALTER TABLE RolloverZoneState ADD COLUMN last_ds_observed_at TEXT"},
 	}
 
 	for _, m := range migrations {

--- a/v2/db_schema.go
+++ b/v2/db_schema.go
@@ -131,7 +131,9 @@ UNIQUE (zonename, keyid)
 		last_poll_at                   TEXT,
 		last_attempt_scheme            TEXT,
 		last_published_cds_index_low   INTEGER,
-		last_published_cds_index_high  INTEGER
+		last_published_cds_index_high  INTEGER,
+		last_ds_observed_keyids        TEXT,
+		last_ds_observed_at            TEXT
 	)`,
 
 	// ZoneSigningState holds per-zone signing-loop state. max_observed_ttl
@@ -144,6 +146,27 @@ UNIQUE (zonename, keyid)
 		zone              TEXT NOT NULL PRIMARY KEY,
 		max_observed_ttl  INTEGER NOT NULL DEFAULT 0,
 		updated_at        TEXT
+	)`,
+
+	// RolloverCdsPublication records the most recent successful CDS
+	// publication via the NOTIFY-scheme rollover push path. Sparse —
+	// only zones that have actually run a NOTIFY publish-and-sign at
+	// least once appear here. Distinct from
+	// RolloverZoneState.last_published_cds_index_*, which is the
+	// cleanup-time ownership marker (cleared by Trigger-1 cleanup).
+	// These columns preserve historical fact across cleanup so the
+	// operator can still see "CDS was published [keyids] at <time>"
+	// in status output after the rollover has completed.
+	//
+	// Storage shape: keyids is a comma-separated list (e.g.
+	// "12345,56789,43215") rendered straight to status output. Range
+	// encoding (low/high index pair) was rejected: it loses keyid
+	// identity if the engine ever publishes a non-contiguous
+	// sequence and is harder to read in operator-facing tools.
+	"RolloverCdsPublication": `CREATE TABLE IF NOT EXISTS 'RolloverCdsPublication' (
+		zone           TEXT NOT NULL PRIMARY KEY,
+		keyids         TEXT NOT NULL,
+		published_at   TEXT NOT NULL
 	)`,
 
 	// RolloverDaemonSentinel is a single-row table written by the auth

--- a/v2/db_schema.go
+++ b/v2/db_schema.go
@@ -128,7 +128,10 @@ UNIQUE (zonename, keyid)
 		last_softfail_detail           TEXT,
 		last_success_at                TEXT,
 		last_attempt_started_at        TEXT,
-		last_poll_at                   TEXT
+		last_poll_at                   TEXT,
+		last_attempt_scheme            TEXT,
+		last_published_cds_index_low   INTEGER,
+		last_published_cds_index_high  INTEGER
 	)`,
 
 	// ZoneSigningState holds per-zone signing-loop state. max_observed_ttl

--- a/v2/edns0/edns0_ede.go
+++ b/v2/edns0/edns0_ede.go
@@ -47,6 +47,23 @@ const (
 	EDEZoneUpdateRRtypeNotAllowed       // RR type not in update-policy.<scope>.rrtypes
 	EDEZoneUpdateOwnerOutsidePolicy     // owner name violates self/selfsub policy
 	EDEZoneUpdateChildUpdatesNotAllowed // OptAllowChildUpdates is false for this zone
+
+	// NOTIFY-side synchronous-rejection detail codes (rollover NOTIFY
+	// scheme phase 8). Mirror the UPDATE-side EDEZoneUpdate* codes:
+	// the parent's NotifyResponder rejects with REFUSED/NOTAUTH/etc.
+	// and attaches one of these so the child rollover engine's
+	// parent-rejected category renders an actionable diagnostic.
+	//
+	// EDENotifyDsyncSchemeNotAdvertised is the most operationally
+	// important: a child mis-pointed at a parent that doesn't
+	// advertise NOTIFY for the RRtype gets an immediate, precise
+	// diagnostic instead of waiting attempt-timeout for a generic
+	// parent-publish-failure.
+	EDENotifyDsyncSchemeNotAdvertised // parent does not advertise NOTIFY for this RRtype
+	EDENotifyTargetNotChildDelegation // qname is not a child delegation in receiving parent zone
+	EDENotifyParentNotAuthoritative   // parent zone not authoritative on this server
+	EDENotifyZoneInErrorState         // target zone in error state
+	EDENotifyUnknownType              // unsupported NOTIFY RRtype
 )
 
 var EDECodeToString = map[uint16]string{
@@ -73,6 +90,12 @@ var EDECodeToString = map[uint16]string{
 	EDEZoneUpdateRRtypeNotAllowed:       "RR type not permitted by update policy",
 	EDEZoneUpdateOwnerOutsidePolicy:     "owner name outside update policy scope",
 	EDEZoneUpdateChildUpdatesNotAllowed: "child updates are not allowed for this zone",
+
+	EDENotifyDsyncSchemeNotAdvertised: "parent does not advertise NOTIFY for this RRtype",
+	EDENotifyTargetNotChildDelegation: "qname is not a child delegation in this parent zone",
+	EDENotifyParentNotAuthoritative:   "this server is not authoritative for the parent zone",
+	EDENotifyZoneInErrorState:         "target zone is in error state",
+	EDENotifyUnknownType:              "unsupported NOTIFY RRtype",
 }
 
 // AttachEDEToResponse attaches an Extended DNS Error (EDE) option to the DNS response

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -59,12 +59,20 @@ func kskIndexPushNeeded(row *RolloverZoneRow, low, high int, indexOK bool, haveD
 
 // RolloverAutomatedTick runs one slice of automated KSK rollover for multi-ds (pipeline fill,
 // DS push / observe phase machine). double-signature is not implemented yet.
-// propagationDelay is the kasp.propagation_delay used by pending-child-publish.
-func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *Imr, zd *ZoneData, propagationDelay time.Duration, now time.Time) error {
-	if zd == nil || zd.DnssecPolicy == nil {
+//
+// All dependencies are passed via RolloverEngineDeps so the engine has no
+// implicit globals. The orchestrator (KeyStateWorker) iterates its zones,
+// builds deps for each, and calls this. deps.PropagationDelay is the
+// kasp.propagation_delay used by pending-child-publish.
+func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
+	zd := deps.Zone
+	if zd == nil {
 		return nil
 	}
-	pol := zd.DnssecPolicy
+	pol := deps.Policy
+	if pol == nil {
+		return nil
+	}
 	if pol.Rollover.Method == RolloverMethodNone {
 		return nil
 	}
@@ -72,14 +80,33 @@ func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *I
 		return nil
 	}
 
+	conf := deps.Conf
+	kdb := deps.KDB
+	imr := deps.Imr
+	propagationDelay := deps.PropagationDelay
+	now := time.Now()
+	if deps.Now != nil {
+		now = deps.Now()
+	}
+
 	zone := dns.Fqdn(zd.ZoneName)
 
 	// Serialize against API mutating handlers (asap, cancel, reset,
 	// unstick). Held for the duration of one tick's per-zone work so
 	// a CLI-driven write cannot interleave with a phase advance.
-	lock := AcquireRolloverLock(zone)
-	lock.Lock()
-	defer lock.Unlock()
+	acquire := deps.AcquireLock
+	if acquire == nil {
+		acquire = defaultAcquireRolloverLock
+	}
+	release, err := acquire(zone)
+	if err != nil {
+		// Soft acquisition failure (e.g. tdns-mp's leader-aware
+		// acquirer returning ErrNotLeader for a zone owned by
+		// another provider). Skip this cycle without escalating.
+		lgSigner.Debug("rollover: lock acquisition skipped", "zone", zone, "err", err)
+		return nil
+	}
+	defer release()
 
 	if err := EnsureRolloverZoneRow(kdb, zone); err != nil {
 		return err
@@ -200,7 +227,7 @@ func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *I
 		}
 		_ = setLastAttemptStarted(kdb, zone, now)
 		pushCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
-		res, err := PushWholeDSRRset(pushCtx, zd, kdb, imr)
+		res, err := PushDSRRsetForRollover(pushCtx, deps)
 		cancel()
 		if err != nil {
 			cat := res.Category
@@ -231,7 +258,7 @@ func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *I
 			return err
 		}
 		lgSigner.Info("rollover: DS UPDATE accepted, arming observe", "zone", zone, "first_poll_at", nextPoll.Format(time.RFC3339))
-		scheduleFastObservePoll(ctx, conf, kdb, imr, zd, propagationDelay, initial)
+		scheduleFastObservePoll(ctx, deps, initial)
 	case rolloverPhasePendingParentObserve:
 		agent := pol.Rollover.ParentAgent
 		if agent == "" {
@@ -396,7 +423,7 @@ func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *I
 		}
 		_ = setLastAttemptStarted(kdb, zone, now)
 		pushCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
-		res, perr := PushWholeDSRRset(pushCtx, zd, kdb, imr)
+		res, perr := PushDSRRsetForRollover(pushCtx, deps)
 		cancel()
 		if perr != nil {
 			cat := res.Category
@@ -424,7 +451,7 @@ func RolloverAutomatedTick(ctx context.Context, conf *Config, kdb *KeyDB, imr *I
 		_ = setObserveSchedule(kdb, zone, now, nextPoll, int(initial.Seconds()))
 		_ = setNextPushAt(kdb, zone, nextPush)
 		lgSigner.Info("rollover: softfail probe accepted, observing", "zone", zone, "first_poll_at", nextPoll.Format(time.RFC3339), "next_probe_at", nextPush.Format(time.RFC3339))
-		scheduleFastObservePoll(ctx, conf, kdb, imr, zd, propagationDelay, initial)
+		scheduleFastObservePoll(ctx, deps, initial)
 	case rolloverPhasePendingChildWithdraw:
 		// §8.8: wait effective_margin = max(policy.clamping.margin,
 		// max_observed_ttl) from each retired SEP key's retired_at, then
@@ -603,11 +630,14 @@ WHERE zone = ?`, zone); err != nil {
 // after restart picks up where this left off (at the cost of being
 // bounded by check_interval — same as the pre-fix behavior). No state
 // is lost; just slower recovery.
-func scheduleFastObservePoll(ctx context.Context, conf *Config, kdb *KeyDB, imr *Imr, zd *ZoneData, propagationDelay, initial time.Duration) {
+func scheduleFastObservePoll(ctx context.Context, deps RolloverEngineDeps, initial time.Duration) {
 	if initial <= 0 {
 		initial = defaultConfirmInitialWait
 	}
-	zone := zd.ZoneName
+	if deps.Zone == nil {
+		return
+	}
+	zone := deps.Zone.ZoneName
 	go func() {
 		timer := time.NewTimer(initial)
 		defer timer.Stop()
@@ -616,7 +646,7 @@ func scheduleFastObservePoll(ctx context.Context, conf *Config, kdb *KeyDB, imr 
 			return
 		case <-timer.C:
 		}
-		if err := RolloverAutomatedTick(ctx, conf, kdb, imr, zd, propagationDelay, time.Now()); err != nil {
+		if err := RolloverAutomatedTick(ctx, deps); err != nil {
 			lgSigner.Debug("rollover: fast-poll tick error", "zone", zone, "err", err)
 		}
 	}()
@@ -929,6 +959,7 @@ func PromoteStandbyKskIfNoActive(conf *Config, kdb *KeyDB, zone string) {
 
 func rolloverAutomatedForAllZones(ctx context.Context, conf *Config, kdb *KeyDB, propagationDelay time.Duration, now time.Time) {
 	imr := conf.Internal.ImrEngine
+	nowFn := func() time.Time { return now }
 	for _, zd := range Zones.Items() {
 		if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
 			continue
@@ -939,7 +970,28 @@ func rolloverAutomatedForAllZones(ctx context.Context, conf *Config, kdb *KeyDB,
 		if zd.DnssecPolicy == nil {
 			continue
 		}
-		if err := RolloverAutomatedTick(ctx, conf, kdb, imr, zd, propagationDelay, now); err != nil {
+		var notifyq chan NotifyRequest
+		if conf.Internal.NotifyQ != nil {
+			notifyq = conf.Internal.NotifyQ
+		}
+		var updateq chan UpdateRequest
+		if kdb != nil {
+			updateq = kdb.UpdateQ
+		}
+		deps := RolloverEngineDeps{
+			Conf:             conf,
+			KDB:              kdb,
+			Zone:             zd,
+			Imr:              imr,
+			NotifyQ:          notifyq,
+			InternalUpdateQ:  updateq,
+			Policy:           zd.DnssecPolicy,
+			AcquireLock:      defaultAcquireRolloverLock,
+			Logger:           lgSigner,
+			PropagationDelay: propagationDelay,
+			Now:              nowFn,
+		}
+		if err := RolloverAutomatedTick(ctx, deps); err != nil {
 			lgSigner.Error("rollover: tick error", "zone", zd.ZoneName, "err", err)
 		}
 	}

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -222,7 +222,7 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 		// under pending-parent-observe.
 		if imr == nil {
 			lgSigner.Warn("rollover: ImrEngine nil, cannot DS push", "zone", zone)
-			handleAttemptFailed(kdb, zone, pol, SoftfailChildConfig, "ImrEngine nil, cannot DS push", now)
+			handleAttemptFailed(kdb, zone, pol, SoftfailChildConfigLocalError, "ImrEngine nil, cannot DS push", now)
 			return nil
 		}
 		_ = setLastAttemptStarted(kdb, zone, now)
@@ -434,7 +434,7 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 		nextPush := now.Add(softfailDelay).Add(jitterUpTo(5 * time.Minute))
 		if imr == nil {
 			lgSigner.Warn("rollover: ImrEngine nil, cannot softfail probe", "zone", zone)
-			_ = setSoftfail(kdb, zone, SoftfailChildConfig, "ImrEngine nil, cannot softfail probe", now, nextPush)
+			_ = setSoftfail(kdb, zone, SoftfailChildConfigLocalError, "ImrEngine nil, cannot softfail probe", now, nextPush)
 			return nil
 		}
 		_ = setLastAttemptStarted(kdb, zone, now)
@@ -450,8 +450,15 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 			if res.Detail != "" {
 				detail = res.Detail
 			}
+			// child-config:waiting-for-parent: cap softfail-delay at 1h
+			// to keep the probe cadence reasonable when the parent is
+			// indefinitely unreachable.
+			probeNext := nextPush
+			if cat == SoftfailChildConfigWaitingForParent {
+				probeNext = now.Add(waitingForParentDelay(pol)).Add(jitterUpTo(5 * time.Minute))
+			}
 			lgSigner.Warn("rollover: softfail probe push failed", "zone", zone, "category", cat, "err", perr, "detail", detail)
-			_ = setSoftfail(kdb, zone, cat, detail, now, nextPush)
+			_ = setSoftfail(kdb, zone, cat, detail, now, probeNext)
 			return nil
 		}
 		if res.Rcode != dns.RcodeSuccess {
@@ -708,6 +715,26 @@ func recordObserveTimeout(kdb *KeyDB, zone string, low, high int, timeout time.D
 	handleAttemptFailed(kdb, zone, pol, SoftfailParentPublishFailure, msg, now)
 }
 
+// waitingForParentDelay returns the capped softfail-delay used by
+// child-config:waiting-for-parent. Falls back to the policy's
+// SoftfailDelay (or defaults) but never exceeds waitingForParentBackoffCap.
+// Pure helper, table-tested.
+func waitingForParentDelay(pol *DnssecPolicy) time.Duration {
+	var softfailDelay time.Duration
+	if pol != nil {
+		softfailDelay = pol.Rollover.SoftfailDelay
+		if softfailDelay <= 0 {
+			softfailDelay = derivedSoftfailDelay(pol.Rollover.DsPublishDelay)
+		}
+	} else {
+		softfailDelay = defaultSoftfailDelayMinimum
+	}
+	if softfailDelay > waitingForParentBackoffCap {
+		softfailDelay = waitingForParentBackoffCap
+	}
+	return softfailDelay
+}
+
 // handleAttemptFailed is the shared decision point for any failed
 // rollover attempt — push error, push non-NOERROR, observe timeout.
 // Increments the hardfail counter and decides the next phase:
@@ -717,11 +744,34 @@ func recordObserveTimeout(kdb *KeyDB, zone string, low, high int, timeout time.D
 //   - count >= max-attempts-before-backoff → enter parent-push-softfail
 //     (long-term mode; one probe per softfail-delay forever).
 //
+// Special-case: child-config:waiting-for-parent never increments
+// hardfail_count and always enters softfail mode immediately with the
+// backoff capped at 1h. The parent has lost the ability to consume
+// our push entirely (no usable DSYNC scheme advertised); there is
+// nothing on the child side that retrying-faster would help. The
+// engine probes forever at the 1h cap until DSYNC reappears, at which
+// point the next probe succeeds and resetHardfailCount + clearLastSoftfail
+// run via the confirmed-observation path.
+//
 // Records the failure category and detail in either case so status
 // output can show what went wrong. Errors from the underlying writes
 // are logged but not propagated — the caller's tick-level error path
 // is for things that prevent the engine from advancing at all.
 func handleAttemptFailed(kdb *KeyDB, zone string, pol *DnssecPolicy, category, detail string, now time.Time) {
+	if category == SoftfailChildConfigWaitingForParent {
+		// Indefinite softfail with 1h cap; do NOT increment hardfail_count.
+		softfailDelay := waitingForParentDelay(pol)
+		nextPush := now.Add(softfailDelay).Add(jitterUpTo(5 * time.Minute))
+		if err := setSoftfail(kdb, zone, category, detail, now, nextPush); err != nil {
+			lgSigner.Warn("rollover: setSoftfail (waiting-for-parent) failed", "zone", zone, "err", err)
+		}
+		if err := SetRolloverPhase(kdb, zone, rolloverPhasePushSoftfail); err != nil {
+			lgSigner.Warn("rollover: set phase parent-push-softfail (waiting-for-parent) failed", "zone", zone, "err", err)
+		}
+		lgSigner.Warn("rollover: parent advertises no usable DSYNC scheme; halting until restored",
+			"zone", zone, "category", category, "next_probe_at", nextPush.Format(time.RFC3339))
+		return
+	}
 	n, err := incrementHardfailCount(kdb, zone)
 	if err != nil {
 		lgSigner.Warn("rollover: increment hardfail_count failed", "zone", zone, "err", err)

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -234,15 +234,25 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 			if cat == "" {
 				cat = SoftfailTransport
 			}
-			lgSigner.Warn("rollover: DS push failed", "zone", zone, "err", err, "category", cat)
-			handleAttemptFailed(kdb, zone, pol, cat, err.Error(), now)
+			detail := err.Error()
+			if res.Detail != "" {
+				detail = res.Detail
+			}
+			lgSigner.Warn("rollover: DS push failed", "zone", zone, "err", err, "category", cat, "detail", detail)
+			handleAttemptFailed(kdb, zone, pol, cat, detail, now)
 			return nil
 		}
 		if res.Rcode != dns.RcodeSuccess {
 			lgSigner.Warn("rollover: DS push non-NOERROR", "zone", zone, "rcode", dns.RcodeToString[res.Rcode])
 			detail := fmt.Sprintf("rcode=%s", dns.RcodeToString[res.Rcode])
+			if res.Detail != "" {
+				detail = res.Detail
+			}
 			handleAttemptFailed(kdb, zone, pol, SoftfailParentRejected, detail, now)
 			return nil
+		}
+		if res.Scheme != "" {
+			_ = setLastAttemptScheme(kdb, zone, res.Scheme)
 		}
 		// Schedule the first parent-agent DS query: wait confirm-initial-wait
 		// from now, then exponential backoff starting at confirm-initial-wait.
@@ -430,15 +440,25 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 			if cat == "" {
 				cat = SoftfailTransport
 			}
-			lgSigner.Warn("rollover: softfail probe push failed", "zone", zone, "category", cat, "err", perr)
-			_ = setSoftfail(kdb, zone, cat, perr.Error(), now, nextPush)
+			detail := perr.Error()
+			if res.Detail != "" {
+				detail = res.Detail
+			}
+			lgSigner.Warn("rollover: softfail probe push failed", "zone", zone, "category", cat, "err", perr, "detail", detail)
+			_ = setSoftfail(kdb, zone, cat, detail, now, nextPush)
 			return nil
 		}
 		if res.Rcode != dns.RcodeSuccess {
 			detail := fmt.Sprintf("rcode=%s", dns.RcodeToString[res.Rcode])
-			lgSigner.Warn("rollover: softfail probe push non-NOERROR", "zone", zone, "rcode", dns.RcodeToString[res.Rcode])
+			if res.Detail != "" {
+				detail = res.Detail
+			}
+			lgSigner.Warn("rollover: softfail probe push non-NOERROR", "zone", zone, "rcode", dns.RcodeToString[res.Rcode], "detail", detail)
 			_ = setSoftfail(kdb, zone, SoftfailParentRejected, detail, now, nextPush)
 			return nil
+		}
+		if res.Scheme != "" {
+			_ = setLastAttemptScheme(kdb, zone, res.Scheme)
 		}
 		// Probe accepted at the wire. Restart observe to pick up DS
 		// when it appears; bump next_push_at without overwriting the

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -671,6 +671,15 @@ func scheduleFastObservePoll(ctx context.Context, deps RolloverEngineDeps, initi
 		return
 	}
 	zone := deps.Zone.ZoneName
+	// rolloverAutomatedForAllZones injects deps.Now as a closure that
+	// returns the tick's frozen `now`. After the goroutine sleeps for
+	// `initial`, that frozen time is stale — the tick handler would
+	// see observe_next_poll_at as still in the future and skip the
+	// poll. Reset Now to nil so the rerun's RolloverAutomatedTick
+	// falls back to its time.Now() default. Copy deps so this
+	// goroutine's mutation doesn't race the caller.
+	fastDeps := deps
+	fastDeps.Now = nil
 	go func() {
 		timer := time.NewTimer(initial)
 		defer timer.Stop()
@@ -679,7 +688,7 @@ func scheduleFastObservePoll(ctx context.Context, deps RolloverEngineDeps, initi
 			return
 		case <-timer.C:
 		}
-		if err := RolloverAutomatedTick(ctx, deps); err != nil {
+		if err := RolloverAutomatedTick(ctx, fastDeps); err != nil {
 			lgSigner.Debug("rollover: fast-poll tick error", "zone", zone, "err", err)
 		}
 	}()

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -350,6 +350,10 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 		// Clear last_softfail_*: the previous softfail event is no
 		// longer informative now that we're back in sync.
 		_ = clearLastSoftfail(kdb, zone)
+		// Trigger 1 — confirmed observation: if NOTIFY-pushed CDS is
+		// still on the wire (last_published_cds_index_low/high
+		// non-NULL), unpublish it now per RFC 7344 §4.1. Best-effort.
+		cleanupCdsAfterConfirm(zd, kdb)
 		if advanced > 0 {
 			triggerResign(conf, zone)
 		}
@@ -405,6 +409,8 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 				_ = setLastSuccess(kdb, zone, now)
 				_ = setLastAttemptStarted(kdb, zone, time.Time{})
 				_ = clearLastSoftfail(kdb, zone)
+				// Trigger 1 — confirmed observation, softfail-recovery path.
+				cleanupCdsAfterConfirm(zd, kdb)
 				if advanced > 0 {
 					triggerResign(conf, zone)
 				}

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -156,6 +156,25 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 		phase = rolloverPhaseIdle
 	}
 
+	// CDS-publication observability: when the engine claims ownership
+	// of an apex CDS RRset (last_published_cds_index_low/high non-NULL),
+	// log whether the CDS is actually present at the apex on this tick.
+	// Mismatch indicates a refresh-time wipe between pushes — the
+	// engine will re-publish on the next attempt but the operator
+	// sees the churn in zone-update warnings.
+	if row.LastPublishedCdsIndexLow.Valid && row.LastPublishedCdsIndexHigh.Valid {
+		apexCdsRRs := 0
+		if owner, _ := zd.GetOwner(zd.ZoneName); owner != nil {
+			if rs, ok := owner.RRtypes.Get(dns.TypeCDS); ok {
+				apexCdsRRs = len(rs.RRs)
+			}
+		}
+		lgRollover.Debug("tick: CDS ownership marker set, observing apex",
+			"zone", zone, "apex_cds_rrs", apexCdsRRs,
+			"index_low", row.LastPublishedCdsIndexLow.Int64,
+			"index_high", row.LastPublishedCdsIndexHigh.Int64)
+	}
+
 	// rollover_due (§8.1): when no rollover is in progress and either the
 	// scheduled lifetime has elapsed OR a manual-ASAP request has reached
 	// its computed earliest time, fire AtomicRollover. The tick then

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -338,6 +338,10 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 			scheduleNextObservePoll(kdb, zone, row, now, pollMax)
 			return nil
 		}
+		// Persist the polled keyid set + timestamp regardless of
+		// whether it matches expected. The "DS observed" status line
+		// shows the latest poll, not the latest confirmed match.
+		_ = setLastDsObserved(kdb, zone, dsKeyids(obs), now)
 		if !ObservedDSSetMatchesExpected(obs, expected) {
 			scheduleNextObservePoll(kdb, zone, row, now, pollMax)
 			return nil
@@ -414,6 +418,12 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 		if pollDue && agent != "" {
 			obs, qerr := QueryParentAgentDS(ctx, zone, agent)
 			_ = setLastPoll(kdb, zone, now)
+			if qerr == nil {
+				// Persist the polled keyid set + timestamp regardless
+				// of match status; the "DS observed" status line
+				// reflects the latest poll, not the latest confirm.
+				_ = setLastDsObserved(kdb, zone, dsKeyids(obs), now)
+			}
 			if qerr == nil && ObservedDSSetMatchesExpected(obs, expected) {
 				if !idxOK {
 					lgSigner.Warn("rollover: DS observed during softfail but rollover_index incomplete; cannot advance", "zone", zone)
@@ -872,6 +882,20 @@ func scheduleNextObservePoll(kdb *KeyDB, zone string, row *RolloverZoneRow, now 
 	if err := setObserveSchedule(kdb, zone, started, now.Add(next), int(next.Seconds())); err != nil {
 		lgSigner.Warn("rollover: set next observe poll", "zone", zone, "err", err)
 	}
+}
+
+// dsKeyids extracts the KeyTag from each DS RR in the slice. Used by
+// the observe-poll path to persist the last observed keyid set
+// (last_ds_observed_keyids on RolloverZoneState) regardless of
+// whether it matches expected.
+func dsKeyids(rrs []dns.RR) []uint16 {
+	out := make([]uint16, 0, len(rrs))
+	for _, rr := range rrs {
+		if ds, ok := rr.(*dns.DS); ok {
+			out = append(out, ds.KeyTag)
+		}
+	}
+	return out
 }
 
 func parseOptionalTime(s sql.NullString) (time.Time, bool) {

--- a/v2/ksk_rollover_categories.go
+++ b/v2/ksk_rollover_categories.go
@@ -1,5 +1,7 @@
 package tdns
 
+import "time"
+
 // RolloverFailureCategory enumerates the four kinds of failure the
 // rollover engine distinguishes when recording a softfail event.
 // Operator action depends on category, so the enum value is exposed
@@ -30,4 +32,28 @@ const (
 	SoftfailTransport            = "transport"
 	SoftfailParentRejected       = "parent-rejected"
 	SoftfailParentPublishFailure = "parent-publish-failure"
+
+	// child-config subcategories (NOTIFY-scheme phase 6).
+	//
+	// SoftfailChildConfigWaitingForParent: parent advertises no
+	// rollover-usable DSYNC scheme (or none matching the policy's
+	// dsync-scheme-preference). Distinct recovery model: the engine
+	// halts but probes forever with backoff capped at 1h. Never
+	// increments hardfail_count and never escalates. Recovers
+	// automatically when the parent restores DSYNC advertisement.
+	//
+	// SoftfailChildConfigLocalError: every other child-config source
+	// — no SIG(0) key, no DS to publish, ParentZone unresolvable,
+	// SignMsg failed, NOTIFY publish-and-sign queue failure. Existing
+	// softfail-then-long-term path. Operator intervention typically
+	// required.
+	SoftfailChildConfigWaitingForParent = "child-config:waiting-for-parent"
+	SoftfailChildConfigLocalError       = "child-config:local-error"
 )
+
+// waitingForParentBackoffCap is the upper bound on softfail-delay
+// when category is SoftfailChildConfigWaitingForParent. The 1h cap
+// matches the natural IMR DSYNC re-fetch cadence (typical parent
+// DSYNC TTL); the probe IS the poll. No separate slow-tick
+// infrastructure needed.
+const waitingForParentBackoffCap = time.Hour

--- a/v2/ksk_rollover_cds_cleanup.go
+++ b/v2/ksk_rollover_cds_cleanup.go
@@ -1,0 +1,217 @@
+package tdns
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// cleanupCdsAfterConfirm releases the rollover engine's CDS-RRset
+// ownership on the child zone, with compare-on-cleanup to avoid
+// unpublishing CDS that another caller (general delegation-sync) has
+// taken over. Called from three trigger sites:
+//
+//  1. confirmed observation in pending-parent-observe — primary path
+//     for steady-state NOTIFY-pushed rollovers (publish, observe,
+//     confirm, clean up).
+//  2. start of any push attempt that won't republish CDS — handles
+//     parent-side scheme transitions mid-rollover (NOTIFY→UPDATE-only
+//     flips, DSYNC withdrawn, ...) so CDS doesn't sit orphaned for
+//     the duration of an outage.
+//  3. terminal hardfail — to be wired when the rollover state machine
+//     adds a terminal-hardfail site. Today the post-overhaul model is
+//     indefinite softfail; no such site exists yet.
+//
+// Behavior:
+//   - last_published_cds_index_low/high NULL → no-op (we own no CDS).
+//   - Reload the KSK rows referenced by the saved range. Re-derive
+//     the expected CDS RRset from those rows (same path as
+//     ComputeTargetCDSSetForZone — the rows' state may have advanced
+//     since publish, but the key material is what defines a CDS).
+//   - Read the current CDS RRset from the in-memory zone. Compare
+//     expected vs current as a set of (KeyTag, Algorithm, DigestType,
+//     Digest) tuples — TTL, ownername case, and order are immaterial.
+//   - Equal sets → queue UnpublishCdsRRs (anti-CDS ClassANY delete);
+//     clear last_published_cds_index_low/high.
+//   - Unequal sets → another caller has taken ownership; log INFO,
+//     clear last_published_cds_index_low/high (so we don't retry next
+//     cycle), leave CDS on the wire untouched.
+//
+// All three triggers are best-effort: on any error, log WARN and
+// return without escalating. CDS RRset is not on any rollover-critical
+// path; an orphaned CDS will eventually be replaced by the general
+// delegation-sync path or by another rollover attempt.
+func cleanupCdsAfterConfirm(zd *ZoneData, kdb *KeyDB) {
+	if zd == nil || kdb == nil {
+		return
+	}
+	zone := dns.Fqdn(zd.ZoneName)
+
+	row, err := LoadRolloverZoneRow(kdb, zone)
+	if err != nil {
+		lgSigner.Warn("rollover: cleanupCdsAfterConfirm: load row", "zone", zone, "err", err)
+		return
+	}
+	if row == nil {
+		return
+	}
+	if !row.LastPublishedCdsIndexLow.Valid || !row.LastPublishedCdsIndexHigh.Valid {
+		return
+	}
+	low := int(row.LastPublishedCdsIndexLow.Int64)
+	high := int(row.LastPublishedCdsIndexHigh.Int64)
+
+	// Re-derive the expected CDS set from KSK rows whose
+	// rollover_index falls in [low, high]. State may have advanced
+	// since we published, but key material is what defines a CDS
+	// tuple — only the digest matters for comparison.
+	expected, err := expectedCdsTuplesForRange(kdb, zone, low, high)
+	if err != nil {
+		lgSigner.Warn("rollover: cleanupCdsAfterConfirm: re-derive expected CDS",
+			"zone", zone, "low", low, "high", high, "err", err)
+		// Treat as "unequal" — clear range, leave CDS in place. The
+		// stored range is no longer authoritative for cleanup.
+		_ = clearPublishedCdsRange(kdb, zone)
+		return
+	}
+
+	current, err := currentCdsTuples(zd)
+	if err != nil {
+		lgSigner.Warn("rollover: cleanupCdsAfterConfirm: read current CDS",
+			"zone", zone, "err", err)
+		_ = clearPublishedCdsRange(kdb, zone)
+		return
+	}
+
+	if !cdsTupleSetsEqual(expected, current) {
+		lgSigner.Info("rollover: CDS no longer matches last push, leaving in place",
+			"zone", zone, "expected_count", len(expected), "current_count", len(current))
+		_ = clearPublishedCdsRange(kdb, zone)
+		return
+	}
+
+	// Equal — we still own this CDS RRset. Unpublish.
+	if err := zd.UnpublishCdsRRs(); err != nil {
+		lgSigner.Warn("rollover: cleanupCdsAfterConfirm: UnpublishCdsRRs",
+			"zone", zone, "err", err)
+		// Don't clear the range yet — we'll retry on the next trigger.
+		return
+	}
+	if err := clearPublishedCdsRange(kdb, zone); err != nil {
+		lgSigner.Warn("rollover: cleanupCdsAfterConfirm: clearPublishedCdsRange",
+			"zone", zone, "err", err)
+		return
+	}
+	lgSigner.Info("rollover: CDS cleanup complete", "zone", zone)
+}
+
+// cdsTuple is the comparison key for compare-on-cleanup. RFC 4034
+// §5.1 defines a DS by these four fields; CDS shares the same shape.
+// TTL, ownername case, and slice order are intentionally excluded so
+// incidental differences (re-canonicalization on re-signing, TTL
+// adjustments) don't cause false-mismatch.
+type cdsTuple struct {
+	KeyTag     uint16
+	Algorithm  uint8
+	DigestType uint8
+	Digest     string
+}
+
+// expectedCdsTuplesForRange recomputes the CDS tuples from the KSK
+// rows whose rollover_index is within [low, high]. Mirrors
+// ComputeTargetCDSSetForZone but filtered by index range and
+// returning tuples instead of RRs.
+func expectedCdsTuplesForRange(kdb *KeyDB, zone string, low, high int) (map[cdsTuple]struct{}, error) {
+	if kdb == nil {
+		return nil, fmt.Errorf("nil kdb")
+	}
+	rows, _, _, _, err := loadTargetKSKsForRollover(kdb, zone)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[cdsTuple]struct{}, len(rows))
+	for _, row := range rows {
+		if !row.ri.Valid {
+			continue
+		}
+		idx := int(row.ri.Int64)
+		if idx < low || idx > high {
+			continue
+		}
+		rr, err := dns.NewRR(row.keyrr)
+		if err != nil {
+			return nil, fmt.Errorf("parse DNSKEY keyid=%d: %w", row.keyid, err)
+		}
+		dk, ok := rr.(*dns.DNSKEY)
+		if !ok {
+			continue
+		}
+		ds := dk.ToDS(uint8(dns.SHA256))
+		if ds == nil {
+			continue
+		}
+		out[cdsTuple{
+			KeyTag:     ds.KeyTag,
+			Algorithm:  ds.Algorithm,
+			DigestType: ds.DigestType,
+			Digest:     ds.Digest,
+		}] = struct{}{}
+	}
+	return out, nil
+}
+
+// currentCdsTuples reads the CDS RRset from the in-memory zone apex
+// and returns its DS-identifying tuples. Returns an empty map if the
+// zone has no CDS RRset.
+func currentCdsTuples(zd *ZoneData) (map[cdsTuple]struct{}, error) {
+	apex, err := zd.GetOwner(zd.ZoneName)
+	if err != nil {
+		return nil, fmt.Errorf("GetOwner: %w", err)
+	}
+	out := make(map[cdsTuple]struct{})
+	if apex == nil {
+		return out, nil
+	}
+	rrset, exists := apex.RRtypes.Get(dns.TypeCDS)
+	if !exists {
+		return out, nil
+	}
+	for _, rr := range rrset.RRs {
+		c, ok := rr.(*dns.CDS)
+		if !ok {
+			continue
+		}
+		out[cdsTuple{
+			KeyTag:     c.DS.KeyTag,
+			Algorithm:  c.DS.Algorithm,
+			DigestType: c.DS.DigestType,
+			Digest:     c.DS.Digest,
+		}] = struct{}{}
+	}
+	return out, nil
+}
+
+func cdsTupleSetsEqual(a, b map[cdsTuple]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// cleanupCdsAfterHardfail is the Trigger 3 hook for terminal hardfail.
+// Today the rollover state machine has no terminal-hardfail state
+// (post-overhaul model is indefinite softfail with one probe per
+// softfail-delay forever). This function exists so a future
+// rollover-state-machine extension that introduces a terminal-hardfail
+// transition can call it without re-discovering the cleanup helper.
+//
+//nolint:unused // wired by the future terminal-hardfail commit.
+func cleanupCdsAfterHardfail(zd *ZoneData, kdb *KeyDB, _ time.Time) {
+	cleanupCdsAfterConfirm(zd, kdb)
+}

--- a/v2/ksk_rollover_ds_notify.go
+++ b/v2/ksk_rollover_ds_notify.go
@@ -47,6 +47,7 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	zd := deps.Zone
 	kdb := deps.KDB
 	notifyq := deps.NotifyQ
+	updateq := deps.InternalUpdateQ
 	if zd == nil || kdb == nil {
 		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: nil argument")
@@ -58,6 +59,10 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	if notifyq == nil {
 		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: NotifyQ not configured")
+	}
+	if updateq == nil {
+		out.Category = SoftfailChildConfigLocalError
+		return out, fmt.Errorf("pushDSRRsetViaNotify: InternalUpdateQ not configured")
 	}
 
 	child := dns.Fqdn(zd.ZoneName)
@@ -87,12 +92,8 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	actions = append(actions, antiCds)
 	actions = append(actions, cdsSet...)
 
-	if kdb.UpdateQ == nil {
-		out.Category = SoftfailChildConfigLocalError
-		return out, fmt.Errorf("pushDSRRsetViaNotify: kdb.UpdateQ nil")
-	}
 	select {
-	case kdb.UpdateQ <- UpdateRequest{
+	case updateq <- UpdateRequest{
 		Cmd:            "ZONE-UPDATE",
 		ZoneName:       child,
 		Actions:        actions,
@@ -100,7 +101,7 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	}:
 	case <-time.After(5 * time.Second):
 		out.Category = SoftfailChildConfigLocalError
-		return out, fmt.Errorf("pushDSRRsetViaNotify: UpdateQ full for 5s, skipping")
+		return out, fmt.Errorf("pushDSRRsetViaNotify: InternalUpdateQ full for 5s, skipping")
 	case <-ctx.Done():
 		out.Category = SoftfailChildConfigLocalError
 		return out, ctx.Err()
@@ -152,16 +153,12 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 
 	out.Rcode = resp.Rcode
 	if resp.Error {
-		// SendNotify returned with no NOERROR target. If the parent
-		// produced a non-NOERROR rcode at least once, that's
-		// parent-rejected; otherwise transport.
-		if resp.Rcode != 0 && resp.Rcode != dns.RcodeSuccess {
-			out.Category = SoftfailParentRejected
-			out.Detail = formatNotifyDetail(resp)
-		} else {
-			out.Category = SoftfailTransport
-			out.Detail = formatNotifyDetail(resp)
-		}
+		// resp.Error is set only on actual transport failure
+		// (no target produced a usable response). Parent-rejected
+		// rcodes come back via the resp.Rcode != NOERROR branch
+		// below with resp.Error == false.
+		out.Category = SoftfailTransport
+		out.Detail = formatNotifyDetail(resp)
 		return out, fmt.Errorf("pushDSRRsetViaNotify: %s", resp.ErrorMsg)
 	}
 	if resp.Rcode != dns.RcodeSuccess {

--- a/v2/ksk_rollover_ds_notify.go
+++ b/v2/ksk_rollover_ds_notify.go
@@ -1,0 +1,198 @@
+package tdns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// pushDSRRsetViaNotify is the NOTIFY(CDS) counterpart to
+// pushDSRRsetViaUpdate. It computes the engine's target CDS set,
+// queues a publish-and-sign for it at the child apex via the
+// internal-update queue, and dispatches NOTIFY(CDS) to the parent's
+// DSYNC NOTIFY target. The publish path is best-effort
+// (queue-and-forget): see "Implementation note" below.
+//
+// On NOTIFY NOERROR: persist last_published_cds_index_low/high to
+// claim ownership of the on-wire CDS for cleanup-time comparison.
+// CDS stays published until cleanupCdsAfterConfirm runs (Phase 5).
+//
+// On NOTIFY failure (transport or parent-rejected): leave CDS
+// published. Next attempt re-derives the same CDS set; the publish
+// step becomes a no-op (anti-CDS ClassANY delete + identical adds)
+// and NOTIFY is re-sent. No churn.
+//
+// Implementation note (divergence from design doc):
+// the design doc specifies "(publish CDS, sign CDS RRset, re-sign
+// apex NSEC) as a single transaction" with a synchronous rollback
+// path on sign failure. The codebase's existing CDS-publish path
+// (PublishCdsRRs in ops_cds.go) is asynchronous fire-and-forget via
+// kdb.UpdateQ — sign and NSEC re-sign happen in the resigner
+// pipeline downstream, not synchronously with the publish. Adding
+// the synchronous transaction would require widening the publish
+// API across the codebase. This implementation uses a short
+// queue-side timeout to detect immediate queue-full failures and
+// otherwise relies on the asynchronous apply+sign racing forward
+// before the parent fetches CDS. Acceptable in practice: a sign
+// failure surfaces as a delay in CDS appearing on the wire, the
+// parent's CDS-fetch retries, and the rollover engine's observe
+// phase categorises it as parent-publish-failure on the next
+// attempt window. The rollback path is unreachable in this design;
+// document this when revisiting publish/sign sync.
+func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *DsyncTarget) (KSKDSPushResult, error) {
+	var out KSKDSPushResult
+	zd := deps.Zone
+	kdb := deps.KDB
+	notifyq := deps.NotifyQ
+	if zd == nil || kdb == nil {
+		out.Category = SoftfailChildConfig
+		return out, fmt.Errorf("pushDSRRsetViaNotify: nil argument")
+	}
+	if target == nil || len(target.Addresses) == 0 {
+		out.Category = SoftfailChildConfig
+		return out, fmt.Errorf("pushDSRRsetViaNotify: no NOTIFY target addresses")
+	}
+	if notifyq == nil {
+		out.Category = SoftfailChildConfig
+		return out, fmt.Errorf("pushDSRRsetViaNotify: NotifyQ not configured")
+	}
+
+	child := dns.Fqdn(zd.ZoneName)
+
+	cdsSet, low, high, idxOK, err := ComputeTargetCDSSetForZone(kdb, child)
+	if err != nil {
+		out.Category = SoftfailChildConfig
+		return out, err
+	}
+	if len(cdsSet) == 0 {
+		out.Category = SoftfailChildConfig
+		return out, fmt.Errorf("pushDSRRsetViaNotify: no CDS records to publish for zone %s", child)
+	}
+
+	// Build the publish payload: anti-CDS ClassANY delete to clear
+	// any prior CDS RRset, then ClassINET adds for the engine-computed
+	// target. Same shape as ops_cds.go PublishCdsRRs but parameterized
+	// on our explicit set.
+	antiCds := &dns.CDS{}
+	antiCds.Hdr = dns.RR_Header{
+		Name:   child,
+		Rrtype: dns.TypeCDS,
+		Class:  dns.ClassANY,
+		Ttl:    0,
+	}
+	actions := make([]dns.RR, 0, 1+len(cdsSet))
+	actions = append(actions, antiCds)
+	actions = append(actions, cdsSet...)
+
+	if kdb.UpdateQ == nil {
+		out.Category = SoftfailChildConfig
+		return out, fmt.Errorf("pushDSRRsetViaNotify: kdb.UpdateQ nil")
+	}
+	select {
+	case kdb.UpdateQ <- UpdateRequest{
+		Cmd:            "ZONE-UPDATE",
+		ZoneName:       child,
+		Actions:        actions,
+		InternalUpdate: true,
+	}:
+	case <-time.After(5 * time.Second):
+		out.Category = SoftfailChildConfig
+		return out, fmt.Errorf("pushDSRRsetViaNotify: UpdateQ full for 5s, skipping")
+	case <-ctx.Done():
+		out.Category = SoftfailChildConfig
+		return out, ctx.Err()
+	}
+
+	// Persist the CDS-ownership marker before sending NOTIFY: if the
+	// daemon crashes between publish and NOTIFY, the next attempt's
+	// Trigger-2 cleanup logic still has a record of what we own, so
+	// we don't orphan CDS.
+	if idxOK {
+		if err := setPublishedCdsRange(kdb, child, low, high); err != nil {
+			out.Category = SoftfailChildConfig
+			return out, fmt.Errorf("pushDSRRsetViaNotify: persist CDS range: %w", err)
+		}
+	} else {
+		// No authoritative range to record. Clear any stale range so a
+		// subsequent cleanup pass doesn't compare against an old set.
+		if err := clearPublishedCdsRange(kdb, child); err != nil {
+			out.Category = SoftfailChildConfig
+			return out, fmt.Errorf("pushDSRRsetViaNotify: clear CDS range: %w", err)
+		}
+	}
+
+	// Send NOTIFY(CDS) and wait for the per-target aggregate response.
+	respCh := make(chan NotifyResponse, 1)
+	req := NotifyRequest{
+		ZoneName: child,
+		ZoneData: zd,
+		RRtype:   dns.TypeCDS,
+		Targets:  target.Addresses,
+		Response: respCh,
+	}
+	notifyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	select {
+	case notifyq <- req:
+	case <-notifyCtx.Done():
+		out.Category = SoftfailTransport
+		return out, fmt.Errorf("pushDSRRsetViaNotify: enqueue NOTIFY: %w", notifyCtx.Err())
+	}
+
+	var resp NotifyResponse
+	select {
+	case resp = <-respCh:
+	case <-notifyCtx.Done():
+		out.Category = SoftfailTransport
+		return out, fmt.Errorf("pushDSRRsetViaNotify: await NOTIFY response: %w", notifyCtx.Err())
+	}
+
+	out.Rcode = resp.Rcode
+	if resp.Error {
+		// SendNotify returned with no NOERROR target. If the parent
+		// produced a non-NOERROR rcode at least once, that's
+		// parent-rejected; otherwise transport.
+		if resp.Rcode != 0 && resp.Rcode != dns.RcodeSuccess {
+			out.Category = SoftfailParentRejected
+			out.Detail = formatNotifyDetail(resp)
+		} else {
+			out.Category = SoftfailTransport
+			out.Detail = formatNotifyDetail(resp)
+		}
+		return out, fmt.Errorf("pushDSRRsetViaNotify: %s", resp.ErrorMsg)
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		out.Category = SoftfailParentRejected
+		out.Detail = formatNotifyDetail(resp)
+		return out, nil
+	}
+	out.Scheme = "NOTIFY"
+	return out, nil
+}
+
+// formatNotifyDetail renders a NotifyResponse's diagnostic info as
+// a single string for KSKDSPushResult.Detail. Includes rcode and
+// any EDE codes/text. Used by status output.
+func formatNotifyDetail(resp NotifyResponse) string {
+	var parts []string
+	if resp.Rcode != 0 {
+		parts = append(parts, "rcode="+dns.RcodeToString[resp.Rcode])
+	}
+	for _, ede := range resp.EDE {
+		s := fmt.Sprintf("EDE=%d", ede.InfoCode)
+		if ede.ExtraText != "" {
+			s += " '" + ede.ExtraText + "'"
+		}
+		parts = append(parts, s)
+	}
+	if resp.ErrorMsg != "" {
+		parts = append(parts, resp.ErrorMsg)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " ")
+}

--- a/v2/ksk_rollover_ds_notify.go
+++ b/v2/ksk_rollover_ds_notify.go
@@ -175,8 +175,37 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 		out.Detail = formatNotifyDetail(resp)
 		return out, nil
 	}
+	// NOTIFY(CDS) acknowledged at the wire. Persist the publication
+	// fact (keyids + timestamp) to the sparse RolloverCdsPublication
+	// table. This survives Trigger-1 cleanup so the operator's
+	// "CDS published [keyids] sent <time>" status line still
+	// reflects the most recent publication after the rollover has
+	// completed and the ownership marker is cleared.
+	keyids := cdsKeyids(cdsSet)
+	if err := setCdsPublication(kdb, child, keyids, time.Now().UTC()); err != nil {
+		// Best-effort: a write failure here doesn't undo the on-wire
+		// publication. Log and continue.
+		lgRollover.Warn("pushDSRRsetViaNotify: setCdsPublication failed",
+			"zone", child, "err", err)
+	} else {
+		lgRollover.Debug("pushDSRRsetViaNotify: CDS publication recorded",
+			"zone", child, "keyids", keyids)
+	}
 	out.Scheme = "NOTIFY"
 	return out, nil
+}
+
+// cdsKeyids extracts the SEP keyid from each CDS RR in the slice.
+// Skips entries that aren't *dns.CDS (defensive; ComputeTargetCDSSetForZone
+// only ever returns CDS RRs but the type assertion is cheap).
+func cdsKeyids(cdsSet []dns.RR) []uint16 {
+	out := make([]uint16, 0, len(cdsSet))
+	for _, rr := range cdsSet {
+		if c, ok := rr.(*dns.CDS); ok {
+			out = append(out, c.DS.KeyTag)
+		}
+	}
+	return out
 }
 
 // formatNotifyDetail renders a NotifyResponse's diagnostic info as

--- a/v2/ksk_rollover_ds_notify.go
+++ b/v2/ksk_rollover_ds_notify.go
@@ -48,15 +48,15 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	kdb := deps.KDB
 	notifyq := deps.NotifyQ
 	if zd == nil || kdb == nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: nil argument")
 	}
 	if target == nil || len(target.Addresses) == 0 {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: no NOTIFY target addresses")
 	}
 	if notifyq == nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: NotifyQ not configured")
 	}
 
@@ -64,11 +64,11 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 
 	cdsSet, low, high, idxOK, err := ComputeTargetCDSSetForZone(kdb, child)
 	if err != nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, err
 	}
 	if len(cdsSet) == 0 {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: no CDS records to publish for zone %s", child)
 	}
 
@@ -88,7 +88,7 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	actions = append(actions, cdsSet...)
 
 	if kdb.UpdateQ == nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: kdb.UpdateQ nil")
 	}
 	select {
@@ -99,10 +99,10 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 		InternalUpdate: true,
 	}:
 	case <-time.After(5 * time.Second):
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: UpdateQ full for 5s, skipping")
 	case <-ctx.Done():
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, ctx.Err()
 	}
 
@@ -112,14 +112,14 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	// we don't orphan CDS.
 	if idxOK {
 		if err := setPublishedCdsRange(kdb, child, low, high); err != nil {
-			out.Category = SoftfailChildConfig
+			out.Category = SoftfailChildConfigLocalError
 			return out, fmt.Errorf("pushDSRRsetViaNotify: persist CDS range: %w", err)
 		}
 	} else {
 		// No authoritative range to record. Clear any stale range so a
 		// subsequent cleanup pass doesn't compare against an old set.
 		if err := clearPublishedCdsRange(kdb, child); err != nil {
-			out.Category = SoftfailChildConfig
+			out.Category = SoftfailChildConfigLocalError
 			return out, fmt.Errorf("pushDSRRsetViaNotify: clear CDS range: %w", err)
 		}
 	}

--- a/v2/ksk_rollover_ds_notify.go
+++ b/v2/ksk_rollover_ds_notify.go
@@ -92,6 +92,9 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 	actions = append(actions, antiCds)
 	actions = append(actions, cdsSet...)
 
+	lgRollover.Debug("pushDSRRsetViaNotify: queueing CDS publish",
+		"zone", child, "cds_count", len(cdsSet), "actions", len(actions),
+		"index_low", low, "index_high", high, "index_known", idxOK)
 	select {
 	case updateq <- UpdateRequest{
 		Cmd:            "ZONE-UPDATE",
@@ -99,6 +102,8 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 		Actions:        actions,
 		InternalUpdate: true,
 	}:
+		lgRollover.Debug("pushDSRRsetViaNotify: CDS publish enqueued on InternalUpdateQ",
+			"zone", child)
 	case <-time.After(5 * time.Second):
 		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaNotify: InternalUpdateQ full for 5s, skipping")
@@ -116,6 +121,8 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 			out.Category = SoftfailChildConfigLocalError
 			return out, fmt.Errorf("pushDSRRsetViaNotify: persist CDS range: %w", err)
 		}
+		lgRollover.Debug("pushDSRRsetViaNotify: CDS ownership marker stored",
+			"zone", child, "index_low", low, "index_high", high)
 	} else {
 		// No authoritative range to record. Clear any stale range so a
 		// subsequent cleanup pass doesn't compare against an old set.
@@ -123,6 +130,8 @@ func pushDSRRsetViaNotify(ctx context.Context, deps RolloverEngineDeps, target *
 			out.Category = SoftfailChildConfigLocalError
 			return out, fmt.Errorf("pushDSRRsetViaNotify: clear CDS range: %w", err)
 		}
+		lgRollover.Debug("pushDSRRsetViaNotify: CDS ownership marker cleared (index range incomplete)",
+			"zone", child)
 	}
 
 	// Send NOTIFY(CDS) and wait for the per-target aggregate response.

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -3,6 +3,7 @@ package tdns
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -213,12 +214,20 @@ func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDS
 		// best-effort. Otherwise CDS sits orphaned for the duration of
 		// the parent-side outage.
 		cleanupCdsAfterConfirm(deps.Zone, deps.KDB)
-		// "No usable scheme" → child-config:waiting-for-parent. The
-		// tick handler caps backoff at 1h and never increments
-		// hardfail_count for this subcategory — recovery is automatic
-		// when the parent restores DSYNC advertisement.
+		// Two error shapes from pickRolloverSchemes:
+		//   - errNoUsableScheme (and force-X-not-advertised wraps of
+		//     it) → child-config:waiting-for-parent. 1h-cap backoff,
+		//     never hardfails, auto-recovers when DSYNC matches.
+		//   - everything else (DSYNC discovery transport failure,
+		//     invalid preference, nil arg, ...) → child-config:
+		//     local-error. Existing softfail bookkeeping; operator
+		//     intervention typically required.
+		cat := SoftfailChildConfigLocalError
+		if errors.Is(err, errNoUsableScheme) {
+			cat = SoftfailChildConfigWaitingForParent
+		}
 		return KSKDSPushResult{
-			Category: SoftfailChildConfigWaitingForParent,
+			Category: cat,
 			Detail:   "pickRolloverSchemes: " + err.Error(),
 		}, fmt.Errorf("PushDSRRsetForRollover: %w", err)
 	}

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -493,6 +493,7 @@ func pushDSRRsetViaUpdate(ctx context.Context, deps RolloverEngineDeps) (KSKDSPu
 		// Clear any stale range from a prior push instead of leaving
 		// stale persisted columns that describe an older submission.
 		if err := clearLastDSSubmittedRange(kdb, child); err != nil {
+			out.Category = SoftfailChildConfigLocalError
 			return out, fmt.Errorf("pushDSRRsetViaUpdate: clear stale submitted range: %w", err)
 		}
 	}

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -10,7 +10,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// KSKDSPushResult is the outcome of PushWholeDSRRset (rcode and wire diagnostics).
+// KSKDSPushResult is the outcome of PushDSRRsetForRollover (rcode and wire diagnostics).
 // Category is empty on success (rcode NOERROR + persisted submitted range);
 // otherwise it is one of the SoftfailXxx constants from
 // ksk_rollover_categories.go and the engine's caller uses it to record a
@@ -54,14 +54,19 @@ type kskForDSRow struct {
 	ri    sql.NullInt64
 }
 
-// ComputeTargetDSSetForZone returns the DS RRset the parent should publish for this child,
-// per §6.1: one DS per KSK (SEP) in states created, ds-published, standby, published, active, retired
-// (created included for multi-DS pre-publish DS at parent).
-// Digest is SHA-256 only in this phase. DS owner names use child as FQDN.
-// indexLow/indexHigh are min/max rollover_index when every contributing key has a
-// RolloverKeyState row; otherwise indexRangeKnown is false and callers must not treat
-// the indices as authoritative for RolloverZoneState.
-func ComputeTargetDSSetForZone(kdb *KeyDB, childZone string, digest uint8) (ds []dns.RR, indexLow, indexHigh int, indexRangeKnown bool, err error) {
+// loadTargetKSKsForRollover is the canonical SQL query for "the keys
+// belonging in the rollover-target DS RRset." Per §6.1: one row per
+// KSK (SEP) in states created, ds-published, standby, published,
+// active, retired (created is included for multi-DS pre-publish DS at
+// the parent). Two callers wrap it: ComputeTargetDSSetForZone (for DS)
+// and ComputeTargetCDSSetForZone (for CDS, see Phase 4). Both must
+// derive their target set from the same key rows; if they diverged, a
+// NOTIFY-pushed CDS would not match the UPDATE-pushed DS.
+//
+// indexLow/indexHigh are min/max rollover_index when every contributing
+// key has a RolloverKeyState row; otherwise indexRangeKnown is false
+// and callers must not treat the indices as authoritative.
+func loadTargetKSKsForRollover(kdb *KeyDB, childZone string) (rows []kskForDSRow, indexLow, indexHigh int, indexRangeKnown bool, err error) {
 	childZone = dns.Fqdn(childZone)
 	const q = `
 SELECT k.keyid, k.flags, k.keyrr, r.rollover_index
@@ -71,40 +76,70 @@ WHERE k.zonename = ? AND k.state IN ('created','ds-published','standby','publish
   AND (CAST(k.flags AS INTEGER) & ?) != 0
 ORDER BY COALESCE(r.rollover_index, 2147483646) ASC, k.keyid ASC`
 
-	rows, err := kdb.Query(q, childZone, int(dns.SEP))
+	sqlRows, err := kdb.Query(q, childZone, int(dns.SEP))
 	if err != nil {
-		return nil, 0, 0, false, fmt.Errorf("ComputeTargetDSSetForZone: %w", err)
+		return nil, 0, 0, false, fmt.Errorf("loadTargetKSKsForRollover: %w", err)
 	}
-	defer rows.Close()
+	defer sqlRows.Close()
 
-	var rowsOut []kskForDSRow
-	for rows.Next() {
+	for sqlRows.Next() {
 		var keyid, flags int
 		var keyrr string
 		var ri sql.NullInt64
-		if err := rows.Scan(&keyid, &flags, &keyrr, &ri); err != nil {
-			return nil, 0, 0, false, fmt.Errorf("ComputeTargetDSSetForZone scan: %w", err)
+		if err := sqlRows.Scan(&keyid, &flags, &keyrr, &ri); err != nil {
+			return nil, 0, 0, false, fmt.Errorf("loadTargetKSKsForRollover scan: %w", err)
 		}
-		rowsOut = append(rowsOut, kskForDSRow{
+		rows = append(rows, kskForDSRow{
 			keyid: uint16(keyid),
 			flags: uint16(flags),
 			keyrr: keyrr,
 			ri:    ri,
 		})
 	}
-	if err := rows.Err(); err != nil {
+	if err := sqlRows.Err(); err != nil {
 		return nil, 0, 0, false, err
 	}
 
-	indexRangeKnown = len(rowsOut) > 0
-	for _, row := range rowsOut {
+	indexRangeKnown = len(rows) > 0
+	for _, row := range rows {
 		if !row.ri.Valid {
 			indexRangeKnown = false
 			break
 		}
 	}
 
-	for _, row := range rowsOut {
+	if indexRangeKnown {
+		for i, row := range rows {
+			v := int(row.ri.Int64)
+			if i == 0 {
+				indexLow, indexHigh = v, v
+			} else {
+				if v < indexLow {
+					indexLow = v
+				}
+				if v > indexHigh {
+					indexHigh = v
+				}
+			}
+		}
+	}
+	return rows, indexLow, indexHigh, indexRangeKnown, nil
+}
+
+// ComputeTargetDSSetForZone returns the DS RRset the parent should publish for this child,
+// per §6.1: one DS per KSK (SEP) in states created, ds-published, standby, published, active, retired
+// (created included for multi-DS pre-publish DS at parent).
+// Digest is SHA-256 only in this phase. DS owner names use child as FQDN.
+// indexLow/indexHigh are min/max rollover_index when every contributing key has a
+// RolloverKeyState row; otherwise indexRangeKnown is false and callers must not treat
+// the indices as authoritative for RolloverZoneState.
+func ComputeTargetDSSetForZone(kdb *KeyDB, childZone string, digest uint8) (ds []dns.RR, indexLow, indexHigh int, indexRangeKnown bool, err error) {
+	childZone = dns.Fqdn(childZone)
+	rows, low, high, idxOK, err := loadTargetKSKsForRollover(kdb, childZone)
+	if err != nil {
+		return nil, 0, 0, false, err
+	}
+	for _, row := range rows {
 		rr, err := dns.NewRR(row.keyrr)
 		if err != nil {
 			return nil, 0, 0, false, fmt.Errorf("ComputeTargetDSSetForZone: parse DNSKEY keyid=%d: %w", row.keyid, err)
@@ -123,33 +158,35 @@ ORDER BY COALESCE(r.rollover_index, 2147483646) ASC, k.keyid ASC`
 		}
 		ds = append(ds, dsRR)
 	}
-
-	if indexRangeKnown {
-		for i, row := range rowsOut {
-			v := int(row.ri.Int64)
-			if i == 0 {
-				indexLow, indexHigh = v, v
-			} else {
-				if v < indexLow {
-					indexLow = v
-				}
-				if v > indexHigh {
-					indexHigh = v
-				}
-			}
-		}
-	}
-	return ds, indexLow, indexHigh, indexRangeKnown, nil
+	return ds, low, high, idxOK, nil
 }
 
-// PushWholeDSRRset computes the target DS RRset from the keystore, builds a whole-RRset
-// replacement UPDATE to the parent, signs with the child's active SIG(0) key, and sends it.
-// On rcode NOERROR, updates last_ds_submitted_index_* when indexRangeKnown from ComputeTargetDSSetForZone.
-func PushWholeDSRRset(ctx context.Context, zd *ZoneData, kdb *KeyDB, imr *Imr) (KSKDSPushResult, error) {
+// PushDSRRsetForRollover is the public dispatcher entry point for the
+// rollover engine's DS push. It picks one or more push schemes from the
+// parent's DSYNC advertisement and the policy's dsync-scheme-preference
+// (Phase 3), dispatches per-scheme push functions in parallel where
+// applicable (Phase 4), and aggregates per-path wire-level results.
+//
+// Phase 1 shape: scheme selection is not yet implemented; the
+// dispatcher always delegates to pushDSRRsetViaUpdate. Phase 4 will
+// extend this with NOTIFY-side and parallel paths.
+func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDSPushResult, error) {
+	return pushDSRRsetViaUpdate(ctx, deps)
+}
+
+// pushDSRRsetViaUpdate computes the target DS RRset from the keystore, builds a
+// whole-RRset replacement UPDATE to the parent, signs with the child's active
+// SIG(0) key, and sends it. On rcode NOERROR, updates
+// last_ds_submitted_index_* when indexRangeKnown from
+// ComputeTargetDSSetForZone.
+func pushDSRRsetViaUpdate(ctx context.Context, deps RolloverEngineDeps) (KSKDSPushResult, error) {
 	var out KSKDSPushResult
+	zd := deps.Zone
+	kdb := deps.KDB
+	imr := deps.Imr
 	if zd == nil || kdb == nil || imr == nil {
 		out.Category = SoftfailChildConfig
-		return out, fmt.Errorf("PushWholeDSRRset: nil argument")
+		return out, fmt.Errorf("pushDSRRsetViaUpdate: nil argument")
 	}
 	child := dns.Fqdn(zd.ZoneName)
 	parent := dns.Fqdn(zd.Parent)
@@ -158,7 +195,7 @@ func PushWholeDSRRset(ctx context.Context, zd *ZoneData, kdb *KeyDB, imr *Imr) (
 		parent, err = imr.ParentZone(child)
 		if err != nil {
 			out.Category = SoftfailTransport
-			return out, fmt.Errorf("PushWholeDSRRset: parent zone: %w", err)
+			return out, fmt.Errorf("pushDSRRsetViaUpdate: parent zone: %w", err)
 		}
 		parent = dns.Fqdn(parent)
 	}
@@ -170,7 +207,7 @@ func PushWholeDSRRset(ctx context.Context, zd *ZoneData, kdb *KeyDB, imr *Imr) (
 	}
 	if len(dsSet) == 0 {
 		out.Category = SoftfailChildConfig
-		return out, fmt.Errorf("PushWholeDSRRset: no DS records to publish for zone %s", child)
+		return out, fmt.Errorf("pushDSRRsetViaUpdate: no DS records to publish for zone %s", child)
 	}
 
 	msg, err := BuildChildWholeDSUpdate(parent, child, dsSet)
@@ -182,17 +219,17 @@ func PushWholeDSRRset(ctx context.Context, zd *ZoneData, kdb *KeyDB, imr *Imr) (
 	sak, err := kdb.GetSig0Keys(child, Sig0StateActive)
 	if err != nil {
 		out.Category = SoftfailChildConfig
-		return out, fmt.Errorf("PushWholeDSRRset: GetSig0Keys: %w", err)
+		return out, fmt.Errorf("pushDSRRsetViaUpdate: GetSig0Keys: %w", err)
 	}
 	if len(sak.Keys) == 0 {
 		out.Category = SoftfailChildConfig
-		return out, fmt.Errorf("PushWholeDSRRset: no active SIG(0) key for zone %s", child)
+		return out, fmt.Errorf("pushDSRRsetViaUpdate: no active SIG(0) key for zone %s", child)
 	}
 
 	smsg, err := SignMsg(*msg, child, sak)
 	if err != nil {
 		out.Category = SoftfailChildConfig
-		return out, fmt.Errorf("PushWholeDSRRset: SignMsg: %w", err)
+		return out, fmt.Errorf("pushDSRRsetViaUpdate: SignMsg: %w", err)
 	}
 
 	dsyncTarget, err := imr.LookupDSYNCTarget(ctx, child, dns.TypeDS, core.SchemeUpdate)
@@ -200,7 +237,7 @@ func PushWholeDSRRset(ctx context.Context, zd *ZoneData, kdb *KeyDB, imr *Imr) (
 		dsyncTarget, err = imr.LookupDSYNCTarget(ctx, child, dns.TypeANY, core.SchemeUpdate)
 		if err != nil {
 			out.Category = SoftfailTransport
-			return out, fmt.Errorf("PushWholeDSRRset: DSYNC target: %w", err)
+			return out, fmt.Errorf("pushDSRRsetViaUpdate: DSYNC target: %w", err)
 		}
 	}
 
@@ -222,7 +259,7 @@ func PushWholeDSRRset(ctx context.Context, zd *ZoneData, kdb *KeyDB, imr *Imr) (
 	if idxOK {
 		if err := saveLastDSSubmittedRange(kdb, child, low, high); err != nil {
 			out.Category = SoftfailChildConfig
-			return out, fmt.Errorf("PushWholeDSRRset: persist submitted range: %w", err)
+			return out, fmt.Errorf("pushDSRRsetViaUpdate: persist submitted range: %w", err)
 		}
 	} else {
 		// Contributors didn't all have authoritative rollover_index
@@ -230,7 +267,7 @@ func PushWholeDSRRset(ctx context.Context, zd *ZoneData, kdb *KeyDB, imr *Imr) (
 		// Clear any stale range from a prior push instead of leaving
 		// stale persisted columns that describe an older submission.
 		if err := clearLastDSSubmittedRange(kdb, child); err != nil {
-			return out, fmt.Errorf("PushWholeDSRRset: clear stale submitted range: %w", err)
+			return out, fmt.Errorf("pushDSRRsetViaUpdate: clear stale submitted range: %w", err)
 		}
 	}
 	return out, nil

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -15,10 +17,21 @@ import (
 // otherwise it is one of the SoftfailXxx constants from
 // ksk_rollover_categories.go and the engine's caller uses it to record a
 // softfail event via setSoftfail.
+//
+// Scheme reflects which scheme(s) actually completed at the wire level
+// for this attempt. Comma-joined when a parallel send had at least one
+// path return NOERROR ("UPDATE", "NOTIFY", or "UPDATE,NOTIFY").
+// Persisted to RolloverZoneState.last_attempt_scheme for status display.
+//
+// Detail concatenates per-path diagnostics from failures (rcode, EDE,
+// transport error). Read by status output to render the cause of a
+// parent-rejected or transport softfail.
 type KSKDSPushResult struct {
 	Rcode        int
 	UpdateResult UpdateResult
 	Category     string
+	Scheme       string
+	Detail       string
 }
 
 // BuildChildWholeDSUpdate builds a DNS UPDATE for the parent zone that replaces the
@@ -162,16 +175,169 @@ func ComputeTargetDSSetForZone(kdb *KeyDB, childZone string, digest uint8) (ds [
 }
 
 // PushDSRRsetForRollover is the public dispatcher entry point for the
-// rollover engine's DS push. It picks one or more push schemes from the
-// parent's DSYNC advertisement and the policy's dsync-scheme-preference
-// (Phase 3), dispatches per-scheme push functions in parallel where
-// applicable (Phase 4), and aggregates per-path wire-level results.
+// rollover engine's DS push. It consults the parent's DSYNC RRset and
+// the policy's dsync-scheme-preference, dispatches one or more
+// per-scheme push functions (in parallel when "auto" matches both
+// schemes), and aggregates per-path wire-level results.
 //
-// Phase 1 shape: scheme selection is not yet implemented; the
-// dispatcher always delegates to pushDSRRsetViaUpdate. Phase 4 will
-// extend this with NOTIFY-side and parallel paths.
+// Aggregation rules:
+//   - Any path returned NOERROR → push succeeds. Scheme is
+//     comma-joined for the paths that returned NOERROR.
+//   - All paths failed → push fails. Category is the most-actionable:
+//     parent-rejected > transport > child-config:local-error.
+//     Detail concatenates per-path diagnostics.
+//   - "no usable scheme" from pickRolloverSchemes (parent advertises
+//     nothing the policy will accept) → child-config:waiting-for-parent
+//     (Phase 6) without dispatching any path. Recovery is automatic
+//     when the parent restores DSYNC advertisement.
+//
+// Single-scheme degenerate case: when only one scheme runs, the
+// aggregate is just that path's result; no special-case path.
+//
+// Note: when the policy has no DsyncSchemePreference set (e.g. the
+// CLI offline ds-push call constructs deps without policy on a stub
+// zd), the dispatcher falls through to the legacy UPDATE-only path
+// to preserve existing CLI behavior.
 func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDSPushResult, error) {
-	return pushDSRRsetViaUpdate(ctx, deps)
+	if deps.Policy == nil {
+		return pushDSRRsetViaUpdate(ctx, deps)
+	}
+	if deps.Imr == nil {
+		return pushDSRRsetViaUpdate(ctx, deps)
+	}
+
+	choices, err := pickRolloverSchemes(ctx, deps.Zone, deps.Imr, deps.Policy)
+	if err != nil {
+		// "No usable scheme" maps to child-config:waiting-for-parent
+		// in Phase 6. Phase 4 emits SoftfailChildConfig — the
+		// subcategorization commit will introduce the new constant
+		// and update this site to use it.
+		return KSKDSPushResult{
+			Category: SoftfailChildConfig,
+			Detail:   "pickRolloverSchemes: " + err.Error(),
+		}, fmt.Errorf("PushDSRRsetForRollover: %w", err)
+	}
+
+	results := make([]pathResultLite, len(choices))
+
+	if len(choices) == 1 {
+		// Single-path degenerate case: avoid goroutine overhead.
+		ch := choices[0]
+		switch ch.Scheme {
+		case core.SchemeUpdate:
+			res, perr := pushDSRRsetViaUpdate(ctx, deps)
+			results[0] = pathResultLite{scheme: "UPDATE", res: res, err: perr}
+		case core.SchemeNotify:
+			res, perr := pushDSRRsetViaNotify(ctx, deps, ch.Target)
+			results[0] = pathResultLite{scheme: "NOTIFY", res: res, err: perr}
+		default:
+			return KSKDSPushResult{
+				Category: SoftfailChildConfig,
+				Detail:   fmt.Sprintf("unknown scheme %d", ch.Scheme),
+			}, fmt.Errorf("PushDSRRsetForRollover: unknown scheme %d", ch.Scheme)
+		}
+	} else {
+		// Parallel: one goroutine per scheme. Each writes its slot in
+		// the pre-allocated results slice; no shared mutation.
+		var wg sync.WaitGroup
+		for i, ch := range choices {
+			wg.Add(1)
+			go func(i int, ch schemeChoice) {
+				defer wg.Done()
+				switch ch.Scheme {
+				case core.SchemeUpdate:
+					res, perr := pushDSRRsetViaUpdate(ctx, deps)
+					results[i] = pathResultLite{scheme: "UPDATE", res: res, err: perr}
+				case core.SchemeNotify:
+					res, perr := pushDSRRsetViaNotify(ctx, deps, ch.Target)
+					results[i] = pathResultLite{scheme: "NOTIFY", res: res, err: perr}
+				default:
+					results[i] = pathResultLite{
+						scheme: schemeName(ch.Scheme),
+						res:    KSKDSPushResult{Category: SoftfailChildConfig, Detail: fmt.Sprintf("unknown scheme %d", ch.Scheme)},
+						err:    fmt.Errorf("unknown scheme %d", ch.Scheme),
+					}
+				}
+			}(i, ch)
+		}
+		wg.Wait()
+	}
+
+	return aggregateRolloverPushResults(results), nil
+}
+
+// aggregateRolloverPushResults applies the dispatcher's any-success-wins
+// policy to the per-path results and returns the engine-functional
+// aggregate KSKDSPushResult. Helper kept separate for clarity (and so
+// future tests can drive it directly without spinning up Imr/UpdateQ).
+func aggregateRolloverPushResults(results []pathResultLite) KSKDSPushResult {
+	var ok []string
+	var failParts []string
+	failedCat := ""
+	failedRcode := 0
+	for _, r := range results {
+		if r.err == nil && r.res.Rcode == dns.RcodeSuccess {
+			ok = append(ok, r.scheme)
+			continue
+		}
+		// Failed path. Aggregate its diagnostics + category.
+		detail := r.scheme + ":"
+		if r.res.Detail != "" {
+			detail += " " + r.res.Detail
+		} else if r.err != nil {
+			detail += " " + r.err.Error()
+		} else if r.res.Rcode != 0 {
+			detail += " rcode=" + dns.RcodeToString[r.res.Rcode]
+		}
+		failParts = append(failParts, detail)
+		// Most-actionable category wins.
+		failedCat = mergeFailureCategory(failedCat, r.res.Category)
+		if r.res.Rcode != 0 && failedRcode == 0 {
+			failedRcode = r.res.Rcode
+		}
+	}
+	if len(ok) > 0 {
+		return KSKDSPushResult{
+			Rcode:  dns.RcodeSuccess,
+			Scheme: strings.Join(ok, ","),
+			Detail: strings.Join(failParts, " | "),
+		}
+	}
+	return KSKDSPushResult{
+		Rcode:    failedRcode,
+		Category: failedCat,
+		Detail:   strings.Join(failParts, " | "),
+	}
+}
+
+// pathResultLite is the trimmed shape aggregateRolloverPushResults
+// consumes — just the scheme name and the per-path result.
+type pathResultLite struct {
+	scheme string
+	res    KSKDSPushResult
+	err    error
+}
+
+// mergeFailureCategory picks the more-actionable of two failure
+// categories. Order: parent-rejected > transport > child-config.
+// Empty strings are treated as least-actionable.
+func mergeFailureCategory(a, b string) string {
+	rank := func(s string) int {
+		switch s {
+		case SoftfailParentRejected:
+			return 3
+		case SoftfailTransport:
+			return 2
+		case SoftfailChildConfig:
+			return 1
+		default:
+			return 0
+		}
+	}
+	if rank(b) > rank(a) {
+		return b
+	}
+	return a
 }
 
 // pushDSRRsetViaUpdate computes the target DS RRset from the keystore, builds a
@@ -270,7 +436,53 @@ func pushDSRRsetViaUpdate(ctx context.Context, deps RolloverEngineDeps) (KSKDSPu
 			return out, fmt.Errorf("pushDSRRsetViaUpdate: clear stale submitted range: %w", err)
 		}
 	}
+	out.Scheme = "UPDATE"
 	return out, nil
+}
+
+// ComputeTargetCDSSetForZone returns the CDS RRset that mirrors the
+// rollover engine's target DS set, derived from the same KSK rows
+// that ComputeTargetDSSetForZone uses. Both functions share
+// loadTargetKSKsForRollover so an UPDATE-pushed DS RRset and a
+// NOTIFY-pushed CDS RRset always describe the same set of keys.
+// Digest is SHA-256 only in this phase. CDS owner names use child
+// as FQDN; TTL is 120s to match ops_cds.go.
+//
+// indexLow/indexHigh / indexRangeKnown are the engine's claim of
+// CDS-RRset ownership for cleanup-time comparison
+// (RolloverZoneState.last_published_cds_index_low/high). The same
+// caveat as ComputeTargetDSSetForZone applies: indexRangeKnown is
+// false when not every contributing key has a RolloverKeyState row,
+// in which case the caller must not persist the range.
+func ComputeTargetCDSSetForZone(kdb *KeyDB, childZone string) (cds []dns.RR, indexLow, indexHigh int, indexRangeKnown bool, err error) {
+	childZone = dns.Fqdn(childZone)
+	rows, low, high, idxOK, err := loadTargetKSKsForRollover(kdb, childZone)
+	if err != nil {
+		return nil, 0, 0, false, err
+	}
+	for _, row := range rows {
+		rr, err := dns.NewRR(row.keyrr)
+		if err != nil {
+			return nil, 0, 0, false, fmt.Errorf("ComputeTargetCDSSetForZone: parse DNSKEY keyid=%d: %w", row.keyid, err)
+		}
+		dk, ok := rr.(*dns.DNSKEY)
+		if !ok {
+			return nil, 0, 0, false, fmt.Errorf("ComputeTargetCDSSetForZone: keyid %d is not DNSKEY", row.keyid)
+		}
+		ds := dk.ToDS(uint8(dns.SHA256))
+		if ds == nil {
+			return nil, 0, 0, false, fmt.Errorf("ComputeTargetCDSSetForZone: ToDS failed for keyid %d", row.keyid)
+		}
+		c := &dns.CDS{DS: *ds}
+		c.Hdr = dns.RR_Header{
+			Name:   childZone,
+			Rrtype: dns.TypeCDS,
+			Class:  dns.ClassINET,
+			Ttl:    120,
+		}
+		cds = append(cds, c)
+	}
+	return cds, low, high, idxOK, nil
 }
 
 func saveLastDSSubmittedRange(kdb *KeyDB, zone string, low, high int) error {

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -285,7 +285,24 @@ func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDS
 		wg.Wait()
 	}
 
-	return aggregateRolloverPushResults(results), nil
+	agg := aggregateRolloverPushResults(results)
+	if agg.Scheme == "" {
+		// Every dispatched path failed. The aggregate carries
+		// category + detail; surface it as a non-nil error so the
+		// tick handler's err branch fires. Without this, a pure
+		// transport failure (no per-path Rcode) leaves agg.Rcode = 0
+		// which equals dns.RcodeSuccess, and the tick would treat
+		// the failed push as successful.
+		msg := agg.Detail
+		if msg == "" {
+			msg = agg.Category
+		}
+		if msg == "" {
+			msg = "all push paths failed"
+		}
+		return agg, fmt.Errorf("PushDSRRsetForRollover: %s", msg)
+	}
+	return agg, nil
 }
 
 // aggregateRolloverPushResults applies the dispatcher's any-success-wins

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -213,12 +213,12 @@ func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDS
 		// best-effort. Otherwise CDS sits orphaned for the duration of
 		// the parent-side outage.
 		cleanupCdsAfterConfirm(deps.Zone, deps.KDB)
-		// "No usable scheme" maps to child-config:waiting-for-parent
-		// in Phase 6. Phase 4 emits SoftfailChildConfig — the
-		// subcategorization commit will introduce the new constant
-		// and update this site to use it.
+		// "No usable scheme" → child-config:waiting-for-parent. The
+		// tick handler caps backoff at 1h and never increments
+		// hardfail_count for this subcategory — recovery is automatic
+		// when the parent restores DSYNC advertisement.
 		return KSKDSPushResult{
-			Category: SoftfailChildConfig,
+			Category: SoftfailChildConfigWaitingForParent,
 			Detail:   "pickRolloverSchemes: " + err.Error(),
 		}, fmt.Errorf("PushDSRRsetForRollover: %w", err)
 	}
@@ -245,7 +245,7 @@ func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDS
 			results[0] = pathResultLite{scheme: "NOTIFY", res: res, err: perr}
 		default:
 			return KSKDSPushResult{
-				Category: SoftfailChildConfig,
+				Category: SoftfailChildConfigLocalError,
 				Detail:   fmt.Sprintf("unknown scheme %d", ch.Scheme),
 			}, fmt.Errorf("PushDSRRsetForRollover: unknown scheme %d", ch.Scheme)
 		}
@@ -267,7 +267,7 @@ func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDS
 				default:
 					results[i] = pathResultLite{
 						scheme: schemeName(ch.Scheme),
-						res:    KSKDSPushResult{Category: SoftfailChildConfig, Detail: fmt.Sprintf("unknown scheme %d", ch.Scheme)},
+						res:    KSKDSPushResult{Category: SoftfailChildConfigLocalError, Detail: fmt.Sprintf("unknown scheme %d", ch.Scheme)},
 						err:    fmt.Errorf("unknown scheme %d", ch.Scheme),
 					}
 				}
@@ -346,8 +346,13 @@ func schemesContainNotify(choices []schemeChoice) bool {
 }
 
 // mergeFailureCategory picks the more-actionable of two failure
-// categories. Order: parent-rejected > transport > child-config.
+// categories. Order: parent-rejected > transport > child-config:*.
 // Empty strings are treated as least-actionable.
+//
+// child-config subcategories (waiting-for-parent, local-error) and
+// the bare child-config string all rank equally at level 1; the
+// dispatcher's per-path categories are passed through to the tick
+// handler which decides on backoff strategy from the subcategory.
 func mergeFailureCategory(a, b string) string {
 	rank := func(s string) int {
 		switch s {
@@ -355,7 +360,9 @@ func mergeFailureCategory(a, b string) string {
 			return 3
 		case SoftfailTransport:
 			return 2
-		case SoftfailChildConfig:
+		case SoftfailChildConfig,
+			SoftfailChildConfigLocalError,
+			SoftfailChildConfigWaitingForParent:
 			return 1
 		default:
 			return 0
@@ -378,7 +385,7 @@ func pushDSRRsetViaUpdate(ctx context.Context, deps RolloverEngineDeps) (KSKDSPu
 	kdb := deps.KDB
 	imr := deps.Imr
 	if zd == nil || kdb == nil || imr == nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaUpdate: nil argument")
 	}
 	child := dns.Fqdn(zd.ZoneName)
@@ -395,33 +402,33 @@ func pushDSRRsetViaUpdate(ctx context.Context, deps RolloverEngineDeps) (KSKDSPu
 
 	dsSet, low, high, idxOK, err := ComputeTargetDSSetForZone(kdb, child, uint8(dns.SHA256))
 	if err != nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, err
 	}
 	if len(dsSet) == 0 {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaUpdate: no DS records to publish for zone %s", child)
 	}
 
 	msg, err := BuildChildWholeDSUpdate(parent, child, dsSet)
 	if err != nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, err
 	}
 
 	sak, err := kdb.GetSig0Keys(child, Sig0StateActive)
 	if err != nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaUpdate: GetSig0Keys: %w", err)
 	}
 	if len(sak.Keys) == 0 {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaUpdate: no active SIG(0) key for zone %s", child)
 	}
 
 	smsg, err := SignMsg(*msg, child, sak)
 	if err != nil {
-		out.Category = SoftfailChildConfig
+		out.Category = SoftfailChildConfigLocalError
 		return out, fmt.Errorf("pushDSRRsetViaUpdate: SignMsg: %w", err)
 	}
 
@@ -451,7 +458,7 @@ func pushDSRRsetViaUpdate(ctx context.Context, deps RolloverEngineDeps) (KSKDSPu
 
 	if idxOK {
 		if err := saveLastDSSubmittedRange(kdb, child, low, high); err != nil {
-			out.Category = SoftfailChildConfig
+			out.Category = SoftfailChildConfigLocalError
 			return out, fmt.Errorf("pushDSRRsetViaUpdate: persist submitted range: %w", err)
 		}
 	} else {

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -208,6 +208,11 @@ func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDS
 
 	choices, err := pickRolloverSchemes(ctx, deps.Zone, deps.Imr, deps.Policy)
 	if err != nil {
+		// Trigger 2 cleanup (err branch): if we still own a CDS RRset
+		// and the parent has lost the ability to consume it, unpublish
+		// best-effort. Otherwise CDS sits orphaned for the duration of
+		// the parent-side outage.
+		cleanupCdsAfterConfirm(deps.Zone, deps.KDB)
 		// "No usable scheme" maps to child-config:waiting-for-parent
 		// in Phase 6. Phase 4 emits SoftfailChildConfig — the
 		// subcategorization commit will introduce the new constant
@@ -216,6 +221,14 @@ func PushDSRRsetForRollover(ctx context.Context, deps RolloverEngineDeps) (KSKDS
 			Category: SoftfailChildConfig,
 			Detail:   "pickRolloverSchemes: " + err.Error(),
 		}, fmt.Errorf("PushDSRRsetForRollover: %w", err)
+	}
+
+	// Trigger 2 cleanup (UPDATE-only branch): if the chosen schemes
+	// don't include NOTIFY but we currently own a CDS RRset, that CDS
+	// will not be republished by this attempt. Unpublish before
+	// dispatch so it doesn't sit stale through the rollover.
+	if !schemesContainNotify(choices) {
+		cleanupCdsAfterConfirm(deps.Zone, deps.KDB)
 	}
 
 	results := make([]pathResultLite, len(choices))
@@ -316,6 +329,20 @@ type pathResultLite struct {
 	scheme string
 	res    KSKDSPushResult
 	err    error
+}
+
+// schemesContainNotify reports whether any chosen scheme is NOTIFY.
+// Used by the dispatcher's Trigger 2 cleanup decision: when NOTIFY
+// is not in the dispatch set, any CDS the engine previously published
+// will not be re-published this attempt and should be cleaned up
+// preemptively.
+func schemesContainNotify(choices []schemeChoice) bool {
+	for _, c := range choices {
+		if c.Scheme == core.SchemeNotify {
+			return true
+		}
+	}
+	return false
 }
 
 // mergeFailureCategory picks the more-actionable of two failure

--- a/v2/ksk_rollover_policy.go
+++ b/v2/ksk_rollover_policy.go
@@ -42,7 +42,21 @@ type RolloverPolicy struct {
 	DsPublishDelay           time.Duration
 	MaxAttemptsBeforeBackoff int
 	SoftfailDelay            time.Duration
+
+	// DsyncSchemePreference is one of the DsyncSchemePreference*
+	// constants below. Default is DsyncSchemePreferenceAuto.
+	DsyncSchemePreference string
 }
+
+// DSYNC scheme preference values for RolloverPolicy.DsyncSchemePreference.
+const (
+	DsyncSchemePreferenceAuto         = "auto"
+	DsyncSchemePreferencePreferUpdate = "prefer-update"
+	DsyncSchemePreferencePreferNotify = "prefer-notify"
+	DsyncSchemePreferenceForceUpdate  = "force-update"
+	DsyncSchemePreferenceForceNotify  = "force-notify"
+	defaultDsyncSchemePreference      = DsyncSchemePreferenceAuto
+)
 
 type ClampingPolicy struct {
 	Enabled bool
@@ -133,6 +147,7 @@ func FinishDnssecPolicy(policyName string, conf *DnssecPolicyConf, out *DnssecPo
 		out.Rollover.DsPublishDelay = 0
 		out.Rollover.MaxAttemptsBeforeBackoff = 0
 		out.Rollover.SoftfailDelay = 0
+		out.Rollover.DsyncSchemePreference = ""
 	case RolloverMethodMultiDS:
 		n := conf.Rollover.NumDS
 		if n == 0 {
@@ -297,6 +312,21 @@ func fillRolloverDurations(policyName string, conf *DnssecPolicyConf, out *Dnsse
 	out.Rollover.MaxAttemptsBeforeBackoff = conf.Rollover.MaxAttemptsBeforeBackoff
 	if out.Rollover.MaxAttemptsBeforeBackoff == 0 {
 		out.Rollover.MaxAttemptsBeforeBackoff = defaultMaxAttemptsBeforeBackoff
+	}
+
+	pref := strings.TrimSpace(strings.ToLower(conf.Rollover.DsyncSchemePreference))
+	switch pref {
+	case "":
+		out.Rollover.DsyncSchemePreference = defaultDsyncSchemePreference
+	case DsyncSchemePreferenceAuto,
+		DsyncSchemePreferencePreferUpdate,
+		DsyncSchemePreferencePreferNotify,
+		DsyncSchemePreferenceForceUpdate,
+		DsyncSchemePreferenceForceNotify:
+		out.Rollover.DsyncSchemePreference = pref
+	default:
+		return fmt.Errorf("dnssec policy %q: rollover.dsync-scheme-preference %q invalid (want auto, prefer-update, prefer-notify, force-update, or force-notify)",
+			policyName, conf.Rollover.DsyncSchemePreference)
 	}
 
 	// Cross-field validation. These constraints catch configurations

--- a/v2/ksk_rollover_schemes.go
+++ b/v2/ksk_rollover_schemes.go
@@ -2,6 +2,7 @@ package tdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -9,6 +10,15 @@ import (
 	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
 )
+
+// errNoUsableScheme is the sentinel returned by pickRolloverSchemes
+// when the parent advertises no DSYNC scheme this rollover policy can
+// use. The dispatcher checks for this with errors.Is and translates
+// it into child-config:waiting-for-parent (1h-capped softfail, never
+// hardfails). Other errors from pickRolloverSchemes — DSYNC
+// discovery transport failure, nil argument, etc. — are NOT
+// "waiting for parent" and stay in their own categories.
+var errNoUsableScheme = errors.New("parent advertises no rollover-usable DSYNC scheme")
 
 // schemeChoice is one (scheme, target) pair the rollover engine
 // intends to dispatch a push to. pickRolloverSchemes returns a slice
@@ -93,12 +103,26 @@ func pickRolloverSchemes(ctx context.Context, zd *ZoneData, imr *Imr, pol *Dnsse
 		}
 		target, terr := resolveDsyncTarget(ctx, imr, rr)
 		if terr != nil {
-			return nil, fmt.Errorf("resolve DSYNC %s target: %w", schemeName(scheme), terr)
+			// Per-scheme address-resolution failure: skip this
+			// scheme and let the survivors carry the rollover. With
+			// "auto" against a both-advertising parent, this means
+			// one broken DSYNC target doesn't block the other from
+			// firing. Logged at WARN so an operator can see it; if
+			// every scheme fails resolution the len(out) == 0 check
+			// below returns the aggregated "no usable scheme" error.
+			lgSigner.Warn("rollover: DSYNC target resolution failed, skipping scheme",
+				"zone", zd.ZoneName, "scheme", schemeName(scheme), "err", terr)
+			continue
 		}
 		out = append(out, schemeChoice{Scheme: scheme, Target: target})
 	}
 	if len(out) == 0 {
-		return nil, fmt.Errorf("pickRolloverSchemes: no DSYNC targets resolvable for zone %s", zd.ZoneName)
+		// Every advertised scheme's target failed address resolution.
+		// Treated as waiting-for-parent: parent's DSYNC target
+		// hostnames don't resolve (DNS misconfig at the parent), and
+		// the recovery model is the same — wait for the parent to fix
+		// it. Wrap the sentinel so the dispatcher takes that path.
+		return nil, fmt.Errorf("pickRolloverSchemes: no DSYNC targets resolvable for zone %s: %w", zd.ZoneName, errNoUsableScheme)
 	}
 	return out, nil
 }
@@ -111,9 +135,16 @@ func pickRolloverSchemes(ctx context.Context, zd *ZoneData, imr *Imr, pol *Dnsse
 // Pulled out of pickRolloverSchemes so it can be exhaustively
 // table-tested without standing up an Imr or a parent zone.
 //
-// "no usable scheme" is signaled by a non-nil error; the caller
-// (dispatcher) translates this into child-config:waiting-for-parent
-// (Phase 6).
+// Errors:
+//   - "no usable scheme advertised" cases (auto/prefer-* with neither
+//     advertised; force-X with X not advertised) wrap errNoUsableScheme.
+//     The dispatcher translates these to child-config:waiting-for-parent
+//     (1h cap, never hardfails). Force-X-not-advertised is included per
+//     design doc Risks #5: "force is force; recover automatically when
+//     parent starts advertising the forced scheme."
+//   - "invalid preference value" is a config error (operator typo),
+//     not a parent issue; returned with no sentinel and dispatched as
+//     child-config:local-error.
 func decideRolloverSchemes(updateAdvertised, notifyAdvertised bool, preference string) ([]core.DsyncScheme, error) {
 	pref := preference
 	if pref == "" {
@@ -129,7 +160,7 @@ func decideRolloverSchemes(updateAdvertised, notifyAdvertised bool, preference s
 		case notifyAdvertised:
 			return []core.DsyncScheme{core.SchemeNotify}, nil
 		default:
-			return nil, fmt.Errorf("parent advertises no rollover-usable DSYNC scheme")
+			return nil, errNoUsableScheme
 		}
 	case DsyncSchemePreferencePreferUpdate:
 		switch {
@@ -138,7 +169,7 @@ func decideRolloverSchemes(updateAdvertised, notifyAdvertised bool, preference s
 		case notifyAdvertised:
 			return []core.DsyncScheme{core.SchemeNotify}, nil
 		default:
-			return nil, fmt.Errorf("parent advertises no rollover-usable DSYNC scheme")
+			return nil, errNoUsableScheme
 		}
 	case DsyncSchemePreferencePreferNotify:
 		switch {
@@ -147,19 +178,22 @@ func decideRolloverSchemes(updateAdvertised, notifyAdvertised bool, preference s
 		case updateAdvertised:
 			return []core.DsyncScheme{core.SchemeUpdate}, nil
 		default:
-			return nil, fmt.Errorf("parent advertises no rollover-usable DSYNC scheme")
+			return nil, errNoUsableScheme
 		}
 	case DsyncSchemePreferenceForceUpdate:
 		if !updateAdvertised {
-			return nil, fmt.Errorf("policy pins force-update but parent does not advertise UPDATE")
+			return nil, fmt.Errorf("policy pins force-update but parent does not advertise UPDATE: %w", errNoUsableScheme)
 		}
 		return []core.DsyncScheme{core.SchemeUpdate}, nil
 	case DsyncSchemePreferenceForceNotify:
 		if !notifyAdvertised {
-			return nil, fmt.Errorf("policy pins force-notify but parent does not advertise NOTIFY for CDS/ANY")
+			return nil, fmt.Errorf("policy pins force-notify but parent does not advertise NOTIFY for CDS/ANY: %w", errNoUsableScheme)
 		}
 		return []core.DsyncScheme{core.SchemeNotify}, nil
 	default:
+		// Invalid preference is a config error, NOT a parent issue.
+		// No sentinel wrap → dispatcher categorizes as
+		// child-config:local-error (operator must fix the YAML).
 		return nil, fmt.Errorf("invalid dsync-scheme-preference %q", preference)
 	}
 }

--- a/v2/ksk_rollover_schemes.go
+++ b/v2/ksk_rollover_schemes.go
@@ -1,0 +1,219 @@
+package tdns
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+// schemeChoice is one (scheme, target) pair the rollover engine
+// intends to dispatch a push to. pickRolloverSchemes returns a slice
+// of these — one element under any single-scheme policy outcome, two
+// elements under "auto" when the parent advertises both UPDATE and
+// NOTIFY.
+type schemeChoice struct {
+	Scheme core.DsyncScheme
+	Target *DsyncTarget
+}
+
+// pickRolloverSchemes consults the parent's DSYNC RRset and the policy's
+// dsync-scheme-preference and returns the list of scheme/target pairs
+// the rollover engine should attempt for this push. The returned slice
+// is non-empty on success and may contain one or two entries: one for
+// any single-scheme outcome, two when "auto" is chosen against a
+// parent advertising both UPDATE and NOTIFY (parallel dispatch).
+//
+// On "no usable scheme" — parent advertises nothing the policy will
+// accept — pickRolloverSchemes returns a non-nil error. The dispatcher
+// translates that error into a child-config:waiting-for-parent softfail
+// that never hardfails (Phase 6); recovery happens automatically when
+// the parent starts advertising a scheme matching the policy.
+//
+// Filter rule for NOTIFY: matches DSYNC RRs with RRtype == TypeCDS or
+// RRtype == TypeANY. The rollover engine pushes DS by publishing CDS;
+// CSYNC-only NOTIFY advertisements do not satisfy the rollover's
+// requirements. (BestSyncScheme uses a different filter — CSYNC or
+// ANY — because it serves the general delegation-sync path, which is
+// CSYNC-driven. Don't unify.)
+//
+// Filter rule for UPDATE: any UPDATE-scheme DSYNC RR (UPDATE
+// advertisements are RRtype-agnostic by spec).
+func pickRolloverSchemes(ctx context.Context, zd *ZoneData, imr *Imr, pol *DnssecPolicy) ([]schemeChoice, error) {
+	if zd == nil || imr == nil || pol == nil {
+		return nil, fmt.Errorf("pickRolloverSchemes: nil argument")
+	}
+
+	dsync, err := imr.DsyncDiscovery(ctx, zd.ZoneName, Globals.Verbose)
+	if err != nil {
+		return nil, fmt.Errorf("DsyncDiscovery: %w", err)
+	}
+
+	var updateRR, notifyRR *core.DSYNC
+	for _, rr := range dsync.Rdata {
+		if rr == nil {
+			continue
+		}
+		switch rr.Scheme {
+		case core.SchemeUpdate:
+			if updateRR == nil {
+				updateRR = rr
+			}
+		case core.SchemeNotify:
+			if rr.Type != dns.TypeCDS && rr.Type != dns.TypeANY {
+				continue
+			}
+			if notifyRR == nil {
+				notifyRR = rr
+			}
+		}
+	}
+
+	want, derr := decideRolloverSchemes(updateRR != nil, notifyRR != nil, pol.Rollover.DsyncSchemePreference)
+	if derr != nil {
+		return nil, fmt.Errorf("zone %s: %w", zd.ZoneName, derr)
+	}
+
+	out := make([]schemeChoice, 0, len(want))
+	for _, scheme := range want {
+		var rr *core.DSYNC
+		switch scheme {
+		case core.SchemeUpdate:
+			rr = updateRR
+		case core.SchemeNotify:
+			rr = notifyRR
+		}
+		if rr == nil {
+			// Should not happen — categorization above guarantees the
+			// chosen scheme has an advertised RR. Defensive only.
+			continue
+		}
+		target, terr := resolveDsyncTarget(ctx, imr, rr)
+		if terr != nil {
+			return nil, fmt.Errorf("resolve DSYNC %s target: %w", schemeName(scheme), terr)
+		}
+		out = append(out, schemeChoice{Scheme: scheme, Target: target})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("pickRolloverSchemes: no DSYNC targets resolvable for zone %s", zd.ZoneName)
+	}
+	return out, nil
+}
+
+// decideRolloverSchemes is the pure decision function: given which
+// schemes the parent advertises (categorized by pickRolloverSchemes
+// from the DSYNC RRset) and the policy's preference, returns the
+// list of schemes the engine should attempt this push.
+//
+// Pulled out of pickRolloverSchemes so it can be exhaustively
+// table-tested without standing up an Imr or a parent zone.
+//
+// "no usable scheme" is signaled by a non-nil error; the caller
+// (dispatcher) translates this into child-config:waiting-for-parent
+// (Phase 6).
+func decideRolloverSchemes(updateAdvertised, notifyAdvertised bool, preference string) ([]core.DsyncScheme, error) {
+	pref := preference
+	if pref == "" {
+		pref = defaultDsyncSchemePreference
+	}
+	switch pref {
+	case DsyncSchemePreferenceAuto:
+		switch {
+		case updateAdvertised && notifyAdvertised:
+			return []core.DsyncScheme{core.SchemeUpdate, core.SchemeNotify}, nil
+		case updateAdvertised:
+			return []core.DsyncScheme{core.SchemeUpdate}, nil
+		case notifyAdvertised:
+			return []core.DsyncScheme{core.SchemeNotify}, nil
+		default:
+			return nil, fmt.Errorf("parent advertises no rollover-usable DSYNC scheme")
+		}
+	case DsyncSchemePreferencePreferUpdate:
+		switch {
+		case updateAdvertised:
+			return []core.DsyncScheme{core.SchemeUpdate}, nil
+		case notifyAdvertised:
+			return []core.DsyncScheme{core.SchemeNotify}, nil
+		default:
+			return nil, fmt.Errorf("parent advertises no rollover-usable DSYNC scheme")
+		}
+	case DsyncSchemePreferencePreferNotify:
+		switch {
+		case notifyAdvertised:
+			return []core.DsyncScheme{core.SchemeNotify}, nil
+		case updateAdvertised:
+			return []core.DsyncScheme{core.SchemeUpdate}, nil
+		default:
+			return nil, fmt.Errorf("parent advertises no rollover-usable DSYNC scheme")
+		}
+	case DsyncSchemePreferenceForceUpdate:
+		if !updateAdvertised {
+			return nil, fmt.Errorf("policy pins force-update but parent does not advertise UPDATE")
+		}
+		return []core.DsyncScheme{core.SchemeUpdate}, nil
+	case DsyncSchemePreferenceForceNotify:
+		if !notifyAdvertised {
+			return nil, fmt.Errorf("policy pins force-notify but parent does not advertise NOTIFY for CDS/ANY")
+		}
+		return []core.DsyncScheme{core.SchemeNotify}, nil
+	default:
+		return nil, fmt.Errorf("invalid dsync-scheme-preference %q", preference)
+	}
+}
+
+// resolveDsyncTarget resolves a DSYNC RR's Target FQDN to A/AAAA
+// addresses via the IMR. Same shape as the address-resolution loop in
+// LookupDSYNCTarget, factored out so pickRolloverSchemes can avoid a
+// second DSYNC discovery query for each scheme.
+func resolveDsyncTarget(ctx context.Context, imr *Imr, rr *core.DSYNC) (*DsyncTarget, error) {
+	target := dns.Fqdn(rr.Target)
+	var addrs []string
+	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
+		resp, qerr := imr.ImrQuery(ctx, target, qtype, dns.ClassINET, nil)
+		if qerr != nil {
+			continue
+		}
+		if resp.Error || resp.RRset == nil {
+			continue
+		}
+		for _, r := range resp.RRset.RRs {
+			switch v := r.(type) {
+			case *dns.A:
+				addrs = append(addrs, v.A.String())
+			case *dns.AAAA:
+				addrs = append(addrs, v.AAAA.String())
+			}
+		}
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no A or AAAA for %s via IMR", target)
+	}
+	dt := &DsyncTarget{
+		Name:   target,
+		Scheme: rr.Scheme,
+		Port:   rr.Port,
+		RR:     rr,
+	}
+	for _, a := range addrs {
+		dt.Addresses = append(dt.Addresses, net.JoinHostPort(a, strconv.Itoa(int(rr.Port))))
+	}
+	return dt, nil
+}
+
+// schemeName renders a DsyncScheme as the diagnostic string used in
+// LastAttemptScheme + status output ("UPDATE" / "NOTIFY"). Other
+// scheme values fall back to a numeric form; the rollover engine only
+// emits UPDATE/NOTIFY in normal operation.
+func schemeName(s core.DsyncScheme) string {
+	switch s {
+	case core.SchemeUpdate:
+		return "UPDATE"
+	case core.SchemeNotify:
+		return "NOTIFY"
+	default:
+		return fmt.Sprintf("scheme%d", s)
+	}
+}

--- a/v2/ksk_rollover_schemes_test.go
+++ b/v2/ksk_rollover_schemes_test.go
@@ -1,0 +1,79 @@
+package tdns
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/johanix/tdns/v2/core"
+)
+
+// TestDecideRolloverSchemes covers the 4 × 5 = 20 cells of
+// (advertised UPDATE? × advertised NOTIFY?) × (auto, prefer-update,
+// prefer-notify, force-update, force-notify), plus an empty-string
+// default-preference cell and an unknown-preference error cell.
+func TestDecideRolloverSchemes(t *testing.T) {
+	tests := []struct {
+		name       string
+		update     bool
+		notify     bool
+		preference string
+		want       []core.DsyncScheme
+		wantErr    string // substring match; empty = no error expected
+	}{
+		// auto
+		{"auto/none", false, false, DsyncSchemePreferenceAuto, nil, "no rollover-usable DSYNC"},
+		{"auto/update-only", true, false, DsyncSchemePreferenceAuto, []core.DsyncScheme{core.SchemeUpdate}, ""},
+		{"auto/notify-only", false, true, DsyncSchemePreferenceAuto, []core.DsyncScheme{core.SchemeNotify}, ""},
+		{"auto/both-parallel", true, true, DsyncSchemePreferenceAuto, []core.DsyncScheme{core.SchemeUpdate, core.SchemeNotify}, ""},
+
+		// prefer-update
+		{"prefer-update/none", false, false, DsyncSchemePreferencePreferUpdate, nil, "no rollover-usable DSYNC"},
+		{"prefer-update/update-only", true, false, DsyncSchemePreferencePreferUpdate, []core.DsyncScheme{core.SchemeUpdate}, ""},
+		{"prefer-update/notify-only", false, true, DsyncSchemePreferencePreferUpdate, []core.DsyncScheme{core.SchemeNotify}, ""},
+		{"prefer-update/both", true, true, DsyncSchemePreferencePreferUpdate, []core.DsyncScheme{core.SchemeUpdate}, ""},
+
+		// prefer-notify
+		{"prefer-notify/none", false, false, DsyncSchemePreferencePreferNotify, nil, "no rollover-usable DSYNC"},
+		{"prefer-notify/update-only", true, false, DsyncSchemePreferencePreferNotify, []core.DsyncScheme{core.SchemeUpdate}, ""},
+		{"prefer-notify/notify-only", false, true, DsyncSchemePreferencePreferNotify, []core.DsyncScheme{core.SchemeNotify}, ""},
+		{"prefer-notify/both", true, true, DsyncSchemePreferencePreferNotify, []core.DsyncScheme{core.SchemeNotify}, ""},
+
+		// force-update
+		{"force-update/none", false, false, DsyncSchemePreferenceForceUpdate, nil, "force-update"},
+		{"force-update/update-only", true, false, DsyncSchemePreferenceForceUpdate, []core.DsyncScheme{core.SchemeUpdate}, ""},
+		{"force-update/notify-only", false, true, DsyncSchemePreferenceForceUpdate, nil, "force-update"},
+		{"force-update/both", true, true, DsyncSchemePreferenceForceUpdate, []core.DsyncScheme{core.SchemeUpdate}, ""},
+
+		// force-notify
+		{"force-notify/none", false, false, DsyncSchemePreferenceForceNotify, nil, "force-notify"},
+		{"force-notify/update-only", true, false, DsyncSchemePreferenceForceNotify, nil, "force-notify"},
+		{"force-notify/notify-only", false, true, DsyncSchemePreferenceForceNotify, []core.DsyncScheme{core.SchemeNotify}, ""},
+		{"force-notify/both", true, true, DsyncSchemePreferenceForceNotify, []core.DsyncScheme{core.SchemeNotify}, ""},
+
+		// edge cases
+		{"empty-pref-defaults-to-auto/both", true, true, "", []core.DsyncScheme{core.SchemeUpdate, core.SchemeNotify}, ""},
+		{"unknown-pref", true, true, "weird", nil, "invalid dsync-scheme-preference"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decideRolloverSchemes(tt.update, tt.notify, tt.preference)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/ksk_rollover_schemes_test.go
+++ b/v2/ksk_rollover_schemes_test.go
@@ -1,6 +1,7 @@
 package tdns
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -73,6 +74,42 @@ func TestDecideRolloverSchemes(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDecideRolloverSchemesSentinel verifies that "no usable scheme"
+// outcomes wrap errNoUsableScheme (so the dispatcher can route them
+// to child-config:waiting-for-parent via errors.Is) while config-error
+// outcomes (invalid preference) do NOT wrap it (so they route to
+// child-config:local-error).
+func TestDecideRolloverSchemesSentinel(t *testing.T) {
+	tests := []struct {
+		name              string
+		update            bool
+		notify            bool
+		preference        string
+		wantWrapsSentinel bool
+	}{
+		{"auto/none wraps", false, false, DsyncSchemePreferenceAuto, true},
+		{"prefer-update/none wraps", false, false, DsyncSchemePreferencePreferUpdate, true},
+		{"prefer-notify/none wraps", false, false, DsyncSchemePreferencePreferNotify, true},
+		{"force-update/none wraps", false, false, DsyncSchemePreferenceForceUpdate, true},
+		{"force-update/notify-only wraps", false, true, DsyncSchemePreferenceForceUpdate, true},
+		{"force-notify/none wraps", false, false, DsyncSchemePreferenceForceNotify, true},
+		{"force-notify/update-only wraps", true, false, DsyncSchemePreferenceForceNotify, true},
+		{"unknown-pref does NOT wrap", true, true, "weird", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := decideRolloverSchemes(tt.update, tt.notify, tt.preference)
+			if err == nil {
+				t.Fatalf("want error, got nil")
+			}
+			gotWraps := errors.Is(err, errNoUsableScheme)
+			if gotWraps != tt.wantWrapsSentinel {
+				t.Fatalf("errors.Is(err, errNoUsableScheme) = %v, want %v (err=%v)", gotWraps, tt.wantWrapsSentinel, err)
 			}
 		})
 	}

--- a/v2/ksk_rollover_softfail_test.go
+++ b/v2/ksk_rollover_softfail_test.go
@@ -1,0 +1,72 @@
+package tdns
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWaitingForParentDelay covers the cap logic for the
+// child-config:waiting-for-parent subcategory: the returned softfail
+// delay must never exceed waitingForParentBackoffCap (1h), regardless
+// of what the policy specifies.
+func TestWaitingForParentDelay(t *testing.T) {
+	tests := []struct {
+		name string
+		pol  *DnssecPolicy
+		want time.Duration
+	}{
+		{
+			name: "nil policy -> default minimum (1h)",
+			pol:  nil,
+			want: defaultSoftfailDelayMinimum,
+		},
+		{
+			name: "explicit short delay -> uses it",
+			pol: func() *DnssecPolicy {
+				p := &DnssecPolicy{}
+				p.Rollover.SoftfailDelay = 15 * time.Minute
+				return p
+			}(),
+			want: 15 * time.Minute,
+		},
+		{
+			name: "explicit at-cap delay -> uses it",
+			pol: func() *DnssecPolicy {
+				p := &DnssecPolicy{}
+				p.Rollover.SoftfailDelay = time.Hour
+				return p
+			}(),
+			want: time.Hour,
+		},
+		{
+			name: "explicit above-cap delay -> capped at 1h",
+			pol: func() *DnssecPolicy {
+				p := &DnssecPolicy{}
+				p.Rollover.SoftfailDelay = 6 * time.Hour
+				return p
+			}(),
+			want: waitingForParentBackoffCap,
+		},
+		{
+			name: "policy zero, derived from ds-publish-delay above cap -> capped",
+			pol: func() *DnssecPolicy {
+				p := &DnssecPolicy{}
+				p.Rollover.DsPublishDelay = 4 * time.Hour
+				return p
+			}(),
+			want: waitingForParentBackoffCap,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := waitingForParentDelay(tt.pol)
+			if got != tt.want {
+				t.Fatalf("got %s, want %s", got, tt.want)
+			}
+			if got > waitingForParentBackoffCap {
+				t.Fatalf("returned delay %s exceeds cap %s", got, waitingForParentBackoffCap)
+			}
+		})
+	}
+}

--- a/v2/ksk_rollover_zone_state.go
+++ b/v2/ksk_rollover_zone_state.go
@@ -39,6 +39,16 @@ type RolloverZoneRow struct {
 	LastSuccessAt        sql.NullString
 	LastAttemptStartedAt sql.NullString
 	LastPollAt           sql.NullString
+
+	// NOTIFY-scheme phase 2 fields. LastAttemptScheme is diagnostic-only
+	// ("UPDATE", "NOTIFY", or "UPDATE,NOTIFY" when a parallel send had
+	// at least one wire-level NOERROR). LastPublishedCdsIndexLow/High
+	// are engine-functional: a non-NULL pair asserts ownership of the
+	// current child-apex CDS RRset for compare-on-cleanup matching.
+	// Cleared when cleanupCdsAfterConfirm queues the unpublish.
+	LastAttemptScheme         sql.NullString
+	LastPublishedCdsIndexLow  sql.NullInt64
+	LastPublishedCdsIndexHigh sql.NullInt64
 }
 
 func EnsureRolloverZoneRow(kdb *KeyDB, zone string) error {
@@ -65,7 +75,8 @@ SELECT zone,
        observe_started_at, observe_next_poll_at, observe_backoff_seconds,
        hardfail_count, next_push_at,
        last_softfail_at, last_softfail_category, last_softfail_detail,
-       last_success_at, last_attempt_started_at, last_poll_at
+       last_success_at, last_attempt_started_at, last_poll_at,
+       last_attempt_scheme, last_published_cds_index_low, last_published_cds_index_high
 FROM RolloverZoneState WHERE zone = ?`
 	var r RolloverZoneRow
 	var inProg int
@@ -79,6 +90,7 @@ FROM RolloverZoneState WHERE zone = ?`
 		&r.HardfailCount, &r.NextPushAt,
 		&r.LastSoftfailAt, &r.LastSoftfailCategory, &r.LastSoftfailDetail,
 		&r.LastSuccessAt, &r.LastAttemptStartedAt, &r.LastPollAt,
+		&r.LastAttemptScheme, &r.LastPublishedCdsIndexLow, &r.LastPublishedCdsIndexHigh,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -718,6 +730,56 @@ func clearLastSoftfail(kdb *KeyDB, zone string) error {
 SET last_softfail_at = NULL,
     last_softfail_category = NULL,
     last_softfail_detail = NULL
+WHERE zone = ?`, zone)
+	return err
+}
+
+// setLastAttemptScheme records the scheme(s) used by the most recent
+// push attempt that completed at the wire level. Diagnostic-only —
+// status output reads this; the engine never decides anything from it.
+// Comma-joined when a parallel send had at least one wire-level NOERROR.
+func setLastAttemptScheme(kdb *KeyDB, zone, scheme string) error {
+	if err := EnsureRolloverZoneRow(kdb, zone); err != nil {
+		return err
+	}
+	var s sql.NullString
+	if scheme != "" {
+		s = sql.NullString{String: scheme, Valid: true}
+	}
+	_, err := kdb.DB.Exec(`UPDATE RolloverZoneState SET last_attempt_scheme = ? WHERE zone = ?`, s, zone)
+	return err
+}
+
+// setPublishedCdsRange asserts ownership of the current child-apex CDS
+// RRset by recording the rollover-index range of the keys that backed
+// the engine's most recent CDS publish. Set after a successful NOTIFY
+// publish-and-sign transaction. The range is read at cleanup time by
+// cleanupCdsAfterConfirm to verify that the on-wire CDS still matches
+// what we wrote (compare-on-cleanup), so that a third-party CDS write
+// in the interim is not unpublished by us.
+func setPublishedCdsRange(kdb *KeyDB, zone string, low, high int) error {
+	if err := EnsureRolloverZoneRow(kdb, zone); err != nil {
+		return err
+	}
+	_, err := kdb.DB.Exec(`UPDATE RolloverZoneState
+SET last_published_cds_index_low = ?,
+    last_published_cds_index_high = ?
+WHERE zone = ?`, low, high, zone)
+	return err
+}
+
+// clearPublishedCdsRange releases the engine's CDS-ownership marker.
+// Called after cleanupCdsAfterConfirm has unpublished the CDS RRset
+// (or has decided not to because the on-wire CDS no longer matches).
+// NULL means "we own no CDS at the apex" or "another caller owns
+// whatever CDS is currently published."
+func clearPublishedCdsRange(kdb *KeyDB, zone string) error {
+	if err := EnsureRolloverZoneRow(kdb, zone); err != nil {
+		return err
+	}
+	_, err := kdb.DB.Exec(`UPDATE RolloverZoneState
+SET last_published_cds_index_low = NULL,
+    last_published_cds_index_high = NULL
 WHERE zone = ?`, zone)
 	return err
 }

--- a/v2/ksk_rollover_zone_state.go
+++ b/v2/ksk_rollover_zone_state.go
@@ -49,6 +49,16 @@ type RolloverZoneRow struct {
 	LastAttemptScheme         sql.NullString
 	LastPublishedCdsIndexLow  sql.NullInt64
 	LastPublishedCdsIndexHigh sql.NullInt64
+
+	// LastDsObservedKeyids is the CSV of SEP keyids returned by the
+	// most recent QueryParentAgentDS call, regardless of whether the
+	// returned set matched the engine's expected set. Updated on
+	// every successful poll. Format: "12345,56789,43215". The
+	// operator's "DS observed" status line is sourced from this so
+	// it tracks the latest poll rather than the latest confirmed
+	// match. LastDsObservedAt is the wallclock of that poll.
+	LastDsObservedKeyids sql.NullString
+	LastDsObservedAt     sql.NullString
 }
 
 func EnsureRolloverZoneRow(kdb *KeyDB, zone string) error {
@@ -76,7 +86,8 @@ SELECT zone,
        hardfail_count, next_push_at,
        last_softfail_at, last_softfail_category, last_softfail_detail,
        last_success_at, last_attempt_started_at, last_poll_at,
-       last_attempt_scheme, last_published_cds_index_low, last_published_cds_index_high
+       last_attempt_scheme, last_published_cds_index_low, last_published_cds_index_high,
+       last_ds_observed_keyids, last_ds_observed_at
 FROM RolloverZoneState WHERE zone = ?`
 	var r RolloverZoneRow
 	var inProg int
@@ -91,6 +102,7 @@ FROM RolloverZoneState WHERE zone = ?`
 		&r.LastSoftfailAt, &r.LastSoftfailCategory, &r.LastSoftfailDetail,
 		&r.LastSuccessAt, &r.LastAttemptStartedAt, &r.LastPollAt,
 		&r.LastAttemptScheme, &r.LastPublishedCdsIndexLow, &r.LastPublishedCdsIndexHigh,
+		&r.LastDsObservedKeyids, &r.LastDsObservedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -782,6 +794,108 @@ SET last_published_cds_index_low = NULL,
     last_published_cds_index_high = NULL
 WHERE zone = ?`, zone)
 	return err
+}
+
+// setCdsPublication records a successful CDS publish-and-NOTIFY into
+// the sparse RolloverCdsPublication table. Distinct from
+// setPublishedCdsRange (the cleanup-time ownership marker on
+// RolloverZoneState that gets cleared after Trigger-1 cleanup);
+// these columns preserve the historical fact across cleanup so the
+// operator can still see "CDS was published [keyids] at <time>" in
+// status output after the rollover has completed.
+//
+// keyids are persisted as a comma-separated list of decimal keyids
+// (e.g. "12345,56789,43215"); status output renders them straight.
+// Only zones that ever ran a NOTIFY publish-and-sign appear in the
+// table, so dense single-provider deployments and UPDATE-only
+// testbeds carry no row here.
+func setCdsPublication(kdb *KeyDB, zone string, keyids []uint16, at time.Time) error {
+	parts := make([]string, 0, len(keyids))
+	for _, k := range keyids {
+		parts = append(parts, fmt.Sprintf("%d", k))
+	}
+	csv := strings.Join(parts, ",")
+	const q = `
+INSERT INTO RolloverCdsPublication (zone, keyids, published_at)
+VALUES (?, ?, ?)
+ON CONFLICT(zone) DO UPDATE SET
+  keyids = excluded.keyids,
+  published_at = excluded.published_at`
+	_, err := kdb.DB.Exec(q, zone, csv, at.UTC().Format(time.RFC3339))
+	return err
+}
+
+// loadCdsPublication returns the most recent successful CDS publication
+// recorded for zone, or (nil, "") when no row exists. The returned
+// keyids slice is a parsed copy of the persisted CSV; parse errors
+// are silently skipped (a malformed CSV stops returning whatever
+// keyids parse correctly up to that point).
+func loadCdsPublication(kdb *KeyDB, zone string) (keyids []uint16, at string, err error) {
+	var csv, atStr string
+	row := kdb.DB.QueryRow(`SELECT keyids, published_at FROM RolloverCdsPublication WHERE zone = ?`, zone)
+	if scanErr := row.Scan(&csv, &atStr); scanErr != nil {
+		if scanErr == sql.ErrNoRows {
+			return nil, "", nil
+		}
+		return nil, "", scanErr
+	}
+	for _, s := range strings.Split(csv, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		var v uint16
+		if _, scanErr := fmt.Sscanf(s, "%d", &v); scanErr != nil {
+			continue
+		}
+		keyids = append(keyids, v)
+	}
+	return keyids, atStr, nil
+}
+
+// setLastDsObserved records the SEP keyids returned by the most
+// recent QueryParentAgentDS call, with the wallclock of the poll.
+// Updated on every successful poll regardless of whether the
+// returned set matches the engine's expected set; the operator's
+// "DS observed" status line shows the latest poll. CSV format
+// matches setCdsPublication. Persists onto RolloverZoneState (every
+// rollover-managed zone polls; not sparse).
+func setLastDsObserved(kdb *KeyDB, zone string, keyids []uint16, at time.Time) error {
+	if err := EnsureRolloverZoneRow(kdb, zone); err != nil {
+		return err
+	}
+	parts := make([]string, 0, len(keyids))
+	for _, k := range keyids {
+		parts = append(parts, fmt.Sprintf("%d", k))
+	}
+	csv := strings.Join(parts, ",")
+	_, err := kdb.DB.Exec(`UPDATE RolloverZoneState
+SET last_ds_observed_keyids = ?,
+    last_ds_observed_at = ?
+WHERE zone = ?`, csv, at.UTC().Format(time.RFC3339), zone)
+	return err
+}
+
+// parseDsObservedKeyids parses a CSV-of-keyids stored in
+// RolloverZoneState.last_ds_observed_keyids. Same forgiving parser
+// as loadCdsPublication.
+func parseDsObservedKeyids(csv string) []uint16 {
+	if csv == "" {
+		return nil
+	}
+	var out []uint16
+	for _, s := range strings.Split(csv, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		var v uint16
+		if _, err := fmt.Sscanf(s, "%d", &v); err != nil {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
 }
 
 // setNextPushAt updates next_push_at without touching last_softfail_*.

--- a/v2/loggers.go
+++ b/v2/loggers.go
@@ -1,6 +1,6 @@
 package tdns
 
-import(
+import (
 	"log/slog"
 )
 
@@ -14,3 +14,4 @@ var lgConnRetryEngine = Logger("conn-retry")
 var lgElect = Logger("elect")
 var lgProviderGroup = Logger("provider-group")
 var lgSigner = Logger("signer")
+var lgRollover = Logger("rollover")

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -45,6 +45,13 @@ type RolloverStatus struct {
 	ManualRequestedAt string `json:"manualRequestedAt,omitempty"`
 	ManualEarliest    string `json:"manualEarliest,omitempty"`
 
+	// LastAttemptScheme records which scheme(s) the most recent push
+	// attempt used at the wire level. Diagnostic only — the engine
+	// never decides anything from it. Values: "UPDATE", "NOTIFY", or
+	// "UPDATE,NOTIFY" when a parallel send had at least one path
+	// return NOERROR. Empty when no push attempt has succeeded yet.
+	LastAttemptScheme string `json:"lastAttemptScheme,omitempty"`
+
 	// Active attempt timing. Populated when an attempt is in flight
 	// (pending-parent-push, pending-parent-observe) or when a
 	// softfail probe has been sent.

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -41,6 +41,17 @@ type RolloverStatus struct {
 	SubmittedKeyIDs []uint16 `json:"submittedKeyids,omitempty"`
 	ConfirmedKeyIDs []uint16 `json:"confirmedKeyids,omitempty"`
 
+	// CdsPublished holds the rollover_index range of the keys
+	// backing the CDS RRset the engine has published at the child
+	// apex via NOTIFY(CDS). Populated ONLY when both
+	// last_published_cds_index_low/high are non-NULL AND the apex
+	// CDS RRset is actually present on the wire — the second check
+	// guards against a misleading "CDS published" status line when
+	// the engine claims ownership but the on-disk CDS has been
+	// wiped. CdsPublishedKeyIDs are the SEP keyids in that range.
+	CdsPublished       *DSRange `json:"cdsPublished,omitempty"`
+	CdsPublishedKeyIDs []uint16 `json:"cdsPublishedKeyids,omitempty"`
+
 	// Manual-rollover schedule (asap/cancel CLI flow).
 	ManualRequestedAt string `json:"manualRequestedAt,omitempty"`
 	ManualEarliest    string `json:"manualEarliest,omitempty"`

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -41,16 +41,25 @@ type RolloverStatus struct {
 	SubmittedKeyIDs []uint16 `json:"submittedKeyids,omitempty"`
 	ConfirmedKeyIDs []uint16 `json:"confirmedKeyids,omitempty"`
 
-	// CdsPublished holds the rollover_index range of the keys
-	// backing the CDS RRset the engine has published at the child
-	// apex via NOTIFY(CDS). Populated ONLY when both
-	// last_published_cds_index_low/high are non-NULL AND the apex
-	// CDS RRset is actually present on the wire — the second check
-	// guards against a misleading "CDS published" status line when
-	// the engine claims ownership but the on-disk CDS has been
-	// wiped. CdsPublishedKeyIDs are the SEP keyids in that range.
-	CdsPublished       *DSRange `json:"cdsPublished,omitempty"`
+	// CdsPublishedKeyIDs is the SEP keyids of the CDS RRset that the
+	// engine published at the child apex via NOTIFY(CDS) in its most
+	// recent successful publish-and-NOTIFY. Sourced from the sparse
+	// RolloverCdsPublication table — the row persists across
+	// Trigger-1 cleanup so the operator can still see "CDS was
+	// published [keyids] sent <CdsPublishedAt>" after the rollover
+	// has completed and the engine no longer owns the apex CDS.
+	// Empty/nil for zones that never ran a NOTIFY publish.
 	CdsPublishedKeyIDs []uint16 `json:"cdsPublishedKeyids,omitempty"`
+	CdsPublishedAt     string   `json:"cdsPublishedAt,omitempty"` // RFC3339
+
+	// ObservedKeyIDs is the SEP keyids returned by the most recent
+	// QueryParentAgentDS poll, regardless of whether the polled set
+	// matched the engine's expected DS set. Refreshed on every
+	// successful poll; used by the operator's "DS observed" line to
+	// show the latest poll rather than the latest confirmed match.
+	// ObservedAt is the wallclock timestamp of that poll.
+	ObservedKeyIDs []uint16 `json:"observedKeyids,omitempty"`
+	ObservedAt     string   `json:"observedAt,omitempty"` // RFC3339
 
 	// Manual-rollover schedule (asap/cancel CLI flow).
 	ManualRequestedAt string `json:"manualRequestedAt,omitempty"`

--- a/v2/notifier.go
+++ b/v2/notifier.go
@@ -25,6 +25,14 @@ type NotifyResponse struct {
 	Rcode    int
 	Error    bool
 	ErrorMsg string
+	// EDE carries any Extended DNS Errors returned by the parent's
+	// NOTIFY response. On any-success-wins overall outcome, EDE is
+	// populated from the first NOERROR target's response (typically
+	// empty). On overall failure, EDE is populated from the most
+	// recent failing target's response. The rollover engine's
+	// parent-rejected category surfaces these for operator
+	// diagnostics.
+	EDE []dns.EDNS0_EDE
 }
 
 // XXX: The whole point with the NotifierEngine is to be able to control the max rate of send notifications per
@@ -47,11 +55,21 @@ func Notifier(ctx context.Context, notifyreqQ chan NotifyRequest) error {
 
 			lgDns.Info("NotifierEngine: will notify downstreams", "zone", zd.ZoneName)
 
-			zd.SendNotify(nr.RRtype, nr.Targets)
+			rcode, ede, sendErr := zd.SendNotify(nr.RRtype, nr.Targets)
 
 			if nr.Response != nil {
+				resp := NotifyResponse{
+					Rcode: rcode,
+					EDE:   ede,
+				}
+				if sendErr != nil {
+					resp.Error = true
+					resp.ErrorMsg = sendErr.Error()
+				} else {
+					resp.Msg = "OK"
+				}
 				select {
-				case nr.Response <- NotifyResponse{Msg: "OK", Rcode: dns.RcodeSuccess, Error: false, ErrorMsg: ""}:
+				case nr.Response <- resp:
 				case <-ctx.Done():
 					lgDns.Warn("NotifierEngine: context cancelled while sending NOTIFY response", "zone", zd.ZoneName)
 					return nil
@@ -61,9 +79,18 @@ func Notifier(ctx context.Context, notifyreqQ chan NotifyRequest) error {
 	}
 }
 
-func (zd *ZoneData) SendNotify(ntype uint16, targets []string) (int, error) {
+// SendNotify sends NOTIFY to every target and aggregates with
+// any-success-wins semantics. On a successful overall outcome (at
+// least one target NOERROR), the returned rcode is NOERROR and EDE
+// is populated from the first NOERROR target's response (typically
+// empty). On overall failure, the returned rcode is the rcode of the
+// most recent failing target's response (or SERVFAIL with err if
+// every target's transport failed) and EDE comes from that target's
+// response. err is non-nil only when no target produced a usable
+// response at all (transport-level failure across the board).
+func (zd *ZoneData) SendNotify(ntype uint16, targets []string) (int, []dns.EDNS0_EDE, error) {
 	if zd.ZoneName == "." {
-		return dns.RcodeServerFailure, fmt.Errorf("zone %q: error: zone name not specified. Ignoring notify request", zd.ZoneName)
+		return dns.RcodeServerFailure, nil, fmt.Errorf("zone %q: error: zone name not specified. Ignoring notify request", zd.ZoneName)
 	}
 
 	var err error
@@ -72,18 +99,18 @@ func (zd *ZoneData) SendNotify(ntype uint16, targets []string) (int, error) {
 	case dns.TypeSOA:
 		// Here we only need the downstreams
 		if len(zd.Downstreams) == 0 {
-			return dns.RcodeServerFailure, fmt.Errorf("zone %q: error: no downstreams. Ignoring notify request", zd.ZoneName)
+			return dns.RcodeServerFailure, nil, fmt.Errorf("zone %q: error: no downstreams. Ignoring notify request", zd.ZoneName)
 		}
 
 	case dns.TypeCSYNC, dns.TypeCDS:
 		// Here we need the parent notify receiver addresses
 		if zd.Parent == "." {
 			if Globals.ImrEngine == nil {
-				return dns.RcodeServerFailure, fmt.Errorf("zone %q: error: ImrEngine not active. Ignoring notify request", zd.ZoneName)
+				return dns.RcodeServerFailure, nil, fmt.Errorf("zone %q: error: ImrEngine not active. Ignoring notify request", zd.ZoneName)
 			}
 			zd.Parent, err = Globals.ImrEngine.ParentZone(zd.ZoneName)
 			if err != nil {
-				return dns.RcodeServerFailure, fmt.Errorf("zone %q: error: failure locating parent zone name. Ignoring notify request", zd.ZoneName)
+				return dns.RcodeServerFailure, nil, fmt.Errorf("zone %q: error: failure locating parent zone name. Ignoring notify request", zd.ZoneName)
 			}
 		}
 
@@ -99,6 +126,11 @@ func (zd *ZoneData) SendNotify(ntype uint16, targets []string) (int, error) {
 	c.Timeout = 5 * time.Second
 
 	successCount := 0
+	var firstSuccessEDE []dns.EDNS0_EDE
+	var lastFailRcode int
+	var lastFailEDE []dns.EDNS0_EDE
+	haveLastFailRcode := false
+
 	for _, dst := range targets {
 		lgDns.Info("NOTIFY: sending", "type", dns.TypeToString[ntype], "zone", zd.ZoneName, "target", dst)
 
@@ -110,23 +142,54 @@ func (zd *ZoneData) SendNotify(ntype uint16, targets []string) (int, error) {
 
 		lgDns.Debug("sending NOTIFY message", "msg", m.String())
 
-		res, _, err := c.Exchange(m, dst)
-		if err != nil {
-			lgDns.Warn("NOTIFY: dns.Exchange failed, trying next target", "target", dst, "type", dns.TypeToString[ntype], "err", err)
+		res, _, exErr := c.Exchange(m, dst)
+		if exErr != nil {
+			lgDns.Warn("NOTIFY: dns.Exchange failed, trying next target", "target", dst, "type", dns.TypeToString[ntype], "err", exErr)
 			continue
 		}
 
+		ede := extractEDEFromMsg(res)
+
 		if res.Rcode != dns.RcodeSuccess {
 			lgDns.Warn("NOTIFY: bad rcode from target", "target", dst, "rcode", dns.RcodeToString[res.Rcode])
+			lastFailRcode = res.Rcode
+			lastFailEDE = ede
+			haveLastFailRcode = true
 		} else {
 			lgDns.Debug("NOTIFY: got NOERROR back", "target", dst)
+			if successCount == 0 {
+				firstSuccessEDE = ede
+			}
 			successCount++
 			// Continue to send NOTIFYs to all targets, don't return early
 		}
 	}
 	if successCount == 0 {
-		return dns.RcodeServerFailure, fmt.Errorf("error: no response from any NOTIFY target to NOTIFY(%q)", dns.TypeToString[ntype])
+		if haveLastFailRcode {
+			return lastFailRcode, lastFailEDE, fmt.Errorf("error: no NOERROR from any NOTIFY target to NOTIFY(%q)", dns.TypeToString[ntype])
+		}
+		return dns.RcodeServerFailure, nil, fmt.Errorf("error: no response from any NOTIFY target to NOTIFY(%q)", dns.TypeToString[ntype])
 	}
 	lgDns.Info("NOTIFY: successfully sent", "type", dns.TypeToString[ntype], "zone", zd.ZoneName, "succeeded", successCount, "total", len(targets))
-	return dns.RcodeSuccess, nil
+	return dns.RcodeSuccess, firstSuccessEDE, nil
+}
+
+// extractEDEFromMsg pulls every EDNS0_EDE option out of a DNS message's
+// OPT record and returns them as typed values. Returns nil when the
+// message has no OPT or no EDEs.
+func extractEDEFromMsg(msg *dns.Msg) []dns.EDNS0_EDE {
+	if msg == nil {
+		return nil
+	}
+	opt := msg.IsEdns0()
+	if opt == nil {
+		return nil
+	}
+	var out []dns.EDNS0_EDE
+	for _, o := range opt.Option {
+		if e, ok := o.(*dns.EDNS0_EDE); ok && e != nil {
+			out = append(out, *e)
+		}
+	}
+	return out
 }

--- a/v2/notifier.go
+++ b/v2/notifier.go
@@ -166,8 +166,17 @@ func (zd *ZoneData) SendNotify(ntype uint16, targets []string) (int, []dns.EDNS0
 	}
 	if successCount == 0 {
 		if haveLastFailRcode {
-			return lastFailRcode, lastFailEDE, fmt.Errorf("error: no NOERROR from any NOTIFY target to NOTIFY(%q)", dns.TypeToString[ntype])
+			// Parent replied — just with a non-NOERROR rcode. Return
+			// the rcode/EDE without an error: this is "parent
+			// rejected" (parent-rejected category), not "transport
+			// failed". The caller categorises from the rcode and
+			// EDE; making this an error would force the rollover
+			// engine into the transport bucket and lose the EDE
+			// context that's the whole point of Phase 4 plumbing.
+			return lastFailRcode, lastFailEDE, nil
 		}
+		// No response from any target at all → genuine transport
+		// failure. err is non-nil only on this branch.
 		return dns.RcodeServerFailure, nil, fmt.Errorf("error: no response from any NOTIFY target to NOTIFY(%q)", dns.TypeToString[ntype])
 	}
 	lgDns.Info("NOTIFY: successfully sent", "type", dns.TypeToString[ntype], "zone", zd.ZoneName, "succeeded", successCount, "total", len(targets))

--- a/v2/notifyresponder.go
+++ b/v2/notifyresponder.go
@@ -155,9 +155,13 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 
 	switch ntype {
 	case dns.TypeSOA, dns.TypeDNSKEY:
-		// For SOA and DNSKEY, target the zone for qname itself
-		var found bool
-		zd, found = FindZone(qname)
+		// For SOA and DNSKEY, target the zone for qname itself.
+		// FindZone walks up from qname so it can return a containing
+		// zone for an interior name (e.g. host.example.com. resolves
+		// to example.com.). NOTIFY(SOA)/NOTIFY(DNSKEY) for an
+		// interior name is not a valid request — refuse it rather
+		// than silently refreshing the containing zone.
+		zd, _ = FindZone(qname)
 		if zd == nil {
 			lgHandler.Warn("received NOTIFY for unknown zone, ignoring", "type", dns.TypeToString[ntype], "zone", qname)
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
@@ -166,11 +170,23 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 			dnr.ResponseWriter.WriteMsg(m)
 			return nil
 		}
-		if !found && zd.IsChildDelegation(qname) {
-			lgHandler.Warn("received NOTIFY for child delegation, ignoring", "type", dns.TypeToString[ntype], "qname", qname)
+		if !strings.EqualFold(dns.Fqdn(zd.ZoneName), dns.Fqdn(qname)) {
+			// FindZone returned a containing zone, not an exact
+			// zone match. Could be a child delegation point or a
+			// plain interior name; either way we don't accept the
+			// NOTIFY against the containing zone.
+			if zd.IsChildDelegation(qname) {
+				lgHandler.Warn("received NOTIFY for child delegation, ignoring", "type", dns.TypeToString[ntype], "qname", qname)
+				m.SetRcode(dnr.Msg, dns.RcodeRefused)
+				edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
+					fmt.Sprintf("%s is a child delegation, not authoritative on this server", qname), false)
+				dnr.ResponseWriter.WriteMsg(m)
+				return nil
+			}
+			lgHandler.Warn("received NOTIFY for interior name in zone, ignoring", "type", dns.TypeToString[ntype], "qname", qname, "zone", zd.ZoneName)
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
-			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
-				fmt.Sprintf("%s is a child delegation, not authoritative on this server", qname), false)
+			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyParentNotAuthoritative,
+				fmt.Sprintf("%s is not a zone apex on this server (containing zone %s)", qname, zd.ZoneName), false)
 			dnr.ResponseWriter.WriteMsg(m)
 			return nil
 		}

--- a/v2/notifyresponder.go
+++ b/v2/notifyresponder.go
@@ -6,11 +6,54 @@ package tdns
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/johanix/tdns/v2/edns0"
 	"github.com/miekg/dns"
 )
+
+// advertisesDsyncNotify reports whether the parent zone's local DSYNC
+// RRset advertises NOTIFY for the given RRtype. ANY-typed DSYNC RRs
+// match every qtype. The DSYNC owner is "_dsync.<zone>" — same lookup
+// that ops_dsync.go uses. In-memory zone read; no DNS round-trip.
+//
+// Returns false if the zone has no DSYNC RRset, no NOTIFY-scheme RR,
+// or no RR matching the qtype. The NOTIFY responder uses this to gate
+// incoming NOTIFY(CDS)/NOTIFY(CSYNC) before kicking off the async
+// scan: a child mis-configured to send NOTIFY at a parent that
+// advertises only UPDATE (or only NOTIFY for the other RRtype) gets
+// REFUSED + EDENotifyDsyncSchemeNotAdvertised on the first attempt
+// instead of a generic parent-publish-failure after attempt-timeout.
+func (zd *ZoneData) advertisesDsyncNotify(qtype uint16) bool {
+	owner, err := zd.GetOwner("_dsync." + zd.ZoneName)
+	if err != nil || owner == nil {
+		return false
+	}
+	rrset := owner.RRtypes.GetOnlyRRSet(core.TypeDSYNC)
+	if rrset.RRs == nil {
+		return false
+	}
+	for _, rr := range rrset.RRs {
+		prr, ok := rr.(*dns.PrivateRR)
+		if !ok {
+			continue
+		}
+		ds, ok := prr.Data.(*core.DSYNC)
+		if !ok {
+			continue
+		}
+		if ds.Scheme != core.SchemeNotify {
+			continue
+		}
+		if ds.Type == qtype || ds.Type == dns.TypeANY {
+			return true
+		}
+	}
+	return false
+}
 
 // NotifyHandlerWithCallback consumes DnsNotifyRequest messages from the DnsNotifyQ channel
 // and calls the provided handler function. This allows custom NOTIFY handlers
@@ -118,12 +161,16 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		if zd == nil {
 			lgHandler.Warn("received NOTIFY for unknown zone, ignoring", "type", dns.TypeToString[ntype], "zone", qname)
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
+			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyParentNotAuthoritative,
+				fmt.Sprintf("server is not authoritative for %s", qname), false)
 			dnr.ResponseWriter.WriteMsg(m)
 			return nil
 		}
 		if !found && zd.IsChildDelegation(qname) {
 			lgHandler.Warn("received NOTIFY for child delegation, ignoring", "type", dns.TypeToString[ntype], "qname", qname)
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
+			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
+				fmt.Sprintf("%s is a child delegation, not authoritative on this server", qname), false)
 			dnr.ResponseWriter.WriteMsg(m)
 			return nil
 		}
@@ -136,6 +183,8 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		if len(labels) < 2 || labels[1] == "" {
 			lgHandler.Warn("NOTIFY(CDS/CSYNC) qname has no parent", "qname", qname)
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
+			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
+				fmt.Sprintf("%s has no parent label", qname), false)
 			dnr.ResponseWriter.WriteMsg(m)
 			return nil
 		}
@@ -143,12 +192,30 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		if zd == nil {
 			lgHandler.Warn("parent zone not authoritative, refusing NOTIFY", "type", dns.TypeToString[ntype], "qname", qname)
 			m.SetRcode(dnr.Msg, dns.RcodeNotAuth)
+			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyParentNotAuthoritative,
+				fmt.Sprintf("server is not authoritative for parent of %s", qname), false)
 			dnr.ResponseWriter.WriteMsg(m)
 			return nil
 		}
 		if !zd.IsChildDelegation(qname) {
 			lgHandler.Warn("qname is not a child delegation in parent zone", "type", dns.TypeToString[ntype], "qname", qname, "parent", zd.ZoneName)
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
+			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
+				fmt.Sprintf("%s is not a child delegation of %s", qname, zd.ZoneName), false)
+			dnr.ResponseWriter.WriteMsg(m)
+			return nil
+		}
+		// DSYNC scheme gate: refuse NOTIFY for an RRtype the parent
+		// does not advertise NOTIFY for. Catches misconfigured
+		// children on the very first push instead of after
+		// attempt-timeout. In-memory zone read; no DNS round-trip.
+		if !zd.advertisesDsyncNotify(ntype) {
+			lgHandler.Warn("parent does not advertise NOTIFY for type, refusing",
+				"type", dns.TypeToString[ntype], "parent", zd.ZoneName, "qname", qname)
+			m.SetRcode(dnr.Msg, dns.RcodeRefused)
+			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyDsyncSchemeNotAdvertised,
+				fmt.Sprintf("parent zone %s does not advertise NOTIFY for type %s; ignoring",
+					zd.ZoneName, dns.TypeToString[ntype]), false)
 			dnr.ResponseWriter.WriteMsg(m)
 			return nil
 		}
@@ -157,6 +224,8 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 	default:
 		lgHandler.Warn("unknown NOTIFY type", "type", dns.TypeToString[ntype])
 		m.SetRcode(dnr.Msg, dns.RcodeRefused)
+		edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyUnknownType,
+			fmt.Sprintf("NOTIFY for type %s not supported", dns.TypeToString[ntype]), false)
 		dnr.ResponseWriter.WriteMsg(m)
 		return nil
 	}
@@ -165,6 +234,8 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 	if zd.Error && zd.ErrorType != RefreshError {
 		lgHandler.Error("zone in error state, refusing NOTIFY", "type", dns.TypeToString[ntype], "qname", qname, "zone", targetZoneName, "errorMsg", zd.ErrorMsg)
 		m.SetRcode(dnr.Msg, dns.RcodeServerFailure)
+		edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyZoneInErrorState,
+			fmt.Sprintf("zone %s in error state: %s", targetZoneName, zd.ErrorMsg), false)
 		dnr.ResponseWriter.WriteMsg(m)
 		return nil
 	}

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -248,6 +248,9 @@ func populateFromZoneRow(out *RolloverStatus, row *RolloverZoneRow) {
 		out.LastUpdate = row.LastAttemptStartedAt.String
 		out.LastAttemptStarted = row.LastAttemptStartedAt.String
 	}
+	if row.LastAttemptScheme.Valid {
+		out.LastAttemptScheme = row.LastAttemptScheme.String
+	}
 
 	out.HardfailCount = row.HardfailCount
 	if row.NextPushAt.Valid {
@@ -332,6 +335,14 @@ func headlineForPhase(phase string) string {
 func hintForState(phase string, row *RolloverZoneRow, pol *DnssecPolicy, now time.Time) string {
 	switch phase {
 	case rolloverPhasePushSoftfail:
+		// child-config:waiting-for-parent has a different operational
+		// shape: polling continues but the parent has lost the ability
+		// to consume our push entirely. Operator action is on the
+		// parent side (advertise DSYNC), not the child side.
+		if row != nil && row.LastSoftfailCategory.Valid &&
+			row.LastSoftfailCategory.String == SoftfailChildConfigWaitingForParent {
+			return "waiting for parent to advertise a usable DSYNC scheme — auto-recovers when restored"
+		}
 		return "parent fix will be auto-detected — polling never stops"
 	case rolloverPhasePendingParentObserve:
 		if row == nil || pol == nil || !row.LastAttemptStartedAt.Valid {

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -49,22 +49,26 @@ func ComputeRolloverStatus(kdb *KeyDB, zone string, pol *DnssecPolicy, checkInte
 		populateFromZoneRow(out, row)
 	}
 
-	// CdsPublished is populated only when the engine claims ownership
-	// AND the apex CDS RRset is actually on disk. Without the
-	// apex-presence guard, a CDS that got wiped by zone refresh
-	// (CollectDynamicRRs allowlist gap) would still show in status
-	// as "CDS published" — misleading the operator into thinking
-	// the parent has something to scan when it does not.
-	if row != nil && row.LastPublishedCdsIndexLow.Valid && row.LastPublishedCdsIndexHigh.Valid {
-		if zd, ok := Zones.Get(zone); ok && zd != nil {
-			if owner, _ := zd.GetOwner(zd.ZoneName); owner != nil {
-				if rs, exists := owner.RRtypes.Get(dns.TypeCDS); exists && len(rs.RRs) > 0 {
-					out.CdsPublished = &DSRange{
-						Low:  int(row.LastPublishedCdsIndexLow.Int64),
-						High: int(row.LastPublishedCdsIndexHigh.Int64),
-					}
-				}
-			}
+	// CdsPublishedKeyIDs / CdsPublishedAt: historical fact — what
+	// CDS RRset did the engine publish at the child apex via
+	// NOTIFY(CDS), and when. Sourced from the sparse
+	// RolloverCdsPublication table; survives Trigger-1 cleanup
+	// (the cleanup-time ownership marker on RolloverZoneState is a
+	// separate concern). The line shows up in status as long as
+	// the most recent NOTIFY publication completed successfully,
+	// regardless of whether the apex CDS RRset is still on disk.
+	if ids, at, perr := loadCdsPublication(kdb, zone); perr == nil && len(ids) > 0 {
+		out.CdsPublishedKeyIDs = ids
+		out.CdsPublishedAt = at
+	} else if perr != nil {
+		lgRollover.Debug("ComputeRolloverStatus: loadCdsPublication failed", "zone", zone, "err", perr)
+	}
+
+	// ObservedKeyIDs / ObservedAt: latest parent-agent poll result.
+	if row != nil && row.LastDsObservedKeyids.Valid {
+		out.ObservedKeyIDs = parseDsObservedKeyids(row.LastDsObservedKeyids.String)
+		if row.LastDsObservedAt.Valid {
+			out.ObservedAt = row.LastDsObservedAt.String
 		}
 	}
 
@@ -160,13 +164,6 @@ func populateDSKeyidsForStatus(kdb *KeyDB, zone string, out *RolloverStatus) err
 			return fmt.Errorf("confirmed keyids: %w", err)
 		}
 		out.ConfirmedKeyIDs = ids
-	}
-	if out.CdsPublished != nil {
-		ids, err := RolloverKeyidsByIndexRange(kdb, zone, int64(out.CdsPublished.Low), int64(out.CdsPublished.High))
-		if err != nil {
-			return fmt.Errorf("cds-published keyids: %w", err)
-		}
-		out.CdsPublishedKeyIDs = ids
 	}
 	return nil
 }

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -49,6 +49,25 @@ func ComputeRolloverStatus(kdb *KeyDB, zone string, pol *DnssecPolicy, checkInte
 		populateFromZoneRow(out, row)
 	}
 
+	// CdsPublished is populated only when the engine claims ownership
+	// AND the apex CDS RRset is actually on disk. Without the
+	// apex-presence guard, a CDS that got wiped by zone refresh
+	// (CollectDynamicRRs allowlist gap) would still show in status
+	// as "CDS published" — misleading the operator into thinking
+	// the parent has something to scan when it does not.
+	if row != nil && row.LastPublishedCdsIndexLow.Valid && row.LastPublishedCdsIndexHigh.Valid {
+		if zd, ok := Zones.Get(zone); ok && zd != nil {
+			if owner, _ := zd.GetOwner(zd.ZoneName); owner != nil {
+				if rs, exists := owner.RRtypes.Get(dns.TypeCDS); exists && len(rs.RRs) > 0 {
+					out.CdsPublished = &DSRange{
+						Low:  int(row.LastPublishedCdsIndexLow.Int64),
+						High: int(row.LastPublishedCdsIndexHigh.Int64),
+					}
+				}
+			}
+		}
+	}
+
 	out.Headline = headlineForPhase(out.Phase)
 	out.Hint = hintForState(out.Phase, row, pol, now)
 
@@ -141,6 +160,13 @@ func populateDSKeyidsForStatus(kdb *KeyDB, zone string, out *RolloverStatus) err
 			return fmt.Errorf("confirmed keyids: %w", err)
 		}
 		out.ConfirmedKeyIDs = ids
+	}
+	if out.CdsPublished != nil {
+		ids, err := RolloverKeyidsByIndexRange(kdb, zone, int64(out.CdsPublished.Low), int64(out.CdsPublished.High))
+		if err != nil {
+			return fmt.Errorf("cds-published keyids: %w", err)
+		}
+		out.CdsPublishedKeyIDs = ids
 	}
 	return nil
 }

--- a/v2/rollover_engine_deps.go
+++ b/v2/rollover_engine_deps.go
@@ -1,0 +1,44 @@
+package tdns
+
+import (
+	"log/slog"
+	"time"
+)
+
+// RolloverEngineDeps bundles every dependency the rollover engine needs to
+// run a single per-zone tick or push. The struct is the seam between the
+// orchestrator (tdns/v2's KeyStateWorker, tdns-mp/v2's KeyStateWorker) and
+// the rollover engine itself: each orchestrator iterates its own zones,
+// builds a deps for each one, and calls RolloverAutomatedTick. The engine
+// has no package-level globals or implicit conf.Internal lookups.
+//
+// Conf is a passthrough for helpers (AtomicRollover, triggerResign,
+// completeRolloverWithdraw, scheduleFastObservePoll) that take *Config
+// directly today and are not in scope for this phase. The "no globals"
+// goal is bounded to the implicit dependencies of the push path itself
+// (Imr, DnssecPolicies, lock acquirer, logger).
+type RolloverEngineDeps struct {
+	Conf             *Config
+	KDB              *KeyDB
+	Zone             *ZoneData
+	Imr              *Imr
+	NotifyQ          chan NotifyRequest
+	InternalUpdateQ  chan UpdateRequest
+	Policy           *DnssecPolicy
+	AcquireLock      func(zoneName string) (release func(), err error)
+	Logger           *slog.Logger
+	PropagationDelay time.Duration
+	Now              func() time.Time
+}
+
+// defaultAcquireRolloverLock is the tdns/v2 lock acquirer wired into
+// RolloverEngineDeps.AcquireLock by the in-tree orchestrator. It blocks
+// on the per-zone mutex from rollover_lock.go and returns an unlock
+// function. tdns/v2 never returns an error here; the error path exists
+// for tdns-mp's leader-aware wrapper, which can refuse with ErrNotLeader
+// when the local instance is not leader for the zone's provider group.
+func defaultAcquireRolloverLock(zone string) (func(), error) {
+	m := AcquireRolloverLock(zone)
+	m.Lock()
+	return m.Unlock, nil
+}

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -247,6 +247,20 @@ type DnssecPolicyRolloverConf struct {
 	DsPublishDelay           string `yaml:"ds-publish-delay" mapstructure:"ds-publish-delay"`
 	MaxAttemptsBeforeBackoff int    `yaml:"max-attempts-before-backoff" mapstructure:"max-attempts-before-backoff"`
 	SoftfailDelay            string `yaml:"softfail-delay" mapstructure:"softfail-delay"`
+
+	// DsyncSchemePreference controls which DSYNC scheme(s) the rollover
+	// engine attempts when pushing DS to the parent. Values:
+	//   - "auto" (default): single advertised scheme is used; if the
+	//     parent advertises both UPDATE and NOTIFY for CDS, both are
+	//     dispatched in parallel and any wire-level NOERROR wins.
+	//   - "prefer-update", "prefer-notify": single-scheme behavior on
+	//     a both-advertising parent, falling through to the only
+	//     advertised scheme on a one-advertising parent.
+	//   - "force-update", "force-notify": only the named scheme is
+	//     attempted; if the parent does not advertise it, the engine
+	//     halts in child-config:waiting-for-parent until the parent
+	//     starts advertising it.
+	DsyncSchemePreference string `yaml:"dsync-scheme-preference" mapstructure:"dsync-scheme-preference"`
 }
 
 // DnssecPolicyTtlsConf is the YAML `ttls:` subtree under a DNSSEC policy.

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -636,6 +636,23 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 		rrtype := rr.Header().Rrtype
 		rrtypestr := dns.TypeToString[rrtype]
 
+		// CDS-publication observability: trace the apex CDS RRset's
+		// lifecycle through the update path so we can see whether the
+		// engine's queued publish is landing on disk and surviving.
+		if rrtype == dns.TypeCDS {
+			before := 0
+			if owner, _ := zd.GetOwner(ownerName); owner != nil {
+				if rs, ok := owner.RRtypes.Get(dns.TypeCDS); ok {
+					before = len(rs.RRs)
+				}
+			}
+			lgRollover.Debug("zone-update CDS action received",
+				"zone", zd.ZoneName, "owner", ownerName,
+				"class", dns.ClassToString[class],
+				"apex_cds_rrs_before", before,
+				"internal_update", ur.InternalUpdate)
+		}
+
 		rrcopy := dns.Copy(rr)
 		rrcopy.Header().Ttl = zd.UpdatePolicy.Zone.TTL
 		rrcopy.Header().Class = dns.ClassINET
@@ -706,6 +723,10 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 			updated = true
 			// zd.Options["dirty"] = true
 			lg.Debug("ApplyZoneUpdateToZoneData: Remove RRset", "rr", rr.String())
+			if rrtype == dns.TypeCDS {
+				lgRollover.Debug("zone-update CDS RRset deleted (ClassANY)",
+					"zone", zd.ZoneName, "owner", ownerName)
+			}
 			continue
 
 		case dns.ClassINET:
@@ -738,6 +759,12 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 		owner.RRtypes.Set(rrtype, rrset)
 		updated = true
 		// zd.Options["dirty"] = true
+		if rrtype == dns.TypeCDS {
+			lgRollover.Debug("zone-update CDS add committed",
+				"zone", zd.ZoneName, "owner", ownerName,
+				"apex_cds_rrs_after", len(rrset.RRs),
+				"rrsigs", len(rrset.RRSIGs))
+		}
 		continue
 	}
 

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -1116,6 +1116,24 @@ func (zd *ZoneData) RepopulateDynamicRRs(dynamicRRs []*core.RRset) {
 	}
 
 	lg.Info("RepopulateDynamicRRs: repopulated dynamic RRsets", "count", len(dynamicRRs), "zone", zd.ZoneName)
+
+	// CDS-publication observability: report whether the apex CDS RRset
+	// survived this refresh. CDS is currently NOT on the
+	// CollectDynamicRRs allowlist, so any CDS the rollover engine
+	// queued via pushDSRRsetViaNotify is wiped here unless the source
+	// zone file re-asserts it. The rollover engine's CDS-ownership
+	// marker (RolloverZoneState.last_published_cds_index_low/high)
+	// outlives the refresh, so the next push will re-publish — but
+	// with a churn cycle visible in zone-update logs as
+	// "no RRset for owner" warnings.
+	apexCdsRRs := 0
+	if owner, _ := zd.GetOwner(zd.ZoneName); owner != nil {
+		if rs, ok := owner.RRtypes.Get(dns.TypeCDS); ok {
+			apexCdsRRs = len(rs.RRs)
+		}
+	}
+	lgRollover.Debug("post-refresh apex CDS observation",
+		"zone", zd.ZoneName, "apex_cds_rrs", apexCdsRRs)
 }
 
 func (zd *ZoneData) SetupZoneSigning(resignq chan<- *ZoneData) error {


### PR DESCRIPTION
## Summary

Adds NOTIFY(CDS) as a second DS-push path alongside UPDATE in the rollover engine, with parallel dispatch as the default policy. Implements phases 1–8 and 10 of [`tdns/docs/2026-04-30-rollover-notify-scheme.md`](docs/2026-04-30-rollover-notify-scheme.md). Phases 9 (tick-handler test harness) and 1a (tdns-mp wiring) deferred to separate PRs.

- **Parallel UPDATE+NOTIFY by default** when the parent advertises both schemes for CDS; any wire-level NOERROR is enough to enter the observe phase. Cost: one extra UDP NOTIFY per attempt; benefit: an "advertised but broken" scheme on one path doesn't block the rollover.
- **Per-policy `dsync-scheme-preference` knob** (`auto` / `prefer-update` / `prefer-notify` / `force-update` / `force-notify`).
- **Orchestrator-agnostic push engine** via the new `RolloverEngineDeps` struct — `RolloverAutomatedTick(ctx, deps)`. Foundation for Phase 1a (tdns-mp `KeyStateWorker` wiring) without modifying the engine.
- **`child-config:waiting-for-parent` subcategory** for "no usable scheme advertised" — indefinite softfail, backoff capped at 1h, never hardfails. Auto-recovers when DSYNC reappears.
- **CDS cleanup** with compare-on-cleanup ownership check (4-tuple set comparison): only unpublish CDS the engine still owns. Three trigger points; 3rd is a no-op hook for a future terminal-hardfail state.
- **Parent-side EDE attachment** for synchronous NOTIFY rejections, including a new `EDENotifyDsyncSchemeNotAdvertised` gate that catches misconfigured children on the very first push.
- **Schema migration** via existing `dbMigrateSchema`: three additive nullable columns on `RolloverZoneState`. Existing testbed rows survive untouched.
- **Status output** "last UPDATE: …" → "last push: … via UPDATE,NOTIFY". `child-config:waiting-for-parent` renders a distinct hint so operators don't confuse parent-config-drift with parent-side-broken.

### Divergences from the design doc

Recorded in the doc's new "Implementation status" section (commit 1f3294f). Most material:

- **Phase 4 publish-and-sign is best-effort, not transactional** (agreed with reviewer mid-implementation). The doc specifies `(publish CDS, sign CDS RRset, re-sign apex NSEC)` as a single transaction with explicit rollback on sign failure; the codebase's existing CDS-publish primitive (`PublishCdsRRs` in `ops_cds.go`) is async fire-and-forget via `kdb.UpdateQ`. Adding the synchronous transaction would have required widening the publish API across the codebase. The rollback path is unreachable in this design; flagged in `pushDSRRsetViaNotify`'s file comment for future publish/sign sync refactor.
- **Phase 1 retains `RolloverEngineDeps.Conf *Config`** as passthrough for helpers (`AtomicRollover`, `triggerResign`, `completeRolloverWithdraw`, `scheduleFastObservePoll`) that take `*Config` directly today. Refactoring those off `*Config` is independent follow-up work.
- **Phase 5 Trigger 3 (terminal hardfail) is a no-op hook**. The post-overhaul state machine has no terminal-hardfail state; softfail mode probes indefinitely. `cleanupCdsAfterHardfail` exists with `//nolint:unused` for a future commit that introduces such a state.

### Commit map

| Phase | Commit | Subject |
|---|---|---|
| 1 | bbf335c | Refactor: orchestrator-agnostic push engine + dispatcher |
| 2 | 9ee7c47 | Schema: `last_attempt_scheme`, `last_published_cds_index_low/high` |
| 3 | ee274de | Policy knob + `pickRolloverSchemes` (22-case decision test) |
| 4 | b3078fe | `pushDSRRsetViaNotify` + parallel dispatch + notifier EDE/rcode plumbing |
| 5 | 5cb4d3d | CDS cleanup with compare-on-cleanup ownership |
| 6 | 75300a6 | `child-config:waiting-for-parent` cap (5-case helper test) |
| 7 | f62fc1d | `RolloverStatus.LastAttemptScheme` + CLI rendering |
| 8 | 7a93300 | Parent-side EDE + DSYNC scheme gate in `NotifyResponder` |
| 10 | 1f3294f | Docs: operator guide + design-doc status section |

## Test plan

Tests covering pure decision logic landed inline:

- [x] `TestDecideRolloverSchemes` — 22 cases over (advertised UPDATE × NOTIFY) × 5 policies + edge cases (empty preference, unknown preference). Asserts parallel return for `auto` × both-advertised, error for "no usable scheme".
- [x] `TestWaitingForParentDelay` — 5 cases asserting the 1h cap holds across nil policy, explicit short/at-cap/above-cap delays, and the derived-from-`ds-publish-delay` above-cap case.
- [x] Build clean at every commit (verified with `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make`).
- [x] Pre-existing test failures (`TestGlobalStuffValidate*`) unchanged from main.

Test harness covering tick-handler state transitions across all push modes is **deferred to a separate PR** (Phase 9 of the design doc — ~750–1000 LOC standalone effort). Pure-helper tests in this branch cover the two high-value decision functions.

End-to-end testing happens on NetBSD VMs in the testbed, not on this development machine — runtime behaviour with a CDS-consuming parent has not been exercised here.

## Notes for review

- **No PR merge.** Push and CodeRabbit review only; merge decision is yours after discussion.
- **No tdns-mp changes.** Phase 1a explicitly out of scope; the Phase 1 extraction makes that follow-up small.
- **No v1 (`tdns/tdns/`) changes.** v2 only.
- **Schema migration is additive** (three nullable columns); existing testbed `RolloverZoneState` rows survive across the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DSYNC scheme preference (auto/prefer/force) with both UPDATE and NOTIFY push paths; NOTIFY(CDS) supported.
  * Persisted per-zone last-attempt scheme and CDS ownership markers; best-effort CDS cleanup and clearer "last push:" status showing "via <scheme>".

* **Improvements**
  * Richer diagnostics via EDNS0 EDE codes and improved waiting-for-parent hints.
  * Notify aggregation reports richer cross-target results and transport/detail handling.

* **Bug Fixes**
  * Bounded softfail/backoff and refined behavior when parent lacks advertised scheme.

* **Tests**
  * Added scheme-selection and waiting-for-parent delay tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->