### PR TITLE
v2: remove dead DeferredUpdate machinery

### DIFF
--- a/v2/config.go
+++ b/v2/config.go
@@ -504,7 +504,6 @@ type InternalDnsConf struct {
 	RecursorCh          chan ImrRequest
 	ScannerQ            chan ScanRequest
 	UpdateQ             chan UpdateRequest
-	DeferredUpdateQ     chan DeferredUpdate
 	DnsUpdateQ          chan DnsUpdateRequest
 	DnsNotifyQ          chan DnsNotifyRequest
 	DnsQueryQ           chan DnsQueryRequest           // Optional: if nil, queries use direct call to QueryResponder

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -210,8 +210,6 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 		kdb := conf.Internal.KeyDB
 		kdb.UpdateQ = make(chan UpdateRequest, 50)
 		conf.Internal.UpdateQ = kdb.UpdateQ
-		kdb.DeferredUpdateQ = make(chan DeferredUpdate, 10)
-		conf.Internal.DeferredUpdateQ = kdb.DeferredUpdateQ
 	}
 	// if Globals.Debug {
 	//	log.Printf("*** MainInit: 5 ***")
@@ -273,7 +271,6 @@ func (conf *Config) StartAuth(ctx context.Context, apirouter *mux.Router) error 
 	StartEngineNoError(&Globals.App, "AuthQueryEngine", func() { AuthQueryEngine(ctx, conf.Internal.AuthQueryQ) })
 	StartEngine(&Globals.App, "ScannerEngine", func() error { return ScannerEngine(ctx, conf) })
 	StartEngine(&Globals.App, "ZoneUpdaterEngine", func() error { return kdb.ZoneUpdaterEngine(ctx) })
-	StartEngine(&Globals.App, "DeferredUpdaterEngine", func() error { return kdb.DeferredUpdaterEngine(ctx) })
 	StartEngine(&Globals.App, "UpdateHandler", func() error { return UpdateHandler(ctx, conf) })
 	StartEngine(&Globals.App, "KeyBootstrapper", func() error { return kdb.KeyBootstrapper(ctx) })
 	StartEngine(&Globals.App, "DelegationSyncher", func() error {
@@ -308,7 +305,6 @@ func (conf *Config) StartAgent(ctx context.Context, apirouter *mux.Router) error
 	StartEngineNoError(&Globals.App, "AuthQueryEngine", func() { AuthQueryEngine(ctx, conf.Internal.AuthQueryQ) })
 	StartEngine(&Globals.App, "ScannerEngine", func() error { return ScannerEngine(ctx, conf) })
 	StartEngine(&Globals.App, "ZoneUpdaterEngine", func() error { return kdb.ZoneUpdaterEngine(ctx) })
-	StartEngine(&Globals.App, "DeferredUpdaterEngine", func() error { return kdb.DeferredUpdaterEngine(ctx) })
 	StartEngine(&Globals.App, "UpdateHandler", func() error { return UpdateHandler(ctx, conf) })
 	StartEngine(&Globals.App, "DelegationSyncher", func() error {
 		return kdb.DelegationSyncher(ctx, conf.Internal.DelegationSyncQ, conf.Internal.NotifyQ, conf)

--- a/v2/ops_dsync.go
+++ b/v2/ops_dsync.go
@@ -249,15 +249,6 @@ func DsyncUpdateTargetName(zonename string) string {
 	return dns.Fqdn(strings.Replace(tpl, "{ZONENAME}", replacer, 1))
 }
 
-// ZoneIsReady returns a function that can be used as a PreCondition for a DeferredUpdate.
-// The returned function will return true if the zone exists and is ready, otherwise false.
-func ZoneIsReady(zonename string) func() bool {
-	return func() bool {
-		_, ok := Zones.Get(zonename)
-		return ok
-	}
-}
-
 func (zd *ZoneData) UnpublishDsyncRRs() error {
 	// Create a string representation of an empty DSYNC record for deletion
 	dsync_str := fmt.Sprintf("_dsync.%s 0 IN DSYNC \"NOTIFY\" 53 1.2.3.4", zd.ZoneName)

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -597,7 +597,6 @@ type KeyDB struct {
 	KeystoreDnskeyCache map[string]*DnssecKeys // map[zonename]*DnssecActiveKeys
 	Ctx                 string
 	UpdateQ             chan UpdateRequest
-	DeferredUpdateQ     chan DeferredUpdate
 	KeyBootstrapperQ    chan KeyBootstrapperRequest
 	Options             map[AuthOption]string
 	// OutboundSoaSerial is the resolved mode for outbound SOA serials:

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -47,15 +47,6 @@ func SprintUpdates(actions []dns.RR) string {
 	return buf
 }
 
-type DeferredUpdate struct {
-	Cmd          string
-	ZoneName     string
-	AddTime      time.Time
-	Description  string
-	PreCondition func() bool
-	Action       func() error
-}
-
 // logUpdateActions logs each RR in an update at Info level with
 // ADDED/DELETED prefix based on the RR class.
 func logUpdateActions(updateType string, actions []dns.RR) {
@@ -281,95 +272,6 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 				lg.Error("ZoneUpdater: unknown command, ignoring", "cmd", ur.Cmd)
 			}
 			lg.Info("ZoneUpdater: update request completed", "type", ur.Cmd)
-		}
-	}
-}
-
-func (kdb *KeyDB) DeferredUpdaterEngine(ctx context.Context) error {
-	deferredq := kdb.DeferredUpdateQ
-
-	var deferredUpdates []DeferredUpdate
-
-	var runQueueTicker = time.NewTicker(10 * time.Second)
-
-	lg.Info("DeferredUpdater starting")
-	defer runQueueTicker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			lg.Info("DeferredUpdater: context cancelled")
-			lg.Info("DeferredUpdater: terminating")
-			return nil
-		case du, ok := <-deferredq:
-			if !ok {
-				lg.Info("DeferredUpdater: deferredq closed")
-				lg.Info("DeferredUpdater: terminating")
-				return nil
-			}
-			lg.Debug("DeferredUpdater received update request")
-			if du.Cmd == "PING" {
-				lg.Debug("DeferredUpdater: PING received, PONG!")
-				continue
-			}
-			_, ok = Zones.Get(du.ZoneName)
-			if !ok && du.Cmd != "DEFERRED-UPDATE" {
-				lg.Warn("DeferredUpdater: unknown zone in update request, ignoring", "cmd", du.Cmd, "zone", du.ZoneName)
-				lg.Debug("DeferredUpdater: known zones", "zones", Zones.Keys())
-				continue
-			}
-
-			switch du.Cmd {
-			case "DEFERRED-UPDATE":
-				// If the PreCondition is true, we execute the Action immediately, otherwise we defer execution an add it to the deferredUpdates queue.
-				if du.PreCondition() {
-					lg.Debug("DeferredUpdater: precondition true, executing immediately", "description", du.Description)
-					err := du.Action()
-					if err != nil {
-						lg.Error("DeferredUpdater: deferred update action failed", "description", du.Description, "error", err)
-					}
-				} else {
-					lg.Debug("DeferredUpdater: precondition false, deferring execution", "description", du.Description)
-					du := DeferredUpdate{
-						Description:  du.Description,
-						PreCondition: du.PreCondition,
-						Action:       du.Action,
-						AddTime:      time.Now(),
-					}
-					deferredUpdates = append(deferredUpdates, du)
-				}
-				continue
-
-			default:
-				lg.Error("DeferredUpdater: unknown command, ignoring", "cmd", du.Cmd)
-			}
-			lg.Info("DeferredUpdater: update request completed", "type", du.Cmd)
-
-		case <-runQueueTicker.C:
-			if len(deferredUpdates) == 0 {
-				continue
-			}
-
-			lg.Debug("DeferredUpdater: running deferred updates queue", "items", len(deferredUpdates))
-			for i := 0; i < len(deferredUpdates); {
-				du := deferredUpdates[i]
-				lg.Debug("DeferredUpdater: running deferred update", "description", du.Description)
-				ok := du.PreCondition()
-				if ok {
-					lg.Debug("DeferredUpdater: precondition true, executing", "description", du.Description)
-					err := du.Action()
-					if err != nil {
-						lg.Error("DeferredUpdater: deferred update action failed", "description", du.Description, "error", err)
-						i++
-					} else {
-						lg.Info("DeferredUpdater: deferred update executed successfully", "description", du.Description)
-						// Remove the item from deferredUpdates queue
-						deferredUpdates = append(deferredUpdates[:i], deferredUpdates[i+1:]...)
-					}
-				} else {
-					lg.Debug("DeferredUpdater: precondition failed, skipping", "description", du.Description)
-					i++
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- OnFirstLoad callbacks have fully replaced DeferredUpdate in v2; no v2 code sends to `DeferredUpdateQ`, and `ZoneIsReady` has no callers.
- Removes the struct, channel fields on `KeyDB` / `InternalConf`, the channel allocation, both `StartEngine("DeferredUpdaterEngine", …)` launches, and the orphaned `ZoneIsReady` helper.
- Pure deletion: 113 lines, 5 files, no behavior change in v2.

## Lockstep change required in tdns-mp
`tdns-mp/v2/start_agent.go` still launches `hdb.DeferredUpdaterEngine(ctx)`. That call site must be removed in tdns-mp before this PR's commit reaches a tdns-mp build, otherwise tdns-mp will fail to compile against the new tdns/v2 API.

## Test plan
- [x] `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make` — green (all v2 binaries build)
- [ ] tdns-mp lockstep change made and tdns-mp builds against this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal update handling architecture for improved system efficiency
  * Optimized service initialization with enhanced engine management
  * Refined delegation synchronization operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->