### PR TITLE
refreshengine: always run; add service.minrefresh

### DIFF
--- a/cmdv2/agentv2/tdns-agent.sample.yaml
+++ b/cmdv2/agentv2/tdns-agent.sample.yaml
@@ -64,8 +64,11 @@ service:
    name:		TDNS-AGENT
    verbose:		true
    debug:		true   # writes processed zone to disk
-   refresh:		true
-   maxrefresh:		1800    # seconds. Cap refresh counter to max this
+   # Optional clamps on the SOA Refresh value used for secondary
+   # zones. Both default in code (min 60s, max 8h) when unset.
+   # Primaries are not affected (they reload from file on SIGHUP).
+   # minrefresh:		60      # seconds, floor for SOA Refresh
+   # maxrefresh:		1800    # seconds, ceiling for SOA Refresh
 
 dnsengine:
    addresses:		[ 127.0.0.1:5357, '[::1]:5357']

--- a/cmdv2/authv2/tdns-auth.sample.yaml
+++ b/cmdv2/authv2/tdns-auth.sample.yaml
@@ -16,8 +16,11 @@ service:
    identities:        [ ns.axfr.net., nsa.johani.org., foo.com. ]
    verbose:           true
    debug:             true     # writes processed zone to disk
-   refresh:           true
-   maxrefresh:        1800     # seconds. Cap refresh counter to max this
+   # Optional clamps on the SOA Refresh value used for secondary
+   # zones. Both default in code (min 60s, max 8h) when unset.
+   # Primaries are not affected (they reload from file on SIGHUP).
+   # minrefresh:      60       # seconds, floor for SOA Refresh
+   # maxrefresh:      1800     # seconds, ceiling for SOA Refresh
 
    transport:
       type:    svcb               # svcb | tsync | none; default is none

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -154,7 +154,6 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 
 	// var refreshCounters = make(map[string]*RefreshCounter, 5)
 	var refreshCounters = core.NewCmap[*RefreshCounter]()
-	var ticker *time.Ticker
 
 	// Build expected zone set from config for a robust post-initialization barrier
 	expected := map[string]struct{}{}
@@ -170,22 +169,8 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 		}
 	}
 
-	if !viper.GetBool("service.refresh") {
-		lgEngine.Info("refresh engine not active, will accept zone definitions but skip periodic refreshes")
-		for {
-			select {
-			case <-ctx.Done():
-				lgEngine.Info("terminating (inactive mode)", "reason", "context cancelled")
-				return
-			case <-zonerefch:
-			}
-			// ensure that we keep reading to keep the channel open
-			continue
-		}
-	} else {
-		ticker = time.NewTicker(1 * time.Second)
-		lgEngine.Info("refresh engine starting")
-	}
+	ticker := time.NewTicker(1 * time.Second)
+	lgEngine.Info("refresh engine starting")
 
 	var zone string
 
@@ -696,21 +681,42 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 	}
 }
 
+// Compile-time bounds applied when service.minrefresh / service.maxrefresh
+// are not configured. They protect against pathological SOA Refresh values
+// (e.g. a 1-second refresh from a misconfigured upstream, or a 30-day SOA
+// that effectively disables secondary refreshes).
+const (
+	defaultMinRefresh uint32 = 60       // 1 minute
+	defaultMaxRefresh uint32 = 8 * 3600 // 8 hours
+)
+
 func FindSoaRefresh(zd *ZoneData) (uint32, error) {
 	var refresh uint32
 	soa, _ := zd.GetSOA()
 	if soa != nil {
 		refresh = soa.Refresh
 	}
-	// Is there a max refresh counter configured, then use it.
+
+	// Primaries reload from file on SIGHUP; refresh just controls how
+	// often we re-stat. 24h is plenty.
+	if zd.ZoneType == Primary {
+		return 86400, nil
+	}
+
 	maxrefresh := uint32(viper.GetInt("service.maxrefresh"))
-	if maxrefresh != 0 && maxrefresh < refresh {
+	if maxrefresh == 0 {
+		maxrefresh = defaultMaxRefresh
+	}
+	if maxrefresh < refresh {
 		refresh = maxrefresh
 	}
 
-	// not refreshing from file all the time. use reload
-	if zd.ZoneType == Primary {
-		refresh = 86400 // 24h
+	minrefresh := uint32(viper.GetInt("service.minrefresh"))
+	if minrefresh == 0 {
+		minrefresh = defaultMinRefresh
+	}
+	if minrefresh > refresh {
+		refresh = minrefresh
 	}
 	return refresh, nil
 }

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -703,17 +703,20 @@ func FindSoaRefresh(zd *ZoneData) (uint32, error) {
 		return 86400, nil
 	}
 
-	maxrefresh := uint32(viper.GetInt("service.maxrefresh"))
-	if maxrefresh == 0 {
-		maxrefresh = defaultMaxRefresh
+	// Use signed-int reads + a positive-value gate so a negative
+	// value in the config falls back to the default rather than
+	// wrapping to ~4 billion seconds via the uint32 cast.
+	maxrefresh := defaultMaxRefresh
+	if cfg := viper.GetInt("service.maxrefresh"); cfg > 0 {
+		maxrefresh = uint32(cfg)
 	}
 	if maxrefresh < refresh {
 		refresh = maxrefresh
 	}
 
-	minrefresh := uint32(viper.GetInt("service.minrefresh"))
-	if minrefresh == 0 {
-		minrefresh = defaultMinRefresh
+	minrefresh := defaultMinRefresh
+	if cfg := viper.GetInt("service.minrefresh"); cfg > 0 {
+		minrefresh = uint32(cfg)
 	}
 	if minrefresh > refresh {
 		refresh = minrefresh


### PR DESCRIPTION
## Summary
- Remove the \`service.refresh\` flag — the engine now always starts. There is no useful configuration where that flag should be false (a daemon with refresh off serves SERVFAIL for every zone it accepts at parse time).
- Add \`service.minrefresh\` as an operator-facing counterpart to the existing \`service.maxrefresh\`.
- Apply compile-time defaults when neither key is set: **min=60s, max=8h**. These bound pathological SOA Refresh values (e.g. a 1-second refresh from a misconfigured upstream, or a 30-day SOA that effectively disables secondary refreshes).
- Primaries return 24h early from \`FindSoaRefresh\` (they reload from file on SIGHUP; the interval only controls re-stat frequency), skipping the clamp.

## Background
On a fresh mpsigner/mpagent testbed, the agent silently failed to AXFR \`customer.example.\` from the signer. Symptom: SERVFAIL with \"zone data is not yet ready\". Root cause: the generated config didn't set \`service.refresh: true\` so the RefreshEngine accepted ZoneRefreshers on its channel and discarded them. The flag does nothing useful and is a foot-gun.

## Test plan
- [x] Build clean on tdns/cmdv2 and tdns-mp/cmd
- [ ] On NetBSD VM: deploy and confirm a fresh secondary zone transfers from its primary without any \`service.refresh\` key in the config
- [ ] Set \`service.minrefresh: 30\` and \`service.maxrefresh: 600\` in config; verify FindSoaRefresh returns values within \[30, 600\] for various SOA Refresh inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refresh engine now runs continuously with periodic refresh operations
  * SOA refresh intervals now properly enforce configured bounds (8-hour default maximum, 1-minute default minimum)
  * Primary zones maintain 24-hour refresh intervals

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/215)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->