### PR TITLE
dnslookup: retry transient errors per-address; UDP→TCP fallback

### DIFF
--- a/v2/dnslookup.go
+++ b/v2/dnslookup.go
@@ -5,6 +5,7 @@ package tdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"log"
@@ -12,6 +13,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	edns0 "github.com/johanix/tdns/v2/edns0"
@@ -21,6 +23,27 @@ import (
 	"github.com/miekg/dns"
 	"github.com/spf13/viper"
 )
+
+// isTransientNetErr reports whether err is a transient network error worth
+// retrying against the same server address: i/o timeout, connection refused,
+// connection reset, or EAGAIN. Authoritative response codes (REFUSED, SERVFAIL,
+// NOTAUTH) come back as successful Exchange calls with a non-zero Rcode — they
+// are NOT errors here and are handled in the caller's per-zone backoff path.
+func isTransientNetErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EAGAIN) {
+		return true
+	}
+	return false
+}
 
 var lgDns = Logger("dns")
 
@@ -1619,15 +1642,79 @@ func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr st
 			return nil, t, 0, err
 		}
 	}
-	r, _, err := c.Exchange(m, addr, Globals.Debug && !imr.Quiet)
+
+	// Per-address retry: a single dropped UDP packet (common on AWS) must not
+	// cause IterativeDNSQuery to abandon an address — especially when the
+	// delegation has only one NS, in which case there is no "next server" to
+	// fall back to. Up to 3 attempts (1 + 2 retries) with short backoff. UDP
+	// timeouts also trigger a single forced-TCP attempt before giving up.
+	// ctx.Done() short-circuits everywhere so the overall query deadline still
+	// bounds total wall time.
+	const maxAttempts = 3
+	backoffs := []time.Duration{50 * time.Millisecond, 150 * time.Millisecond}
+	var (
+		r       *dns.Msg
+		lastErr error
+	)
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, t, 0, ctx.Err()
+			case <-time.After(backoffs[attempt-1]):
+			}
+		}
+		r, _, err = c.Exchange(m, addr, Globals.Debug && !imr.Quiet)
+		if err == nil {
+			break
+		}
+		if !isTransientNetErr(err) {
+			// Non-transient (e.g. config/protocol error) — no point retrying.
+			lastErr = err
+			break
+		}
+		lastErr = err
+		if Globals.Debug {
+			lgDns.Debug("tryServer: transient error, will retry",
+				"attempt", attempt+1,
+				"max", maxAttempts,
+				"addr", addr,
+				"qname", qname,
+				"qtype", dns.TypeToString[qtype],
+				"error", err)
+		}
+	}
+
+	// UDP timeout fallback: if Do53 still failed after all UDP retries with a
+	// transient error, take one shot over TCP against the same address before
+	// declaring this address dead. (DoT/DoH/DoQ are already TCP/QUIC-based.)
+	if err != nil && t == core.TransportDo53 && c.DNSClientTCP != nil && isTransientNetErr(err) {
+		select {
+		case <-ctx.Done():
+			return nil, t, 0, ctx.Err()
+		default:
+		}
+		if Globals.Debug {
+			lgDns.Debug("tryServer: UDP retries exhausted, attempting TCP fallback",
+				"addr", addr, "qname", qname, "qtype", dns.TypeToString[qtype])
+		}
+		tcpAddr := net.JoinHostPort(addr, c.Port)
+		tr, _, terr := c.DNSClientTCP.Exchange(m, tcpAddr)
+		if terr == nil && tr != nil {
+			r, err = tr, nil
+		} else if terr != nil {
+			lastErr = terr
+		}
+	}
+
 	if err != nil {
 		lgDns.Error("*** tryServer: query \" \" sent to returned error",
 			"qname", qname,
 			"s", dns.TypeToString[qtype],
 			"addr", addr,
-			"error", err)
-		server.RecordAddressFailure(addr, err)
-		return nil, t, 0, err
+			"error", lastErr)
+		server.RecordAddressFailure(addr, lastErr)
+		return nil, t, 0, lastErr
 	}
 	if r != nil {
 		server.RecordAddressSuccess(addr)
@@ -1640,7 +1727,7 @@ func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr st
 				"addr", addr)
 		}
 	}
-	return r, t, 0, err
+	return r, t, 0, nil
 }
 
 // applyTransportSignalToServer parses a colon-separated transport string and applies it to the given server.


### PR DESCRIPTION
## Summary

`IterativeDNSQuery`'s per-server loop in [v2/dnslookup.go](v2/dnslookup.go) previously
abandoned an address on the first error returned by `tryServer` (e.g. a dropped
UDP packet → i/o timeout) and moved on to the "next server". When a delegation
has only one NS — for example a zone served exclusively by `nsb.axfr.net.` —
there *is* no next server, so a single transient UDP loss returned "no
Answers" even though a retry would have succeeded. Visible in practice from
an mpagent in AWS doing peer-discovery JWK/URI/SVCB lookups: intermittent
"no Answers", while manual `dogv2 @nsb.axfr.net. …` always works.

## What changed

Per-address bounded retry inside `tryServer` (only — no caller-side
restructuring):

- Up to 3 attempts (1 + 2 retries) against the same address, with 50ms then
  150ms backoff. `ctx.Done()` is re-checked between attempts so the overall
  query deadline still bounds total wall time.
- Only transient network errors trigger a retry: `net.Error.Timeout()`,
  `ECONNREFUSED`, `ECONNRESET`, `EAGAIN`. Detected via `errors.As` /
  `errors.Is` so wrapped errors from miekg/dns are reached correctly.
- Authoritative DNS response codes (REFUSED, SERVFAIL, NOTAUTH, NOTIMP)
  come back as **successful** `Exchange` calls with a non-zero `Rcode` —
  they are not network errors and are NOT retried. They continue through
  the existing per-zone backoff path in `IterativeDNSQuery` unchanged.
- If Do53 UDP retries still fail with a transient error, one final attempt
  is made over TCP (using `c.DNSClientTCP` on the same client struct)
  against the same address before declaring the address dead. DoT/DoH/DoQ
  are already stream-based and skip this step.
- `RecordAddressFailure` now fires only on the **final** failed attempt,
  not once per intermediate retry, so a single recovered timeout no
  longer pollutes per-address failure statistics.

No call-signature change. Caller's REFUSED/NOTAUTH/SERVFAIL handling and
the PR-flag (require-encrypted) short-circuit are untouched.

## Test plan

- [ ] Build green (verified locally: all five `cmdv2/` binaries built).
- [ ] Manual: delegation with a single NS that drops the first UDP packet
      (`iptables -A OUTPUT -p udp --dport 53 -m statistic --mode nth
      --every 2 --packet 0 -j DROP`, or equivalent) should resolve on
      retry instead of failing with "no Answers".
- [ ] Manual: confirm REFUSED/SERVFAIL from a lame delegation still
      record per-zone backoff via the existing path (no behaviour
      change there).
- [ ] Manual: confirm peer-discovery JWK/URI/SVCB lookups against
      `nsb.axfr.net.` from the AWS mpagent are no longer intermittent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DNS resolution reliability through automatic retries for transient network errors
  * Added TCP fallback mechanism for DNS queries when UDP encounters temporary connectivity issues
  * Improved error handling for timeouts and connection failures during DNS lookups

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/216)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->