### PR TITLE
dnsutils: fix nil-pointer segfault on zone/zonefile apex mismatch

### DIFF
--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -439,8 +439,10 @@ func (zd *ZoneData) ParseZoneFromReader(r io.Reader, force bool, filename string
 
 		if firstSoaSeen && !checkedForUnchanged {
 			checkedForUnchanged = true
-			apex, _ := zd.Data.Get(zd.ZoneName)
-			//dump.P(apex)
+			apex, ok := zd.Data.Get(zd.ZoneName)
+			if !ok || apex.RRtypes == nil {
+				return false, 0, fmt.Errorf("zone %s: zonefile contains no records for the configured apex; parsed apexes: [%s] (likely wrong zonefile path or stale file content)", zd.ZoneName, strings.Join(zd.Data.Keys(), ", "))
+			}
 			soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs[0].(*dns.SOA)
 			zd.Logger.Printf("ParseZoneFromReader: %s: old incoming serial: %d new SOA serial: %d",
 				zd.ZoneName, zd.IncomingSerial, soa.Serial)
@@ -469,9 +471,9 @@ func (zd *ZoneData) ParseZoneFromReader(r io.Reader, force bool, filename string
 		return false, 0, err
 	}
 
-	apex, _ := zd.Data.Get(zd.ZoneName)
-	if err != nil {
-		return false, 0, fmt.Errorf("ParseZoneFromReader: Zone %s: Error: failed to get zone apex %v", zd.ZoneName, err)
+	apex, ok := zd.Data.Get(zd.ZoneName)
+	if !ok || apex.RRtypes == nil {
+		return false, 0, fmt.Errorf("zone %s: zonefile contains no records for the configured apex; parsed apexes: [%s] (likely wrong zonefile path or stale file content)", zd.ZoneName, strings.Join(zd.Data.Keys(), ", "))
 	}
 
 	soa_rrset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)


### PR DESCRIPTION
## Summary
- `ParseZoneFromReader` called `zd.Data.Get(zd.ZoneName)` and dereferenced `apex.RRtypes` without checking the bool. When a zonefile contains records for a different apex (e.g. operator pointed a zone at the wrong file), `Get` returns a zero-value `OwnerData` with `RRtypes == nil` and `GetOnlyRRSet` segfaults.
- Check `ok` at both call sites (line ~442 and ~474) and return a descriptive error that lists the configured zone name alongside the apexes actually parsed from the file, so the mismatch is obvious to the operator.

## Trigger
tdns-mpsigner panicked when its config pointed `fox.mp.axfr.net.` at a zonefile whose SOA owner was `customer.mptest.`:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/johanix/tdns/v2.(*RRTypeStore).GetOnlyRRSet
    rrtypestore.go:25
github.com/johanix/tdns/v2.(*ZoneData).ParseZoneFromReader
    dnsutils.go:477
```

## Scope
Defensive-check fix on the caller side only. No parser changes, no zone-load-lifecycle changes. Other `zd.Data.Get` sites in `dnsutils.go` were audited; they iterate `zd.Data.Keys()` first so `Get` is guaranteed-present and was left alone.

## Test plan
- [ ] Configure a zone with `name: foo.` but a zonefile whose SOA owner is `bar.` — daemon refuses to load with the new error message instead of panicking.
- [ ] Configure a zone correctly — loads normally (regression check).
- [ ] `cd v2/cmdv2 && GOROOT=/opt/local/lib/go make` builds clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved validation and error handling for DNS zone apex records during zone file parsing, providing clearer error messages when apex records are incomplete or missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/217)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->