### PR TITLE
delegation: require backend for zones with allow-child-updates

### DIFF
--- a/cmdv2/agent/tdns-agent.sample.yaml
+++ b/cmdv2/agent/tdns-agent.sample.yaml
@@ -103,13 +103,13 @@ resolver:
 # Named delegation backends for parent zones that receive child UPDATEs.
 # Two predefined backends need no config: "db" and "direct".
 # Named backends are only needed for types that require parameters.
-# Zones reference backends by name via "delegation-backend: <name>".
+# Zones reference backends by name via "delegationbackend: <name>".
 #
-# A zone that has 'allow-child-updates' MUST specify a 'delegation-backend:'.
+# A zone that has 'allow-child-updates' MUST specify a 'delegationbackend:'.
 # Without one the read path (scanner) and write path (zone updater) disagree
 # on where current delegation data lives, and DS/NS records accumulate
 # without ever being removed.
-delegation-backends:
+delegationbackends:
    - name:		files-dnslab
      type:		zonefile
      directory:	/var/lib/tdns/delegations/dnslab
@@ -118,9 +118,9 @@ delegation-backends:
 # In zone config, reference a backend:
 #   zones:
 #     - name:  dnslab.
-#       delegation-backend: db           # predefined, no config needed
+#       delegationbackend: db            # predefined, no config needed
 #     - name:  example.com.
-#       delegation-backend: files-dnslab  # looked up from delegation-backends above
+#       delegationbackend: files-dnslab  # looked up from delegationbackends above
 
 delegationsync:
    # Leader election TTL: how long a leader remains valid before re-election.

--- a/cmdv2/agent/tdns-agent.sample.yaml
+++ b/cmdv2/agent/tdns-agent.sample.yaml
@@ -104,6 +104,11 @@ resolver:
 # Two predefined backends need no config: "db" and "direct".
 # Named backends are only needed for types that require parameters.
 # Zones reference backends by name via "delegation-backend: <name>".
+#
+# A zone that has 'allow-child-updates' MUST specify a 'delegation-backend:'.
+# Without one the read path (scanner) and write path (zone updater) disagree
+# on where current delegation data lives, and DS/NS records accumulate
+# without ever being removed.
 delegation-backends:
    - name:		files-dnslab
      type:		zonefile

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -81,11 +81,11 @@ childsync:                 # What to do when we are the child
 # Named delegation backends for parent zones that receive child UPDATEs.
 # Predefined: "db" and "direct" (no config needed).
 #
-# A zone that has 'allow-child-updates' MUST specify a 'delegation-backend:'.
+# A zone that has 'allow-child-updates' MUST specify a 'delegationbackend:'.
 # Without one the read path (scanner) and write path (zone updater) disagree
 # on where current delegation data lives, and DS/NS records accumulate
 # without ever being removed.
-# delegation-backends:
+# delegationbackends:
 #   - name:       files-dnslab
 #     type:       zonefile
 #     directory:  /var/lib/tdns/delegations/dnslab

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -80,6 +80,11 @@ childsync:                 # What to do when we are the child
 
 # Named delegation backends for parent zones that receive child UPDATEs.
 # Predefined: "db" and "direct" (no config needed).
+#
+# A zone that has 'allow-child-updates' MUST specify a 'delegation-backend:'.
+# Without one the read path (scanner) and write path (zone updater) disagree
+# on where current delegation data lives, and DS/NS records accumulate
+# without ever being removed.
 # delegation-backends:
 #   - name:       files-dnslab
 #     type:       zonefile

--- a/docs/2026-05-15-delegation-backend-invariant.md
+++ b/docs/2026-05-15-delegation-backend-invariant.md
@@ -29,7 +29,7 @@ which is a code bug:
 ## Root cause: asymmetric read and write paths
 
 The parent zone (`p.axfr.net`) was configured with
-`allow-child-updates: true` but no `delegation-backend:`.
+`allow-child-updates: true` but no `delegationbackend:`.
 That made the write path and the read path disagree on
 where "current child delegation data" lives:
 
@@ -64,15 +64,15 @@ Enforced at config-parse time. Choices:
   reflect child updates until a reload.
 - `zonefile` — DB + on-disk zone file fragment. Same
   in-memory caveat as `db`.
-- A named custom backend from the `delegation-backends:`
+- A named custom backend from the `delegationbackends:`
   config block.
 
 There is no silent default. A zone with
-`allow-child-updates: true` and no `delegation-backend:`
+`allow-child-updates: true` and no `delegationbackend:`
 is marked broken at parse time with:
 
 ```
-zone has 'allow-child-updates' but no 'delegation-backend' configured, zone in error state
+zone has 'allow-child-updates' but no 'delegationbackend' configured, zone in error state
 ```
 
 ## Code changes
@@ -153,7 +153,7 @@ successful update or explicit zone-write will catch up).
 ## Operator impact
 
 Any existing config with `allow-child-updates: true` and
-no `delegation-backend:` will now refuse to load the zone.
+no `delegationbackend:` will now refuse to load the zone.
 Operators must explicitly choose a backend:
 
 ```yaml
@@ -162,7 +162,7 @@ zones:
       type: primary
       zonefile: /etc/tdns/zones/p.axfr.net
       options: [allow-child-updates, delegation-sync-parent]
-      delegation-backend: direct   # <-- now required
+      delegationbackend: direct    # <-- now required
 ```
 
 `direct` preserves the prior in-memory behavior and adds
@@ -171,7 +171,7 @@ zonefile persistence on each apply.
 ## Recovery: cleaning the stale accumulation
 
 Once the fix is deployed and the affected parent zone is
-restarted with `delegation-backend: direct`, the next CDS
+restarted with `delegationbackend: direct`, the next CDS
 scan will compute its diff against the real current DS
 set in the in-memory zone. For a zone that has
 accumulated `N` stale DS RRs while only `K` are valid in

--- a/docs/2026-05-15-delegation-backend-invariant.md
+++ b/docs/2026-05-15-delegation-backend-invariant.md
@@ -1,0 +1,192 @@
+# Delegation Backend Required for Child Updates
+
+**Date:** 2026-05-15
+**Status:** Implemented (branch `delegation-backend-invariant`)
+
+## Background: the bug
+
+A parent zone running tdns-authv2 was observed to accumulate
+DS records for one child indefinitely — 247 DS RRs for a
+single child after two days of automated KSK rollover
+testing.
+
+Investigation showed two unrelated problems, only one of
+which is a code bug:
+
+1. **Operator mistake (not in scope here)**: the parent's
+   binary lacked ML-DSA-44 algorithm support; the child's
+   SIG(0)-signed DDNS UPDATEs were rejected with
+   `dns: bad algorithm` at the SIG(0) validation step.
+   The DEL-old-DS + ADD-new-DS update never landed.
+
+2. **The bug**: the parallel CDS-NOTIFY path continued to
+   work and continued to push DS records into the parent's
+   zone, but always reported `N adds, 0 removes` from the
+   scanner's diff. After every rollover, the parent
+   accumulated more DS records without ever removing the
+   stale ones.
+
+## Root cause: asymmetric read and write paths
+
+The parent zone (`p.axfr.net`) was configured with
+`allow-child-updates: true` but no `delegation-backend:`.
+That made the write path and the read path disagree on
+where "current child delegation data" lives:
+
+- **Write path**:
+  `ZoneUpdater` for `CHILD-UPDATE` fell through to the
+  legacy `ApplyChildUpdateToZoneData`, which mutated the
+  in-memory zone tree directly (no
+  `ChildDelegationData` DB rows, no zonefile fragment).
+- **Read path** (scanner, building "current DS" for the
+  diff): guarded by `if zd.DelegationBackend != nil`.
+  With no backend configured the block was skipped, the
+  "current DS" set stayed empty, and `RRsetDiffer(new, [])`
+  always returned `len(new) adds, 0 removes`.
+
+Every CDS NOTIFY → scanner → CHILD-UPDATE cycle therefore
+added the child's full CDS-derived DS set to the parent
+zone again. The in-memory zone deduplicated identical RRs
+but every unique DS the child had ever published accumulated.
+
+## The invariant
+
+> **A zone that accepts child updates must have a
+> delegation backend.**
+
+Enforced at config-parse time. Choices:
+
+- `direct` — mutates the in-memory zone tree and persists
+  to the source zonefile after each apply. This is the
+  back-compat option for primary zones loaded from a file.
+- `db` — writes to the `ChildDelegationData` SQLite table.
+  The in-memory zone is **not** updated, so AXFR will not
+  reflect child updates until a reload.
+- `zonefile` — DB + on-disk zone file fragment. Same
+  in-memory caveat as `db`.
+- A named custom backend from the `delegation-backends:`
+  config block.
+
+There is no silent default. A zone with
+`allow-child-updates: true` and no `delegation-backend:`
+is marked broken at parse time with:
+
+```
+zone has 'allow-child-updates' but no 'delegation-backend' configured, zone in error state
+```
+
+## Code changes
+
+### `parseconfig.go`
+
+1. New cross-field validation after the child-update-policy
+   switch: if `OptAllowChildUpdates` is set and
+   `zconf.DelegationBackend` is empty, mark the zone broken
+   and skip it.
+
+2. Backend wiring moved **out** of the `if zdp.FirstZoneLoad`
+   block. The backend is now resolved and assigned to
+   `zd.DelegationBackend` synchronously on every parse
+   pass — both initial load and reload (SIGHUP / `config
+   reload-zones`). Backend constructors don't touch zone
+   data, so this is safe before `FirstZoneLoad` has
+   completed.
+
+3. The `OptDelSyncParent &&` gate is dropped — a zone that
+   accepts child updates needs a backend regardless of
+   whether it advertises itself as a delegation-sync
+   parent.
+
+4. Signing setup and delegation-sync setup conditions are
+   also lifted out of the `if zdp.FirstZoneLoad` block, so
+   their option checks are re-evaluated on every reload.
+   On first load they still register `OnFirstLoad`
+   callbacks; on reload they call the (idempotent) setup
+   functions directly. Rollover-policy setup is left
+   first-load-only because `ObserveParentDSTTL` spawns a
+   long-running goroutine and re-spawning on reload would
+   leak; a follow-up should make that reload-safe.
+
+### `zone_updater.go`
+
+The fallback path in the `CHILD-UPDATE` handler is gone.
+If a CHILD-UPDATE arrives for a zone with
+`OptAllowChildUpdates=false` it is dropped with a WARN; if
+`DelegationBackend` is nil despite the option being set
+(should be impossible after config validation) it is
+dropped with an ERROR (`invariant violation`).
+
+`OptDirty` management is now the backend's responsibility.
+`direct` sets and clears it as it persists; `db` and
+`zonefile` leave it alone because they don't touch
+in-memory zone data.
+
+### `scanner.go`
+
+Both `ProcessCDSNotify` (DS diff synthesis) and
+`ProcessCSYNCNotify` (NS/glue) now log loudly when a
+parent zone with `OptAllowChildUpdates` lacks a
+DelegationBackend, rather than silently producing
+"empty current state". `ProcessCSYNCNotify` refuses to
+continue in that case (returns an error). This is
+defensive — config validation should make the situation
+impossible — but it ensures a future regression of the
+same class surfaces in the log on first NOTIFY rather
+than after days of silent accumulation.
+
+### `delegation_backend_direct.go`
+
+`DirectDelegationBackend.ApplyChildUpdate` now persists
+to the source zonefile via `zd.WriteZone(true, false)`
+after a successful in-memory mutation. Without
+persistence, every CHILD-UPDATE mutates RAM only, is
+lost on restart, and the scanner re-discovers the
+"missing" delegation on first NOTIFY — reaccumulating
+from scratch.
+
+If the zone has no source zonefile (in-memory-only),
+persistence is skipped with a debug log. If the file
+write fails, the in-memory state is kept and the error
+is logged as a WARN; the update is not failed (next
+successful update or explicit zone-write will catch up).
+
+## Operator impact
+
+Any existing config with `allow-child-updates: true` and
+no `delegation-backend:` will now refuse to load the zone.
+Operators must explicitly choose a backend:
+
+```yaml
+zones:
+   p.axfr.net.:
+      type: primary
+      zonefile: /etc/tdns/zones/p.axfr.net
+      options: [allow-child-updates, delegation-sync-parent]
+      delegation-backend: direct   # <-- now required
+```
+
+`direct` preserves the prior in-memory behavior and adds
+zonefile persistence on each apply.
+
+## Recovery: cleaning the stale accumulation
+
+Once the fix is deployed and the affected parent zone is
+restarted with `delegation-backend: direct`, the next CDS
+scan will compute its diff against the real current DS
+set in the in-memory zone. For a zone that has
+accumulated `N` stale DS RRs while only `K` are valid in
+the child's current CDS, the scanner will report
+`0 adds, N-K removes` and `ApplyChildUpdateToZoneData`
+will delete the stale records in one pass — automatically.
+
+## Follow-ups (not in this change)
+
+- Make rollover-policy setup (`EvaluateRolloverPolicyInvariants`
+  + `ObserveParentDSTTL`) reload-safe so its condition
+  check can also leave the `FirstZoneLoad` gate.
+- Decide whether `db` and `zonefile` backends should
+  also update the in-memory zone tree (currently they
+  don't, which means AXFR is stale until reload).
+- Consider whether all `*OnFirstLoad` setup functions
+  should be runnable on reload, with explicit
+  idempotency guarantees, as the general policy.

--- a/v2/delegation_backend.go
+++ b/v2/delegation_backend.go
@@ -49,7 +49,7 @@ type DelegationBackendConf struct {
 //   - "db"     → DBDelegationBackend (uses the zone's existing KeyDB)
 //   - "direct" → DirectDelegationBackend (modifies in-memory zone data)
 //
-// Any other name is looked up in the "delegation-backends" config list.
+// Any other name is looked up in the "delegationbackends" config list.
 func LookupDelegationBackend(name string, kdb *KeyDB, zd *ZoneData) (DelegationBackend, error) {
 	switch name {
 	case "db":
@@ -60,8 +60,8 @@ func LookupDelegationBackend(name string, kdb *KeyDB, zd *ZoneData) (DelegationB
 
 	// Look up named backend in config
 	var backends []DelegationBackendConf
-	if err := viper.UnmarshalKey("delegation-backends", &backends); err != nil {
-		return nil, fmt.Errorf("failed to parse delegation-backends config: %w", err)
+	if err := viper.UnmarshalKey("delegationbackends", &backends); err != nil {
+		return nil, fmt.Errorf("failed to parse delegationbackends config: %w", err)
 	}
 
 	for _, bc := range backends {
@@ -88,7 +88,7 @@ func LookupDelegationBackend(name string, kdb *KeyDB, zd *ZoneData) (DelegationB
 		}
 	}
 
-	return nil, fmt.Errorf("delegation backend %q not found in delegation-backends config", name)
+	return nil, fmt.Errorf("delegation backend %q not found in delegationbackends config", name)
 }
 
 // ExportDelegationData writes all delegation data for a parent zone to a file

--- a/v2/delegation_backend_direct.go
+++ b/v2/delegation_backend_direct.go
@@ -38,10 +38,14 @@ func (b *DirectDelegationBackend) ApplyChildUpdate(parentZone string, ur UpdateR
 	}
 	msg, werr := b.zd.WriteZone(true, false)
 	if werr != nil {
+		// Propagate the persistence failure. The in-memory state did
+		// receive the update, but the zonefile didn't — and if the
+		// daemon restarts before the next successful update lands, the
+		// change is lost on reload and the scanner will rediscover the
+		// "missing" delegation and re-accumulate. Surface the error
+		// upstream so operators see it and can act.
 		lg.Warn("DirectDelegationBackend: failed to persist zone after CHILD-UPDATE", "zone", b.zd.ZoneName, "file", b.zd.Zonefile, "error", werr)
-		// Don't propagate — the in-memory state is correct; the next
-		// successful CHILD-UPDATE (or explicit zone write) will catch up.
-		return nil
+		return fmt.Errorf("persist zone after CHILD-UPDATE: %w", werr)
 	}
 	lg.Info("DirectDelegationBackend: persisted zone after CHILD-UPDATE", "zone", b.zd.ZoneName, "msg", msg)
 	return nil

--- a/v2/delegation_backend_direct.go
+++ b/v2/delegation_backend_direct.go
@@ -20,8 +20,31 @@ type DirectDelegationBackend struct {
 func (b *DirectDelegationBackend) Name() string { return "direct" }
 
 func (b *DirectDelegationBackend) ApplyChildUpdate(parentZone string, ur UpdateRequest) error {
-	_, err := b.zd.ApplyChildUpdateToZoneData(ur, b.kdb)
-	return err
+	updated, err := b.zd.ApplyChildUpdateToZoneData(ur, b.kdb)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		return nil
+	}
+	// Persist to source zonefile so accumulated child updates survive a
+	// restart. Without this, every CHILD-UPDATE only mutates RAM, gets
+	// lost on next start, and the scanner re-discovers the "missing"
+	// delegation on first NOTIFY — re-accumulating from scratch. The
+	// in-memory mutation set OptDirty; WriteZone clears it on success.
+	if b.zd.Zonefile == "" {
+		lg.Debug("DirectDelegationBackend: no source zonefile, skipping persist", "zone", b.zd.ZoneName)
+		return nil
+	}
+	msg, werr := b.zd.WriteZone(true, false)
+	if werr != nil {
+		lg.Warn("DirectDelegationBackend: failed to persist zone after CHILD-UPDATE", "zone", b.zd.ZoneName, "file", b.zd.Zonefile, "error", werr)
+		// Don't propagate — the in-memory state is correct; the next
+		// successful CHILD-UPDATE (or explicit zone write) will catch up.
+		return nil
+	}
+	lg.Info("DirectDelegationBackend: persisted zone after CHILD-UPDATE", "zone", b.zd.ZoneName, "msg", msg)
+	return nil
 }
 
 func (b *DirectDelegationBackend) GetDelegationData(parentZone, childZone string) (map[string]map[uint16][]dns.RR, error) {

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -635,8 +635,8 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// without ever being removed. Refuse to start such a zone rather
 		// than letting it silently misbehave.
 		if options[OptAllowChildUpdates] && zconf.DelegationBackend == "" {
-			lgConfig.Error("zone has 'allow-child-updates' but no 'delegation-backend' configured, zone in error state", "zone", zname)
-			zd.SetError(ConfigError, "allow-child-updates requires delegation-backend to be configured (e.g. 'delegation-backend: direct')")
+			lgConfig.Error("zone has 'allow-child-updates' but no 'delegationbackend' configured, zone in error state", "zone", zname)
+			zd.SetError(ConfigError, "allow-child-updates requires delegationbackend to be configured (e.g. 'delegationbackend: direct')")
 			broken_zones = append(broken_zones, zname)
 			continue
 		}
@@ -767,7 +767,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			backend, err := LookupDelegationBackend(zconf.DelegationBackend, kdb, zdp)
 			if err != nil {
 				lgConfig.Error("failed to create delegation backend, zone in error state", "zone", zname, "backend", zconf.DelegationBackend, "error", err)
-				zd.SetError(ConfigError, "delegation-backend %q: %v", zconf.DelegationBackend, err)
+				zd.SetError(ConfigError, "delegationbackend %q: %v", zconf.DelegationBackend, err)
 				broken_zones = append(broken_zones, zname)
 				continue
 			}
@@ -857,7 +857,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 		// Note: DelegationBackend wiring is done synchronously above,
 		// outside the FirstZoneLoad guard, so config-reload picks up
-		// changes to the 'delegation-backend' key.
+		// changes to the 'delegationbackend' key.
 
 		// Leader election OnFirstLoad is registered in StartAgent() (not here)
 		// because LeaderElectionManager doesn't exist until StartAgent runs.

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -628,6 +628,19 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			continue
 		}
 
+		// A zone that accepts child updates MUST have a delegation backend.
+		// Without one, the write path mutates in-memory zone data while the
+		// scanner read path queries the (nil) backend, so diff computation
+		// always sees "empty current state" and child updates accumulate
+		// without ever being removed. Refuse to start such a zone rather
+		// than letting it silently misbehave.
+		if options[OptAllowChildUpdates] && zconf.DelegationBackend == "" {
+			lgConfig.Error("zone has 'allow-child-updates' but no 'delegation-backend' configured, zone in error state", "zone", zname)
+			zd.SetError(ConfigError, "allow-child-updates requires delegation-backend to be configured (e.g. 'delegation-backend: direct')")
+			broken_zones = append(broken_zones, zname)
+			continue
+		}
+
 		switch zconf.UpdatePolicy.Zone.Type {
 		case "selfsub", "self":
 			// all ok, we know these
@@ -738,27 +751,71 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 		invokeOptionHandlers(zname, options)
 
-		if zdp.FirstZoneLoad {
-			lgConfig.Info("considering OnFirstLoad callbacks", "zone", zname,
-				"online-signing", options[OptOnlineSigning],
-				"inline-signing", options[OptInlineSigning],
-				"multi-provider", options[OptMultiProvider],
-				"apptype", AppTypeToString[Globals.App.Type])
+		// Wire the delegation backend synchronously on every parse pass
+		// (initial load + reload). Backend constructors don't touch zone
+		// data, so this works before FirstZoneLoad has completed.
+		// Config validation above guarantees that OptAllowChildUpdates
+		// implies a non-empty zconf.DelegationBackend.
+		if options[OptAllowChildUpdates] {
+			kdb := conf.Internal.KeyDB
+			if kdb == nil {
+				lgConfig.Error("KeyDB unavailable, cannot wire delegation backend", "zone", zname)
+				zd.SetError(ConfigError, "KeyDB unavailable")
+				broken_zones = append(broken_zones, zname)
+				continue
+			}
+			backend, err := LookupDelegationBackend(zconf.DelegationBackend, kdb, zdp)
+			if err != nil {
+				lgConfig.Error("failed to create delegation backend, zone in error state", "zone", zname, "backend", zconf.DelegationBackend, "error", err)
+				zd.SetError(ConfigError, "delegation-backend %q: %v", zconf.DelegationBackend, err)
+				broken_zones = append(broken_zones, zname)
+				continue
+			}
+			zdp.mu.Lock()
+			zdp.DelegationBackend = backend
+			zdp.mu.Unlock()
+			lgConfig.Info("delegation backend wired", "zone", zname, "backend", backend.Name())
+		} else {
+			// Reload may have cleared OptAllowChildUpdates; drop any
+			// previously-wired backend so the live state matches config.
+			zdp.mu.Lock()
+			zdp.DelegationBackend = nil
+			zdp.mu.Unlock()
+		}
 
-			// Signing callback: zones with explicit signing options in config
-			if options[OptOnlineSigning] || options[OptInlineSigning] {
+		lgConfig.Info("evaluating zone option flags", "zone", zname,
+			"online-signing", options[OptOnlineSigning],
+			"inline-signing", options[OptInlineSigning],
+			"multi-provider", options[OptMultiProvider],
+			"firstLoad", zdp.FirstZoneLoad,
+			"apptype", AppTypeToString[Globals.App.Type])
+
+		// Condition checks are evaluated on every parse pass (initial +
+		// reload) so config-reload picks up flag changes. The setup
+		// functions need the zone to be loaded; on initial load we defer
+		// via OnFirstLoad, on reload (zone already loaded) we call them
+		// directly. The setup functions are idempotent.
+
+		// Signing setup: zones with explicit signing options in config.
+		if options[OptOnlineSigning] || options[OptInlineSigning] {
+			if zdp.FirstZoneLoad {
 				zdp.OnFirstLoad = append(zdp.OnFirstLoad, func(zd *ZoneData) {
 					if err := zd.SetupZoneSigning(conf.Internal.ResignQ); err != nil {
 						lgConfig.Error("SetupZoneSigning failed in OnFirstLoad", "zone", zd.ZoneName, "error", err)
 					}
 				})
+			} else {
+				if err := zdp.SetupZoneSigning(conf.Internal.ResignQ); err != nil {
+					lgConfig.Error("SetupZoneSigning failed on reload", "zone", zname, "error", err)
+				}
 			}
+		}
 
-			// Rollover policy validation callback: at first zone load,
-			// run E5 immediately (it doesn't need the parent's DS TTL),
-			// then issue an asynchronous parent-DS query so E10/E11 can
-			// run as soon as the observation comes back. This is W2 of
-			// the rollover-timing-fixes plan.
+		// Rollover policy validation: requires loaded zone data. Only
+		// registered on first load; the ObserveParentDSTTL goroutine it
+		// spawns is long-running and re-spawning on reload would leak.
+		// (See follow-up: make rollover setup reload-safe.)
+		if zdp.FirstZoneLoad {
 			zdp.OnFirstLoad = append(zdp.OnFirstLoad, func(zd *ZoneData) {
 				if zd.DnssecPolicy == nil || zd.DnssecPolicy.Rollover.Method == RolloverMethodNone {
 					return
@@ -768,51 +825,43 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				// goroutine cancels on daemon shutdown.
 				go ObserveParentDSTTL(ctx, zd, zd.DnssecPolicy)
 			})
-
-			// Delegation sync callback: set up DSYNC publication (parent) or
-			// delegation sync monitoring (child) after zone is loaded.
-			if options[OptDelSyncParent] || options[OptDelSyncChild] {
-				zdp.OnFirstLoad = append(zdp.OnFirstLoad, func(zd *ZoneData) {
-					// Skip if the MP HSYNCPARAM callback already set up delegation sync for this zone.
-					if zd.Options[OptDelSyncChild] && !options[OptDelSyncChild] {
-						return
-					}
-					if zd.Options[OptDelSyncParent] && !options[OptDelSyncParent] {
-						return
-					}
-					delegationSyncQ := conf.Internal.DelegationSyncQ
-					if delegationSyncQ == nil {
-						lgConfig.Error("DelegationSyncQ not available in OnFirstLoad", "zone", zd.ZoneName)
-						return
-					}
-					if err := zd.SetupZoneSync(delegationSyncQ); err != nil {
-						lgConfig.Error("SetupZoneSync failed in OnFirstLoad", "zone", zd.ZoneName, "error", err)
-					}
-				})
-			}
-
-			// Parent delegation backend: initialize on parent zones that accept child updates.
-			if options[OptDelSyncParent] && options[OptAllowChildUpdates] && zconf.DelegationBackend != "" {
-				backendName := zconf.DelegationBackend
-				kdb := conf.Internal.KeyDB
-				zdp.OnFirstLoad = append(zdp.OnFirstLoad, func(zd *ZoneData) {
-					if kdb == nil {
-						return
-					}
-					backend, err := LookupDelegationBackend(backendName, kdb, zd)
-					if err != nil {
-						lgConfig.Error("failed to create delegation backend", "zone", zd.ZoneName, "backend", backendName, "error", err)
-						return
-					}
-					zd.DelegationBackend = backend
-					lgConfig.Info("delegation backend initialized", "zone", zd.ZoneName, "backend", backend.Name())
-				})
-			}
-
-			// Leader election OnFirstLoad is registered in StartAgent() (not here)
-			// because LeaderElectionManager doesn't exist until StartAgent runs.
-			// MP zone KEY publication is registered in tdns-mp's StartAgent.
 		}
+
+		// Delegation sync setup: DSYNC publication (parent) or
+		// delegation sync monitoring (child).
+		if options[OptDelSyncParent] || options[OptDelSyncChild] {
+			capturedOpts := options
+			setupSync := func(zd *ZoneData) {
+				// Skip if the MP HSYNCPARAM callback already set up delegation sync for this zone.
+				if zd.Options[OptDelSyncChild] && !capturedOpts[OptDelSyncChild] {
+					return
+				}
+				if zd.Options[OptDelSyncParent] && !capturedOpts[OptDelSyncParent] {
+					return
+				}
+				delegationSyncQ := conf.Internal.DelegationSyncQ
+				if delegationSyncQ == nil {
+					lgConfig.Error("DelegationSyncQ not available", "zone", zd.ZoneName)
+					return
+				}
+				if err := zd.SetupZoneSync(delegationSyncQ); err != nil {
+					lgConfig.Error("SetupZoneSync failed", "zone", zd.ZoneName, "error", err)
+				}
+			}
+			if zdp.FirstZoneLoad {
+				zdp.OnFirstLoad = append(zdp.OnFirstLoad, setupSync)
+			} else {
+				setupSync(zdp)
+			}
+		}
+
+		// Note: DelegationBackend wiring is done synchronously above,
+		// outside the FirstZoneLoad guard, so config-reload picks up
+		// changes to the 'delegation-backend' key.
+
+		// Leader election OnFirstLoad is registered in StartAgent() (not here)
+		// because LeaderElectionManager doesn't exist until StartAgent runs.
+		// MP zone KEY publication is registered in tdns-mp's StartAgent.
 
 		switch Globals.App.Type {
 		case AppTypeAuth, AppTypeAgent, // AppTypeCombiner,

--- a/v2/scanner.go
+++ b/v2/scanner.go
@@ -232,8 +232,22 @@ func ScannerEngine(ctx context.Context, conf *Config) error {
 						Zone: sr.ChildZone,
 					}
 
-					// Fetch current DS from delegation backend for comparison
-					if sr.ZoneData != nil && sr.ZoneData.DelegationBackend != nil {
+					// Fetch current DS from delegation backend for comparison.
+					// A parent zone that accepts child updates MUST have a
+					// DelegationBackend (enforced at config-validation time).
+					// Without it the scanner has no way to know the current
+					// DS state, so every CDS-NOTIFY would look like a fresh
+					// delegation and DS records would accumulate without
+					// ever being removed.
+					if sr.ZoneData == nil {
+						lg.Error("ScannerEngine: no ZoneData on scan request, cannot compute current delegation state", "child", sr.ChildZone)
+					} else if sr.ZoneData.DelegationBackend == nil {
+						if sr.ZoneData.Options[OptAllowChildUpdates] {
+							lg.Error("ScannerEngine: zone allows child updates but has no DelegationBackend; diff against empty current state will produce spurious adds (invariant violation)", "child", sr.ChildZone, "parent", sr.ZoneData.ZoneName)
+						} else {
+							lg.Warn("ScannerEngine: parent zone has no DelegationBackend, cannot read current DS for diff", "child", sr.ChildZone, "parent", sr.ZoneData.ZoneName)
+						}
+					} else {
 						delegData, err := sr.ZoneData.DelegationBackend.GetDelegationData(sr.ZoneData.ZoneName, sr.ChildZone)
 						if err != nil {
 							lg.Warn("ScannerEngine: error fetching delegation data", "child", sr.ChildZone, "error", err)
@@ -819,9 +833,22 @@ func (scanner *Scanner) ProcessCSYNCNotify(ctx context.Context, tuple ScanTuple,
 		return
 	}
 
-	// Get current delegation data from backend
+	// Get current delegation data from backend. A parent zone that
+	// accepts child updates MUST have a DelegationBackend (enforced at
+	// config-validation time). Without one, NS/glue diffs would be
+	// computed against an empty current state and spurious adds would
+	// accumulate (the same class of bug as DS accumulation on CDS).
 	var delegationData map[string]map[uint16][]dns.RR
-	if parentZD.DelegationBackend != nil {
+	if parentZD.DelegationBackend == nil {
+		if parentZD.Options[OptAllowChildUpdates] {
+			scanLog.Printf("ProcessCSYNCNotify: %s: parent zone %s allows child updates but has no DelegationBackend; refusing to compute diff against empty current state (invariant violation)", childZone, parentZD.ZoneName)
+			response.Error = true
+			response.ErrorMsg = "parent zone has no DelegationBackend"
+			responseCh <- response
+			return
+		}
+		scanLog.Printf("ProcessCSYNCNotify: %s: parent zone %s has no DelegationBackend, proceeding with empty current state", childZone, parentZD.ZoneName)
+	} else {
 		delegationData, err = parentZD.DelegationBackend.GetDelegationData(parentZD.ZoneName, childZone)
 		if err != nil {
 			scanLog.Printf("ProcessCSYNCNotify: %s: error fetching delegation data: %v", childZone, err)

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -186,7 +186,7 @@ type ZoneConf struct {
 	Frozen            bool         // true if zone is frozen; not a config param
 	Dirty             bool         // true if zone has been modified; not a config param
 	UpdatePolicy      UpdatePolicyConf
-	DelegationBackend string    `yaml:"delegation-backend" mapstructure:"delegation-backend"` // named backend for child delegation data
+	DelegationBackend string    `yaml:"delegationbackend" mapstructure:"delegationbackend"` // named backend for child delegation data
 	DnssecPolicy      string    `yaml:"dnssecpolicy" mapstructure:"dnssecpolicy"`
 	Template          string    `yaml:"template" mapstructure:"template"`
 	MultiSigner       string    `yaml:"multisigner" mapstructure:"multisigner"`

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -108,20 +108,30 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 				// in-memory zone state behind the scanner's back.
 				lg.Debug("ZoneUpdater: CHILD-UPDATE request", "zone", ur.ZoneName, "actions", len(ur.Actions))
 				lg.Debug("ZoneUpdater: CHILD-UPDATE actions detail", "actions", SprintUpdates(ur.Actions))
-				if !zd.Options[OptAllowChildUpdates] {
+				// Snapshot the two fields parseconfig.go mutates under
+				// zd.mu during config reload (Options + DelegationBackend).
+				// Reading them independently without the lock would let a
+				// concurrent reload flip one between checks, producing a
+				// spurious "invariant violation" ERROR.
+				zd.mu.Lock()
+				allowChildUpdates := zd.Options[OptAllowChildUpdates]
+				backend := zd.DelegationBackend
+				zd.mu.Unlock()
+
+				if !allowChildUpdates {
 					lg.Warn("ZoneUpdater: zone does not allow child updates, dropping CHILD-UPDATE", "zone", ur.ZoneName)
 					continue
 				}
-				if zd.DelegationBackend == nil {
+				if backend == nil {
 					lg.Error("ZoneUpdater: zone allows child updates but has no DelegationBackend, dropping CHILD-UPDATE (invariant violation)", "zone", ur.ZoneName)
 					continue
 				}
-				if err := zd.DelegationBackend.ApplyChildUpdate(ur.ZoneName, ur); err != nil {
+				if err := backend.ApplyChildUpdate(ur.ZoneName, ur); err != nil {
 					lg.Error("ZoneUpdater: DelegationBackend.ApplyChildUpdate failed",
-						"backend", zd.DelegationBackend.Name(), "error", err)
+						"backend", backend.Name(), "error", err)
 				} else {
 					lg.Info("ZoneUpdater: CHILD-UPDATE applied",
-						"zone", ur.ZoneName, "backend", zd.DelegationBackend.Name())
+						"zone", ur.ZoneName, "backend", backend.Name())
 					// OptDirty is managed by the backend: 'direct' sets
 					// then clears it via WriteZone after persisting; DB-
 					// and zonefile-backends don't touch in-memory zone

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -100,42 +100,33 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 
 			case "CHILD-UPDATE":
 				// Child delegation data update: dispatch to the configured DelegationBackend.
+				// Config validation guarantees that any zone with
+				// OptAllowChildUpdates has a non-nil DelegationBackend, so
+				// there is no fallback path. If the invariant is violated
+				// (which would indicate a code bug, not a config bug),
+				// drop the update loudly rather than silently mutating
+				// in-memory zone state behind the scanner's back.
 				lg.Debug("ZoneUpdater: CHILD-UPDATE request", "zone", ur.ZoneName, "actions", len(ur.Actions))
 				lg.Debug("ZoneUpdater: CHILD-UPDATE actions detail", "actions", SprintUpdates(ur.Actions))
-				if zd.Options[OptAllowChildUpdates] {
-					if zd.DelegationBackend != nil {
-						err := zd.DelegationBackend.ApplyChildUpdate(ur.ZoneName, ur)
-						if err != nil {
-							lg.Error("ZoneUpdater: DelegationBackend.ApplyChildUpdate failed",
-								"backend", zd.DelegationBackend.Name(), "error", err)
-						} else {
-							lg.Info("ZoneUpdater: CHILD-UPDATE applied",
-								"zone", ur.ZoneName, "backend", zd.DelegationBackend.Name())
-							zd.Options[OptDirty] = true
-							logUpdateActions("CHILD-UPDATE", ur.Actions)
-						}
-					} else {
-						// Fallback: no backend configured, use legacy dispatch
-						var updated bool
-						var err error
-
-						switch zd.ZoneType {
-						case Primary:
-							updated, err = zd.ApplyChildUpdateToZoneData(ur, kdb)
-							if err != nil {
-								lg.Error("ZoneUpdater: ApplyChildUpdateToZoneData failed", "error", err)
-							}
-						case Secondary:
-							err = kdb.ApplyChildUpdateToDB(ur)
-							if err != nil {
-								lg.Error("ZoneUpdater: ApplyChildUpdateToDB failed", "error", err)
-							}
-						}
-						if updated {
-							zd.Options[OptDirty] = true
-							logUpdateActions("CHILD-UPDATE", ur.Actions)
-						}
-					}
+				if !zd.Options[OptAllowChildUpdates] {
+					lg.Warn("ZoneUpdater: zone does not allow child updates, dropping CHILD-UPDATE", "zone", ur.ZoneName)
+					continue
+				}
+				if zd.DelegationBackend == nil {
+					lg.Error("ZoneUpdater: zone allows child updates but has no DelegationBackend, dropping CHILD-UPDATE (invariant violation)", "zone", ur.ZoneName)
+					continue
+				}
+				if err := zd.DelegationBackend.ApplyChildUpdate(ur.ZoneName, ur); err != nil {
+					lg.Error("ZoneUpdater: DelegationBackend.ApplyChildUpdate failed",
+						"backend", zd.DelegationBackend.Name(), "error", err)
+				} else {
+					lg.Info("ZoneUpdater: CHILD-UPDATE applied",
+						"zone", ur.ZoneName, "backend", zd.DelegationBackend.Name())
+					// OptDirty is managed by the backend: 'direct' sets
+					// then clears it via WriteZone after persisting; DB-
+					// and zonefile-backends don't touch in-memory zone
+					// data so OptDirty stays as it was.
+					logUpdateActions("CHILD-UPDATE", ur.Actions)
 				}
 
 			case "ZONE-UPDATE":


### PR DESCRIPTION
## Summary

Fixes a silent-asymmetry bug where a parent zone configured with `allow-child-updates: true` but no `delegation-backend:` would accumulate DS (and potentially NS/glue) records forever from CDS/CSYNC NOTIFYs without ever removing them.

Observed in the wild: `cpt.p.axfr.net` had 247 DS records in `p.axfr.net` after two days of automated KSK rollover testing. Root cause and full investigation in [docs/2026-05-15-delegation-backend-invariant.md](https://github.com/johanix/tdns/blob/delegation-backend-invariant/docs/2026-05-15-delegation-backend-invariant.md).

The write path (`zone_updater`) fell through to a legacy in-memory mutation. The scanner's read path queried `zd.DelegationBackend.GetDelegationData()` under a nil-guard. With no backend wired, the scanner silently used an empty "current state" and every CDS NOTIFY produced `N adds / 0 removes`.

## Changes

- **Invariant enforced at parse time** (`parseconfig.go`): a zone with `allow-child-updates` and empty `delegation-backend` is marked broken with a clear error. No silent default.
- **Backend wiring lifted out of `OnFirstLoad`**: `zd.DelegationBackend` is now resolved synchronously on every parse pass (initial load + `config reload-zones` / SIGHUP), so editing the `delegation-backend:` field and reloading takes effect. The `OptDelSyncParent &&` gate is dropped.
- **Signing + delegation-sync condition checks also lifted** out of the `FirstZoneLoad` gate. Their setup functions are idempotent and now run directly on reload. Rollover-policy setup left first-load-only (its `ObserveParentDSTTL` goroutine needs a separate fix to be reload-safe).
- **Legacy fallback in `zone_updater.go` deleted**: every `CHILD-UPDATE` goes through `zd.DelegationBackend.ApplyChildUpdate`. Nil backend at runtime is an `ERROR`, not a fallback. `OptDirty` bookkeeping moved into each backend.
- **Scanner is loud** (`scanner.go`): `ProcessCDSNotify` and `ProcessCSYNCNotify` log loudly (CSYNC refuses to continue) when the invariant is violated, so a regression surfaces on first NOTIFY rather than after days.
- **`DirectDelegationBackend` persists**: calls `zd.WriteZone(true, false)` after each successful in-memory apply so accumulated child updates survive restart.
- Sample yamls updated to note the new requirement.

## Operator impact

Any zone with `allow-child-updates: true` and no `delegation-backend:` will fail to load with a clear error. Fix by picking a backend: `direct` (matches the prior in-memory behavior, plus zonefile persistence), `db`, `zonefile`, or a named custom backend.

## Recovery property

Once a previously-broken zone is restarted with `delegation-backend: direct` wired up, the next CDS scan computes its diff against the real current DS set in memory and reports `0 adds, N-K removes` — the apply path deletes the accumulated stale DSes automatically.

## Test plan

- [x] `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make` clean
- [x] `cd tdns-mp/cmd && GOROOT=/opt/local/lib/go make` clean
- [x] `go vet ./...` clean
- [x] No new test regressions (two pre-existing failures in `tdns_test.go` BaseURI validation are unrelated and present on `main`)
- [ ] Field test: deploy to hub, verify `p.axfr.net` AXFR drops from 247 cpt.p.axfr.net DSes to ~4 after first CDS NOTIFY post-restart
- [ ] Field test: SIGHUP `config reload-zones` picks up adding/removing `delegation-backend:` without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Child updates to zones are now properly persisted to the zonefile
  * Improved validation: zones requiring child updates now fail validation unless a delegation backend is configured
  * Enhanced error handling for delegation backend initialization with stricter invariant checks

* **Refactor**
  * Consolidated delegation backend initialization and synchronous wiring during configuration parsing
  * Removed fallback behavior for child updates when backend is unavailable; now treated as configuration violation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/219)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->