### PR TITLE
cli: reparent commands under daemon/util parents; fix asymmetric root

### DIFF
--- a/cmdv2/cli/root.go
+++ b/cmdv2/cli/root.go
@@ -61,8 +61,9 @@ func isRootKeysCommand(cmd *cobra.Command) bool {
 func init() {
 	// Config/API init moved to rootCmd.PersistentPreRun (skipped for root-level "keys")
 
-	// Register catalog zone management commands
-	rootCmd.AddCommand(cli.CatalogCmd)
+	// Catalog zone management lives under 'auth' — catalog zones are an
+	// auth-daemon concern (RFC 9432 catalog zones served by tdns-auth).
+	cli.AuthCmd.AddCommand(cli.CatalogCmd)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
 		fmt.Sprintf("config file (default is %s)", tdns.DefaultCliCfgFile))

--- a/cmdv2/cli/root.go
+++ b/cmdv2/cli/root.go
@@ -46,14 +46,26 @@ func ExecuteContext(ctx context.Context) {
 	cobra.CheckErr(rootCmd.ExecuteContext(ctx))
 }
 
-// isRootKeysCommand returns true if cmd is the root-level "keys" (e.g. keys generate).
-// Those commands do not require config or API. Root has Use "tdns-cli".
+// isRootKeysCommand returns true if cmd is the no-config "keys" subtree
+// (e.g. keys generate). Those commands do not require config or API.
+// Two accepted ancestries:
+//   - legacy: tdns-cli keys ...
+//   - current: tdns-cli util keys ...   (moved under 'util' in the
+//     CLI restructure; same no-config semantics).
 func isRootKeysCommand(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
-		if c.Name() == "keys" {
-			p := c.Parent()
-			return p != nil && p.Name() == "tdns-cli"
+		if c.Name() != "keys" {
+			continue
 		}
+		p := c.Parent()
+		if p == nil {
+			return false
+		}
+		if p.Name() == "tdns-cli" {
+			return true
+		}
+		gp := p.Parent()
+		return p.Name() == "util" && gp != nil && gp.Name() == "tdns-cli"
 	}
 	return false
 }

--- a/cmdv2/cli/shared_cmds.go
+++ b/cmdv2/cli/shared_cmds.go
@@ -8,24 +8,26 @@ import (
 )
 
 func init() {
-	// From ../tdns/cli/db_cmds.go:
-	rootCmd.AddCommand(cli.DbCmd)
+	// From ../tdns/cli/db_cmds.go: per-daemon factory; both auth and agent
+	// have their own SQLite DB so each gets its own 'db init' command.
+	cli.AuthCmd.AddCommand(cli.NewDbCmd("auth"))
+	cli.AgentCmd.AddCommand(cli.NewDbCmd("agent"))
 
-	// From ../tdns/cli/start_cmds.go:
-	// Root-level ping targets the auth daemon.
-	rootCmd.AddCommand(cli.NewPingCmd("auth"))
+	// Note: 'auth ping' is already wired in v2/cli/auth_cmds.go init().
 
-	// From ../tdns/cli/report.go:
-	rootCmd.AddCommand(cli.ReportCmd)
+	// From ../tdns/cli/report.go: 'auth report' — reports are an
+	// auth-daemon concern (CDS/CSYNC/error reports about a zone).
+	cli.AuthCmd.AddCommand(cli.ReportCmd)
 
-	rootCmd.AddCommand(cli.NewDaemonCmd("auth"))
+	// Note: 'auth daemon' is already wired in v2/cli/auth_cmds.go init().
 	cli.AgentCmd.AddCommand(cli.NewDaemonCmd("agent"))
 
-	// From ../tdns/cli/ddns_cmds.go:
-	rootCmd.AddCommand(cli.DdnsCmd, cli.DelCmd)
+	// From ../tdns/cli/ddns_cmds.go: 'auth ddns' and 'auth del' —
+	// DDNS update protocol + delegation-sync are auth-daemon concerns.
+	cli.AuthCmd.AddCommand(cli.DdnsCmd, cli.DelCmd)
 
 	// From ../tdns/cli/debug_cmds.go:
-	rootCmd.AddCommand(cli.NewDebugCmd("auth"))
+	cli.AuthCmd.AddCommand(cli.NewDebugCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewDebugCmd("agent"))
 
 	// Keystore and truststore are under AuthCmd and AgentCmd
@@ -33,21 +35,23 @@ func init() {
 	cli.AgentCmd.AddCommand(cli.NewKeystoreCmd("agent"))
 	cli.AgentCmd.AddCommand(cli.NewTruststoreCmd("agent"))
 
-	// From ../tdns/cli/dsync_cmds.go:
-	rootCmd.AddCommand(cli.DsyncDiscoveryCmd)
+	// From ../tdns/cli/dsync_cmds.go: 'imr dsync-query' — DSYNC discovery
+	// resolves via the IMR resolver, so it sits under the imr daemon parent.
+	cli.ImrCmd.AddCommand(cli.DsyncDiscoveryCmd)
 
 	// From ../tdns/cli/config_cmds.go:
-	rootCmd.AddCommand(cli.NewConfigCmd("auth"))
+	cli.AuthCmd.AddCommand(cli.NewConfigCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewConfigCmd("agent"))
 
 	// From ../tdns/cli/generate_cmds.go: daemon-agnostic record syntax helpers
 	cli.UtilCmd.AddCommand(cli.GenerateCmd)
 
-	// From ../tdns/cli/notify_cmds.go:
-	rootCmd.AddCommand(cli.NotifyCmd)
+	// From ../tdns/cli/notify_cmds.go: 'auth notify' — sends NOTIFY
+	// (CDS/CSYNC/DNSKEY) toward the parent or signer, an auth-daemon op.
+	cli.AuthCmd.AddCommand(cli.NotifyCmd)
 
-	// From ../tdns/cli/commands.go:
-	rootCmd.AddCommand(cli.NewStopCmd("auth"))
+	// From ../tdns/cli/commands.go: 'auth stop' (matches 'agent stop' via NewDaemonCmd).
+	cli.AuthCmd.AddCommand(cli.NewStopCmd("auth"))
 
 	// From ../tdns/cli/combiner_cmds.go:
 	//	rootCmd.AddCommand(cli.CombinerCmd)

--- a/cmdv2/cli/shared_cmds.go
+++ b/cmdv2/cli/shared_cmds.go
@@ -40,8 +40,8 @@ func init() {
 	rootCmd.AddCommand(cli.NewConfigCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewConfigCmd("agent"))
 
-	// From ../tdns/cli/generate_cmds.go:
-	rootCmd.AddCommand(cli.GenerateCmd)
+	// From ../tdns/cli/generate_cmds.go: daemon-agnostic record syntax helpers
+	cli.UtilCmd.AddCommand(cli.GenerateCmd)
 
 	// From ../tdns/cli/notify_cmds.go:
 	rootCmd.AddCommand(cli.NotifyCmd)
@@ -55,8 +55,9 @@ func init() {
 	// From ../tdns/cli/agent_cmds.go:
 	rootCmd.AddCommand(cli.AgentCmd)
 
-	// Root-level keys (generate JOSE for agent/combiner; no config required)
-	rootCmd.AddCommand(cli.RootKeysCmd)
+	// JOSE key generation utility: 'util keys generate'. No config required
+	// (intentionally; that's why it sits under util rather than agent/combiner).
+	cli.UtilCmd.AddCommand(cli.RootKeysCmd)
 
 	// From ../tdns/cli/jose_keys_cmds.go: agent/combiner keys (generate, show) — under agent/combiner, uses config
 	cli.AgentCmd.AddCommand(cli.NewKeysCmd("agent"))
@@ -66,8 +67,8 @@ func init() {
 	// Agent uses AgentZoneCmd (wired in cli/agent_zone_cmds.go).
 	// Combiner uses combinerZoneCmd (wired in cli/legacy_combiner_edits_cmds.go).
 
-	// From ../tdns/cli/base32_cmds.go
-	rootCmd.AddCommand(cli.Base32Cmd)
+	// From ../tdns/cli/base32_cmds.go: daemon-agnostic encode/decode helper
+	cli.UtilCmd.AddCommand(cli.Base32Cmd)
 
 	// From ../tdns/cli/scanner_cmds.go:
 	rootCmd.AddCommand(cli.ScannerCmd)
@@ -78,8 +79,11 @@ func init() {
 	// From ../tdns/cli/auth_cmds.go:
 	rootCmd.AddCommand(cli.AuthCmd)
 
-	// From ../tdns/cli/jwt_cmds.go:
-	rootCmd.AddCommand(cli.JwtCmd)
+	// From ../tdns/cli/jwt_cmds.go: daemon-agnostic JWT inspection
+	cli.UtilCmd.AddCommand(cli.JwtCmd)
+
+	// Synthetic 'util' parent itself (must be added once, after children).
+	rootCmd.AddCommand(cli.UtilCmd)
 
 	// distrib_cmds.go and transaction_cmds.go live in tdns-mp/v2/cli;
 	// their endpoints are only served by mp daemons, so they are wired

--- a/v2/cli/db_cmds.go
+++ b/v2/cli/db_cmds.go
@@ -13,46 +13,50 @@ import (
 	"github.com/spf13/viper"
 )
 
-var tdnsDbFile string
+// NewDbCmd returns a fresh 'db' subtree for attachment under a daemon
+// parent (auth/agent). Each call returns independent cobra.Command
+// instances so the same subtree can be wired under multiple parents
+// without violating cobra's single-parent rule.
+func NewDbCmd(parent string) *cobra.Command {
+	var dbFile string
 
-var DbCmd = &cobra.Command{
-	Use:   "db",
-	Short: "TDNS DB commands",
-}
+	dbCmd := &cobra.Command{
+		Use:   "db",
+		Short: fmt.Sprintf("Manage the %s daemon's SQLite database", parent),
+	}
 
-var dbInitCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize TDNS DB",
-	Run: func(cmd *cobra.Command, args []string) {
-		if tdnsDbFile == "" {
-			tdnsDbFile = viper.GetString("db.file")
-		}
-		if tdnsDbFile == "" {
-			log.Fatalf("Error: TDNS DB file not specified in config nor on command line")
-		}
+	dbInitCmd := &cobra.Command{
+		Use:   "init",
+		Short: fmt.Sprintf("Initialize the %s daemon's TDNS DB file", parent),
+		Run: func(cmd *cobra.Command, args []string) {
+			if dbFile == "" {
+				dbFile = viper.GetString("db.file")
+			}
+			if dbFile == "" {
+				log.Fatalf("Error: TDNS DB file not specified in config nor on command line")
+			}
 
-		if _, err := os.Stat(tdnsDbFile); err == nil {
-			fmt.Printf("Warning: TDNS DB file '%s' already exists.\n", tdnsDbFile)
-		} else if os.IsNotExist(err) {
-			// Validate parent directory
-			parentDir := filepath.Dir(tdnsDbFile)
+			if _, err := os.Stat(dbFile); err == nil {
+				fmt.Printf("Warning: TDNS DB file '%s' already exists.\n", dbFile)
+				return
+			} else if !os.IsNotExist(err) {
+				log.Fatalf("Error checking TDNS DB file '%s': %v", dbFile, err)
+			}
+
+			parentDir := filepath.Dir(dbFile)
 			if _, err := os.Stat(parentDir); os.IsNotExist(err) {
 				log.Fatalf("Error: Parent directory '%s' does not exist", parentDir)
 			}
-			file, err := os.OpenFile(tdnsDbFile, os.O_CREATE|os.O_RDWR, 0600)
+			file, err := os.OpenFile(dbFile, os.O_CREATE|os.O_RDWR, 0600)
 			if err != nil {
-				log.Fatalf("Error creating TDNS DB file '%s': %v", tdnsDbFile, err)
+				log.Fatalf("Error creating TDNS DB file '%s': %v", dbFile, err)
 			}
 			defer file.Close()
-			fmt.Printf("TDNS DB file '%s' created successfully.\n", tdnsDbFile)
-		} else {
-			log.Fatalf("Error checking TDNS DB file '%s': %v", tdnsDbFile, err)
-		}
-	},
-}
+			fmt.Printf("TDNS DB file '%s' created successfully.\n", dbFile)
+		},
+	}
+	dbInitCmd.Flags().StringVarP(&dbFile, "file", "f", "", "TDNS DB file")
 
-func init() {
-	DbCmd.AddCommand(dbInitCmd)
-
-	dbInitCmd.Flags().StringVarP(&tdnsDbFile, "file", "f", "", "TDNS DB file")
+	dbCmd.AddCommand(dbInitCmd)
+	return dbCmd
 }

--- a/v2/cli/db_cmds.go
+++ b/v2/cli/db_cmds.go
@@ -36,19 +36,19 @@ func NewDbCmd(parent string) *cobra.Command {
 				log.Fatalf("Error: TDNS DB file not specified in config nor on command line")
 			}
 
-			if _, err := os.Stat(dbFile); err == nil {
-				fmt.Printf("Warning: TDNS DB file '%s' already exists.\n", dbFile)
-				return
-			} else if !os.IsNotExist(err) {
-				log.Fatalf("Error checking TDNS DB file '%s': %v", dbFile, err)
-			}
-
 			parentDir := filepath.Dir(dbFile)
 			if _, err := os.Stat(parentDir); os.IsNotExist(err) {
 				log.Fatalf("Error: Parent directory '%s' does not exist", parentDir)
 			}
-			file, err := os.OpenFile(dbFile, os.O_CREATE|os.O_RDWR, 0600)
+			// O_EXCL makes creation atomic: if another process raced us,
+			// open returns ErrExist and we report "already exists"
+			// instead of silently treating a foreign file as ours.
+			file, err := os.OpenFile(dbFile, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0600)
 			if err != nil {
+				if os.IsExist(err) {
+					fmt.Printf("Warning: TDNS DB file '%s' already exists.\n", dbFile)
+					return
+				}
 				log.Fatalf("Error creating TDNS DB file '%s': %v", dbFile, err)
 			}
 			defer file.Close()

--- a/v2/cli/util_cmds.go
+++ b/v2/cli/util_cmds.go
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ */
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// UtilCmd is a synthetic parent for daemon-agnostic helper commands
+// (base32 encoding, JWT inspection, record-syntax generators, root-level
+// JOSE key generation). Putting these under a single 'util' parent keeps
+// the top-level uncluttered and reserves it for daemon parents
+// (auth, agent, imr, scanner) plus 'version'.
+var UtilCmd = &cobra.Command{
+	Use:   "util",
+	Short: "Daemon-agnostic utility commands (base32, jwt, generate, keys)",
+}


### PR DESCRIPTION
## Summary

tdns-cli's top level was a mix of daemon parents (`agent`, `auth`, `imr`, `scanner`) and one-off commands attached directly to root. The auth-side factory variants (`config`, `daemon`, `debug`, `ping`, `stop`) lived at root, while the agent-side variants of the same factories lived under `agent`. Hence \`tdns-cli config reload\` (auth) vs \`tdns-cli agent config reload\` (agent) — the asymmetry was the actual day-to-day irritant.

This PR brings the tree in line with tdns-mp's already-cleaned-up CLI: every command lives under an application parent or under `util` (synthetic parent for daemon-agnostic helpers). Root-level is now only the daemon parents, `util`, and `version`.

## Changes

**Commit 1 — `util` parent**
- New `v2/cli/util_cmds.go` defining `UtilCmd`.
- Reparented under `util`: `base32`, `jwt`, `generate` (TLSA + RFC3597), `keys` (the rootless JOSE generator that needs no config).

**Commit 2 — reparent the rest**
- Under `auth`: `catalog`, `notify`, `ddns`, `del`, `report`, plus the factory variants `config`, `debug`, `stop` (matching the existing `agent` pattern).
- Under `imr`: `dsync-query` (DSYNC discovery uses the IMR resolver).
- `db` converted from a shared package-level var to `NewDbCmd(parent)` factory; wired under both `auth` and `agent` since each daemon has its own SQLite DB.

`scanner` is left at root since it talks to its own daemon — and is moving to `tdns-apps` anyway (no scanner CLI commands replicated there yet, so a layout decision now would just be wasted work). `version` stays at root by convention.

## Verification

```
$ tdns-cli --help
Available Commands:
  agent       TDNS Agent commands
  auth        Interact with tdns-auth (authoritative) via API
  imr         Interact with tdns-imr via API
  scanner     Interact with tdns-scanner via API
  util        Daemon-agnostic utility commands (base32, jwt, generate, keys)
  version     Print the version of the app, more or less verbosely
```

\`auth\` and \`agent\` subtrees now mirror each other (both have `config`, `daemon`, `db`, `debug`, `keystore`, `ping`, `stop`, `truststore`, `zone`, plus their daemon-specific subcommands).

## Notes

- No cobra `getCommandContext()` usage anywhere in the tree (verified) and no shared package-level `cobra.Command` vars attached to multiple parents in the same binary (verified).
- tdns-mp's mpcli attaches some of these shared vars (`ReportCmd`, `JwtCmd`, `RootKeysCmd`, `AuthCmd`) to its own `SignerCmd`. Those attachments live in a different binary and don't conflict with tdns-cli's tree — but worth a follow-up to give mpcli its own `util` parent for the same hygiene.

## Test plan

- [x] `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make` clean
- [x] `cd tdns-mp/cmd && GOROOT=/opt/local/lib/go make` clean
- [x] `tdns-cli --help` shows only daemon parents + util + version at root
- [x] `tdns-cli auth --help` shows full auth subtree, no duplicates
- [x] `tdns-cli agent --help` shows full agent subtree
- [x] `tdns-cli util --help` shows base32/generate/jwt/keys
- [x] `tdns-cli imr --help` shows dsync-query alongside the other imr subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI commands reorganized into logical parents (auth, util, imr, etc.) for clearer discovery; many former root-level commands are now nested.
* **New Features**
  * Added a top-level "util" parent for daemon-agnostic helpers (base32, jwt, key/record generators).
  * `catalog` and `keys` commands now appear under more appropriate parents and the `keys` subtree is recognized across legacy and current CLI layouts.
* **Behavior**
  * DB initialization now accepts a local file flag and uses safer creation semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->