### PR TITLE
keystore: add 'dnssec purge' to delete old removed keys

### DIFF
--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -29,6 +29,7 @@ type KeystorePost struct {
 	State           string
 	ParentState     uint8
 	Creator         string
+	Force           bool // commit destructive operation; otherwise dry-run (used by 'purge')
 }
 
 type KeystoreResponse struct {

--- a/v2/cli/keystore_cmds.go
+++ b/v2/cli/keystore_cmds.go
@@ -281,7 +281,24 @@ containing either the private or the public SIG(0) key and the name of the zone.
 	clear.Flags().Bool("force", false, "Skip confirmation prompt")
 	clear.MarkFlagRequired("zone")
 
-	c.AddCommand(add, importCmd, generate, list, delete, setstate, genDS, rollover, clear, newKeystoreDnssecPolicyCmd(role), newKeystoreDnssecDsPushCmd(role), newKeystoreDnssecQueryParentCmd(role), newAutoRolloverCmd(role))
+	purge := &cobra.Command{
+		Use:   "purge",
+		Short: "Delete keys in 'removed' state, keeping the 3 most recent per zone",
+		Long: `Delete keys in 'removed' state from the keystore, keeping the 3
+most recent per zone (by insert order). Use --zone all to apply to
+every zone with removed keys at once.
+
+Dry-run by default: prints the keys that would be deleted and exits
+without modifying anything. Pass --force to actually delete.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			dnssecKeyPurgeCmd(role, cmd)
+		},
+	}
+	purge.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to purge ('all' for every zone)")
+	purge.Flags().Bool("force", false, "Actually delete; otherwise dry-run")
+	purge.MarkFlagRequired("zone")
+
+	c.AddCommand(add, importCmd, generate, list, delete, setstate, genDS, rollover, clear, purge, newKeystoreDnssecPolicyCmd(role), newKeystoreDnssecDsPushCmd(role), newKeystoreDnssecQueryParentCmd(role), newAutoRolloverCmd(role))
 	return c
 }
 
@@ -579,6 +596,88 @@ func dnssecKeyMgmt(role, cmd string) {
 		}
 	}
 
+}
+
+// dnssecKeyPurgeCmd handles "keystore dnssec purge". The zone "all"
+// passes through verbatim (no Fqdn); anything else is normalized. The
+// server returns the set of keys it deleted (or would delete in
+// dry-run mode); we print them in the same column format as 'list'.
+func dnssecKeyPurgeCmd(role string, cmd *cobra.Command) {
+	zoneArg := strings.TrimSpace(tdns.Globals.Zonename)
+	if zoneArg == "" {
+		fmt.Println("Error: --zone is required (use 'all' to purge every zone)")
+		os.Exit(1)
+	}
+	if strings.EqualFold(zoneArg, "all") {
+		zoneArg = "all"
+	} else {
+		zoneArg = dns.Fqdn(zoneArg)
+	}
+	force, _ := cmd.Flags().GetBool("force")
+
+	api, err := GetApiClient(role, true)
+	if err != nil {
+		log.Fatalf("Error creating API client: %v", err)
+	}
+
+	tr, err := SendKeystoreCmd(api, tdns.KeystorePost{
+		Command:    "dnssec-mgmt",
+		SubCommand: "purge",
+		Zone:       zoneArg,
+		Force:      force,
+	})
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+	if tr.Error {
+		fmt.Printf("Error from TDNSD: %s\n", tr.ErrorMsg)
+		os.Exit(1)
+	}
+
+	if len(tr.Dnskeys) > 0 {
+		if force {
+			fmt.Println("Purged DNSSEC key pairs:")
+		} else {
+			fmt.Println("DNSSEC key pairs that would be purged:")
+		}
+		type entry struct {
+			zone, keyid, alg, keystr string
+			flags                    uint16
+		}
+		var entries []entry
+		for k, v := range tr.Dnskeys {
+			tmp := strings.SplitN(k, "::", 2)
+			if len(tmp) != 2 {
+				continue
+			}
+			entries = append(entries, entry{
+				zone:   tmp[0],
+				keyid:  tmp[1],
+				flags:  v.Flags,
+				alg:    v.Algorithm,
+				keystr: v.Keystr,
+			})
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].zone != entries[j].zone {
+				return entries[i].zone < entries[j].zone
+			}
+			return entries[i].keyid < entries[j].keyid
+		})
+		var out []string
+		for _, e := range entries {
+			out = append(out, fmt.Sprintf("%s|%s|%d|%s|%.50s...\n",
+				e.zone, e.keyid, e.flags, e.alg, e.keystr))
+		}
+		if tdns.Globals.ShowHeaders {
+			out = append([]string{"Signer|KeyID|Flags|Algorithm|DNSKEY Record"}, out...)
+		}
+		fmt.Printf("%s\n", columnize.SimpleFormat(out))
+	}
+	if tr.Msg != "" {
+		fmt.Println(tr.Msg)
+	}
 }
 
 func dnssecGenDS(role string) {

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -563,6 +563,13 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 		resp.Msg = fmt.Sprintf("Deleted %d keys for zone %s. Generated: %s. Standby keys will follow via KeyStateWorker.",
 			count, kp.Zone, strings.Join(generated, ", "))
 
+	case "purge":
+		purgeResp, err := kdb.dnssecKeyPurge(tx, kp)
+		if err != nil {
+			return purgeResp, err
+		}
+		resp = *purgeResp
+
 	default:
 		resp.Msg = fmt.Sprintf("Unknown keystore dnssec sub-command: %s", kp.SubCommand)
 		lgSigner.Warn("unknown DnssecKeyMgmt subcommand", "subcommand", kp.SubCommand)
@@ -572,6 +579,149 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 
 	txSuccess = true
 	return &resp, nil
+}
+
+// dnssecKeyPurge deletes DNSKEY keystore rows in state 'removed', keeping
+// the 3 most recent per zone (highest auto-increment id). When kp.Zone is
+// "all" (case-insensitive), every zone with removed keys is processed.
+// kp.Force=false means dry-run: the rows that would be deleted are
+// returned in resp.Dnskeys but no DELETE runs.
+//
+// Ordering by id (rather than a transition timestamp) is pragmatic — the
+// DnssecKeyStore schema has no removed_at column, but in a normal
+// KSK-rollover lifecycle keys are removed in creation order, so the
+// highest 3 ids among removed keys are exactly the most recent.
+func (kdb *KeyDB) dnssecKeyPurge(tx *Tx, kp KeystorePost) (*KeystoreResponse, error) {
+	const keepN = 3
+
+	resp := &KeystoreResponse{Time: time.Now()}
+
+	// Resolve target zone list.
+	var zones []string
+	if strings.EqualFold(strings.TrimSpace(kp.Zone), "all") {
+		rows, err := tx.Query(
+			`SELECT DISTINCT zonename FROM DnssecKeyStore WHERE state=? ORDER BY zonename`,
+			DnskeyStateRemoved)
+		if err != nil {
+			return resp, fmt.Errorf("dnssecKeyPurge: list zones: %w", err)
+		}
+		for rows.Next() {
+			var z string
+			if err := rows.Scan(&z); err != nil {
+				rows.Close()
+				return resp, fmt.Errorf("dnssecKeyPurge: scan zone: %w", err)
+			}
+			zones = append(zones, z)
+		}
+		rows.Close()
+	} else {
+		if kp.Zone == "" {
+			resp.Error = true
+			resp.ErrorMsg = "zone is required for purge (use 'all' to purge every zone)"
+			return resp, fmt.Errorf("%s", resp.ErrorMsg)
+		}
+		zones = []string{kp.Zone}
+	}
+
+	purged := map[string]DnssecKey{}
+	deletedCount := 0
+	zonesAffected := 0
+
+	for _, zone := range zones {
+		// Find the ids to keep: 3 most recent removed keys for this zone.
+		rows, err := tx.Query(
+			`SELECT id FROM DnssecKeyStore WHERE zonename=? AND state=? ORDER BY id DESC LIMIT ?`,
+			zone, DnskeyStateRemoved, keepN)
+		if err != nil {
+			return resp, fmt.Errorf("dnssecKeyPurge: keep query for %s: %w", zone, err)
+		}
+		var keepIDs []int
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return resp, fmt.Errorf("dnssecKeyPurge: scan keep id for %s: %w", zone, err)
+			}
+			keepIDs = append(keepIDs, id)
+		}
+		rows.Close()
+
+		// Build the "NOT IN (?,?,?)" clause and arg list. With fewer than
+		// keepN removed keys for this zone, the clause collapses to a no-op
+		// and there's nothing to purge for that zone.
+		args := []interface{}{zone, DnskeyStateRemoved}
+		notInClause := ""
+		if len(keepIDs) > 0 {
+			placeholders := make([]string, len(keepIDs))
+			for i, id := range keepIDs {
+				placeholders[i] = "?"
+				args = append(args, id)
+			}
+			notInClause = " AND id NOT IN (" + strings.Join(placeholders, ",") + ")"
+		}
+
+		// Collect the to-be-purged keys for the response (for both dry-run
+		// and commit — operators want to see what was/will be deleted).
+		listSQL := `SELECT keyid, flags, algorithm, keyrr FROM DnssecKeyStore WHERE zonename=? AND state=?` + notInClause
+		listRows, err := tx.Query(listSQL, args...)
+		if err != nil {
+			return resp, fmt.Errorf("dnssecKeyPurge: list query for %s: %w", zone, err)
+		}
+		zonePurgedCount := 0
+		for listRows.Next() {
+			var keyid, flags int
+			var algorithm, keyrr string
+			if err := listRows.Scan(&keyid, &flags, &algorithm, &keyrr); err != nil {
+				listRows.Close()
+				return resp, fmt.Errorf("dnssecKeyPurge: scan key for %s: %w", zone, err)
+			}
+			mapkey := fmt.Sprintf("%s::%d", zone, keyid)
+			purged[mapkey] = DnssecKey{
+				Name:      zone,
+				State:     DnskeyStateRemoved,
+				Flags:     uint16(flags),
+				Algorithm: algorithm,
+				Keystr:    keyrr,
+			}
+			zonePurgedCount++
+		}
+		listRows.Close()
+		if zonePurgedCount > 0 {
+			zonesAffected++
+		}
+
+		if !kp.Force {
+			continue // dry-run: don't actually delete
+		}
+
+		// Commit path: delete the rows + invalidate caches for this zone.
+		delSQL := `DELETE FROM DnssecKeyStore WHERE zonename=? AND state=?` + notInClause
+		res, err := tx.Exec(delSQL, args...)
+		if err != nil {
+			return resp, fmt.Errorf("dnssecKeyPurge: delete for %s: %w", zone, err)
+		}
+		n, _ := res.RowsAffected()
+		deletedCount += int(n)
+
+		kdb.mu.Lock()
+		for cacheKey := range kdb.KeystoreDnskeyCache {
+			if strings.HasPrefix(cacheKey, zone+"+") {
+				delete(kdb.KeystoreDnskeyCache, cacheKey)
+			}
+		}
+		kdb.mu.Unlock()
+	}
+
+	resp.Dnskeys = purged
+	if kp.Force {
+		resp.Msg = fmt.Sprintf("Purged %d removed key(s) across %d zone(s) (kept %d most recent per zone).",
+			deletedCount, zonesAffected, keepN)
+		lgSigner.Info("dnssec keystore purge", "deleted", deletedCount, "zones", zonesAffected)
+	} else {
+		resp.Msg = fmt.Sprintf("DRY RUN: would purge %d removed key(s) across %d zone(s) (keeping %d most recent per zone). Pass --force to actually delete.",
+			len(purged), zonesAffected, keepN)
+	}
+	return resp, nil
 }
 
 func (kdb *KeyDB) GetSig0Keys(zonename, state string) (*Sig0ActiveKeys, error) {


### PR DESCRIPTION
## Summary

Adds \`tdns-cli {auth,agent} keystore dnssec purge --zone <name|all> [--force]\` to delete old keys in state \`removed\`, keeping the 3 most recent per zone. Dry-run by default; \`--force\` commits.

Motivated by the long-running KSK-rollover testbed, where \`removed\` keys accumulate to thousands and clutter the DB / slow down \`list\`.

## Behavior

- Operates only on keys in state \`removed\`. Anything in \`created\`, \`published\`, \`active\`, \`retired\`, etc. is untouched.
- Keeps the 3 most recent per zone, ordered by the auto-increment \`id\` column.
- \`--zone all\` is treated as a special token: the server iterates every zone that has any \`removed\` keys and applies the same keep-3 policy per zone.
- Anything else is normalized to FQDN by the CLI before being sent to the API.
- Dry-run by default. The summary message tells the operator \`--force\` is needed:
  > \`DRY RUN: would purge 2253 removed key(s) across 1 zone(s) (keeping 3 most recent per zone). Pass --force to actually delete.\`
- On \`--force\` commit, server invalidates \`KeystoreDnskeyCache\` for affected zones (mirrors the existing \`clear\` path). No resign trigger since \`removed\` keys are already inactive.

## Why id-order rather than removed-at

\`DnssecKeyStore\` has no \`removed_at\` column. The schema does have \`retired_at\` but that fires at the previous lifecycle step, not removal. The auto-increment \`id\` is monotonic in insert order, and in a normal KSK-rollover lifecycle keys are removed in creation order — so the 3 highest ids among \`removed\` keys are precisely the keys you want to keep. Documented inline.

Adding a real \`removed_at\` column would require a schema migration plus retrofitting existing rows; not worth the churn for this housekeeping feature. If we ever want stricter ordering later, the migration is straightforward.

## Test plan

- [x] Both builds clean: \`tdns/cmdv2/\`, \`tdns-mp/cmd/\`
- [x] \`tdns-cli auth keystore dnssec purge --help\` text correct
- [x] \`tdns-cli agent keystore dnssec purge --help\` correct (factory wires it under both roles)
- [ ] Field: \`tdns-cli auth keystore dnssec purge --zone all\` on a busy testbed → see expected dry-run list
- [ ] Field: same with \`--force\` → list count drops to (#zones × 3) or fewer for \`removed\` keys; other states untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `keystore dnssec purge` subcommand to remove DNSSEC keys in removed state, retaining the 3 most recent keys per zone.
  * Supports `--zone` (including `all`) and `--force` flags to control dry-run vs. actual deletion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->