### PR TITLE
chase: fix DS leaf queries — parent is the deepest validated zone

### DIFF
--- a/v2/chase.go
+++ b/v2/chase.go
@@ -114,6 +114,17 @@ func (c *Chaser) Chase(qname string, qtype uint16) (*ChainResult, error) {
 	}
 	qname = dns.Fqdn(qname)
 	zones := zoneCutsFromRoot(qname) // root-first
+	// DS records live at the PARENT zone, not at qname's own zone. So
+	// for a DS leaf query, drop qname from the zone chain — the parent
+	// becomes the deepest validated zone, and the leaf RRset is then
+	// verified against that parent's DNSKEYs (whose ZSK signed the DS).
+	// Without this, the chaser would try to fetch DS for qname itself
+	// (a redundant second wire query to fetch what the leaf will get),
+	// and even on success would attempt leaf verification against the
+	// child zone's DNSKEYs — which never signed the DS.
+	if qtype == dns.TypeDS && len(zones) > 1 {
+		zones = zones[:len(zones)-1]
+	}
 	result := &ChainResult{Status: ChainStatusSecure}
 
 	for i, zone := range zones {


### PR DESCRIPTION
## Summary

dog +sigchase was reporting DS leaf queries (e.g. \`dog cpt.p.axfr.net ds +sigchase\`) as **indeterminate** even when the chain was fully signed and the data validated correctly. Root cause: the chaser walked \`zoneCutsFromRoot\` blindly and treated qname as a zone in the chain — wrong for DS, where the data lives at the **parent** zone (the parent's ZSK signs the DS RRset).

For \`cpt.p.axfr.net IN DS\` this caused:

1. A redundant inner wire query (queryDSAtParent for qname) that fetched the same RRset the leaf would fetch a moment later.
2. Leaf verification picked the child link as deepest and tried to verify the DS signature against the child zone's DNSKEYs — which never signed the DS — so it always failed.

**Fix**: in \`Chase\`, when \`qtype == TypeDS\` and the chain has more than just the root, drop qname from the zone list. The parent naturally becomes the deepest validated zone, and the leaf RRset is verified against the parent's already-validated DNSKEY RRset.

## Test plan

- [x] Build clean (\`cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make\`)
- [x] \`./dog @9.9.9.9 cpt.p.axfr.net ds +sigchase\` now reports the full chain as **secure** with \`sig keytag=33283 verified\` (33283 is one of p.axfr.net's ZSKs)
- [x] \`./dog @9.9.9.9 p.axfr.net SOA +sigchase\` still works (non-DS leaf path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DNS security validation to correctly verify delegation records against parent zone credentials rather than child zone credentials, improving verification accuracy and reliability throughout the query resolution chain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->