### PR TITLE
Move MP AppType + ZoneOption to tdns-mp; range-allocation gates

### DIFF
--- a/v2/cli/jose_keys_cmds.go
+++ b/v2/cli/jose_keys_cmds.go
@@ -73,11 +73,6 @@ func runKeysCommand(role string, cmd *cobra.Command, subcommand string, args []s
 		log.Fatalf("Load config %s: %v", serverConfigPath, err)
 	}
 
-	appType := tdns.AppTypeAgent
-	if role == "combiner" {
-		appType = tdns.AppTypeMPCombiner
-	}
-
 	runArgs := []string{subcommand}
 	if subcommand == "generate" {
 		output, _ := cmd.Flags().GetString("output")
@@ -86,7 +81,7 @@ func runKeysCommand(role string, cmd *cobra.Command, subcommand string, args []s
 		}
 	}
 
-	if err := tdns.RunKeysCmd(conf, appType, runArgs); err != nil {
+	if err := tdns.RunKeysCmd(conf, runArgs); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -7,6 +7,22 @@ import "fmt"
 
 type ZoneOption uint8
 
+// Range allocation for ZoneOption across the tdns ecosystem.
+// Each downstream repo gets a numeric range starting one past the
+// previous max. Downstream packages assign their values via:
+//
+//	const X tdns.ZoneOption = tdns.TdnsZoneOptionMax + 1 + iota
+//
+// and use a compile-time gate to ensure they stay in their range
+// (see enums.go in each downstream package). Resizing a range:
+// change the value here and recompile.
+const (
+	TdnsZoneOptionMax   ZoneOption = 32
+	TdnsMpZoneOptionMax ZoneOption = 64
+	TdnsNmZoneOptionMax ZoneOption = 96
+	TdnsEsZoneOptionMax ZoneOption = 128
+)
+
 const (
 	OptDelSyncParent ZoneOption = iota + 1
 	OptDelSyncChild
@@ -162,6 +178,22 @@ var AgentOptionToString = map[AgentOption]string{}
 var StringToAgentOption = map[string]AgentOption{}
 
 type AppType uint8
+
+// Range allocation for AppType across the tdns ecosystem.
+// Each downstream repo gets a numeric range starting one past the
+// previous max. Downstream packages assign their values via:
+//
+//	const X tdns.AppType = tdns.TdnsAppTypeMax + 1 + iota
+//
+// and use a compile-time gate to ensure they stay in their range
+// (see enums.go in each downstream package). Resizing a range:
+// change the value here and recompile.
+const (
+	TdnsAppTypeMax   AppType = 16
+	TdnsMpAppTypeMax AppType = 32
+	TdnsNmAppTypeMax AppType = 48
+	TdnsEsAppTypeMax AppType = 64
+)
 
 const (
 	AppTypeAuth AppType = iota + 1

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -44,11 +44,15 @@ const (
 	OptCatalogZone
 	OptCatalogMemberAutoCreate
 	OptCatalogMemberAutoDelete
-	OptMPManualApproval
-	OptMultiSigner     // Dynamically set by signer when HSYNC shows multiple signers
-	OptMPNotListedErr  // Warning: zone has HSYNC3 but we are not listed as a provider
-	OptMPDisallowEdits // Zone is signed but we are not a signer: no edits allowed
+	OptMultiSigner // Dynamically set by signer when HSYNC shows multiple signers
+	optZoneOptionTdnsSentinel
 )
+
+// Compile-time gate: tdns's own ZoneOption values must fit in
+// tdns's allocated range. If a new constant added above crosses
+// TdnsZoneOptionMax, the unsigned subtraction underflows and
+// the build fails.
+const _ uint = uint(TdnsZoneOptionMax) - uint(optZoneOptionTdnsSentinel-1)
 
 var ZoneOptionToString = map[ZoneOption]string{
 	OptDelSyncParent:     "delegation-sync-parent",
@@ -71,10 +75,7 @@ var ZoneOptionToString = map[ZoneOption]string{
 	OptCatalogZone:             "catalog-zone",
 	OptCatalogMemberAutoCreate: "catalog-member-auto-create",
 	OptCatalogMemberAutoDelete: "catalog-member-auto-delete",
-	OptMPManualApproval:        "mp-manual-approval",
 	OptMultiSigner:             "multi-signer",
-	OptMPNotListedErr:          "mp-not-listed-error",
-	OptMPDisallowEdits:         "mp-disallow-edits",
 }
 
 var StringToZoneOption = map[string]ZoneOption{
@@ -97,10 +98,7 @@ var StringToZoneOption = map[string]ZoneOption{
 	"catalog-zone":               OptCatalogZone,
 	"catalog-member-auto-create": OptCatalogMemberAutoCreate,
 	"catalog-member-auto-delete": OptCatalogMemberAutoDelete,
-	"mp-manual-approval":         OptMPManualApproval,
 	"multi-signer":               OptMultiSigner,
-	"mp-not-listed-error":        OptMPNotListedErr,
-	"mp-disallow-edits":          OptMPDisallowEdits,
 }
 
 type ImrOption uint8
@@ -198,7 +196,6 @@ const (
 const (
 	AppTypeAuth AppType = iota + 1
 	AppTypeAgent
-	// AppTypeCombiner
 	AppTypeImr // simplified recursor
 	AppTypeCli
 	AppTypeReporter
@@ -206,16 +203,21 @@ const (
 	AppTypeKdc        // Key Distribution Center
 	AppTypeKrs        // Key Receiving Service (edge receiver)
 	AppTypeEdgeSigner // NYI
-	AppTypeMPSigner   // MP signer (tdns-mp): DNS infra from tdns, MP wiring from tdns-mp
-	AppTypeMPAgent    // MP agent (tdns-mp): DNS infra from tdns, MP wiring from tdns-mp
-	AppTypeMPCombiner // MP combiner (tdns-mp): DNS infra from tdns, MP wiring from tdns-mp
-	AppTypeMPAuditor  // MP auditor (tdns-mp): read-only observer, no zone contributions
+	appTypeTdnsSentinel
 )
 
+// Compile-time gate: tdns's own AppType values must fit in tdns's
+// allocated range. If a new constant added above crosses
+// TdnsAppTypeMax, the unsigned subtraction underflows and the
+// build fails.
+const _ uint = uint(TdnsAppTypeMax) - uint(appTypeTdnsSentinel-1)
+
+// AppTypeToString and StringToAppType cover tdns-owned values
+// only. Downstream packages (tdns-mp, tdns-nm, tdns-es) extend
+// these maps via init() in their own enums.go.
 var AppTypeToString = map[AppType]string{
-	AppTypeAuth:  "auth",
-	AppTypeAgent: "agent",
-	//AppTypeCombiner:   "combiner",
+	AppTypeAuth:       "auth",
+	AppTypeAgent:      "agent",
 	AppTypeImr:        "imr",
 	AppTypeCli:        "cli",
 	AppTypeReporter:   "reporter",
@@ -223,16 +225,11 @@ var AppTypeToString = map[AppType]string{
 	AppTypeKdc:        "kdc",
 	AppTypeKrs:        "krs",
 	AppTypeEdgeSigner: "edgeSigner", // NYI
-	AppTypeMPSigner:   "mpsigner",
-	AppTypeMPAgent:    "mpagent",
-	AppTypeMPCombiner: "mpcombiner",
-	AppTypeMPAuditor:  "mpauditor",
 }
 
 var StringToAppType = map[string]AppType{
-	"auth":  AppTypeAuth,
-	"agent": AppTypeAgent,
-	//"combiner":   AppTypeCombiner,
+	"auth":       AppTypeAuth,
+	"agent":      AppTypeAgent,
 	"imr":        AppTypeImr,
 	"cli":        AppTypeCli,
 	"reporter":   AppTypeReporter,
@@ -240,10 +237,6 @@ var StringToAppType = map[string]AppType{
 	"kdc":        AppTypeKdc,
 	"krs":        AppTypeKrs,
 	"edgeSigner": AppTypeEdgeSigner, // NYI
-	"mpsigner":   AppTypeMPSigner,
-	"mpagent":    AppTypeMPAgent,
-	"mpcombiner": AppTypeMPCombiner,
-	"mpauditor":  AppTypeMPAuditor,
 }
 
 type ErrorType uint8

--- a/v2/keys_cmd.go
+++ b/v2/keys_cmd.go
@@ -1,8 +1,9 @@
 /*
  * Copyright (c) 2025 Johan Stenstam, johani@johani.org
  *
- * JOSE keypair CLI (generate, show) for agent and combiner secure CHUNK comms.
- * Invoked from tdns-agent and tdns-combiner when first argument is "keys".
+ * JOSE keypair CLI (generate, show). Used by CLI commands that
+ * manage long_term_jose_priv_key for any role that publishes
+ * JWK records.
  */
 
 package tdns
@@ -20,7 +21,7 @@ import (
 )
 
 // LoadConfigForKeys reads the given YAML config file and decodes it into Config.
-// Used by tdns-cli agent/combiner keys to get long_term_jose_priv_key path.
+// Used by CLI keys commands to get the long_term_jose_priv_key path.
 // Does not process includes or run full ParseConfig.
 func LoadConfigForKeys(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
@@ -34,11 +35,11 @@ func LoadConfigForKeys(path string) (*Config, error) {
 	return &conf, nil
 }
 
-// RunKeysCmd runs the "keys" subcommand (generate | show).
-// Used by tdns-cli agent keys / tdns-cli combiner keys. conf must be loaded from the server's config file.
-func RunKeysCmd(conf *Config, appType AppType, args []string) error {
+// RunKeysCmd runs the "keys" subcommand (generate | show). The
+// caller (a cobra command) is expected to pass a valid subcommand;
+// arg validation lives in the cobra layer.
+func RunKeysCmd(conf *Config, args []string) error {
 	if len(args) < 1 {
-		printKeysUsage(appType)
 		return fmt.Errorf("missing subcommand (generate or show)")
 	}
 
@@ -46,23 +47,22 @@ func RunKeysCmd(conf *Config, appType AppType, args []string) error {
 
 	switch args[0] {
 	case "generate":
-		return runKeysGenerate(conf, appType, backend, args[1:])
+		return runKeysGenerate(conf, backend, args[1:])
 	case "show":
-		return runKeysShow(conf, appType, backend, args[1:])
+		return runKeysShow(conf, backend, args[1:])
 	default:
-		printKeysUsage(appType)
 		return fmt.Errorf("unknown keys command: %q", args[0])
 	}
 }
 
-func runKeysGenerate(conf *Config, appType AppType, backend crypto.Backend, args []string) error {
+func runKeysGenerate(conf *Config, backend crypto.Backend, args []string) error {
 	fs := flag.NewFlagSet("keys generate", flag.ContinueOnError)
 	output := fs.String("output", "", "path for generated private key (default from config)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	privPath := strings.TrimSpace(getKeysPrivKeyPath(conf, appType))
+	privPath := strings.TrimSpace(getKeysPrivKeyPath(conf))
 	if *output != "" {
 		privPath = strings.TrimSpace(*output)
 	}
@@ -100,8 +100,8 @@ func runKeysGenerate(conf *Config, appType AppType, backend crypto.Backend, args
 	return nil
 }
 
-func runKeysShow(conf *Config, appType AppType, backend crypto.Backend, args []string) error {
-	privPath := strings.TrimSpace(getKeysPrivKeyPath(conf, appType))
+func runKeysShow(conf *Config, backend crypto.Backend, args []string) error {
+	privPath := strings.TrimSpace(getKeysPrivKeyPath(conf))
 	if privPath == "" {
 		return fmt.Errorf("no key path: set long_term_jose_priv_key in server config")
 	}
@@ -137,32 +137,9 @@ func runKeysShow(conf *Config, appType AppType, backend crypto.Backend, args []s
 	return nil
 }
 
-func getKeysPrivKeyPath(conf *Config, appType AppType) string {
-	switch appType {
-	case AppTypeAgent, AppTypeMPAgent, AppTypeMPSigner, AppTypeMPCombiner:
-		if conf.MultiProvider != nil {
-			return conf.MultiProvider.LongTermJosePrivKey
-		}
-		return ""
-	default:
-		return ""
+func getKeysPrivKeyPath(conf *Config) string {
+	if conf.MultiProvider != nil {
+		return conf.MultiProvider.LongTermJosePrivKey
 	}
-}
-
-func printKeysUsage(appType AppType) {
-	var name string
-	switch appType {
-	case AppTypeMPCombiner:
-		name = "tdns-combiner"
-	case AppTypeMPAgent:
-		name = "tdns-mpagent"
-	case AppTypeMPSigner:
-		name = "tdns-mpsigner"
-	default:
-		name = "tdns-agent"
-	}
-	fmt.Fprintf(os.Stderr, "Usage: %s keys generate [-output path]\n", name)
-	fmt.Fprintf(os.Stderr, "       %s keys show\n", name)
-	fmt.Fprintf(os.Stderr, "  generate  Write JOSE keypair; path from config long_term_jose_priv_key or -output.\n")
-	fmt.Fprintf(os.Stderr, "  show      Print public key (JWK) from configured long_term_jose_priv_key.\n")
+	return ""
 }

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -101,9 +101,13 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 			return fmt.Errorf("cannot determine default config file: Globals.App.Name is not set")
 		}
 	}
-	switch Globals.App.Type {
-	case AppTypeAuth, AppTypeAgent, AppTypeScanner, AppTypeReporter, AppTypeKdc, AppTypeKrs,
-		AppTypeMPSigner, AppTypeMPAgent, AppTypeMPCombiner, AppTypeMPAuditor:
+	// Imr uses the default config file directly. Every other app
+	// type accepts flag-driven overrides. This inversion avoids
+	// enumerating AppType values defined in downstream packages
+	// (tdns-mp, tdns-nm, tdns-es).
+	if Globals.App.Type == AppTypeImr {
+		conf.Internal.CfgFile = defaultcfg
+	} else {
 		flag.StringVar(&conf.Internal.CfgFile, "config", defaultcfg, "config file path")
 		flag.BoolVarP(&Globals.Debug, "debug", "", false, "run in debug mode (may activate dangerous tests)")
 		flag.BoolVarP(&Globals.Verbose, "verbose", "v", false, "Verbose mode")
@@ -111,23 +115,20 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 		flag.Usage = func() {
 			flag.PrintDefaults()
 		}
-	case AppTypeImr:
-		conf.Internal.CfgFile = defaultcfg
 	}
 	lgConfig.Debug("MainInit starting", "defaultcfg", defaultcfg, "cfgfile", conf.Internal.CfgFile)
-	switch Globals.App.Type {
-	case AppTypeAuth, AppTypeAgent, AppTypeImr, AppTypeScanner, AppTypeReporter, AppTypeCli, AppTypeKdc, AppTypeKrs,
-		AppTypeMPSigner, AppTypeMPAgent, AppTypeMPCombiner, AppTypeMPAuditor:
-		// Long-running daemons keep the startup banner. CLI prints it
-		// only when -v / --verbose is set; otherwise the banner clutters
-		// every short command invocation.
-		if Globals.App.Type != AppTypeCli || Globals.Verbose {
-			fmt.Printf("*** TDNS %s version %s mode of operation: %q (verbose: %t, debug: %t)\n",
-				Globals.App.Name, Globals.App.Version, AppTypeToString[Globals.App.Type], Globals.Verbose, Globals.Debug)
-		}
-	default:
-		return fmt.Errorf("*** TDNS %s: Error: unknown mode of operation: %q",
-			Globals.App.Name, Globals.App.Type)
+	// Defensive: catch an unset Globals.App.Type. Every binary's
+	// main() must set this before calling MainInit.
+	if Globals.App.Type == 0 {
+		return fmt.Errorf("*** TDNS %s: Error: Globals.App.Type not set",
+			Globals.App.Name)
+	}
+	// Long-running daemons keep the startup banner. CLI prints it
+	// only when -v / --verbose is set; otherwise the banner clutters
+	// every short command invocation.
+	if Globals.App.Type != AppTypeCli || Globals.Verbose {
+		fmt.Printf("*** TDNS %s version %s mode of operation: %q (verbose: %t, debug: %t)\n",
+			Globals.App.Name, Globals.App.Version, AppTypeToString[Globals.App.Type], Globals.Verbose, Globals.Debug)
 	}
 	err := conf.ParseConfig(false) // false = initial config, not reload
 	if err != nil {

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -215,13 +215,13 @@ func (conf *Config) ParseConfig(reload bool) error {
 	// Config files may omit trailing dots; wire protocol always uses FQDN.
 	conf.normalizeConfigIdentities()
 
-	// Validate multi-provider.role matches the application type
+	// Validate multi-provider.role matches the application type for
+	// tdns-side roles. Downstream packages (tdns-mp, tdns-nm, tdns-es)
+	// validate their own roles in their own config-validation paths.
 	if conf.MultiProvider != nil {
 		expectedRole := map[AppType]string{
-			AppTypeAuth: "signer",
-			//AppTypeCombiner:   "combiner",
-			AppTypeMPCombiner: "combiner",
-			AppTypeAgent:      "agent",
+			AppTypeAuth:  "signer",
+			AppTypeAgent: "agent",
 		}
 		if expected, ok := expectedRole[Globals.App.Type]; ok {
 			if conf.MultiProvider.Role != expected {
@@ -863,9 +863,13 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// because LeaderElectionManager doesn't exist until StartAgent runs.
 		// MP zone KEY publication is registered in tdns-mp's StartAgent.
 
+		// Non-zone-serving app types skip zone refresh. Everything
+		// else (Auth, Agent, downstream MP/NM/ES roles) queues each
+		// parsed zone for refresh.
 		switch Globals.App.Type {
-		case AppTypeAuth, AppTypeAgent, // AppTypeCombiner,
-			AppTypeMPSigner, AppTypeMPAgent, AppTypeMPCombiner, AppTypeMPAuditor:
+		case AppTypeImr, AppTypeCli, AppTypeReporter, AppTypeScanner, AppTypeKdc, AppTypeKrs, AppTypeEdgeSigner:
+			// skip — these app types don't serve zones
+		default:
 			if conf.Internal.RefreshZoneCh == nil {
 				lgConfig.Error("refresh channel is not configured, zones will not be refreshed, terminating")
 				return nil, nil, errors.New("parseZones: error: refresh channel is not configured, zones will not be refreshed, terminating")

--- a/v2/parseoptions.go
+++ b/v2/parseoptions.go
@@ -331,14 +331,6 @@ func parseZoneOptions(conf *Config, zname string, zconf *ZoneConf, zd *ZoneData)
 			cleanoptions = append(cleanoptions, opt)
 			lg.Debug("catalog member auto-delete enabled", "zone", zname)
 
-		case OptMPManualApproval:
-			if !invokeOptionValidator(opt, conf, zname, zd, options) {
-				continue
-			}
-			options[opt] = true
-			cleanoptions = append(cleanoptions, opt)
-			lg.Debug("mp-manual-approval enabled", "zone", zname)
-
 		default:
 			lg.Warn("unknown zone option in switch, ignoring", "zone", zname, "option", ZoneOptionToString[opt])
 			if zd != nil {


### PR DESCRIPTION
## Summary

Cleans tdns of MP-specific enum values and introduces a named range-allocation scheme for AppType and ZoneOption so each downstream repo (tdns-mp, future tdns-nm, tdns-es) gets a fixed numeric range with a compile-time gate against overflow.

**Paired with:** https://github.com/johanix/tdns-mp/pull/25 — both PRs need to merge together. tdns first, then tdns-mp.

## Range scheme

| Enum | tdns | tdns-mp | tdns-nm | tdns-es |
|---|---|---|---|---|
| AppType    | 1–16  | 17–32 | 33–48 | 49–64  |
| ZoneOption | 1–32  | 33–64 | 65–96 | 97–128 |

Resizing a range later is a one-line edit to the boundary constants (`TdnsAppTypeMax`, `TdnsMpAppTypeMax`, `TdnsZoneOptionMax`, `TdnsMpZoneOptionMax`, etc.) in `tdns/v2/enums.go` plus a recompile.

Each downstream package declares its values as `const X tdns.AppType = tdns.TdnsAppTypeMax + 1 + iota` and ends the const block with an unexported sentinel + unsigned subtraction. If a downstream package adds enough constants to cross into the next range, the build fails with `constant -1 overflows uint` pointing at the gate.

## Commits

1. `7e8e3fa` Add range-allocation boundary constants (purely additive).
2. `28aa6cf` main_initfuncs: invert the two MP-AppType switches.
3. `d564f5d` keys_cmd: drop the cargo-culted AppType parameter, delete dead `printKeysUsage`.
4. `844f546` parseconfig: drop MP role-validation entry; invert zone-refresh switch.
5. `a2596b6` parseoptions: drop dead `OptMPManualApproval` case.
6. `d42d4e0` Move MP AppType + ZoneOption values out of tdns (the cross-repo breaking commit).

After these commits, tdns has zero references to MP-specific constants. JWK / JOSE infrastructure (`keys_cmd.go`) stays in tdns as generic infrastructure that any role can use.

## Test plan

- [x] Local build of all tdns binaries (tdns-cli, tdns-agent, tdns-imr, dog) green after every commit.
- [x] Local build of all tdns-mp binaries (tdns-mpagent, tdns-mpcombiner, tdns-mpsigner, tdns-mpauditor, tdns-mpcli) green against this branch with the matching tdns-mp PR's changes.
- [ ] Reviewer to confirm no regressions on agent / auth / scanner / reporter / imr flows.

## Merge order

Merge this PR first, then immediately merge https://github.com/johanix/tdns-mp/pull/25. Between the two merges, tdns-mp main does not compile. The window is whatever the reviewer takes between the two clicks.