### PR TITLE
Automated ZSK rollover (includes configurable RRSIG validity)

### DIFF
--- a/cmdv2/agent/tdns-agent.sample.yaml
+++ b/cmdv2/agent/tdns-agent.sample.yaml
@@ -181,7 +181,7 @@ dnssecpolicies:
       ksk:
          lifetime:  48h
       zsk:
-         lifetime:  12h
+         lifetime:  12h   # drives automated ZSK rollover (KeyStateWorker)
       csk:
          lifetime:  none
       sigvalidity:

--- a/cmdv2/agent/tdns-agent.sample.yaml
+++ b/cmdv2/agent/tdns-agent.sample.yaml
@@ -164,28 +164,30 @@ keybootstrap:
 
 dnssecpolicies:
    default:
-      algorithm:        ED25519
+      algorithm:  ED25519
       ksk:
-         lifetime:      forever
-         sigvalidity:   168h    # 24*7h = 1 week
+         lifetime:  forever
       zsk:
-         lifetime:      forever
-         sigvalidity:   2h
+         lifetime:  forever
       csk:
-         lifetime:      none
-         sigvalidity:   168h
+         lifetime:  none
+      sigvalidity:
+         default:  14d
+         dnskey:   30d
+         ds:       14d
 
    fastroll:
-      algorithm:        ED25519
+      algorithm:  ED25519
       ksk:
-         lifetime:      48h
-         sigvalidity:   5h
+         lifetime:  48h
       zsk:
-         lifetime:      12h
-         sigvalidity:   2h
+         lifetime:  12h
       csk:
-         lifetime:      none
-         sigvalidity:   168h
+         lifetime:  none
+      sigvalidity:
+         default:  14d
+         dnskey:   30d
+         ds:       14d
 
 db:
    file:		/var/tmp/tdns-agent.db

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -193,7 +193,7 @@ dnssecpolicies:
       ksk:
          lifetime:  48h
       zsk:
-         lifetime:  12h
+         lifetime:  12h   # drives automated ZSK rollover (KeyStateWorker)
       csk:
          lifetime:  none
       sigvalidity:

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -174,14 +174,15 @@ dnssecpolicies:
    default:
       algorithm:  ED25519
       ksk:
-         lifetime:     forever
-         sigvalidity:  168h     # 24*7h = 1 week
+         lifetime:  forever
       zsk:
-         lifetime:     forever
-         sigvalidity:  2h
+         lifetime:  forever
       csk:
-         lifetime:     none
-         sigvalidity:  168h
+         lifetime:  none
+      sigvalidity:
+         default:  14d
+         dnskey:   30d
+         ds:       14d
       # rollover: omitted → method: none (static keys)
       # clamping: omitted → disabled (no TTL clamping)
 
@@ -190,14 +191,15 @@ dnssecpolicies:
    fastroll:
       algorithm:  ED25519
       ksk:
-         lifetime:     48h
-         sigvalidity:  168h     # exceed lifetime so RRSIGs outlive the key cycle
+         lifetime:  48h
       zsk:
-         lifetime:     12h
-         sigvalidity:  2h
+         lifetime:  12h
       csk:
-         lifetime:     none
-         sigvalidity:  168h
+         lifetime:  none
+      sigvalidity:
+         default:  14d
+         dnskey:   30d
+         ds:       14d
       rollover:
          method:                multi-ds
          num-ds:                3                  # pipeline depth

--- a/docs/2026-05-21-automated-zsk-rollover-plan.md
+++ b/docs/2026-05-21-automated-zsk-rollover-plan.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-21
 **Author:** Johan Stenstam
-**Status:** Planning — ready to implement
+**Status:** Implemented (2026-05-22)
 **Depends on:** `2026-05-21-configurable-rrsig-validity-plan.md`
 (configurable, adhered-to RRSIG validity + floor invariant; supplies the
 "signatures outlive the served TTL" guarantee S4 relies on).
@@ -323,11 +323,11 @@ at least its floor invariant, so S4's "signatures outlive the TTL"
 assumption is enforced rather than assumed. ZSK rollover can be built in
 parallel but should not be enabled in production ahead of it.
 
-1. **S1 `ZSK.Lifetime` wiring** (read in S3). Trivial on its own.
-2. **S2 `active_at` column** + stamping. Schema + write sites.
-3. **S3 `rolloverZsksForAllZones`** wired into the tick. Core feature.
-4. **S4 TTL-aware removal** for ZSK.
-5. **S5 status** rendering.
+1. **S1 `ZSK.Lifetime` wiring** (read in S3). **DONE**
+2. **S2 `active_at` column** + stamping. Schema + write sites. **DONE**
+3. **S3 `rolloverZsksForAllZones`** wired into the tick. Core feature. **DONE**
+4. **S4 TTL-aware removal** for ZSK. **DONE**
+5. **S5 status** rendering. **DONE**
 
 Build after each Go change:
 `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make`. `gofmt -w` every

--- a/docs/2026-05-21-configurable-rrsig-validity-plan.md
+++ b/docs/2026-05-21-configurable-rrsig-validity-plan.md
@@ -295,16 +295,18 @@ numbers during implementation against the default policy's own TTLs.
    rename + new `ttls.ds`. Drop per-keytype `SigValidity`. Update the
    default policy + samples (new safe defaults). **DONE** (2026-05-22)
 2. **`DnssecPolicyWarning` error type** in `enums.go` (non-impacting;
-   reused later by plan #3's A.4).
+   reused later by plan #3's A.4). **DONE** (2026-05-22)
 3. **Floor validation:** the universal config-load check with the
    three bands (hard `DnssecError` ≤ 2×H or unset; `DnssecPolicyWarning`
    in (2×,4×)); runtime guard via `max_observed_ttl`. Land before
    adherence so bad values mark zones broken, not silently obeyed.
+   **DONE** (2026-05-22)
 4. **Signer adherence:** `sign.go:236` picks validity by RRtype.
+   **DONE** (2026-05-22)
 5. **Resigner coupling:** `NeedsResigning` driven by per-RRtype
-   validity + served TTL + scan-interval slack.
+   validity + served TTL + scan-interval slack. **DONE** (2026-05-22)
 6. **Validator rename:** E5 / CLI / status read `SigValidity.DNSKEY`;
-   E10/E11 read `ttls.parent-ds`.
+   E10/E11 read `ttls.parent-ds`. **DONE** (2026-05-22, step 1)
 
 Steps 3 and 4 must ship together (3 before 4). Build after each:
 `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make`; `gofmt -w` edits.

--- a/docs/2026-05-21-configurable-rrsig-validity-plan.md
+++ b/docs/2026-05-21-configurable-rrsig-validity-plan.md
@@ -293,7 +293,7 @@ numbers during implementation against the default policy's own TTLs.
 1. **Config/struct reshape:** move sig-validity to
    `default/dnskey/ds`; parse + resolve. `ttls.ds` → `ttls.parent-ds`
    rename + new `ttls.ds`. Drop per-keytype `SigValidity`. Update the
-   default policy + samples (new safe defaults).
+   default policy + samples (new safe defaults). **DONE** (2026-05-22)
 2. **`DnssecPolicyWarning` error type** in `enums.go` (non-impacting;
    reused later by plan #3's A.4).
 3. **Floor validation:** the universal config-load check with the

--- a/v2/cli/auto_rollover_validate.go
+++ b/v2/cli/auto_rollover_validate.go
@@ -57,7 +57,7 @@ the YAML's zones: block (when --zone matches a configured zone).
 
 DS_TTL handling: the runtime engine uses the parent's observed DS
 RRset TTL. validate doesn't have that observation, so it uses the
-ttls.ds policy override if set, OR --parent-ds-ttl <duration> if
+ttls.parent-ds policy override if set, OR --parent-ds-ttl <duration> if
 supplied. Without either, E10/E11 are skipped (and the report says
 so).`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -117,11 +117,11 @@ so).`,
 				}
 				dsTTL = d
 				dsTTLSrc = fmt.Sprintf("--parent-ds-ttl %s", parentDSTTL)
-			case pol.TTLS.DS > 0:
-				dsTTL = time.Duration(pol.TTLS.DS) * time.Second
-				dsTTLSrc = fmt.Sprintf("ttls.ds = %s (policy override)", dsTTL)
+			case pol.TTLS.ParentDS > 0:
+				dsTTL = time.Duration(pol.TTLS.ParentDS) * time.Second
+				dsTTLSrc = fmt.Sprintf("ttls.parent-ds = %s (policy override)", dsTTL)
 			default:
-				dsTTLSrc = "(unknown — no ttls.ds in policy and no --parent-ds-ttl supplied; E10/E11 skipped)"
+				dsTTLSrc = "(unknown — no ttls.parent-ds in policy and no --parent-ds-ttl supplied; E10/E11 skipped)"
 			}
 
 			renderValidateReport(cfgPath, z, polName, pol, dsTTL, dsTTLSrc)
@@ -130,7 +130,7 @@ so).`,
 	c.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone")
 	c.Flags().StringVar(&serverConfig, "serverconfig", "", "Read this YAML file instead of asking the daemon (offline)")
 	c.Flags().StringVar(&policyName, "policy", "", "Override the dnssecpolicy name to validate (offline mode only)")
-	c.Flags().StringVar(&parentDSTTL, "parent-ds-ttl", "", "Hypothetical DS RRset TTL (e.g. 1h) for E10/E11; overrides ttls.ds")
+	c.Flags().StringVar(&parentDSTTL, "parent-ds-ttl", "", "Hypothetical parent DS RRset TTL (e.g. 1h) for E10/E11; overrides ttls.parent-ds")
 	_ = c.MarkFlagRequired("zone")
 	return c
 }
@@ -209,15 +209,19 @@ func loadPolicyFromYAMLFile(path, zone, policyName string) (*tdns.DnssecPolicy, 
 func renderValidateReport(cfgPath, zone, policyName string, pol *tdns.DnssecPolicy, dsTTL time.Duration, dsTTLSrc string) {
 	fmt.Printf("Zone:    %s\n", zone)
 	fmt.Printf("Policy:  %s  (from %s)\n", policyName, cfgPath)
-	fmt.Printf("Method:  %s, num-ds: %d, ksk.lifetime: %s, ksk.sig-validity: %s\n",
+	fmt.Printf("Method:  %s, num-ds: %d, ksk.lifetime: %s\n",
 		rolloverMethodString(pol.Rollover.Method),
 		pol.Rollover.NumDS,
-		(time.Duration(pol.KSK.Lifetime) * time.Second).String(),
-		(time.Duration(pol.KSK.SigValidity) * time.Second).String())
+		(time.Duration(pol.KSK.Lifetime) * time.Second).String())
+	fmt.Printf("SigValidity: default=%s dnskey=%s ds=%s\n",
+		(time.Duration(pol.SigValidity.Default) * time.Second).String(),
+		(time.Duration(pol.SigValidity.DNSKEY) * time.Second).String(),
+		(time.Duration(pol.SigValidity.DS) * time.Second).String())
 	fmt.Printf("Clamping: enabled=%t margin=%s\n", pol.Clamping.Enabled, pol.Clamping.Margin)
-	fmt.Printf("TTLs:    dnskey=%ss max_served=%ss ds(override)=%ss\n",
+	fmt.Printf("TTLs:    dnskey=%ss max_served=%ss parent-ds(override)=%ss child-ds(fallback)=%ss\n",
 		fmt.Sprintf("%d", pol.TTLS.DNSKEY),
 		fmt.Sprintf("%d", pol.TTLS.MaxServed),
+		fmt.Sprintf("%d", pol.TTLS.ParentDS),
 		fmt.Sprintf("%d", pol.TTLS.DS))
 	fmt.Printf("Cadence: ds-publish-delay=%s scheme-pref=%s parent-cds-poll-estimate=%s standby-time=%s\n",
 		pol.Rollover.DsPublishDelay,

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -841,7 +841,7 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 			fmt.Printf("ZSK rollover state for zone %s  Current time: %s\n", s.Zone, currentTime)
 			currentTimePrinted = true
 		}
-		fmt.Println("  no rollovers ongoing (automated ZSK rollover not implemented)")
+		printZskRolloverSummary(s)
 		if len(s.ZSKs) > 0 {
 			fmt.Println()
 			printRolloverKeyTable(s.ZSKs, verbose, false)
@@ -855,12 +855,15 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 	// gives the message room to breathe.
 	printRolloverKeyErrors(s, showKSK, showZSK, verbose)
 
-	if verbose && s.Policy != nil && showKSK {
+	if verbose && s.Policy != nil && (showKSK || showZSK) {
 		fmt.Println()
 		fmt.Println("  policy:")
 		fmt.Printf("    name                         %s\n", s.Policy.Name)
 		fmt.Printf("    algorithm                    %s\n", s.Policy.Algorithm)
 		fmt.Printf("    ksk.lifetime                 %s\n", s.Policy.KskLifetime)
+		if s.Policy.ZskLifetime != "" {
+			fmt.Printf("    zsk.lifetime                 %s\n", s.Policy.ZskLifetime)
+		}
 		fmt.Printf("    rollover.ds-publish-delay    %s\n", s.Policy.DsPublishDelay)
 		fmt.Printf("    rollover.max-attempts        %d\n", s.Policy.MaxAttemptsBeforeBackoff)
 		fmt.Printf("    rollover.softfail-delay      %s\n", s.Policy.SoftfailDelay)
@@ -1206,21 +1209,90 @@ func printRolloverKeyTable(keys []tdns.RolloverKeyEntry, verbose bool, kskTable 
 				seqStr, keyidStr, k.State, pub, sinceStr, nextCol, expectedCol))
 		}
 	} else {
-		rows = append(rows, "keyid|state|published_at")
+		rows = append(rows, "keyid|state|active_at|next_roll")
 		for _, k := range keys {
-			pub := "-"
-			if k.Published != "" {
-				if t, err := time.Parse(time.RFC3339, k.Published); err == nil {
-					pub = formatTimeWithDelta(t)
-				}
-			}
-			rows = append(rows, fmt.Sprintf("%d|%s|%s", k.KeyID, k.State, pub))
+			at := formatStateSinceCol(k)
+			nextRoll := formatZskNextRollCol(k)
+			rows = append(rows, fmt.Sprintf("%d|%s|%s|%s", k.KeyID, k.State, at, nextRoll))
 		}
 	}
 	formatted := columnize.SimpleFormat(rows)
 	for _, line := range strings.Split(formatted, "\n") {
 		fmt.Printf("  %s\n", line)
 	}
+}
+
+func printZskRolloverSummary(s *tdns.RolloverStatus) {
+	if s.Policy == nil {
+		fmt.Println("  automated ZSK rollover: no policy attached")
+		return
+	}
+	lifetimeStr := s.Policy.ZskLifetime
+	if lifetimeStr == "" || lifetimeStr == "0s" {
+		fmt.Println("  automated ZSK rollover: disabled (zsk.lifetime not set)")
+		return
+	}
+	lifetime, err := time.ParseDuration(lifetimeStr)
+	if err != nil || lifetime <= 0 {
+		fmt.Printf("  automated ZSK rollover: zsk.lifetime %q invalid\n", lifetimeStr)
+		return
+	}
+
+	var activeKey *tdns.RolloverKeyEntry
+	standbyReady := false
+	for i := range s.ZSKs {
+		switch s.ZSKs[i].State {
+		case tdns.DnskeyStateActive:
+			if activeKey == nil {
+				activeKey = &s.ZSKs[i]
+			}
+		case tdns.DnskeyStateStandby:
+			standbyReady = true
+		}
+	}
+
+	fmt.Printf("  zsk.lifetime                 %s\n", lifetimeStr)
+	if activeKey == nil {
+		fmt.Println("  active ZSK                   none")
+	} else {
+		fmt.Printf("  active ZSK                   keyid %d\n", activeKey.KeyID)
+		if activeKey.StateSince != "" {
+			if t, err := time.Parse(time.RFC3339, activeKey.StateSince); err == nil {
+				fmt.Printf("  active_at                    %s\n", formatTimeWithDelta(t))
+				next := t.Add(lifetime)
+				fmt.Printf("  next roll (scheduled)        %s\n", formatTimeWithDelta(next))
+			} else {
+				fmt.Println("  active_at                    unknown")
+			}
+		} else {
+			fmt.Println("  active_at                    unknown (not stamped yet)")
+		}
+	}
+	if standbyReady {
+		fmt.Println("  standby ZSK                  ready")
+	} else {
+		fmt.Println("  standby ZSK                  not ready")
+	}
+}
+
+func formatStateSinceCol(k tdns.RolloverKeyEntry) string {
+	if k.StateSince == "" {
+		return "-"
+	}
+	if t, err := time.Parse(time.RFC3339, k.StateSince); err == nil {
+		return formatTimeWithDelta(t)
+	}
+	return "-"
+}
+
+func formatZskNextRollCol(k tdns.RolloverKeyEntry) string {
+	if k.State != tdns.DnskeyStateActive || k.NextTransitionAt == "" {
+		return "-"
+	}
+	if t, err := time.Parse(time.RFC3339, k.NextTransitionAt); err == nil {
+		return formatTimeWithDelta(t)
+	}
+	return "-"
 }
 
 // headlinePhraseFor returns the phrase appended after the headline

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -201,7 +201,7 @@ Use --dry-run to print the DS set and the UPDATE without sending.`,
 			// documented above.
 
 			if dryRun {
-				dsSet, low, high, idxOK, err := tdns.ComputeTargetDSSetForZone(kdb, z, uint8(dns.SHA256))
+				dsSet, low, high, idxOK, err := tdns.ComputeTargetDSSetForZone(kdb, z, uint8(dns.SHA256), nil)
 				if err != nil {
 					log.Fatalf("compute DS: %v", err)
 				}
@@ -304,7 +304,7 @@ or 2s / 60s / 1h when those are unset.
 				log.Fatal("parent-agent not set: configure rollover.parent-agent on the dnssec policy or pass --parent-agent host:port")
 			}
 
-			expected, _, _, _, err := tdns.ComputeTargetDSSetForZone(kdb, z, uint8(dns.SHA256))
+			expected, _, _, _, err := tdns.ComputeTargetDSSetForZone(kdb, z, uint8(dns.SHA256), pol)
 			if err != nil {
 				log.Fatalf("compute expected DS: %v", err)
 			}

--- a/v2/config.go
+++ b/v2/config.go
@@ -655,6 +655,20 @@ type InternalConf struct {
 // AuditResponseMsg, StatusUpdateMsg) live in tdns-mp/v2/config.go.
 // They are MP-only and were removed from tdns during the tdns-mp
 // extraction.
+const defaultKaspPropagationDelay = time.Hour
+
+// KaspPropagationDelay returns the configured kasp.propagation_delay, or 1h.
+func (conf *Config) KaspPropagationDelay() time.Duration {
+	if conf == nil || conf.Kasp.PropagationDelay == "" {
+		return defaultKaspPropagationDelay
+	}
+	d, err := time.ParseDuration(conf.Kasp.PropagationDelay)
+	if err != nil || d <= 0 {
+		return defaultKaspPropagationDelay
+	}
+	return d
+}
+
 func (conf *Config) ReloadConfig() (string, error) {
 	confMu.Lock()
 	defer confMu.Unlock()

--- a/v2/config.go
+++ b/v2/config.go
@@ -657,6 +657,21 @@ type InternalConf struct {
 // extraction.
 const defaultKaspPropagationDelay = time.Hour
 
+// validateKaspPropagationDelay rejects invalid kasp.propagation_delay at config load.
+func validateKaspPropagationDelay(s string) error {
+	if s == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("kasp.propagation_delay: invalid duration %q: %w", s, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("kasp.propagation_delay: must be positive, got %s", d)
+	}
+	return nil
+}
+
 // KaspPropagationDelay returns the configured kasp.propagation_delay, or 1h.
 func (conf *Config) KaspPropagationDelay() time.Duration {
 	if conf == nil || conf.Kasp.PropagationDelay == "" {
@@ -664,6 +679,13 @@ func (conf *Config) KaspPropagationDelay() time.Duration {
 	}
 	d, err := time.ParseDuration(conf.Kasp.PropagationDelay)
 	if err != nil || d <= 0 {
+		if err != nil {
+			lgConfig.Warn("invalid kasp.propagation_delay, using default",
+				"value", conf.Kasp.PropagationDelay, "default", defaultKaspPropagationDelay, "err", err)
+		} else {
+			lgConfig.Warn("kasp.propagation_delay must be positive, using default",
+				"value", conf.Kasp.PropagationDelay, "default", defaultKaspPropagationDelay)
+		}
 		return defaultKaspPropagationDelay
 	}
 	return d

--- a/v2/db_schema.go
+++ b/v2/db_schema.go
@@ -77,6 +77,7 @@ privatekey	  TEXT,
 keyrr		  TEXT,
 comment		  TEXT,
 published_at              TEXT DEFAULT '',
+active_at                 TEXT DEFAULT '',
 retired_at                TEXT DEFAULT '',
 UNIQUE (zonename, keyid)
 )`,

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -295,9 +295,9 @@ var errorTypeReportOrder = []ErrorType{
 	RefreshError,
 	AgentError,
 	DnssecError,
-	DnssecPolicyWarning,
 	RolloverPolicyViolation,
 	RolloverParentBlocker,
+	DnssecPolicyWarning,
 	RolloverPolicyWarning,
 }
 

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -247,6 +247,9 @@ const (
 	RefreshError
 	AgentError
 	DnssecError
+	// DnssecPolicyWarning: sig-validity floor headroom warning (2×H <
+	// validity < 4×H). Zone keeps signing; visibility-only.
+	DnssecPolicyWarning
 	// RolloverPolicyViolation: hard cache-flush invariant violation
 	// (E5/E10) detected from policy + observed parent state. The
 	// rollover engine refuses to advance keys for the affected zone:
@@ -276,6 +279,7 @@ var ErrorTypeToString = map[ErrorType]string{
 	RefreshError:            "refresh",
 	AgentError:              "agent",
 	DnssecError:             "DNSSEC",
+	DnssecPolicyWarning:     "dnssec-policy-warning",
 	RolloverPolicyViolation: "rollover-policy",
 	RolloverPolicyWarning:   "rollover-policy-warning",
 	RolloverParentBlocker:   "rollover-parent-blocker",
@@ -291,6 +295,7 @@ var errorTypeReportOrder = []ErrorType{
 	RefreshError,
 	AgentError,
 	DnssecError,
+	DnssecPolicyWarning,
 	RolloverPolicyViolation,
 	RolloverParentBlocker,
 	RolloverPolicyWarning,

--- a/v2/key_state_worker.go
+++ b/v2/key_state_worker.go
@@ -117,6 +117,8 @@ func checkAndTransitionKeys(ctx context.Context, conf *Config, kdb *KeyDB, propa
 
 	transitionPublishedToStandby(conf, kdb, now, propagationDelay)
 
+	rolloverZsksForAllZones(ctx, conf, kdb, propagationDelay, now)
+
 	transitionRetiredToRemoved(conf, kdb, now, propagationDelay)
 
 	maintainStandbyKeys(conf, kdb, standbyZskCount, standbyKskCount)
@@ -204,8 +206,18 @@ func transitionRetiredToRemoved(conf *Config, kdb *KeyDB, now time.Time, propaga
 			continue
 		}
 
+		margin := propagationDelay
+		if key.Flags&dns.SEP == 0 {
+			maxTTL, err := LoadZoneSigningMaxTTL(kdb, key.ZoneName)
+			if err != nil {
+				lgSigner.Warn("KeyStateWorker: LoadZoneSigningMaxTTL failed, using propagation_delay only", "zone", key.ZoneName, "err", err)
+			} else {
+				margin = zskRemovalMargin(propagationDelay, maxTTL)
+			}
+		}
+
 		elapsed := now.Sub(*key.RetiredAt)
-		if elapsed < propagationDelay {
+		if elapsed < margin {
 			continue
 		}
 

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -958,8 +958,14 @@ func (kdb *KeyDB) PromoteDnssecKey(zonename string, keyid uint16, oldstate, news
 		return fmt.Errorf("key with keyid %d in zone %s is not in state %s", keyid, zonename, oldstate)
 	}
 
-	// Update the state in the DnssecKeyStore table
-	res, err := tx.Exec(updateDnskeyStateSql, newstate, zonename, keyid, oldstate)
+	now := time.Now().UTC().Format(time.RFC3339)
+	var res sql.Result
+	if newstate == DnskeyStateActive {
+		res, err = tx.Exec(`UPDATE DnssecKeyStore SET state=?, active_at=? WHERE zonename=? AND keyid=? AND state=?`,
+			newstate, now, zonename, keyid, oldstate)
+	} else {
+		res, err = tx.Exec(updateDnskeyStateSql, newstate, zonename, keyid, oldstate)
+	}
 	if err != nil {
 		return fmt.Errorf("error updating DnssecKeyStore: %v", err)
 	}
@@ -972,7 +978,6 @@ func (kdb *KeyDB) PromoteDnssecKey(zonename string, keyid uint16, oldstate, news
 		return fmt.Errorf("no rows updated, key with keyid %d in zone %s might not be in state %s", keyid, zonename, oldstate)
 	}
 
-	// Delete cached data for both old and new states
 	delete(kdb.KeystoreDnskeyCache, zonename+"+"+oldstate)
 	delete(kdb.KeystoreDnskeyCache, zonename+"+"+newstate)
 
@@ -1059,6 +1064,7 @@ type DnssecKeyWithTimestamps struct {
 	State       string
 	KeyRR       string
 	PublishedAt *time.Time
+	ActiveAt    *time.Time
 	RetiredAt   *time.Time
 }
 
@@ -1069,10 +1075,10 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 	var args []interface{}
 
 	if zone == "" {
-		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(retired_at, '') FROM DnssecKeyStore WHERE state=?`
+		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, '') FROM DnssecKeyStore WHERE state=?`
 		args = []interface{}{state}
 	} else {
-		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(retired_at, '') FROM DnssecKeyStore WHERE zonename=? AND state=?`
+		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, '') FROM DnssecKeyStore WHERE zonename=? AND state=?`
 		args = []interface{}{zone, state}
 	}
 
@@ -1084,9 +1090,9 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 
 	var entries []DnssecKeyWithTimestamps
 	for rows.Next() {
-		var zonename, algorithm, st, keyrr, publishedAtStr, retiredAtStr string
+		var zonename, algorithm, st, keyrr, publishedAtStr, activeAtStr, retiredAtStr string
 		var keyid, flags int
-		if err := rows.Scan(&zonename, &keyid, &flags, &algorithm, &st, &keyrr, &publishedAtStr, &retiredAtStr); err != nil {
+		if err := rows.Scan(&zonename, &keyid, &flags, &algorithm, &st, &keyrr, &publishedAtStr, &activeAtStr, &retiredAtStr); err != nil {
 			return nil, fmt.Errorf("GetDnssecKeysByState: scan failed: %w", err)
 		}
 
@@ -1107,6 +1113,11 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 		if publishedAtStr != "" {
 			if t, err := time.Parse(time.RFC3339, publishedAtStr); err == nil {
 				entry.PublishedAt = &t
+			}
+		}
+		if activeAtStr != "" {
+			if t, err := time.Parse(time.RFC3339, activeAtStr); err == nil {
+				entry.ActiveAt = &t
 			}
 		}
 		if retiredAtStr != "" {
@@ -1166,6 +1177,9 @@ func UpdateDnssecKeyStateTx(tx *Tx, kdb *KeyDB, zonename string, keyid uint16, n
 	switch newstate {
 	case DnskeyStatePublished:
 		res, err = tx.Exec(`UPDATE DnssecKeyStore SET state=?, published_at=? WHERE zonename=? AND keyid=?`,
+			newstate, now, zonename, keyid)
+	case DnskeyStateActive:
+		res, err = tx.Exec(`UPDATE DnssecKeyStore SET state=?, active_at=? WHERE zonename=? AND keyid=?`,
 			newstate, now, zonename, keyid)
 	case DnskeyStateRetired:
 		res, err = tx.Exec(`UPDATE DnssecKeyStore SET state=?, retired_at=? WHERE zonename=? AND keyid=?`,
@@ -1265,8 +1279,8 @@ func (kdb *KeyDB) RolloverKey(zonename string, keytype string, tx *Tx) (uint16, 
 	}()
 
 	// standby → active
-	_, txErr = tx.Exec(`UPDATE DnssecKeyStore SET state=? WHERE zonename=? AND keyid=?`,
-		DnskeyStateActive, zonename, standbyKey.KeyTag)
+	_, txErr = tx.Exec(`UPDATE DnssecKeyStore SET state=?, active_at=? WHERE zonename=? AND keyid=?`,
+		DnskeyStateActive, now, zonename, standbyKey.KeyTag)
 	if txErr != nil {
 		return 0, 0, fmt.Errorf("standby→active transition failed: %w", txErr)
 	}

--- a/v2/ksk_rollover_automated.go
+++ b/v2/ksk_rollover_automated.go
@@ -247,7 +247,7 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 		// push phase if the target DS RRset differs from what we have
 		// submitted. Arming is the single advance on this tick — the
 		// actual push happens on the next tick under pending-parent-push.
-		ds, low, high, idxOK, err := ComputeTargetDSSetForZone(kdb, zone, uint8(dns.SHA256))
+		ds, low, high, idxOK, err := ComputeTargetDSSetForZone(kdb, zone, uint8(dns.SHA256), pol)
 		if err != nil {
 			return err
 		}
@@ -331,7 +331,7 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 			lgSigner.Warn("rollover: parent-agent unset, cannot observe", "zone", zone)
 			return nil
 		}
-		expected, low, high, idxOK, err := ComputeTargetDSSetForZone(kdb, zone, uint8(dns.SHA256))
+		expected, low, high, idxOK, err := ComputeTargetDSSetForZone(kdb, zone, uint8(dns.SHA256), pol)
 		if err != nil {
 			return err
 		}
@@ -439,7 +439,7 @@ func RolloverAutomatedTick(ctx context.Context, deps RolloverEngineDeps) error {
 		//      shared parent). Probe failures keep the engine in this
 		//      phase; we do NOT enter pending-parent-push as a fresh
 		//      attempt group.
-		expected, low, high, idxOK, err := ComputeTargetDSSetForZone(kdb, zone, uint8(dns.SHA256))
+		expected, low, high, idxOK, err := ComputeTargetDSSetForZone(kdb, zone, uint8(dns.SHA256), pol)
 		if err != nil {
 			return err
 		}

--- a/v2/ksk_rollover_ds_push.go
+++ b/v2/ksk_rollover_ds_push.go
@@ -150,7 +150,7 @@ ORDER BY COALESCE(r.rollover_index, 2147483646) ASC, k.keyid ASC`
 // dsSetFromSnapshot derives DS RRset from a precomputed key-row
 // snapshot. Used by W5 to ensure UPDATE and NOTIFY paths describe
 // identical sets in auto-mode parallel dispatch.
-func dsSetFromSnapshot(snap *RolloverTargetKeySnapshot, childZone string, digest uint8) ([]dns.RR, int, int, bool, error) {
+func dsSetFromSnapshot(snap *RolloverTargetKeySnapshot, childZone string, digest uint8, pol *DnssecPolicy) ([]dns.RR, int, int, bool, error) {
 	childZone = dns.Fqdn(childZone)
 	out := make([]dns.RR, 0, len(snap.Rows))
 	for _, row := range snap.Rows {
@@ -167,14 +167,7 @@ func dsSetFromSnapshot(snap *RolloverTargetKeySnapshot, childZone string, digest
 			return nil, 0, 0, false, fmt.Errorf("dsSetFromSnapshot: ToDS failed for keyid %d", row.keyid)
 		}
 		ds.Hdr.Name = childZone
-		// Match ComputeTargetDSSetForZone's TTL fixup: when the parsed
-		// DNSKEY had no TTL (or ToDS produced a TTL=0 header), use the
-		// 3600s legacy default. Without this the snapshot path emitted
-		// TTL=0 DS records while the non-snapshot path emitted 3600,
-		// defeating W5's "same set on both paths" guarantee.
-		if ds.Hdr.Ttl == 0 {
-			ds.Hdr.Ttl = 3600
-		}
+		applyChildDSFallbackTTL(&ds.Hdr, pol)
 		out = append(out, ds)
 	}
 	return out, snap.IndexLow, snap.IndexHigh, snap.IndexRangeKnown, nil
@@ -209,7 +202,7 @@ func cdsSetFromSnapshot(snap *RolloverTargetKeySnapshot, childZone string) ([]dn
 	return out, snap.IndexLow, snap.IndexHigh, snap.IndexRangeKnown, nil
 }
 
-func ComputeTargetDSSetForZone(kdb *KeyDB, childZone string, digest uint8) (ds []dns.RR, indexLow, indexHigh int, indexRangeKnown bool, err error) {
+func ComputeTargetDSSetForZone(kdb *KeyDB, childZone string, digest uint8, pol *DnssecPolicy) (ds []dns.RR, indexLow, indexHigh int, indexRangeKnown bool, err error) {
 	childZone = dns.Fqdn(childZone)
 	rows, low, high, idxOK, err := loadTargetKSKsForRollover(kdb, childZone)
 	if err != nil {
@@ -229,9 +222,7 @@ func ComputeTargetDSSetForZone(kdb *KeyDB, childZone string, digest uint8) (ds [
 			return nil, 0, 0, false, fmt.Errorf("ComputeTargetDSSetForZone: ToDS failed for keyid %d", row.keyid)
 		}
 		dsRR.Hdr.Name = childZone
-		if dsRR.Hdr.Ttl == 0 {
-			dsRR.Hdr.Ttl = 3600
-		}
+		applyChildDSFallbackTTL(&dsRR.Hdr, pol)
 		ds = append(ds, dsRR)
 	}
 	return ds, low, high, idxOK, nil
@@ -539,9 +530,9 @@ func pushDSRRsetViaUpdate(ctx context.Context, deps RolloverEngineDeps) (KSKDSPu
 		err   error
 	)
 	if deps.TargetKeySnapshot != nil {
-		dsSet, low, high, idxOK, err = dsSetFromSnapshot(deps.TargetKeySnapshot, child, uint8(dns.SHA256))
+		dsSet, low, high, idxOK, err = dsSetFromSnapshot(deps.TargetKeySnapshot, child, uint8(dns.SHA256), deps.Policy)
 	} else {
-		dsSet, low, high, idxOK, err = ComputeTargetDSSetForZone(kdb, child, uint8(dns.SHA256))
+		dsSet, low, high, idxOK, err = ComputeTargetDSSetForZone(kdb, child, uint8(dns.SHA256), deps.Policy)
 	}
 	if err != nil {
 		out.Category = SoftfailChildConfigLocalError

--- a/v2/ksk_rollover_policy.go
+++ b/v2/ksk_rollover_policy.go
@@ -242,6 +242,17 @@ func FinishDnssecPolicy(policyName string, conf *DnssecPolicyConf, out *DnssecPo
 		out.Clamping.Margin = 0
 	}
 
+	if s := strings.TrimSpace(conf.Ttls.ParentDS); s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("dnssec policy %q: ttls.parent-ds: %w", policyName, err)
+		}
+		if d < 0 {
+			return fmt.Errorf("dnssec policy %q: ttls.parent-ds must be non-negative", policyName)
+		}
+		out.TTLS.ParentDS = uint32(d.Seconds())
+	}
+
 	if s := strings.TrimSpace(conf.Ttls.DS); s != "" {
 		d, err := time.ParseDuration(s)
 		if err != nil {
@@ -252,6 +263,12 @@ func FinishDnssecPolicy(policyName string, conf *DnssecPolicyConf, out *DnssecPo
 		}
 		out.TTLS.DS = uint32(d.Seconds())
 	}
+
+	sv, err := parsePolicySigValidity(policyName, conf.SigValidity)
+	if err != nil {
+		return err
+	}
+	out.SigValidity = sv
 
 	// max_served must be parsed AFTER clamping so the cross-check against
 	// clamping.margin sees the resolved margin value.
@@ -283,6 +300,61 @@ func FinishDnssecPolicy(policyName string, conf *DnssecPolicyConf, out *DnssecPo
 
 	warnDnssecPolicyCoupling(policyName, out)
 	return nil
+}
+
+func parsePolicySigValidity(policyName string, conf DnssecPolicySigValidityConf) (PolicySigValidity, error) {
+	defaultStr := strings.TrimSpace(conf.Default)
+	if defaultStr == "" {
+		return PolicySigValidity{}, fmt.Errorf("dnssec policy %q: sigvalidity.default is required", policyName)
+	}
+	defaultDur, err := time.ParseDuration(defaultStr)
+	if err != nil {
+		return PolicySigValidity{}, fmt.Errorf("dnssec policy %q: sigvalidity.default: %w", policyName, err)
+	}
+	if defaultDur <= 0 {
+		return PolicySigValidity{}, fmt.Errorf("dnssec policy %q: sigvalidity.default must be positive", policyName)
+	}
+	out := PolicySigValidity{Default: uint32(defaultDur.Seconds())}
+
+	dnskeyStr := strings.TrimSpace(conf.Dnskey)
+	if dnskeyStr == "" {
+		out.DNSKEY = out.Default
+	} else {
+		d, err := time.ParseDuration(dnskeyStr)
+		if err != nil {
+			return PolicySigValidity{}, fmt.Errorf("dnssec policy %q: sigvalidity.dnskey: %w", policyName, err)
+		}
+		if d <= 0 {
+			return PolicySigValidity{}, fmt.Errorf("dnssec policy %q: sigvalidity.dnskey must be positive", policyName)
+		}
+		out.DNSKEY = uint32(d.Seconds())
+	}
+
+	dsStr := strings.TrimSpace(conf.Ds)
+	if dsStr == "" {
+		out.DS = out.Default
+	} else {
+		d, err := time.ParseDuration(dsStr)
+		if err != nil {
+			return PolicySigValidity{}, fmt.Errorf("dnssec policy %q: sigvalidity.ds: %w", policyName, err)
+		}
+		if d <= 0 {
+			return PolicySigValidity{}, fmt.Errorf("dnssec policy %q: sigvalidity.ds must be positive", policyName)
+		}
+		out.DS = uint32(d.Seconds())
+	}
+	return out, nil
+}
+
+// applyChildDSFallbackTTL sets hdr.Ttl from policy ttls.ds when the child
+// has not expressed a TTL (zero header). Child-driven TTLs are never changed.
+func applyChildDSFallbackTTL(hdr *dns.RR_Header, pol *DnssecPolicy) {
+	if hdr == nil || hdr.Ttl != 0 || pol == nil {
+		return
+	}
+	if pol.TTLS.DS > 0 {
+		hdr.Ttl = pol.TTLS.DS
+	}
 }
 
 func parseRolloverMethod(s string) (RolloverMethod, error) {
@@ -485,9 +557,9 @@ func parseDnssecPolicyConfImpl(name string, dp *DnssecPolicyConf, quiet bool) (*
 	out := &DnssecPolicy{
 		Name:      name,
 		Algorithm: alg,
-		KSK:       GenKeyLifetime(dp.KSK.Lifetime, dp.KSK.SigValidity),
-		ZSK:       GenKeyLifetime(dp.ZSK.Lifetime, dp.ZSK.SigValidity),
-		CSK:       GenKeyLifetime(dp.CSK.Lifetime, dp.CSK.SigValidity),
+		KSK:       GenKeyLifetime(dp.KSK.Lifetime),
+		ZSK:       GenKeyLifetime(dp.ZSK.Lifetime),
+		CSK:       GenKeyLifetime(dp.CSK.Lifetime),
 	}
 	if quiet {
 		// Mark the policy so FinishDnssecPolicy / warnDnssecPolicyCoupling
@@ -528,9 +600,9 @@ func ValidateDnssecPoliciesFromFile(path string) error {
 		tmp := DnssecPolicy{
 			Name:      name,
 			Algorithm: alg,
-			KSK:       GenKeyLifetime(dp.KSK.Lifetime, dp.KSK.SigValidity),
-			ZSK:       GenKeyLifetime(dp.ZSK.Lifetime, dp.ZSK.SigValidity),
-			CSK:       GenKeyLifetime(dp.CSK.Lifetime, dp.CSK.SigValidity),
+			KSK:       GenKeyLifetime(dp.KSK.Lifetime),
+			ZSK:       GenKeyLifetime(dp.ZSK.Lifetime),
+			CSK:       GenKeyLifetime(dp.CSK.Lifetime),
 		}
 		if err := FinishDnssecPolicy(name, &dp, &tmp); err != nil {
 			errs = append(errs, err)

--- a/v2/ksk_rollover_policy.go
+++ b/v2/ksk_rollover_policy.go
@@ -554,12 +554,24 @@ func parseDnssecPolicyConfImpl(name string, dp *DnssecPolicyConf, quiet bool) (*
 	if alg == 0 {
 		return nil, fmt.Errorf("policy %q: unknown algorithm %q", name, dp.Algorithm)
 	}
+	kskLT, err := GenKeyLifetime(dp.KSK.Lifetime)
+	if err != nil {
+		return nil, fmt.Errorf("policy %q: %w", name, err)
+	}
+	zskLT, err := GenKeyLifetime(dp.ZSK.Lifetime)
+	if err != nil {
+		return nil, fmt.Errorf("policy %q: %w", name, err)
+	}
+	cskLT, err := GenKeyLifetime(dp.CSK.Lifetime)
+	if err != nil {
+		return nil, fmt.Errorf("policy %q: %w", name, err)
+	}
 	out := &DnssecPolicy{
 		Name:      name,
 		Algorithm: alg,
-		KSK:       GenKeyLifetime(dp.KSK.Lifetime),
-		ZSK:       GenKeyLifetime(dp.ZSK.Lifetime),
-		CSK:       GenKeyLifetime(dp.CSK.Lifetime),
+		KSK:       kskLT,
+		ZSK:       zskLT,
+		CSK:       cskLT,
 	}
 	if quiet {
 		// Mark the policy so FinishDnssecPolicy / warnDnssecPolicyCoupling
@@ -597,12 +609,27 @@ func ValidateDnssecPoliciesFromFile(path string) error {
 			errs = append(errs, fmt.Errorf("policy %q: unknown algorithm %q", name, dp.Algorithm))
 			continue
 		}
+		kskLT, err := GenKeyLifetime(dp.KSK.Lifetime)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("policy %q: %w", name, err))
+			continue
+		}
+		zskLT, err := GenKeyLifetime(dp.ZSK.Lifetime)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("policy %q: %w", name, err))
+			continue
+		}
+		cskLT, err := GenKeyLifetime(dp.CSK.Lifetime)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("policy %q: %w", name, err))
+			continue
+		}
 		tmp := DnssecPolicy{
 			Name:      name,
 			Algorithm: alg,
-			KSK:       GenKeyLifetime(dp.KSK.Lifetime),
-			ZSK:       GenKeyLifetime(dp.ZSK.Lifetime),
-			CSK:       GenKeyLifetime(dp.CSK.Lifetime),
+			KSK:       kskLT,
+			ZSK:       zskLT,
+			CSK:       cskLT,
 		}
 		if err := FinishDnssecPolicy(name, &dp, &tmp); err != nil {
 			errs = append(errs, err)

--- a/v2/ksk_rollover_standby_time_test.go
+++ b/v2/ksk_rollover_standby_time_test.go
@@ -124,11 +124,9 @@ func TestStandbyTimePolicyParse(t *testing.T) {
 				Algorithm: "ECDSAP256SHA256",
 			}
 			conf.KSK.Lifetime = "10m"
-			conf.KSK.SigValidity = "20m"
 			conf.ZSK.Lifetime = "10m"
-			conf.ZSK.SigValidity = "20m"
 			conf.CSK.Lifetime = "10m"
-			conf.CSK.SigValidity = "20m"
+			conf.SigValidity.Default = "20m"
 			conf.Rollover.Method = "multi-ds"
 			conf.Rollover.NumDS = 3
 			conf.Rollover.ParentAgent = "127.0.0.1:53"

--- a/v2/ksk_rollover_validation.go
+++ b/v2/ksk_rollover_validation.go
@@ -17,14 +17,14 @@ import (
 //
 // Inputs the function reads:
 //
-//   - pol.KSK.Lifetime, KSK.SigValidity
+//   - pol.KSK.Lifetime, SigValidity.DNSKEY
 //   - pol.Rollover.NumDS
 //   - pol.Rollover.DsPublishDelay (proxy for parent_prop, per §4.9)
 //   - pol.Clamping.{Enabled, Margin}
 //   - pol.TTLS.{DNSKEY, MaxServed, DS}
 //   - zd.ParentDSTTLObserved
 //
-// Behaviour when DS_TTL is not yet known (pol.TTLS.DS == 0 AND
+// Behaviour when DS_TTL is not yet known (pol.TTLS.ParentDS == 0 AND
 // zd.ParentDSTTLObserved == 0): E10/E11 are deferred (no error
 // raised, but no clearance either if E10/E11 were the active
 // condition). E5 is checked unconditionally — it does not depend on
@@ -44,7 +44,7 @@ func EvaluateRolloverPolicyInvariants(zd *ZoneData, pol *DnssecPolicy) {
 	//
 	// E5 is config-only (no DS_TTL needed); E10/E11 require a
 	// resolved DS_TTL. When DS_TTL is unknown (parent unreachable
-	// at zone init, no ttls.ds override, no prior observation),
+	// at zone init, no ttls.parent-ds override, no prior observation),
 	// we can only freshly evaluate E5 — so we must NOT clobber any
 	// prior E10/E11 state. Strategy:
 	//
@@ -98,13 +98,13 @@ func EvaluateRolloverPolicyInvariants(zd *ZoneData, pol *DnssecPolicy) {
 }
 
 // resolveDSTTL returns the DS TTL the engine should use for E10/E11.
-// Override (pol.TTLS.DS) wins over observation (zd.ParentDSTTLObserved)
+// Override (pol.TTLS.ParentDS) wins over observation (zd.ParentDSTTLObserved)
 // when both are set: the operator may have explicit knowledge that the
 // observation doesn't capture (e.g., parent's DS RRset cached behind
 // a CDN with a shorter TTL than the authoritative answer).
 func resolveDSTTL(zd *ZoneData, pol *DnssecPolicy) (time.Duration, bool) {
-	if pol.TTLS.DS > 0 {
-		return time.Duration(pol.TTLS.DS) * time.Second, true
+	if pol.TTLS.ParentDS > 0 {
+		return time.Duration(pol.TTLS.ParentDS) * time.Second, true
 	}
 	if zd != nil && zd.ParentDSTTLObserved > 0 {
 		return time.Duration(zd.ParentDSTTLObserved) * time.Second, true
@@ -131,7 +131,7 @@ func CheckE5(pol *DnssecPolicy) InvariantResult                       { return c
 func CheckE10(pol *DnssecPolicy, dsTTL time.Duration) InvariantResult { return checkE10(pol, dsTTL) }
 func CheckE11(pol *DnssecPolicy, dsTTL time.Duration) InvariantResult { return checkE11(pol, dsTTL) }
 
-// checkE5: retirement_period ≥ min(DNSKEY_TTL, KSK.SigValidity), per
+// checkE5: retirement_period ≥ min(DNSKEY_TTL, SigValidity.DNSKEY), per
 // spec §4.5.1. DNSKEY_TTL here is the **served** TTL (E13 form,
 // min(ttls.dnskey, ttls.max_served)), NOT the operator-configured
 // ttls.dnskey alone — validators can only cache DNSKEY for as long
@@ -156,7 +156,7 @@ func checkE5(pol *DnssecPolicy) InvariantResult {
 		return InvariantResult{}
 	}
 	dnskeyTTL := configuredServedDnskeyTTL(pol)
-	sigVal := time.Duration(pol.KSK.SigValidity) * time.Second
+	sigVal := time.Duration(pol.SigValidity.DNSKEY) * time.Second
 	if dnskeyTTL == 0 && sigVal == 0 {
 		return InvariantResult{}
 	}
@@ -245,7 +245,7 @@ func checkE10(pol *DnssecPolicy, dsTTL time.Duration) InvariantResult {
 			"(%s = %s + %s + %s + %s); parent DS replacement too late before next rollover",
 			available, n-1, kskLifetime,
 			required, retirement, parentProp, dsTTL, standbyTime),
-		Suggestion: fmt.Sprintf("Raise rollover.num-ds to ≥ %d, OR raise ksk.lifetime, OR lower clamping.margin/rollover.ds-publish-delay/ttls.ds/rollover.standby-time.",
+		Suggestion: fmt.Sprintf("Raise rollover.num-ds to ≥ %d, OR raise ksk.lifetime, OR lower clamping.margin/rollover.ds-publish-delay/ttls.parent-ds/rollover.standby-time.",
 			requiredN),
 	}
 }

--- a/v2/ksk_rollover_validation.go
+++ b/v2/ksk_rollover_validation.go
@@ -168,10 +168,10 @@ func checkE5(pol *DnssecPolicy) InvariantResult {
 		return InvariantResult{}
 	}
 	return InvariantResult{
-		Message: fmt.Sprintf("E5: clamping.margin (%s) < min(served DNSKEY_TTL, ksk.sig-validity) (%s); "+
+		Message: fmt.Sprintf("E5: clamping.margin (%s) < min(served DNSKEY_TTL, sigvalidity.dnskey) (%s); "+
 			"retirement period too short to flush DNSKEY/RRSIG caches before next rollover",
 			pol.Clamping.Margin, floor),
-		Suggestion: fmt.Sprintf("Raise clamping.margin to ≥ %s, OR lower min(ttls.dnskey, ttls.max_served) and/or ksk.sig-validity so their min is ≤ %s.",
+		Suggestion: fmt.Sprintf("Raise clamping.margin to ≥ %s, OR lower min(ttls.dnskey, ttls.max_served) and/or sigvalidity.dnskey so their min is ≤ %s.",
 			floor, pol.Clamping.Margin),
 	}
 }
@@ -431,6 +431,7 @@ func UpdateSigValidityFloor(zd *ZoneData, pol *DnssecPolicy, propagationDelay ti
 	if runtime {
 		if maxObservedTTL == 0 {
 			zd.ClearError(DnssecPolicyWarning)
+			zd.ClearError(DnssecError)
 			return
 		}
 		served := time.Duration(maxObservedTTL) * time.Second

--- a/v2/ksk_rollover_validation.go
+++ b/v2/ksk_rollover_validation.go
@@ -372,3 +372,120 @@ func minDSTTL(rrs []dns.RR) uint32 {
 	}
 	return min
 }
+
+type sigValidityFloorBand int
+
+const (
+	sigValidityFloorOK sigValidityFloorBand = iota
+	sigValidityFloorWarning
+	sigValidityFloorError
+)
+
+func checkSigValidityFloorBand(validity, servedTTL, propagationDelay time.Duration) sigValidityFloorBand {
+	if servedTTL == 0 {
+		return sigValidityFloorOK
+	}
+	if validity == 0 {
+		return sigValidityFloorError
+	}
+	h := servedTTL + propagationDelay
+	if validity <= 2*h {
+		return sigValidityFloorError
+	}
+	if validity < 4*h {
+		return sigValidityFloorWarning
+	}
+	return sigValidityFloorOK
+}
+
+func configuredServedTTLForSigValidity(pol *DnssecPolicy, which string) time.Duration {
+	switch which {
+	case "dnskey":
+		return configuredServedDnskeyTTL(pol)
+	case "ds":
+		if pol.TTLS.DS == 0 {
+			return 0
+		}
+		return time.Duration(pol.TTLS.DS) * time.Second
+	default:
+		if pol.TTLS.MaxServed == 0 {
+			return 0
+		}
+		return time.Duration(pol.TTLS.MaxServed) * time.Second
+	}
+}
+
+// UpdateSigValidityFloor applies config-load or runtime sig-validity floor
+// checks and sets/clears DnssecError / DnssecPolicyWarning on zd.
+// When runtime is true, maxObservedTTL is the bound for all three values.
+func UpdateSigValidityFloor(zd *ZoneData, pol *DnssecPolicy, propagationDelay time.Duration, maxObservedTTL uint32, runtime bool) {
+	if zd == nil || pol == nil {
+		return
+	}
+	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+		return
+	}
+
+	var hardMsgs, warnMsgs []string
+
+	if runtime {
+		if maxObservedTTL == 0 {
+			zd.ClearError(DnssecPolicyWarning)
+			return
+		}
+		served := time.Duration(maxObservedTTL) * time.Second
+		for _, spec := range []struct {
+			label string
+			secs  uint32
+		}{
+			{"sigvalidity.default", pol.SigValidity.Default},
+			{"sigvalidity.dnskey", pol.SigValidity.DNSKEY},
+			{"sigvalidity.ds", pol.SigValidity.DS},
+		} {
+			validity := time.Duration(spec.secs) * time.Second
+			switch checkSigValidityFloorBand(validity, served, propagationDelay) {
+			case sigValidityFloorError:
+				hardMsgs = append(hardMsgs, fmt.Sprintf("%s (%s) ≤ 2×(servedTTL+propagationDelay) with servedTTL=%s",
+					spec.label, validity, served))
+			case sigValidityFloorWarning:
+				warnMsgs = append(warnMsgs, fmt.Sprintf("%s (%s) < 4×(servedTTL+propagationDelay) with servedTTL=%s",
+					spec.label, validity, served))
+			}
+		}
+	} else {
+		for _, spec := range []struct {
+			label    string
+			secs     uint32
+			whichTTL string
+		}{
+			{"sigvalidity.default", pol.SigValidity.Default, "default"},
+			{"sigvalidity.dnskey", pol.SigValidity.DNSKEY, "dnskey"},
+			{"sigvalidity.ds", pol.SigValidity.DS, "ds"},
+		} {
+			served := configuredServedTTLForSigValidity(pol, spec.whichTTL)
+			validity := time.Duration(spec.secs) * time.Second
+			if served == 0 {
+				continue
+			}
+			switch checkSigValidityFloorBand(validity, served, propagationDelay) {
+			case sigValidityFloorError:
+				hardMsgs = append(hardMsgs, fmt.Sprintf("%s (%s) ≤ 2×(servedTTL+propagationDelay) with servedTTL=%s",
+					spec.label, validity, served))
+			case sigValidityFloorWarning:
+				warnMsgs = append(warnMsgs, fmt.Sprintf("%s (%s) < 4×(servedTTL+propagationDelay) with servedTTL=%s",
+					spec.label, validity, served))
+			}
+		}
+	}
+
+	if len(hardMsgs) == 0 {
+		zd.ClearError(DnssecError)
+	} else {
+		zd.SetError(DnssecError, "sig-validity floor: %s", strings.Join(hardMsgs, "; "))
+	}
+	if len(warnMsgs) == 0 {
+		zd.ClearError(DnssecPolicyWarning)
+	} else {
+		zd.SetError(DnssecPolicyWarning, "%s", strings.Join(warnMsgs, "; "))
+	}
+}

--- a/v2/ksk_rollover_validation_test.go
+++ b/v2/ksk_rollover_validation_test.go
@@ -195,6 +195,56 @@ func TestCheckE10(t *testing.T) {
 	}
 }
 
+func TestUpdateSigValidityFloorConfig(t *testing.T) {
+	prop := time.Hour
+	pol := &DnssecPolicy{
+		SigValidity: PolicySigValidity{
+			Default: uint32((14 * 24 * time.Hour).Seconds()),
+			DNSKEY:  uint32((30 * 24 * time.Hour).Seconds()),
+			DS:      uint32((14 * 24 * time.Hour).Seconds()),
+		},
+	}
+	zd := &ZoneData{ZoneName: "test.example."}
+	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+	UpdateSigValidityFloor(zd, pol, prop, 0, false)
+	if zd.HasError(DnssecError) || zd.HasError(DnssecPolicyWarning) {
+		t.Fatalf("no TTL ceilings: expected no floor errors, got dnssec=%v warn=%v",
+			zd.HasError(DnssecError), zd.HasError(DnssecPolicyWarning))
+	}
+
+	pol.TTLS.MaxServed = 3600
+	pol.SigValidity.Default = 3600 // 1h, H=2h with prop=1h → 2h ≤ 2×H
+	zd2 := &ZoneData{ZoneName: "tight.example."}
+	zd2.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+	UpdateSigValidityFloor(zd2, pol, prop, 0, false)
+	if !zd2.HasError(DnssecError) {
+		t.Fatal("expected hard floor error for short default validity")
+	}
+}
+
+func TestUpdateSigValidityFloorRuntime(t *testing.T) {
+	prop := time.Hour
+	pol := &DnssecPolicy{
+		SigValidity: PolicySigValidity{
+			Default: uint32((14 * 24 * time.Hour).Seconds()),
+			DNSKEY:  uint32((30 * 24 * time.Hour).Seconds()),
+			DS:      uint32((14 * 24 * time.Hour).Seconds()),
+		},
+	}
+	zd := &ZoneData{ZoneName: "test.example."}
+	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+	UpdateSigValidityFloor(zd, pol, prop, 300, true)
+	if zd.HasError(DnssecError) {
+		t.Fatalf("runtime floor should pass: %s", zd.ErrorMsg)
+	}
+
+	pol.SigValidity.Default = 1800 // 30m
+	UpdateSigValidityFloor(zd, pol, prop, 3600, true)
+	if !zd.HasError(DnssecError) {
+		t.Fatal("expected runtime hard error when validity too short for observed TTL")
+	}
+}
+
 // TestResolveDSTTL confirms the resolution priority: override > observation > none.
 func TestResolveDSTTL(t *testing.T) {
 	policy := func(override uint32) *DnssecPolicy {

--- a/v2/ksk_rollover_validation_test.go
+++ b/v2/ksk_rollover_validation_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // TestCheckE5 exercises the §4.5.1 retirement_period bound check.
-// E5: retirement_period ≥ min(DNSKEY_TTL, KSK.SigValidity).
+// E5: retirement_period ≥ min(DNSKEY_TTL, SigValidity.DNSKEY).
 func TestCheckE5(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -19,7 +19,7 @@ func TestCheckE5(t *testing.T) {
 				p := &DnssecPolicy{}
 				p.Clamping.Enabled = false
 				p.TTLS.DNSKEY = 300
-				p.KSK.SigValidity = 60
+				p.SigValidity.DNSKEY = 60
 				return p
 			}(),
 			wantEmpty: true,
@@ -30,8 +30,8 @@ func TestCheckE5(t *testing.T) {
 				p := &DnssecPolicy{}
 				p.Clamping.Enabled = true
 				p.Clamping.Margin = 5 * time.Minute
-				p.TTLS.DNSKEY = 300         // 5m
-				p.KSK.SigValidity = 60 * 60 // 1h
+				p.TTLS.DNSKEY = 300            // 5m
+				p.SigValidity.DNSKEY = 60 * 60 // 1h
 				return p
 			}(),
 			wantEmpty: true,
@@ -44,9 +44,9 @@ func TestCheckE5(t *testing.T) {
 				p := &DnssecPolicy{}
 				p.Clamping.Enabled = true
 				p.Clamping.Margin = 5 * time.Minute
-				p.TTLS.DNSKEY = 7200        // 2h configured
-				p.TTLS.MaxServed = 300      // 5m clamp
-				p.KSK.SigValidity = 20 * 60 // 20m
+				p.TTLS.DNSKEY = 7200           // 2h configured
+				p.TTLS.MaxServed = 300         // 5m clamp
+				p.SigValidity.DNSKEY = 20 * 60 // 20m
 				return p
 			}(),
 			wantEmpty: true,
@@ -61,7 +61,7 @@ func TestCheckE5(t *testing.T) {
 				p.Clamping.Margin = 1 * time.Minute
 				p.TTLS.DNSKEY = 7200
 				p.TTLS.MaxServed = 300
-				p.KSK.SigValidity = 20 * 60
+				p.SigValidity.DNSKEY = 20 * 60
 				return p
 			}(),
 			wantEmpty: false,
@@ -72,8 +72,8 @@ func TestCheckE5(t *testing.T) {
 				p := &DnssecPolicy{}
 				p.Clamping.Enabled = true
 				p.Clamping.Margin = 1 * time.Minute
-				p.TTLS.DNSKEY = 300         // 5m -> floor
-				p.KSK.SigValidity = 60 * 60 // 1h
+				p.TTLS.DNSKEY = 300            // 5m -> floor
+				p.SigValidity.DNSKEY = 60 * 60 // 1h
 				return p
 			}(),
 			wantEmpty: false,
@@ -199,7 +199,7 @@ func TestCheckE10(t *testing.T) {
 func TestResolveDSTTL(t *testing.T) {
 	policy := func(override uint32) *DnssecPolicy {
 		p := &DnssecPolicy{}
-		p.TTLS.DS = override
+		p.TTLS.ParentDS = override
 		return p
 	}
 	zone := func(observed uint32) *ZoneData {

--- a/v2/ksk_rollover_zone_state.go
+++ b/v2/ksk_rollover_zone_state.go
@@ -994,9 +994,15 @@ func StateSinceForDnssecKey(kdb *KeyDB, zone string, k *DnssecKeyWithTimestamps)
 			return *k.RetiredAt
 		}
 	case DnskeyStateActive:
+		if k.Flags&dns.SEP == 0 && k.ActiveAt != nil {
+			return *k.ActiveAt
+		}
 		at, err := RolloverKeyActiveAt(kdb, zone, k.KeyTag)
 		if err == nil && at != nil {
 			return *at
+		}
+		if k.ActiveAt != nil {
+			return *k.ActiveAt
 		}
 	case DnskeyStateStandby:
 		// Genuine standby (post-C18): the key reached propagated-

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -198,6 +198,7 @@ type PolicySummary struct {
 	Name                     string `json:"name"`
 	Algorithm                string `json:"algorithm"`
 	KskLifetime              string `json:"kskLifetime"`
+	ZskLifetime              string `json:"zskLifetime,omitempty"`
 	DsPublishDelay           string `json:"dsPublishDelay"`
 	MaxAttemptsBeforeBackoff int    `json:"maxAttemptsBeforeBackoff"`
 	SoftfailDelay            string `json:"softfailDelay"`

--- a/v2/multi_error_test.go
+++ b/v2/multi_error_test.go
@@ -198,13 +198,13 @@ func TestEvaluateRolloverPolicyInvariantsSeveritySplit(t *testing.T) {
 	pol := &DnssecPolicy{}
 	pol.Rollover.Method = RolloverMethodMultiDS
 	pol.Rollover.NumDS = 2
-	pol.KSK.Lifetime = 21 * 60    // 21m
-	pol.KSK.SigValidity = 60 * 60 // 1h
+	pol.KSK.Lifetime = 21 * 60       // 21m
+	pol.SigValidity.DNSKEY = 60 * 60 // 1h
 	pol.Rollover.DsPublishDelay = 5 * time.Minute
 	pol.Clamping.Enabled = true
 	pol.Clamping.Margin = 1 * time.Minute // < min(5m dnskey, 1h sigvalidity) → E5 fail
 	pol.TTLS.DNSKEY = 300                 // 5m
-	pol.TTLS.DS = 600                     // 10m so E10/E11 can run
+	pol.TTLS.ParentDS = 600               // 10m so E10/E11 can run
 
 	zd := &ZoneData{ZoneName: "test.example."}
 	EvaluateRolloverPolicyInvariants(zd, pol)
@@ -233,13 +233,13 @@ func TestEvaluateRolloverPolicyInvariantsPreservesStateWhenDSTTLUnknown(t *testi
 	pol.Rollover.Method = RolloverMethodMultiDS
 	pol.Rollover.NumDS = 2
 	pol.KSK.Lifetime = 60 // 1m, deliberately tight to fail E10
-	pol.KSK.SigValidity = 60 * 60
+	pol.SigValidity.DNSKEY = 60 * 60
 	pol.Rollover.DsPublishDelay = 5 * time.Minute
 	pol.Clamping.Enabled = true
 	pol.Clamping.Margin = 5 * time.Minute
 	pol.TTLS.DNSKEY = 300
 	pol.TTLS.MaxServed = 300
-	pol.TTLS.DS = 600 // Known DS TTL — first eval can run E10.
+	pol.TTLS.ParentDS = 600 // Known parent DS TTL — first eval can run E10.
 
 	zd := &ZoneData{ZoneName: "test.example."}
 	EvaluateRolloverPolicyInvariants(zd, pol)
@@ -255,7 +255,7 @@ func TestEvaluateRolloverPolicyInvariantsPreservesStateWhenDSTTLUnknown(t *testi
 
 	// Now simulate parent observation gone — clear the DS override
 	// AND the observed value. Re-evaluate.
-	pol.TTLS.DS = 0
+	pol.TTLS.ParentDS = 0
 	zd.ParentDSTTLObserved = 0
 	EvaluateRolloverPolicyInvariants(zd, pol)
 	if !zd.HasError(RolloverPolicyViolation) {

--- a/v2/multi_error_test.go
+++ b/v2/multi_error_test.go
@@ -150,6 +150,11 @@ func TestHasServiceImpactingError(t *testing.T) {
 		t.Fatal("rollover-policy warning: serving must continue")
 	}
 
+	zd.SetError(DnssecPolicyWarning, "sig-validity headroom")
+	if zd.HasServiceImpactingError() {
+		t.Fatal("dnssec-policy warning: serving must continue")
+	}
+
 	zd.SetError(ConfigError, "bad config")
 	if !zd.HasServiceImpactingError() {
 		t.Fatal("ConfigError: serving must stop")

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -817,6 +817,10 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// (See follow-up: make rollover setup reload-safe.)
 		if zdp.FirstZoneLoad {
 			zdp.OnFirstLoad = append(zdp.OnFirstLoad, func(zd *ZoneData) {
+				if zd.DnssecPolicy != nil &&
+					(zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) {
+					UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false)
+				}
 				if zd.DnssecPolicy == nil || zd.DnssecPolicy.Rollover.Method == RolloverMethodNone {
 					return
 				}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -274,9 +274,9 @@ func (conf *Config) ParseConfig(reload bool) error {
 		tmp := DnssecPolicy{
 			Name:      name,
 			Algorithm: dns.StringToAlgorithm[strings.ToUpper(dpLocal.Algorithm)],
-			KSK:       GenKeyLifetime(dpLocal.KSK.Lifetime, dpLocal.KSK.SigValidity),
-			ZSK:       GenKeyLifetime(dpLocal.ZSK.Lifetime, dpLocal.ZSK.SigValidity),
-			CSK:       GenKeyLifetime(dpLocal.CSK.Lifetime, dpLocal.CSK.SigValidity),
+			KSK:       GenKeyLifetime(dpLocal.KSK.Lifetime),
+			ZSK:       GenKeyLifetime(dpLocal.ZSK.Lifetime),
+			CSK:       GenKeyLifetime(dpLocal.CSK.Lifetime),
 		}
 		if tmp.Algorithm == 0 {
 			lgConfig.Error("DNSSEC policy has unknown algorithm, ignored", "policy", name, "algorithm", dpLocal.Algorithm)
@@ -1096,18 +1096,24 @@ func expandTemplateChain(name string, stack []string, onStack map[string]bool, d
 // no dnssecpolicies.default is defined in config (e.g. for agent autozone). An explicit
 // dnssecpolicies.default in YAML overrides this. No automatic key rollovers.
 func BuiltinDefaultDnssecPolicy() DnssecPolicy {
+	const day = 24 * time.Hour
 	return DnssecPolicy{
 		Name:      "default",
 		Algorithm: dns.ED25519,
 		Mode:      DnssecPolicyModeKSKZSK,
-		KSK:       GenKeyLifetime("forever", "168h"),
-		ZSK:       GenKeyLifetime("forever", "2h"),
-		CSK:       GenKeyLifetime("none", "168h"),
+		KSK:       GenKeyLifetime("forever"),
+		ZSK:       GenKeyLifetime("forever"),
+		CSK:       GenKeyLifetime("none"),
+		SigValidity: PolicySigValidity{
+			Default: uint32((14 * day).Seconds()),
+			DNSKEY:  uint32((30 * day).Seconds()),
+			DS:      uint32((14 * day).Seconds()),
+		},
 	}
 }
 
-func GenKeyLifetime(lifetime, sigvalidity string) KeyLifetime {
-	var lifetime_secs, sigvalidity_secs time.Duration
+func GenKeyLifetime(lifetime string) KeyLifetime {
+	var lifetime_secs time.Duration
 	var err error
 
 	switch lifetime {
@@ -1123,14 +1129,8 @@ func GenKeyLifetime(lifetime, sigvalidity string) KeyLifetime {
 			Fatal("error from ParseDuration", "err", err)
 		}
 	}
-
-	sigvalidity_secs, err = time.ParseDuration(sigvalidity)
-	if err != nil {
-		Fatal("error from ParseDuration", "err", err)
-	}
 	return KeyLifetime{
-		Lifetime:    uint32(lifetime_secs.Seconds()),
-		SigValidity: uint32(sigvalidity_secs.Seconds()),
+		Lifetime: uint32(lifetime_secs.Seconds()),
 	}
 }
 

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -231,6 +231,10 @@ func (conf *Config) ParseConfig(reload bool) error {
 		}
 	}
 
+	if err := validateKaspPropagationDelay(conf.Kasp.PropagationDelay); err != nil {
+		return err
+	}
+
 	// Normalize service.transport.type (default: none)
 	if conf.Service.Transport.Type == "" {
 		conf.Service.Transport.Type = "none"
@@ -271,12 +275,27 @@ func (conf *Config) ParseConfig(reload bool) error {
 	conf.Internal.DnssecPolicies = make(map[string]DnssecPolicy)
 	for name, dp := range conf.DnssecPolicies {
 		dpLocal := dp
+		kskLT, err := GenKeyLifetime(dpLocal.KSK.Lifetime)
+		if err != nil {
+			lgConfig.Error("DNSSEC policy invalid ksk.lifetime, ignored", "policy", name, "err", err)
+			continue
+		}
+		zskLT, err := GenKeyLifetime(dpLocal.ZSK.Lifetime)
+		if err != nil {
+			lgConfig.Error("DNSSEC policy invalid zsk.lifetime, ignored", "policy", name, "err", err)
+			continue
+		}
+		cskLT, err := GenKeyLifetime(dpLocal.CSK.Lifetime)
+		if err != nil {
+			lgConfig.Error("DNSSEC policy invalid csk.lifetime, ignored", "policy", name, "err", err)
+			continue
+		}
 		tmp := DnssecPolicy{
 			Name:      name,
 			Algorithm: dns.StringToAlgorithm[strings.ToUpper(dpLocal.Algorithm)],
-			KSK:       GenKeyLifetime(dpLocal.KSK.Lifetime),
-			ZSK:       GenKeyLifetime(dpLocal.ZSK.Lifetime),
-			CSK:       GenKeyLifetime(dpLocal.CSK.Lifetime),
+			KSK:       kskLT,
+			ZSK:       zskLT,
+			CSK:       cskLT,
 		}
 		if tmp.Algorithm == 0 {
 			lgConfig.Error("DNSSEC policy has unknown algorithm, ignored", "policy", name, "algorithm", dpLocal.Algorithm)
@@ -811,16 +830,20 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			}
 		}
 
+		// Sig-validity floor: config-load check on every parse pass so
+		// policy/kasp edits on reload refresh DnssecError/Warning state.
+		if options[OptOnlineSigning] || options[OptInlineSigning] {
+			if zdp.DnssecPolicy != nil {
+				UpdateSigValidityFloor(zdp, zdp.DnssecPolicy, conf.KaspPropagationDelay(), 0, false)
+			}
+		}
+
 		// Rollover policy validation: requires loaded zone data. Only
 		// registered on first load; the ObserveParentDSTTL goroutine it
 		// spawns is long-running and re-spawning on reload would leak.
 		// (See follow-up: make rollover setup reload-safe.)
 		if zdp.FirstZoneLoad {
 			zdp.OnFirstLoad = append(zdp.OnFirstLoad, func(zd *ZoneData) {
-				if zd.DnssecPolicy != nil &&
-					(zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) {
-					UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false)
-				}
 				if zd.DnssecPolicy == nil || zd.DnssecPolicy.Rollover.Method == RolloverMethodNone {
 					return
 				}
@@ -1101,13 +1124,25 @@ func expandTemplateChain(name string, stack []string, onStack map[string]bool, d
 // dnssecpolicies.default in YAML overrides this. No automatic key rollovers.
 func BuiltinDefaultDnssecPolicy() DnssecPolicy {
 	const day = 24 * time.Hour
+	kskLT, err := GenKeyLifetime("forever")
+	if err != nil {
+		panic(err)
+	}
+	zskLT, err := GenKeyLifetime("forever")
+	if err != nil {
+		panic(err)
+	}
+	cskLT, err := GenKeyLifetime("none")
+	if err != nil {
+		panic(err)
+	}
 	return DnssecPolicy{
 		Name:      "default",
 		Algorithm: dns.ED25519,
 		Mode:      DnssecPolicyModeKSKZSK,
-		KSK:       GenKeyLifetime("forever"),
-		ZSK:       GenKeyLifetime("forever"),
-		CSK:       GenKeyLifetime("none"),
+		KSK:       kskLT,
+		ZSK:       zskLT,
+		CSK:       cskLT,
 		SigValidity: PolicySigValidity{
 			Default: uint32((14 * day).Seconds()),
 			DNSKEY:  uint32((30 * day).Seconds()),
@@ -1116,7 +1151,7 @@ func BuiltinDefaultDnssecPolicy() DnssecPolicy {
 	}
 }
 
-func GenKeyLifetime(lifetime string) KeyLifetime {
+func GenKeyLifetime(lifetime string) (KeyLifetime, error) {
 	var lifetime_secs time.Duration
 	var err error
 
@@ -1130,12 +1165,12 @@ func GenKeyLifetime(lifetime string) KeyLifetime {
 	default:
 		lifetime_secs, err = time.ParseDuration(lifetime)
 		if err != nil {
-			Fatal("error from ParseDuration", "err", err)
+			return KeyLifetime{}, fmt.Errorf("invalid key lifetime %q: %w", lifetime, err)
 		}
 	}
 	return KeyLifetime{
 		Lifetime: uint32(lifetime_secs.Seconds()),
-	}
+	}, nil
 }
 
 // NormalizeAddress ensures an address has a port number.

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -224,6 +224,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							zd.KeyDB = conf.Internal.KeyDB
 							zd.Data = core.NewCmap[OwnerData]()
 							zd.mu.Unlock()
+							if zd.DnssecPolicy != nil &&
+								(zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) {
+								UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false)
+							}
 						}
 
 						if _, err := initialLoadZone(ctx, zd, zone, zr, conf, refreshCounters,
@@ -334,6 +338,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// converges on the next sign pass instead of waiting
 						// for a key-state event.
 						if dnssecPolicyChanged {
+							if zd.DnssecPolicy != nil &&
+								(zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) {
+								UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false)
+							}
 							triggerResign(conf, zone)
 						}
 						lgEngine.Debug("updated configuration for zone", "zone", zone, "notify", zd.Downstreams, "upstream", zd.Upstream, "zonefile", zd.Zonefile, "store", ZoneStoreToString[zd.ZoneStore])

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -547,6 +547,7 @@ func policySummary(pol *DnssecPolicy) *PolicySummary {
 		Name:                     pol.Name,
 		Algorithm:                dns.AlgorithmToString[pol.Algorithm],
 		KskLifetime:              (time.Duration(pol.KSK.Lifetime) * time.Second).String(),
+		ZskLifetime:              (time.Duration(pol.ZSK.Lifetime) * time.Second).String(),
 		DsPublishDelay:           pol.Rollover.DsPublishDelay.String(),
 		MaxAttemptsBeforeBackoff: pol.Rollover.MaxAttemptsBeforeBackoff,
 		SoftfailDelay:            pol.Rollover.SoftfailDelay.String(),

--- a/v2/rollover_next_transitions.go
+++ b/v2/rollover_next_transitions.go
@@ -26,6 +26,7 @@ import (
 // current intent and shifts when an asap fires. The renderer is
 // guidance, not contract.
 func populateNextTransitions(out *RolloverStatus, kdb *KeyDB, zone string, pol *DnssecPolicy, propagationDelay time.Duration, now time.Time) {
+	populateZskNextTransitions(out, kdb, zone, pol, propagationDelay)
 	if pol == nil || pol.Rollover.Method == RolloverMethodNone || pol.KSK.Lifetime == 0 {
 		return
 	}
@@ -407,6 +408,58 @@ func slotFromKid(ordered []uint16, kid uint16) int {
 		}
 	}
 	return 0
+}
+
+// populateZskNextTransitions fills NextTransition fields on ZSK entries
+// for ksk-zsk mode zones with a configured ZSK.Lifetime.
+func populateZskNextTransitions(out *RolloverStatus, kdb *KeyDB, zone string, pol *DnssecPolicy, propagationDelay time.Duration) {
+	if pol == nil || pol.Mode != DnssecPolicyModeKSKZSK || pol.ZSK.Lifetime == 0 {
+		return
+	}
+	lifetime := time.Duration(pol.ZSK.Lifetime) * time.Second
+
+	var activeAt *time.Time
+	for i := range out.ZSKs {
+		if out.ZSKs[i].State != DnskeyStateActive {
+			continue
+		}
+		if t, ok := parseRFC3339(out.ZSKs[i].StateSince); ok {
+			activeAt = &t
+		}
+		break
+	}
+
+	maxTTL, _ := LoadZoneSigningMaxTTL(kdb, zone)
+	removalMargin := zskRemovalMargin(propagationDelay, maxTTL)
+
+	for i := range out.ZSKs {
+		e := &out.ZSKs[i]
+		switch e.State {
+		case DnskeyStateActive:
+			if activeAt == nil {
+				e.NextTransitionNote = "no active_at — roll timing unknown"
+				break
+			}
+			e.NextTransition = "ZSK roll (standby → active)"
+			t := activeAt.Add(lifetime)
+			e.NextTransitionAt = t.UTC().Format(time.RFC3339)
+		case DnskeyStateStandby:
+			if activeAt != nil {
+				e.NextTransition = "promote on ZSK roll"
+				e.NextTransitionAt = activeAt.Add(lifetime).UTC().Format(time.RFC3339)
+			}
+		case DnskeyStateRetired:
+			if t, ok := parseRFC3339(e.StateSince); ok {
+				e.NextTransition = "retired → removed"
+				e.NextTransitionAt = t.Add(removalMargin).UTC().Format(time.RFC3339)
+			}
+		case DnskeyStatePublished:
+			e.NextTransition = "published → standby"
+			if t, ok := parseRFC3339(e.StateSince); ok {
+				e.NextTransitionAt = t.Add(propagationDelay).UTC().Format(time.RFC3339)
+			}
+		}
+	}
 }
 
 func parseRFC3339(s string) (time.Time, bool) {

--- a/v2/sig0_utils.go
+++ b/v2/sig0_utils.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/gookit/goutil/dump"
 	core "github.com/johanix/tdns/v2/core"
@@ -313,6 +314,11 @@ INSERT OR REPLACE INTO DnssecKeyStore (zonename, state, keyid, algorithm, flags,
 		// pkc.PrivateKey should already be in PEM format from above
 		_, err = tx.Exec(addDnssecKeySql, owner, state, pkc.KeyId,
 			dns.AlgorithmToString[pkc.Algorithm], flags, creator, pkc.PrivateKey, pkc.DnskeyRR.String())
+		if err == nil && state == DnskeyStateActive {
+			now := time.Now().UTC().Format(time.RFC3339)
+			_, err = tx.Exec(`UPDATE DnssecKeyStore SET active_at=? WHERE zonename=? AND keyid=?`,
+				now, owner, pkc.KeyId)
+		}
 	}
 	if err != nil {
 		lgDns.Error("GenerateKeypair: error storing key in keystore", "err", err)

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -114,6 +114,20 @@ func SignMsg(m dns.Msg, signer string, sak *Sig0ActiveKeys) (*dns.Msg, error) {
 // clamp == nil disables clamping entirely (no behavior change from the
 // pre-4D signature). Most callers pass nil; SignZone builds a *ClampParams
 // once per pass for clamping zones and threads it down.
+func sigValiditySeconds(pol *DnssecPolicy, rrtype uint16) uint32 {
+	if pol == nil {
+		return 0
+	}
+	switch rrtype {
+	case dns.TypeDNSKEY:
+		return pol.SigValidity.DNSKEY
+	case dns.TypeDS:
+		return pol.SigValidity.DS
+	default:
+		return pol.SigValidity.Default
+	}
+}
+
 func (zd *ZoneData) SignRRset(rrset *core.RRset, name string, dak *DnssecKeys, force bool, clamp *ClampParams) (bool, error) {
 
 	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
@@ -215,7 +229,7 @@ func (zd *ZoneData) SignRRset(rrset *core.RRset, name string, dak *DnssecKeys, f
 		shouldSign := true
 		for idx, oldsig := range rrset.RRSIGs {
 			if oldsig.(*dns.RRSIG).KeyTag == key.DnskeyRR.KeyTag() {
-				shouldSign = NeedsResigning(oldsig.(*dns.RRSIG)) || force
+				shouldSign = NeedsResigning(oldsig.(*dns.RRSIG), rrset.RRs[0].Header().Ttl) || force
 				if shouldSign {
 					lgSigner.Debug("removing older RRSIG by same DNSKEY", "name", oldsig.Header().Name, "rrtype", dns.TypeToString[uint16(rrset.RRs[0].Header().Rrtype)])
 					rrset.RRSIGs = append(rrset.RRSIGs[:idx], rrset.RRSIGs[idx+1:]...)
@@ -233,8 +247,9 @@ func (zd *ZoneData) SignRRset(rrset *core.RRset, name string, dak *DnssecKeys, f
 			}
 			rrsig.KeyTag = key.DnskeyRR.KeyTag()
 			rrsig.Algorithm = key.DnskeyRR.Algorithm
-			rrsig.Inception, rrsig.Expiration = sigLifetime(now, 3600*24*30) // 30 days
-			rrsig.SignerName = zd.ZoneName                                   // name
+			lifetime := sigValiditySeconds(zd.DnssecPolicy, rrset.RRs[0].Header().Rrtype)
+			rrsig.Inception, rrsig.Expiration = sigLifetime(now, lifetime)
+			rrsig.SignerName = zd.ZoneName // name
 
 			err := rrsig.Sign(key.CS, rrset.RRs)
 			if err != nil {
@@ -258,15 +273,25 @@ func (zd *ZoneData) SignRRset(rrset *core.RRset, name string, dak *DnssecKeys, f
 // XXX: Perhaps a working algorithm woul be to test for the remaining signature lifetime to be something like
 //
 //	less than 3 x resigning interval?
-func NeedsResigning(rrsig *dns.RRSIG) bool {
-	// here we should check is enough lifetime is left for the RRSIG
-	// to be valid.
-
-	// inceptionTime := time.Unix(int64(rrsig.Inception), 0)
+func NeedsResigning(rrsig *dns.RRSIG, servedTTL uint32) bool {
 	expirationTime := time.Unix(int64(rrsig.Expiration), 0)
+	remaining := time.Until(expirationTime)
 
-	if time.Until(expirationTime) < 3*time.Duration(viper.GetInt("resignerengine.interval")) {
-		lgSigner.Info("RRSIG needs resigning, less than 3 intervals left", "name", rrsig.Header().Name, "rrtype", dns.TypeToString[uint16(rrsig.Header().Rrtype)])
+	scanInterval := time.Duration(viper.GetInt("resignerengine.interval")) * time.Second
+	if scanInterval < 60*time.Second {
+		scanInterval = 60 * time.Second
+	}
+	if scanInterval > 3600*time.Second {
+		scanInterval = 3600 * time.Second
+	}
+
+	threshold := time.Duration(servedTTL)*time.Second + Conf.KaspPropagationDelay() + scanInterval
+	if remaining < threshold {
+		lgSigner.Info("RRSIG needs resigning, remaining validity below served TTL headroom",
+			"name", rrsig.Header().Name,
+			"type_covered", dns.TypeToString[uint16(rrsig.TypeCovered)],
+			"remaining", remaining.String(),
+			"threshold", threshold.String())
 		return true
 	}
 	return false
@@ -433,6 +458,9 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
 		return 0, fmt.Errorf("SignZone: zone %s should not be signed here (neither online-signing nor inline-signing)", zd.ZoneName)
 	}
+	if zd.HasError(DnssecError) {
+		return 0, fmt.Errorf("SignZone: zone %s has DNSSEC error: %s", zd.ZoneName, zd.ErrorMsg)
+	}
 
 	// Single-signer signing (mode 1). Multi-provider signing
 	// (modes 2-4) is handled by mpzd.SignZone() in tdns-mp.
@@ -587,6 +615,9 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 	// Reset per pass: a TTL reduction takes effect after one full cycle.
 	if err := UpsertZoneSigningMaxTTL(kdb, zd.ZoneName, maxObservedTTL); err != nil {
 		lgSigner.Warn("SignZone: persist max_observed_ttl", "zone", zd.ZoneName, "err", err)
+	}
+	if zd.DnssecPolicy != nil {
+		UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), maxObservedTTL, true)
 	}
 
 	return newrrsigs, nil

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -139,7 +139,7 @@ type ZoneData struct {
 	// ParentDSTTLObserved is the most recent TTL observed on the parent's
 	// DS RRset (seconds). Refreshed by every successful QueryParentAgentDS
 	// call. Zero means "not yet observed" — the E10 cache-flush invariant
-	// check defers until either this value or DnssecPolicy.TTLS.DS is set.
+	// check defers until either this value or DnssecPolicy.TTLS.ParentDS is set.
 	ParentDSTTLObserved uint32
 	TransportSignal     *core.RRset // transport signal RRset (SVCB or TSYNC)
 	AddTransportSignal  bool        // whether to attach TransportSignal in responses
@@ -306,14 +306,25 @@ type DnssecPolicyRolloverConf struct {
 type DnssecPolicyTtlsConf struct {
 	DNSKEY    string `yaml:"dnskey" mapstructure:"dnskey"`
 	MaxServed string `yaml:"max_served" mapstructure:"max_served"`
-	// DS is an optional override for the parent's DS RRset TTL when the
-	// engine cannot observe it (parent unreachable at zone init, testbed
-	// determinism, registries that gate DS queries). Used by the E10
-	// cache-flush invariant check: (N − 1) × KSK.Lifetime ≥
+	// ParentDS is an optional override for the parent's DS RRset TTL when
+	// the engine cannot observe it (parent unreachable at zone init,
+	// testbed determinism, registries that gate DS queries). Used by the
+	// E10 cache-flush invariant check: (N − 1) × KSK.Lifetime ≥
 	// retirement_period + parent_prop + DS_TTL. When unset, the engine
 	// defers E10 validation until the first successful
 	// QueryParentAgentDS observation supplies the live TTL.
+	ParentDS string `yaml:"parent-ds" mapstructure:"parent-ds"`
+	// DS is the fallback TTL for DS RRsets this zone publishes at its
+	// children's secure delegations when the child has not expressed a
+	// TTL (CDS / DNS UPDATE). Child-driven TTLs are never overridden.
 	DS string `yaml:"ds" mapstructure:"ds"`
+}
+
+// DnssecPolicySigValidityConf is the YAML `sigvalidity:` subtree.
+type DnssecPolicySigValidityConf struct {
+	Default string `yaml:"default" mapstructure:"default"`
+	Dnskey  string `yaml:"dnskey" mapstructure:"dnskey"`
+	Ds      string `yaml:"ds" mapstructure:"ds"`
 }
 
 // DnssecPolicyClampingConf is the YAML `clamping:` subtree under a DNSSEC policy.
@@ -329,17 +340,16 @@ type DnssecPolicyConf struct {
 	Mode      string `yaml:"mode" mapstructure:"mode"`
 
 	KSK struct {
-		Lifetime    string
-		SigValidity string
+		Lifetime string
 	}
 	ZSK struct {
-		Lifetime    string
-		SigValidity string
+		Lifetime string
 	}
 	CSK struct {
-		Lifetime    string
-		SigValidity string
+		Lifetime string
 	}
+
+	SigValidity DnssecPolicySigValidityConf `yaml:"sigvalidity" mapstructure:"sigvalidity"`
 
 	Rollover DnssecPolicyRolloverConf `yaml:"rollover" mapstructure:"rollover"`
 	Ttls     DnssecPolicyTtlsConf     `yaml:"ttls" mapstructure:"ttls"`
@@ -347,8 +357,14 @@ type DnssecPolicyConf struct {
 }
 
 type KeyLifetime struct {
-	Lifetime    uint32
-	SigValidity uint32
+	Lifetime uint32
+}
+
+// PolicySigValidity holds resolved RRSIG validity periods (seconds).
+type PolicySigValidity struct {
+	Default uint32
+	DNSKEY  uint32
+	DS      uint32
 }
 
 // DnssecPolicy is what is actually used; it is created from the corresponding DnssecPolicyConf
@@ -360,6 +376,8 @@ type DnssecPolicy struct {
 	KSK KeyLifetime
 	ZSK KeyLifetime
 	CSK KeyLifetime
+
+	SigValidity PolicySigValidity
 
 	Rollover RolloverPolicy
 	TTLS     DnssecPolicyTTLS
@@ -382,10 +400,14 @@ type DnssecPolicyTTLS struct {
 	// the operator can't directly edit (e.g. inbound zone transfers).
 	// Zero means no ceiling. Validation: must be >= 60s when set.
 	MaxServed uint32
-	// DS is the operator-provided override for the parent's DS RRset TTL.
-	// Zero means "observe at runtime" — the engine queries the parent
-	// agent and stores the observed TTL on zd.ParentDSTTLObserved. Used
-	// by the E10 invariant check.
+	// ParentDS is the operator-provided override for the parent's DS RRset
+	// TTL. Zero means "observe at runtime" — the engine queries the parent
+	// agent and stores the observed TTL on zd.ParentDSTTLObserved. Used by
+	// the E10 invariant check.
+	ParentDS uint32
+	// DS is the fallback TTL for child DS RRsets when the child has not
+	// expressed a TTL. Zero means no fallback (TTL may remain 0 until set
+	// elsewhere). Bounds sigvalidity.ds at config-load time.
 	DS uint32
 }
 

--- a/v2/zsk_rollover.go
+++ b/v2/zsk_rollover.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Automated ZSK rollover: age-based pre-publish roll driven by ZSK.Lifetime.
+ */
+
+package tdns
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// zskRollDue reports whether an active ZSK has lived past policy.ZSK.Lifetime.
+func zskRollDue(now time.Time, activeAt *time.Time, lifetimeSec uint32) bool {
+	if lifetimeSec == 0 || activeAt == nil {
+		return false
+	}
+	lifetime := time.Duration(lifetimeSec) * time.Second
+	return now.Sub(*activeAt) >= lifetime
+}
+
+// zskRemovalMargin is the hold time before a retired ZSK may be removed:
+// propagationDelay + max observed signing TTL (sum, not max).
+func zskRemovalMargin(propagationDelay time.Duration, maxObservedTTL uint32) time.Duration {
+	margin := propagationDelay
+	if maxObservedTTL > 0 {
+		margin += time.Duration(maxObservedTTL) * time.Second
+	}
+	return margin
+}
+
+// rolloverZsksForAllZones runs automated ZSK rollover for every eligible zone.
+// Invoked from KeyStateWorker after published→standby and before retired→removed.
+func rolloverZsksForAllZones(ctx context.Context, conf *Config, kdb *KeyDB, propagationDelay time.Duration, now time.Time) {
+	for _, zd := range Zones.Items() {
+		if ctx.Err() != nil {
+			return
+		}
+		if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+			continue
+		}
+		if zd.Options[OptMultiProvider] {
+			continue
+		}
+		pol := zd.DnssecPolicy
+		if pol == nil || pol.Mode != DnssecPolicyModeKSKZSK || pol.ZSK.Lifetime == 0 {
+			continue
+		}
+		if err := rolloverZskForZone(ctx, conf, kdb, zd, propagationDelay, now); err != nil {
+			lgSigner.Error("zsk rollover: tick error", "zone", zd.ZoneName, "err", err)
+		}
+	}
+}
+
+func rolloverZskForZone(ctx context.Context, conf *Config, kdb *KeyDB, zd *ZoneData, propagationDelay time.Duration, now time.Time) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	pol := zd.DnssecPolicy
+	zone := dns.Fqdn(zd.ZoneName)
+
+	release, err := defaultAcquireRolloverLock(zone)
+	if err != nil {
+		lgSigner.Debug("zsk rollover: lock acquisition skipped", "zone", zone, "err", err)
+		return nil
+	}
+	defer release()
+
+	activeKeys, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
+	if err != nil {
+		return fmt.Errorf("list active keys: %w", err)
+	}
+	var activeZSK *DnssecKeyWithTimestamps
+	for i := range activeKeys {
+		if activeKeys[i].Flags == 256 {
+			activeZSK = &activeKeys[i]
+			break
+		}
+	}
+	if activeZSK == nil {
+		return nil
+	}
+
+	if !zskRollDue(now, activeZSK.ActiveAt, pol.ZSK.Lifetime) {
+		return nil
+	}
+
+	standbyKeys, err := GetDnssecKeysByState(kdb, zone, DnskeyStateStandby)
+	if err != nil {
+		return fmt.Errorf("list standby keys: %w", err)
+	}
+	haveStandby := false
+	for i := range standbyKeys {
+		if standbyKeys[i].Flags == 256 {
+			haveStandby = true
+			break
+		}
+	}
+	if !haveStandby {
+		lgSigner.Warn("zsk rollover: roll due but no standby ZSK available", "zone", zone, "active_keyid", activeZSK.KeyTag)
+		return nil
+	}
+
+	oldActive, newActive, err := kdb.RolloverKey(zone, "ZSK", nil)
+	if err != nil {
+		return fmt.Errorf("RolloverKey: %w", err)
+	}
+	lgSigner.Info("zsk rollover: completed", "zone", zone, "old_active", oldActive, "new_active", newActive)
+	triggerResign(conf, zd.ZoneName)
+	return nil
+}

--- a/v2/zsk_rollover_test.go
+++ b/v2/zsk_rollover_test.go
@@ -1,0 +1,38 @@
+package tdns
+
+import (
+	"testing"
+	"time"
+)
+
+func TestZskRollDue(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	activeAt := now.Add(-48 * time.Hour)
+	lifetime := uint32((24 * time.Hour).Seconds())
+
+	if !zskRollDue(now, &activeAt, lifetime) {
+		t.Fatal("expected roll due when active age exceeds lifetime")
+	}
+	if zskRollDue(now, &activeAt, 0) {
+		t.Fatal("lifetime 0 must never roll")
+	}
+	if zskRollDue(now, nil, lifetime) {
+		t.Fatal("nil active_at must not roll")
+	}
+	if zskRollDue(now, &now, lifetime) {
+		t.Fatal("fresh active key must not roll")
+	}
+}
+
+func TestZskRemovalMargin(t *testing.T) {
+	prop := time.Hour
+	maxTTL := uint32(7200)
+	got := zskRemovalMargin(prop, maxTTL)
+	want := prop + 2*time.Hour
+	if got != want {
+		t.Fatalf("margin = %v, want %v", got, want)
+	}
+	if zskRemovalMargin(prop, 0) != prop {
+		t.Fatal("zero max TTL should leave propagation_delay only")
+	}
+}


### PR DESCRIPTION
## Summary

- Automate ZSK rollover in `KeyStateWorker` driven by `zsk.lifetime`, with `active_at` on `DnssecKeyStore`, TTL-aware retired-ZSK removal (`propagation_delay + max_observed_ttl`), and ZSK status in `auto-rollover status`.
- Includes the configurable RRSIG validity work from `feat/configurable-rrsig-validity` (merged, not rebased), plus CodeRabbit review fixes on that stack.

## Context

- Plan #1 is also open as https://github.com/johanix/tdns/pull/227.
- This PR is opened now primarily to trigger CodeRabbit review; **not intended for merge yet**.

## Test plan

- [ ] `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make`
- [ ] `cd tdns/v2 && go test -run 'TestZsk|TestUpdateSigValidityFloor'`
- [ ] Lab: short `zsk.lifetime` zone rolls ZSK end-to-end without validation break


Made with [Cursor](https://cursor.com)