### PR TITLE
Make liboqs an opt-in build dependency (WITH_LIBOQS=1)

### DIFF
--- a/cmdv2/Makefile
+++ b/cmdv2/Makefile
@@ -1,5 +1,10 @@
 .PHONY: all v2 version clean install install-dirs check-root tarball
 
+# WITH_LIBOQS=1 enables the liboqs-backed PQ algorithms (Falcon-512,
+# MAYO-1, SNOVA-24_5_4) in agent/auth/imr. See utils/Makefile.common.
+WITH_LIBOQS ?= 0
+export WITH_LIBOQS
+
 # all apps in this directory
 all: v2
 

--- a/cmdv2/README.md
+++ b/cmdv2/README.md
@@ -1,0 +1,51 @@
+# tdns cmdv2 — building
+
+The five applications under this directory share `utils/Makefile.common`.
+
+## Default build (no liboqs needed)
+
+```
+cd cmdv2 && make
+```
+
+Produces `tdns-auth`, `tdns-agent`, `tdns-imr`, `tdns-cli`, and `dog`.
+Pure-Go post-quantum algorithms (ML-DSA-44, SLH-DSA-128s) are wired in;
+the liboqs-backed ones (Falcon-512, MAYO-1, SNOVA-24_5_4) are present
+as metadata only — recognized by name but not usable for sign/verify.
+
+## Full PQ build (`WITH_LIBOQS=1`)
+
+To enable Falcon-512, MAYO-1, and SNOVA-24_5_4, the build host needs
+liboqs installed and reachable via pkg-config.
+
+```
+# one-time per shell session — auto-detects liboqs install
+. ../../dnssec-algorithms/liboqs/liboqs-env.sh
+
+cd cmdv2 && make WITH_LIBOQS=1
+```
+
+The env script probes well-known prefixes (`/opt/local` for MacPorts,
+`/opt/homebrew` for Homebrew on Apple Silicon, `/usr/pkg` for NetBSD
+pkgsrc, `/usr/local`, `/usr` for Linux distro packages). Override with
+`LIBOQS_PREFIX=/your/path` or set `LIBOQS_INCLUDE_DIR` +
+`LIBOQS_LIB_DIR` explicitly.
+
+If `make WITH_LIBOQS=1` is run without the env sourced, the build
+fails fast with a pointer back to the env script. No silent fallback.
+
+See `dnssec-algorithms/README.md` for per-platform liboqs install
+notes (MacPorts, Homebrew, pkgsrc; Linux template still pending).
+
+## Adding a liboqs algorithm to a binary
+
+Each server binary has two files declaring its PQ algorithm bindings:
+
+- `pq_algorithms_liboqs.go` — built only with `-tags liboqs`. Real
+  registrations via `algs.Register`.
+- `pq_algorithms_noliboqs.go` — built by default. Metadata-only via
+  `algs.RegisterMetadata`.
+
+The split keeps the default-build dependency graph free of CGO/liboqs.
+`dog` and `tdns-cli` never need liboqs (they don't sign/verify with
+the relevant algorithms) — they have no `_liboqs.go` file at all.

--- a/cmdv2/agent/main.go
+++ b/cmdv2/agent/main.go
@@ -14,25 +14,20 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/johanix/dnssec-algorithms/falcon512"
-	"github.com/johanix/dnssec-algorithms/mayo1"
 	"github.com/johanix/dnssec-algorithms/mldsa44"
 	"github.com/johanix/dnssec-algorithms/slhdsa128s"
-	"github.com/johanix/dnssec-algorithms/snova24_5_4"
 
 	tdns "github.com/johanix/tdns/v2"
 	algs "github.com/johanix/tdns/v2/algorithms"
 )
 
-// Register out-of-tree DNSSEC algorithms. Per-binary choice — tdns/v2
-// itself stays free of third-party crypto deps; each application
-// decides what to import and at which codepoints to register them.
+// Pure-Go PQ algorithms (CIRCL-backed) — always registered. The
+// liboqs-backed ones (falcon512, mayo1, snova24_5_4) are registered
+// from pq_algorithms_liboqs.go (build tag liboqs) or have their
+// metadata declared from pq_algorithms_noliboqs.go.
 func init() {
-	algs.Register(199, mldsa44.New(),     algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(200, slhdsa128s.New(),  algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(201, falcon512.New(),   algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(202, mayo1.New(),       algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(199, mldsa44.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(200, slhdsa128s.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }
 
 func main() {

--- a/cmdv2/agent/pq_algorithms_liboqs.go
+++ b/cmdv2/agent/pq_algorithms_liboqs.go
@@ -1,0 +1,28 @@
+//go:build liboqs
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * liboqs-backed PQ algorithms. CGO + system liboqs required at
+ * build time; resulting binaries link against liboqs (statically on
+ * NetBSD pkgsrc, dynamically on macOS MacPorts).
+ *
+ * Build with `make WITH_LIBOQS=1` (which passes `-tags liboqs`).
+ * See dnssec-algorithms/liboqs/liboqs-env.sh for environment setup.
+ */
+
+package main
+
+import (
+	"github.com/johanix/dnssec-algorithms/falcon512"
+	"github.com/johanix/dnssec-algorithms/mayo1"
+	"github.com/johanix/dnssec-algorithms/snova24_5_4"
+
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.Register(201, falcon512.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/cmdv2/agent/pq_algorithms_noliboqs.go
+++ b/cmdv2/agent/pq_algorithms_noliboqs.go
@@ -1,0 +1,26 @@
+//go:build !liboqs
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Default build: liboqs-backed PQ algorithms are NOT compiled in.
+ * Only their codepoints and names are registered as metadata so the
+ * CLI argument validator and --help text still recognize them. Any
+ * attempt to sign or verify with codepoints 201, 202, or 203 will
+ * fail at runtime.
+ *
+ * Build with `make WITH_LIBOQS=1` (-tags liboqs) to wire in the real
+ * implementations from pq_algorithms_liboqs.go.
+ */
+
+package main
+
+import (
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.RegisterMetadata(201, "FALCON512", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(202, "MAYO1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(203, "SNOVA24_5_4", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/cmdv2/auth/main.go
+++ b/cmdv2/auth/main.go
@@ -14,22 +14,20 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/johanix/dnssec-algorithms/falcon512"
-	"github.com/johanix/dnssec-algorithms/mayo1"
 	"github.com/johanix/dnssec-algorithms/mldsa44"
 	"github.com/johanix/dnssec-algorithms/slhdsa128s"
-	"github.com/johanix/dnssec-algorithms/snova24_5_4"
 
 	tdns "github.com/johanix/tdns/v2"
 	algs "github.com/johanix/tdns/v2/algorithms"
 )
 
+// Pure-Go PQ algorithms (CIRCL-backed) — always registered. The
+// liboqs-backed ones (falcon512, mayo1, snova24_5_4) are registered
+// from pq_algorithms_liboqs.go (build tag liboqs) or have their
+// metadata declared from pq_algorithms_noliboqs.go.
 func init() {
-	algs.Register(199, mldsa44.New(),     algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(200, slhdsa128s.New(),  algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(201, falcon512.New(),   algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(202, mayo1.New(),       algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(199, mldsa44.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(200, slhdsa128s.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }
 
 func main() {

--- a/cmdv2/auth/pq_algorithms_liboqs.go
+++ b/cmdv2/auth/pq_algorithms_liboqs.go
@@ -1,0 +1,28 @@
+//go:build liboqs
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * liboqs-backed PQ algorithms. CGO + system liboqs required at
+ * build time; resulting binaries link against liboqs (statically on
+ * NetBSD pkgsrc, dynamically on macOS MacPorts).
+ *
+ * Build with `make WITH_LIBOQS=1` (which passes `-tags liboqs`).
+ * See dnssec-algorithms/liboqs/liboqs-env.sh for environment setup.
+ */
+
+package main
+
+import (
+	"github.com/johanix/dnssec-algorithms/falcon512"
+	"github.com/johanix/dnssec-algorithms/mayo1"
+	"github.com/johanix/dnssec-algorithms/snova24_5_4"
+
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.Register(201, falcon512.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/cmdv2/auth/pq_algorithms_noliboqs.go
+++ b/cmdv2/auth/pq_algorithms_noliboqs.go
@@ -1,0 +1,26 @@
+//go:build !liboqs
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Default build: liboqs-backed PQ algorithms are NOT compiled in.
+ * Only their codepoints and names are registered as metadata so the
+ * CLI argument validator and --help text still recognize them. Any
+ * attempt to sign or verify with codepoints 201, 202, or 203 will
+ * fail at runtime.
+ *
+ * Build with `make WITH_LIBOQS=1` (-tags liboqs) to wire in the real
+ * implementations from pq_algorithms_liboqs.go.
+ */
+
+package main
+
+import (
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.RegisterMetadata(201, "FALCON512", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(202, "MAYO1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(203, "SNOVA24_5_4", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/cmdv2/imr/main.go
+++ b/cmdv2/imr/main.go
@@ -9,22 +9,20 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/johanix/dnssec-algorithms/falcon512"
-	"github.com/johanix/dnssec-algorithms/mayo1"
 	"github.com/johanix/dnssec-algorithms/mldsa44"
 	"github.com/johanix/dnssec-algorithms/slhdsa128s"
-	"github.com/johanix/dnssec-algorithms/snova24_5_4"
 
 	tdns "github.com/johanix/tdns/v2"
 	algs "github.com/johanix/tdns/v2/algorithms"
 )
 
+// Pure-Go PQ algorithms (CIRCL-backed) — always registered. The
+// liboqs-backed ones (falcon512, mayo1, snova24_5_4) are registered
+// from pq_algorithms_liboqs.go (build tag liboqs) or have their
+// metadata declared from pq_algorithms_noliboqs.go.
 func init() {
 	algs.Register(199, mldsa44.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(200, slhdsa128s.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(201, falcon512.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }
 
 func main() {

--- a/cmdv2/imr/pq_algorithms_liboqs.go
+++ b/cmdv2/imr/pq_algorithms_liboqs.go
@@ -1,0 +1,28 @@
+//go:build liboqs
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * liboqs-backed PQ algorithms. CGO + system liboqs required at
+ * build time; resulting binaries link against liboqs (statically on
+ * NetBSD pkgsrc, dynamically on macOS MacPorts).
+ *
+ * Build with `make WITH_LIBOQS=1` (which passes `-tags liboqs`).
+ * See dnssec-algorithms/liboqs/liboqs-env.sh for environment setup.
+ */
+
+package main
+
+import (
+	"github.com/johanix/dnssec-algorithms/falcon512"
+	"github.com/johanix/dnssec-algorithms/mayo1"
+	"github.com/johanix/dnssec-algorithms/snova24_5_4"
+
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.Register(201, falcon512.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/cmdv2/imr/pq_algorithms_noliboqs.go
+++ b/cmdv2/imr/pq_algorithms_noliboqs.go
@@ -1,0 +1,26 @@
+//go:build !liboqs
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Default build: liboqs-backed PQ algorithms are NOT compiled in.
+ * Only their codepoints and names are registered as metadata so the
+ * CLI argument validator and --help text still recognize them. Any
+ * attempt to sign or verify with codepoints 201, 202, or 203 will
+ * fail at runtime.
+ *
+ * Build with `make WITH_LIBOQS=1` (-tags liboqs) to wire in the real
+ * implementations from pq_algorithms_liboqs.go.
+ */
+
+package main
+
+import (
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.RegisterMetadata(201, "FALCON512", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(202, "MAYO1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(203, "SNOVA24_5_4", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -5,6 +5,18 @@ APPDATE=`date +"%Y-%m-%d-%H:%M"`
 
 GOFLAGS:=-v
 
+# WITH_LIBOQS=1 wires in liboqs-backed PQ algorithms (Falcon-512,
+# MAYO-1, SNOVA-24_5_4) in cmdv2/{agent,auth,imr}. Requires the build
+# host to have liboqs installed (pkgsrc on NetBSD, MacPorts on macOS).
+# Before building, source the env script in this same shell:
+#   . ../../../dnssec-algorithms/liboqs/liboqs-env.sh
+# Default (unset): those algorithms are metadata-only — recognized
+# by name but not usable for sign/verify.
+WITH_LIBOQS ?= 0
+ifeq ($(WITH_LIBOQS),1)
+GOFLAGS += -tags liboqs
+endif
+
 GOOS ?= $(shell uname -s | tr A-Z a-z)
 
 default: ${PROG}
@@ -16,9 +28,28 @@ all: $(PROG)
 version:
 	/bin/sh ../../utils/make-version.sh $(VERSION)-$(BRANCH)-$(COMMIT) $(APPDATE) $(PROG)
 
-build:
+build: check-liboqs
 	@test -f version.go || /bin/sh ../../utils/make-version.sh "unknown" "unknown" $(PROG)
 	$(GO) build $(GOFLAGS) -o ${PROG}
+
+# Pre-flight check: when WITH_LIBOQS=1, verify pkg-config can find
+# liboqs-go.pc and print actionable guidance otherwise. No-op when
+# WITH_LIBOQS is unset.
+check-liboqs:
+ifeq ($(WITH_LIBOQS),1)
+	@pkg-config --exists liboqs-go 2>/dev/null || { \
+	   echo ""; \
+	   echo "  WITH_LIBOQS=1 was set but pkg-config cannot find liboqs-go."; \
+	   echo "  Source the env script in this shell first:"; \
+	   echo ""; \
+	   echo "    . ../../../dnssec-algorithms/liboqs/liboqs-env.sh"; \
+	   echo ""; \
+	   echo "  Then re-run make. See dnssec-algorithms/README.md for"; \
+	   echo "  per-platform liboqs install instructions."; \
+	   echo ""; \
+	   exit 1; \
+	}
+endif
 
 netbsd:
 	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) -o ${PROG}.netbsd
@@ -67,4 +98,4 @@ lint:
 	gosec ./...
 	golangci-lint run
 
-.PHONY: build version clean
+.PHONY: build version clean check-liboqs


### PR DESCRIPTION
## Summary

Default builds (\`make\`) no longer need liboqs installed on the build host. The pure-Go PQ algorithms (ML-DSA-44, SLH-DSA-128s) stay wired in unconditionally; the liboqs-backed ones (Falcon-512, MAYO-1, SNOVA-24_5_4) are gated behind \`-tags liboqs\` and opt in via \`make WITH_LIBOQS=1\`.

This fixes the build regression on any host without liboqs/liboqs-go (every dev machine that hasn't run \`pkg-config liboqs-go\` setup).

## What changed

**E.1 — per-binary file split** in \`cmdv2/{agent,auth,imr}/\`:
- \`pq_algorithms_liboqs.go\` (\`//go:build liboqs\`): \`algs.Register(falcon512.New(), ...)\` etc.
- \`pq_algorithms_noliboqs.go\` (\`//go:build !liboqs\`): \`algs.RegisterMetadata(201, \"FALCON512\", ...)\` etc.

The split puts the CGO/liboqs dependency at the natural decision point — the application's own main package — and makes it obvious in the file name what's gated. \`dog\` and \`cli\` never need liboqs (they don't sign/verify with the relevant algorithms) and have no \`_liboqs.go\` files.

**B — Makefile pre-flight check**: \`utils/Makefile.common\` adds a \`check-liboqs\` target that runs only when \`WITH_LIBOQS=1\`, calls \`pkg-config --exists liboqs-go\`, and on failure prints an actionable message pointing at the env script. Build aborts immediately instead of cascading into cryptic cgo errors.

**A — docs**: new \`cmdv2/README.md\` documents the build matrix; updated \`tdns-project/CLAUDE.md\` (project-level instruction file, not in this repo) records the opt-in build command for future sessions.

**C** — separate PR in \`dnssec-algorithms/\` for the smart env-script (auto-detects install prefix, portable across sh/bash/zsh).

## Build matrix

| Command | What's built |
|---|---|
| \`make\` | All 5 binaries. PQ: ML-DSA-44 + SLH-DSA-128s (real); Falcon/MAYO/SNOVA (metadata-only). No liboqs needed. |
| \`make WITH_LIBOQS=1\` | All 5 binaries. PQ: all 5 algorithms wired in. Requires \`. dnssec-algorithms/liboqs/liboqs-env.sh\` first. |
| \`make WITH_LIBOQS=1\` (env missing) | Aborts at pre-flight with pointer to env script. |

## Test plan

- [x] Verified default build: clean shell, no PKG_CONFIG_PATH, \`make\` builds all 5 binaries cleanly.
- [x] Verified opt-in build: \`. liboqs-env.sh && make WITH_LIBOQS=1\` builds with \`-tags liboqs\` on every sub-make.
- [x] Verified precheck fires: \`make WITH_LIBOQS=1\` without env sourced prints the actionable message and aborts.
- [ ] CodeRabbit review
- [ ] NetBSD build server verification with \`make WITH_LIBOQS=1\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized post-quantum algorithm registration to support conditional compilation based on cryptographic library availability, enabling flexible builds with or without extended post-quantum algorithm support.

* **Chores**
  * Updated algorithm initialization across agent, auth, and IMR modules to accommodate build-time configuration of post-quantum signature algorithms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->