### PR TITLE
cli: export GetClientKeyFromParent + GetApiDetailsByClientKey

### DIFF
--- a/v2/cli/apiclient.go
+++ b/v2/cli/apiclient.go
@@ -159,6 +159,13 @@ func getClientKeyFromParent(role string) string {
 	return roleToClientKey[role]
 }
 
+// GetClientKeyFromParent is the exported form of getClientKeyFromParent
+// for cross-package CLI consumers (e.g. tdns-mp/v2/cli's JOSE keys
+// commands) that need to resolve a role name to its clientKey.
+func GetClientKeyFromParent(role string) string {
+	return getClientKeyFromParent(role)
+}
+
 // getApiDetailsByClientKey returns the ApiDetails entry whose Name
 // matches clientKey, or nil if no such entry exists. Data comes from
 // the CliConf handed to InitApiClients — no viper reach-through.
@@ -172,4 +179,10 @@ func getApiDetailsByClientKey(clientKey string) *ApiDetails {
 		}
 	}
 	return nil
+}
+
+// GetApiDetailsByClientKey is the exported form of
+// getApiDetailsByClientKey for cross-package CLI consumers.
+func GetApiDetailsByClientKey(clientKey string) *ApiDetails {
+	return getApiDetailsByClientKey(clientKey)
 }


### PR DESCRIPTION
## Summary

Adds exported wrappers for two unexported helpers in \`tdns/v2/cli/apiclient.go\`:

- \`GetClientKeyFromParent(role string) string\`
- \`GetApiDetailsByClientKey(clientKey string) *ApiDetails\`

Both delegate to their unexported originals. No existing callers updated.

## Why

Prep for an upcoming \`tdns-mp\` change that moves the JOSE keys CLI commands (currently in \`tdns/v2/cli\`) to \`tdns-mp/v2/cli\`. The moved cobra handlers need to resolve a role name to its configured server-config-file path before reading the JOSE key path — that lookup logic lives in these two helpers.

Tiny additive surface change, zero behavior change.

## Test plan

- [x] Builds locally (\`make\` in \`tdns/cmdv2\` succeeds)
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal CLI package APIs to improve code modularity and enable better organization across CLI components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->