### PR TITLE
Makefile: add bump-johanix-deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default v1 all v2 clean install
+.PHONY: default v1 all v2 clean install bump-johanix-deps
 
 default: v2
 
@@ -27,5 +27,29 @@ install:
 	$(MAKE) -C ./cmdv2/ install
 #	$(MAKE) -C ./msa/ install
 #	$(MAKE) -C ./sidecar-cli/ install
+
+# bump-johanix-deps: in every go.mod under this repo, refresh every
+# github.com/johanix/* require line to its current proxy 'latest'
+# (default-branch HEAD of the corresponding repo). Third-party deps
+# are not touched. Runs `go mod tidy` per-module afterwards.
+#
+# Caveat: some johanix sub-modules (notably tdns/v2/cli) currently
+# have unresolved pseudo-versions for their sibling sub-modules and
+# will fail to fetch externally. The target prints the failure and
+# moves on; rerun once the underlying structural issue is fixed.
+bump-johanix-deps:
+	@for mod in $$(find . -name go.mod -not -path './obe/*' -not -path './music/*' -not -path './.git/*'); do \
+	   dir=$$(dirname $$mod); \
+	   deps=$$(awk '/^require \(/,/^\)/ { if ($$1 ~ /^github\.com\/johanix\//) print $$1 }' $$mod | sort -u); \
+	   if [ -z "$$deps" ]; then \
+	      continue; \
+	   fi; \
+	   echo "=== $$dir ==="; \
+	   for dep in $$deps; do \
+	      echo "  $$dep"; \
+	      (cd $$dir && go get $$dep@latest) || echo "  ! $$dep@latest failed (likely unresolved sub-module pin)"; \
+	   done; \
+	   (cd $$dir && go mod tidy) || echo "  ! go mod tidy failed in $$dir"; \
+	done
 
 include utils/Makefile.common


### PR DESCRIPTION
Walks every go.mod in the repo and refreshes each `github.com/johanix/*` require line to its proxy 'latest' (default-branch HEAD). Third-party requires untouched. Runs `go mod tidy` per-module after.

The Go module system doesn't allow `@latest` in go.mod (require lines must be concrete pseudo-versions), so 'use the github main version' translates to 'run this target whenever you want to refresh the pins'.

**Caveat**: some johanix sub-modules currently have unresolved pseudo-versions for their sibling sub-modules and may fail to fetch externally on a clean cache. Target prints failure + moves on; rerun once the underlying structural issue is fixed.

Mirrors the same target added to tdns-mp and tdns-transport (separate PRs).