### PR TITLE
dog: allow +tcp / +tls / +https / +quic after @server

### DIFF
--- a/cmdv2/dog/dog.go
+++ b/cmdv2/dog/dog.go
@@ -475,25 +475,29 @@ func ProcessOptions(options map[string]string, ucarg string) (map[string]string,
 		options["sigchase"] = "true"
 		return options, nil
 	case "+TCP":
-		if transport, exists := options["transport"]; exists {
+		// A pre-existing "Do53" is the default ParseServer writes when
+		// the user supplied @host without a scheme; treat it as an
+		// upgrade target. Only reject when a different encrypted
+		// transport was already explicitly selected.
+		if transport, exists := options["transport"]; exists && transport != "Do53" {
 			return nil, fmt.Errorf("Error: multiple transport options specified (%s and TCP)", transport)
 		}
 		options["transport"] = "Do53-TCP"
 		return options, nil
 	case "+TLS", "+DOT":
-		if transport, exists := options["transport"]; exists {
+		if transport, exists := options["transport"]; exists && transport != "Do53" {
 			return nil, fmt.Errorf("Error: multiple transport options specified (%s and DoT)", transport)
 		}
 		options["transport"] = "DoT"
 		return options, nil
 	case "+HTTPS", "+DOH":
-		if transport, exists := options["transport"]; exists {
+		if transport, exists := options["transport"]; exists && transport != "Do53" {
 			return nil, fmt.Errorf("Error: multiple transport options specified (%s and DoH)", transport)
 		}
 		options["transport"] = "DoH"
 		return options, nil
 	case "+QUIC", "+DOQ":
-		if transport, exists := options["transport"]; exists {
+		if transport, exists := options["transport"]; exists && transport != "Do53" {
 			return nil, fmt.Errorf("Error: multiple transport options specified (%s and DoQ)", transport)
 		}
 		options["transport"] = "DoQ"


### PR DESCRIPTION
## Summary

`dog @127.0.0.1 test.foo dnskey +tcp` failed with "multiple transport options specified (Do53 and TCP)" even though no real conflict existed.

## Root cause

`ParseServer` unconditionally stamps `options["transport"] = "Do53"` when it processes a bare `@host` (no `://` scheme). The four transport `+flags` (+tcp, +tls/+dot, +https/+doh, +quic/+doq) then saw the stamp as a pre-existing transport and refused to overwrite it.

So `+tcp` worked when written *before* the @server arg, failed when written *after* — the same command, parsing order changing semantics.

## Fix

Relax the conflict check in each of the four `+flag` cases: only reject when the pre-existing transport is *not* `Do53`. A `Do53` value is exactly the default ParseServer writes for a bare `@host` and is the expected upgrade target for any of the four flags.

A real conflict — e.g. `+tls +tcp` — still errors as before.

## Test plan

- [x] `dog @127.0.0.1 -p 5354 test.foo dnskey +tcp` (previously broken) — now works
- [x] `dog +tcp @127.0.0.1 -p 5354 test.foo dnskey` (previously working) — still works
- [x] `dog @127.0.0.1 -p 5354 test.foo dnskey +tls +tcp` — still errors (real conflict)
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transport option handling to allow seamless upgrades from implicit defaults to explicitly specified protocols without triggering unnecessary conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->