### PR TITLE
config: add PostParseConfigHook

### DIFF
--- a/v2/config.go
+++ b/v2/config.go
@@ -660,6 +660,19 @@ type InternalConf struct {
 	// Set by MP apps (before calling parent MainInit) to run
 	// MP-specific config validators alongside the built-in ones.
 	PostValidateConfigHook func(conf *Config) error
+
+	// PostParseConfigHook is called at the very end of ParseConfig,
+	// after tdns has decoded the YAML, run its own normalization,
+	// and executed all tdns-side validation. Downstream packages
+	// (tdns-mp, tdns-nm, etc.) can register a hook that decodes
+	// their own config-section structs from the same processed
+	// configMap, running in parallel with the tdns-side decode.
+	//
+	// The configMap argument is the post-include, post-default
+	// processed map that tdns itself decoded into conf — pass it
+	// to mapstructure to decode any downstream sub-tree without
+	// re-reading the file from disk.
+	PostParseConfigHook func(conf *Config, configMap map[string]interface{}) error
 }
 
 // NOTE: MsgQs and its associated message types (KeystateInventoryMsg,

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -420,6 +420,12 @@ func (conf *Config) ParseConfig(reload bool) error {
 		}
 	}
 
+	if hook := conf.Internal.PostParseConfigHook; hook != nil {
+		if err := hook(conf, configMap); err != nil {
+			return fmt.Errorf("PostParseConfigHook: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Adds `Internal.PostParseConfigHook func(*Config, map[string]interface{}) error`, fired at the very end of `ParseConfig` (after tdns has decoded the YAML, normalized identities, validated roles, and parsed multi-provider option strings).

The hook receives both the post-decode `*Config` and the processed `configMap`, so downstream packages can decode their own config-section structs via mapstructure without re-reading the file from disk.

Pure additive change: hook defaults to nil, no behavior change unless a downstream package registers it.

## Why

Prep for a tdns-mp PR that will shadow-parse the `multi-provider:` config block from its own copy of `MultiProviderConf` and deep-compare against tdns's parsed version. Once the shadow parser is proven faithful (no diffs across operator configs), the struct itself can migrate to tdns-mp, breaking the last remaining MP coupling between the two repos.

## Test plan

- [x] Builds locally (`make` in `tdns/cmdv2` with WITH_LIBOQS=1)
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configuration processing extension point that enables third-party validation and customization logic to execute after configuration parsing, decoding, and default processing steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->