### PR TITLE
Makefile: bmake portability for WITH_LIBOQS

### DIFF
--- a/cmdv2/Makefile
+++ b/cmdv2/Makefile
@@ -2,33 +2,36 @@
 
 # WITH_LIBOQS=1 enables the liboqs-backed PQ algorithms (Falcon-512,
 # MAYO-1, SNOVA-24_5_4) in agent/auth/imr. See utils/Makefile.common.
+# Passed explicitly on each recursive $(MAKE) call below — works on
+# both GNU make and NetBSD bmake (bmake's `export` requires VAR=value
+# syntax, which differs from GNU make's bare-name form).
 WITH_LIBOQS ?= 0
-export WITH_LIBOQS
+MAKE_VARS = WITH_LIBOQS=$(WITH_LIBOQS)
 
 # all apps in this directory
 all: v2
 
 version:
-	$(MAKE) -C ./auth/ version
-	$(MAKE) -C ./cli/ version
-	$(MAKE) -C ./agent/ version
-	$(MAKE) -C ./imr/ version
-	$(MAKE) -C ./dog/ version
+	$(MAKE) $(MAKE_VARS) -C ./auth/ version
+	$(MAKE) $(MAKE_VARS) -C ./cli/ version
+	$(MAKE) $(MAKE_VARS) -C ./agent/ version
+	$(MAKE) $(MAKE_VARS) -C ./imr/ version
+	$(MAKE) $(MAKE_VARS) -C ./dog/ version
 
 # experimental version of major apps
 v2:
-	$(MAKE) -C ./auth/
-	$(MAKE) -C ./cli/
-	$(MAKE) -C ./agent/
-	$(MAKE) -C ./imr/
-	$(MAKE) -C ./dog/
+	$(MAKE) $(MAKE_VARS) -C ./auth/
+	$(MAKE) $(MAKE_VARS) -C ./cli/
+	$(MAKE) $(MAKE_VARS) -C ./agent/
+	$(MAKE) $(MAKE_VARS) -C ./imr/
+	$(MAKE) $(MAKE_VARS) -C ./dog/
 
 clean:
-	$(MAKE) -C ./auth/ clean
-	$(MAKE) -C ./cli/ clean
-	$(MAKE) -C ./agent/ clean
-	$(MAKE) -C ./imr/ clean
-	$(MAKE) -C ./dog/ clean
+	$(MAKE) $(MAKE_VARS) -C ./auth/ clean
+	$(MAKE) $(MAKE_VARS) -C ./cli/ clean
+	$(MAKE) $(MAKE_VARS) -C ./agent/ clean
+	$(MAKE) $(MAKE_VARS) -C ./imr/ clean
+	$(MAKE) $(MAKE_VARS) -C ./dog/ clean
 
 check-root:
 	@if [ "$$(id -u)" -ne 0 ]; then echo "Must run as root"; exit 1; fi
@@ -37,11 +40,11 @@ install-dirs: check-root
 	mkdir -p /usr/local/bin /usr/local/libexec
 
 install: check-root install-dirs
-	$(MAKE) -C ./auth/ install
-	$(MAKE) -C ./cli/ install
-	$(MAKE) -C ./agent/ install
-	$(MAKE) -C ./imr/ install
-	$(MAKE) -C ./dog/ install
+	$(MAKE) $(MAKE_VARS) -C ./auth/ install
+	$(MAKE) $(MAKE_VARS) -C ./cli/ install
+	$(MAKE) $(MAKE_VARS) -C ./agent/ install
+	$(MAKE) $(MAKE_VARS) -C ./imr/ install
+	$(MAKE) $(MAKE_VARS) -C ./dog/ install
 
 TAR_VERSION:=v2
 TARFILE:=/tmp/usr.local.tdns.$(TAR_VERSION).tar.gz

--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -12,10 +12,12 @@ GOFLAGS:=-v
 #   . ../../../dnssec-algorithms/liboqs/liboqs-env.sh
 # Default (unset): those algorithms are metadata-only — recognized
 # by name but not usable for sign/verify.
+#
+# The conditional is evaluated in shell rather than via make's ifeq,
+# because GNU make's ifeq/endif and bmake's .if/.endif are not portable
+# to each other. Backtick command substitution works on both.
 WITH_LIBOQS ?= 0
-ifeq ($(WITH_LIBOQS),1)
-GOFLAGS += -tags liboqs
-endif
+LIBOQS_TAGS = `test "$(WITH_LIBOQS)" = 1 && echo -tags liboqs`
 
 GOOS ?= $(shell uname -s | tr A-Z a-z)
 
@@ -30,29 +32,30 @@ version:
 
 build: check-liboqs
 	@test -f version.go || /bin/sh ../../utils/make-version.sh "unknown" "unknown" $(PROG)
-	$(GO) build $(GOFLAGS) -o ${PROG}
+	$(GO) build $(GOFLAGS) $(LIBOQS_TAGS) -o ${PROG}
 
 # Pre-flight check: when WITH_LIBOQS=1, verify pkg-config can find
 # liboqs-go.pc and print actionable guidance otherwise. No-op when
-# WITH_LIBOQS is unset.
+# WITH_LIBOQS is unset. The conditional runs in shell to stay portable
+# between GNU make and bmake.
 check-liboqs:
-ifeq ($(WITH_LIBOQS),1)
-	@pkg-config --exists liboqs-go 2>/dev/null || { \
-	   echo ""; \
-	   echo "  WITH_LIBOQS=1 was set but pkg-config cannot find liboqs-go."; \
-	   echo "  Source the env script in this shell first:"; \
-	   echo ""; \
-	   echo "    . ../../../dnssec-algorithms/liboqs/liboqs-env.sh"; \
-	   echo ""; \
-	   echo "  Then re-run make. See dnssec-algorithms/README.md for"; \
-	   echo "  per-platform liboqs install instructions."; \
-	   echo ""; \
-	   exit 1; \
-	}
-endif
+	@if [ "$(WITH_LIBOQS)" = "1" ]; then \
+	   pkg-config --exists liboqs-go 2>/dev/null || { \
+	      echo ""; \
+	      echo "  WITH_LIBOQS=1 was set but pkg-config cannot find liboqs-go."; \
+	      echo "  Source the env script in this shell first:"; \
+	      echo ""; \
+	      echo "    . ../../../dnssec-algorithms/liboqs/liboqs-env.sh"; \
+	      echo ""; \
+	      echo "  Then re-run make. See dnssec-algorithms/README.md for"; \
+	      echo "  per-platform liboqs install instructions."; \
+	      echo ""; \
+	      exit 1; \
+	   }; \
+	fi
 
 netbsd:
-	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) -o ${PROG}.netbsd
+	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) $(LIBOQS_TAGS) -o ${PROG}.netbsd
 
 # johaniaws: Sync local tdns source to remote AWS environment.
 # Requires: sshfs mount at ~/sshfs/msigner1


### PR DESCRIPTION
## Summary
PR #231 broke the NetBSD build server: bmake doesn't accept GNU make's bare-name `export` directive nor `ifeq`/`endif` conditionals. Two minimal fixes:

- `cmdv2/Makefile`: drop `export WITH_LIBOQS`, instead pass `WITH_LIBOQS=$(WITH_LIBOQS)` explicitly on each recursive `$(MAKE)` via a `MAKE_VARS` helper.
- `utils/Makefile.common`: replace the two `ifeq ($(WITH_LIBOQS),1)` blocks with shell-side conditionals — `LIBOQS_TAGS = \`test "$(WITH_LIBOQS)" = 1 && echo -tags liboqs\`` and an `if/then/fi` inside the `check-liboqs` recipe.

No behavioral change on GNU make.

## Test plan
- [x] macOS / GNU make: default build green, `WITH_LIBOQS=1` correctly hits pkg-config preflight.
- [x] NetBSD / bmake: default build green (all 5 binaries), `WITH_LIBOQS=1` with `liboqs-env.sh` sourced builds and links against falcon512/mayo1/snova24_5_4. Verified on gocpt101.