### PR TITLE
cmdv2: WITH_SQISIGN=1 build knob

### DIFF
--- a/cmdv2/Makefile
+++ b/cmdv2/Makefile
@@ -1,12 +1,16 @@
 .PHONY: all v2 version clean install install-dirs check-root tarball
 
-# WITH_LIBOQS=1 enables the liboqs-backed PQ algorithms (Falcon-512,
-# MAYO-1, SNOVA-24_5_4) in agent/auth/imr. See utils/Makefile.common.
-# Passed explicitly on each recursive $(MAKE) call below — works on
-# both GNU make and NetBSD bmake (bmake's `export` requires VAR=value
-# syntax, which differs from GNU make's bare-name form).
-WITH_LIBOQS ?= 0
-MAKE_VARS = WITH_LIBOQS=$(WITH_LIBOQS)
+# WITH_LIBOQS=1  enables the liboqs-backed PQ algorithms (Falcon-512,
+#                MAYO-1, SNOVA-24_5_4) in agent/auth/imr.
+# WITH_SQISIGN=1 enables the the-sqisign-backed PQ algorithm
+#                (SQIsign-I) in auth.
+# Both knobs are independent. Each is forwarded explicitly on every
+# recursive $(MAKE) below — works on both GNU make and NetBSD bmake
+# (bmake's `export` syntax differs from GNU make's bare-name form).
+# See utils/Makefile.common for the build-tag wiring.
+WITH_LIBOQS  ?= 0
+WITH_SQISIGN ?= 0
+MAKE_VARS = WITH_LIBOQS=$(WITH_LIBOQS) WITH_SQISIGN=$(WITH_SQISIGN)
 
 # all apps in this directory
 all: v2

--- a/cmdv2/auth/go.mod
+++ b/cmdv2/auth/go.mod
@@ -10,7 +10,7 @@ replace (
 )
 
 require (
-	github.com/johanix/dnssec-algorithms v0.0.0-20260515092703-423a9a3a4bf5
+	github.com/johanix/dnssec-algorithms v0.0.0-20260526193209-1b12dcda9b31
 	github.com/johanix/tdns/v2 v2.0.0-00010101000000-000000000000
 	github.com/mattn/go-sqlite3 v1.14.28
 )

--- a/cmdv2/auth/go.sum
+++ b/cmdv2/auth/go.sum
@@ -145,8 +145,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/johanix/dns v0.0.0-20260515091838-3300006a8466 h1:XPf9HP+LpU8FPXIvc3zaz/AwjI2Qa9cRRkTJoq8R590=
 github.com/johanix/dns v0.0.0-20260515091838-3300006a8466/go.mod h1:hBcNfObhP6OL8tg/LRRiRxqToCk64JmTahUFw2q39GM=
-github.com/johanix/dnssec-algorithms v0.0.0-20260515092703-423a9a3a4bf5 h1:ifLEEyglYuFsSGGhOkNt32Ecx7vJwu9T9VB04YJ95WQ=
-github.com/johanix/dnssec-algorithms v0.0.0-20260515092703-423a9a3a4bf5/go.mod h1:9bqZgp2xuoeqFcMazjYzAFOOygrDieZAwlySt+UWe8s=
+github.com/johanix/dnssec-algorithms v0.0.0-20260526193209-1b12dcda9b31 h1:yhnYliIEVO5r98rxQWDBWubCHv9bJSOyljTtE0scLIs=
+github.com/johanix/dnssec-algorithms v0.0.0-20260526193209-1b12dcda9b31/go.mod h1:9bqZgp2xuoeqFcMazjYzAFOOygrDieZAwlySt+UWe8s=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/cmdv2/auth/pq_algorithms_sqisign.go
+++ b/cmdv2/auth/pq_algorithms_sqisign.go
@@ -1,0 +1,26 @@
+//go:build sqisign
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * SQIsign-backed PQ algorithm. CGO + the SQIsign reference C library
+ * required at build time; resulting binaries link against
+ * libsqisign_lvl1*.a (statically) and libgmp (dynamically).
+ *
+ * Build with `make WITH_SQISIGN=1` (which passes `-tags sqisign`).
+ * See dnssec-algorithms/sqisignc/sqisign-env.sh for environment setup
+ * and dnssec-algorithms/sqisignc/build-sqisign.sh for installing the
+ * SQIsign reference library.
+ */
+
+package main
+
+import (
+	"github.com/johanix/dnssec-algorithms/sqisign1"
+
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.Register(204, sqisign1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -13,11 +13,29 @@ GOFLAGS:=-v
 # Default (unset): those algorithms are metadata-only — recognized
 # by name but not usable for sign/verify.
 #
+# WITH_SQISIGN=1 wires in the SQIsign reference C library (SQIsign-I)
+# in cmdv2/auth. The two knobs are independent — use either or both.
+# The reference library is not packaged anywhere; install it once via
+# dnssec-algorithms/sqisignc/build-sqisign.sh, then source the env
+# script before each `make`:
+#   . ../../../dnssec-algorithms/sqisignc/sqisign-env.sh
+#
 # The conditional is evaluated in shell rather than via make's ifeq,
 # because GNU make's ifeq/endif and bmake's .if/.endif are not portable
 # to each other. Backtick command substitution works on both.
-WITH_LIBOQS ?= 0
-LIBOQS_TAGS = `test "$(WITH_LIBOQS)" = 1 && echo -tags liboqs`
+WITH_LIBOQS  ?= 0
+WITH_SQISIGN ?= 0
+# Compose `-tags a,b` only when at least one knob is set. Backtick
+# command substitution stays portable between GNU make and NetBSD
+# bmake. The body is one shell pipeline that emits each enabled tag
+# on its own line, then joins them with paste so the result is empty
+# when no knob is set (and has no stray leading/trailing comma when
+# exactly one is set). Avoids ${var#prefix} shell-parameter expansion,
+# whose `#` would be eaten by make as a comment delimiter.
+GO_BUILD_TAGS = `{ test "$(WITH_LIBOQS)"  = 1 && echo liboqs ; \
+                   test "$(WITH_SQISIGN)" = 1 && echo sqisign ; } | \
+                 paste -sd, - | \
+                 sed -e 's/^./-tags &/'`
 
 GOOS ?= $(shell uname -s | tr A-Z a-z)
 
@@ -30,9 +48,9 @@ all: $(PROG)
 version:
 	/bin/sh ../../utils/make-version.sh $(VERSION)-$(BRANCH)-$(COMMIT) $(APPDATE) $(PROG)
 
-build: check-liboqs
+build: check-liboqs check-sqisign
 	@test -f version.go || /bin/sh ../../utils/make-version.sh "unknown" "unknown" $(PROG)
-	$(GO) build $(GOFLAGS) $(LIBOQS_TAGS) -o ${PROG}
+	$(GO) build $(GOFLAGS) $(GO_BUILD_TAGS) -o ${PROG}
 
 # Pre-flight check: when WITH_LIBOQS=1, verify pkg-config can find
 # liboqs-go.pc and print actionable guidance otherwise. No-op when
@@ -54,8 +72,28 @@ check-liboqs:
 	   }; \
 	fi
 
+# Pre-flight check: when WITH_SQISIGN=1, verify pkg-config can find
+# sqisign.pc and print actionable guidance otherwise. Symmetric to
+# check-liboqs above.
+check-sqisign:
+	@if [ "$(WITH_SQISIGN)" = "1" ]; then \
+	   pkg-config --exists sqisign 2>/dev/null || { \
+	      echo ""; \
+	      echo "  WITH_SQISIGN=1 was set but pkg-config cannot find sqisign."; \
+	      echo "  Source the env script in this shell first:"; \
+	      echo ""; \
+	      echo "    . ../../../dnssec-algorithms/sqisignc/sqisign-env.sh"; \
+	      echo ""; \
+	      echo "  If no install is found, build the reference C library:"; \
+	      echo ""; \
+	      echo "    sh ../../../dnssec-algorithms/sqisignc/build-sqisign.sh"; \
+	      echo ""; \
+	      exit 1; \
+	   }; \
+	fi
+
 netbsd:
-	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) $(LIBOQS_TAGS) -o ${PROG}.netbsd
+	GOOS=netbsd GOARCH=amd64 $(GO) build $(GOFLAGS) $(GO_BUILD_TAGS) -o ${PROG}.netbsd
 
 # johaniaws: Sync local tdns source to remote AWS environment.
 # Requires: sshfs mount at ~/sshfs/msigner1
@@ -101,4 +139,4 @@ lint:
 	gosec ./...
 	golangci-lint run
 
-.PHONY: build version clean check-liboqs
+.PHONY: build version clean check-liboqs check-sqisign


### PR DESCRIPTION
## Summary
Adds \`WITH_SQISIGN=1\` parallel to the existing \`WITH_LIBOQS=1\` knob, so tdns-auth can link the SQIsign-I reference C library independently. liboqs does not ship SQIsign, so this is a distinct toolchain dependency, not a switch on top of liboqs.

- New file \`cmdv2/auth/pq_algorithms_sqisign.go\` (tagged \`//go:build sqisign\`) registers SQIsign-I at codepoint 204. Its sibling \`pq_algorithms_liboqs.go\` now carries only the liboqs-backed algorithms.
- \`utils/Makefile.common\` learns about \`WITH_SQISIGN\` and emits \`-tags\` via a small shell pipeline. Make's comment delimiter rules out the \`\${var#prefix}\` idiom that would have been cleaner, hence the \`paste -sd, + sed\` form.
- \`check-sqisign\` pre-flight target mirrors \`check-liboqs\`: actionable error when pkg-config can't find sqisign.pc.
- \`cmdv2/auth/go.mod\` bumped to the dnssec-algorithms commit that ships \`sqisign1/\`.

## Test plan
- [ ] \`make WITH_LIBOQS=1 WITH_SQISIGN=1\` — both PQ stacks linked
- [ ] \`make WITH_LIBOQS=1\` — liboqs algorithms only (existing behavior unchanged)
- [ ] \`make WITH_SQISIGN=1\` — SQIsign-I only (no liboqs dep needed)
- [ ] \`make\` (neither) — no PQ
- [ ] \`make WITH_SQISIGN=1\` with PKG_CONFIG_PATH empty — confirms helpful error
- [ ] On NetBSD bmake: same matrix
- [ ] Top-level \`make v2 WITH_LIBOQS=1 WITH_SQISIGN=1\` — knobs forward to all sub-makes

## Notes
- The agent and imr binaries don't yet import \`sqisign1\` (auth-only for now). Adding them later requires only a new \`pq_algorithms_sqisign.go\` file under each, no Makefile change.