### PR TITLE
cmdv2: SQISIGN1 metadata everywhere; imr verify support

### DIFF
--- a/cmdv2/auth/pq_algorithms_nosqisign.go
+++ b/cmdv2/auth/pq_algorithms_nosqisign.go
@@ -1,0 +1,24 @@
+//go:build !sqisign
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Default build: the SQIsign-backed PQ algorithm (SQIsign-I) is NOT
+ * compiled in. Only its codepoint and name are registered as metadata
+ * so the CLI argument validator and --help text still recognize it.
+ * Any attempt to sign or verify with codepoint 204 will fail at
+ * runtime.
+ *
+ * Build with `make WITH_SQISIGN=1` (-tags sqisign) to wire in the
+ * real implementation from pq_algorithms_sqisign.go.
+ */
+
+package main
+
+import (
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.RegisterMetadata(204, "SQISIGN1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/cmdv2/cli/main.go
+++ b/cmdv2/cli/main.go
@@ -28,6 +28,7 @@ func init() {
 	algs.RegisterMetadata(201, "FALCON512", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.RegisterMetadata(202, "MAYO1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.RegisterMetadata(203, "SNOVA24_5_4", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(204, "SQISIGN1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }
 
 func main() {

--- a/cmdv2/imr/go.mod
+++ b/cmdv2/imr/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	github.com/johanix/dnssec-algorithms v0.0.0-20260515092703-423a9a3a4bf5
+	github.com/johanix/dnssec-algorithms v0.0.0-20260526195409-65f546532819
 	github.com/johanix/tdns/v2 v2.0.0-00010101000000-000000000000
 	github.com/johanix/tdns/v2/cli v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.8.1

--- a/cmdv2/imr/go.sum
+++ b/cmdv2/imr/go.sum
@@ -155,6 +155,8 @@ github.com/johanix/dns v0.0.0-20260515091838-3300006a8466 h1:XPf9HP+LpU8FPXIvc3z
 github.com/johanix/dns v0.0.0-20260515091838-3300006a8466/go.mod h1:hBcNfObhP6OL8tg/LRRiRxqToCk64JmTahUFw2q39GM=
 github.com/johanix/dnssec-algorithms v0.0.0-20260515092703-423a9a3a4bf5 h1:ifLEEyglYuFsSGGhOkNt32Ecx7vJwu9T9VB04YJ95WQ=
 github.com/johanix/dnssec-algorithms v0.0.0-20260515092703-423a9a3a4bf5/go.mod h1:9bqZgp2xuoeqFcMazjYzAFOOygrDieZAwlySt+UWe8s=
+github.com/johanix/dnssec-algorithms v0.0.0-20260526195409-65f546532819 h1:CiXR4gsxzH08qVIhVHkructrEcnuzUtTSxGStdGM3P0=
+github.com/johanix/dnssec-algorithms v0.0.0-20260526195409-65f546532819/go.mod h1:9bqZgp2xuoeqFcMazjYzAFOOygrDieZAwlySt+UWe8s=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/cmdv2/imr/pq_algorithms_nosqisign.go
+++ b/cmdv2/imr/pq_algorithms_nosqisign.go
@@ -1,0 +1,23 @@
+//go:build !sqisign
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Default build: the SQIsign-backed PQ algorithm (SQIsign-I) is NOT
+ * compiled in. Only its codepoint and name are registered as metadata
+ * so the CLI argument validator and --help text still recognize it.
+ * Any attempt to verify a SQIsign signature with codepoint 204 will
+ * fail at runtime — DNSSEC validation of SQIsign-signed zones
+ * requires building with `make WITH_SQISIGN=1` (-tags sqisign), which
+ * wires in the real implementation from pq_algorithms_sqisign.go.
+ */
+
+package main
+
+import (
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.RegisterMetadata(204, "SQISIGN1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}

--- a/cmdv2/imr/pq_algorithms_sqisign.go
+++ b/cmdv2/imr/pq_algorithms_sqisign.go
@@ -1,0 +1,32 @@
+//go:build sqisign
+
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * SQIsign-backed PQ algorithm. CGO + the SQIsign reference C library
+ * required at build time; resulting binaries link against
+ * libsqisign_lvl1*.a (statically) and libgmp (dynamically).
+ *
+ * tdns-imr needs the real implementation (not just metadata) because
+ * iterative resolution includes DNSSEC validation — it must be able
+ * to verify SQIsign signatures on incoming responses. The same
+ * dns.Algorithm interface that auth uses to sign serves imr's
+ * verify path.
+ *
+ * Build with `make WITH_SQISIGN=1` (which passes `-tags sqisign`).
+ * See dnssec-algorithms/sqisignc/sqisign-env.sh for environment setup
+ * and dnssec-algorithms/sqisignc/build-sqisign.sh for installing the
+ * SQIsign reference library.
+ */
+
+package main
+
+import (
+	"github.com/johanix/dnssec-algorithms/sqisign1"
+
+	algs "github.com/johanix/tdns/v2/algorithms"
+)
+
+func init() {
+	algs.Register(204, sqisign1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+}


### PR DESCRIPTION
## Summary
Fixes three gaps left by #240 (the WITH_SQISIGN=1 Makefile knob):

1. **auth** had a real-impl file (\`pq_algorithms_sqisign.go\`) but no \`pq_algorithms_nosqisign.go\` sibling. Default builds were missing codepoint 204 from the runtime registry, so tdns-cli's \`--help\` didn't list SQISIGN1.
2. **tdns-cli** never registered SQISIGN1 metadata. Fixed by adding an unconditional \`RegisterMetadata(204, "SQISIGN1", ...)\` next to the other PQ entries in \`cmdv2/cli/main.go\`.
3. **tdns-imr** did DNSSEC validation but had no SQIsign verify path. The \`dns.Algorithm\` interface covers both sign and verify, so wiring the real \`sqisign1\` impl into imr (under \`//go:build sqisign\`) gives it verify capability. Symmetric \`!sqisign\` file registers metadata-only.

## Files
- \`cmdv2/auth/pq_algorithms_nosqisign.go\` (new, \`!sqisign\` metadata)
- \`cmdv2/imr/pq_algorithms_sqisign.go\` (new, \`sqisign\` real impl)
- \`cmdv2/imr/pq_algorithms_nosqisign.go\` (new, \`!sqisign\` metadata)
- \`cmdv2/cli/main.go\` — one line added
- \`cmdv2/imr/go.mod\`, \`go.sum\` — bump dnssec-algorithms to commit with sqisign1/

## Not touched
- \`cmdv2/agent/\` — agent signs no zones
- \`cmdv2/dog/\` — pure DNS query tool, no crypto

## Test plan
- [ ] \`make WITH_LIBOQS=1 WITH_SQISIGN=0\` — auth/cli/imr build, all PQ alg names appear in tdns-cli help
- [ ] \`make WITH_LIBOQS=1 WITH_SQISIGN=1\` — auth/imr link libsqisign, cli unchanged
- [ ] \`tdns-cli auth keystore dnssec generate --help\` shows SQISIGN1 in Supported
- [ ] On NetBSD bmake: same matrix
- [ ] Generate a SQIsign DNSKEY (\`-a SQISIGN1\`) on tdns-auth — sign a zone — validate via tdns-imr