### PR TITLE
zone resign: replacement-semantics counterpart to zone sign

### DIFF
--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -80,6 +80,14 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			}
 			resp.Msg = fmt.Sprintf("Zone %s: signed with %d new RRSIGs", zd.ZoneName, newrrsigs)
 
+		case "resign-zone":
+			newrrsigs, err := zd.ResignZone(kdb)
+			if err != nil {
+				resp.Error = true
+				resp.ErrorMsg = err.Error()
+			}
+			resp.Msg = fmt.Sprintf("Zone %s: resigned, %d RRSIGs written by currently-active keys", zd.ZoneName, newrrsigs)
+
 		case "generate-nsec":
 			err := zd.GenerateNsecChain(kdb)
 			if err != nil {

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -46,9 +46,17 @@ func NewZoneCmd(role string, extras ...*cobra.Command) *cobra.Command {
 
 	sign := &cobra.Command{
 		Use:   "sign",
-		Short: "Request signing of a zone",
+		Short: "Request signing of a zone (additive: cover gaps with active keys)",
 		Run: func(cmd *cobra.Command, args []string) {
 			runZoneSimpleCmd(role, "sign-zone")
+		},
+	}
+
+	resign := &cobra.Command{
+		Use:   "resign",
+		Short: "Re-sign zone from scratch with currently-active keys (drops all existing RRSIGs)",
+		Run: func(cmd *cobra.Command, args []string) {
+			runZoneSimpleCmd(role, "resign-zone")
 		},
 	}
 
@@ -100,7 +108,7 @@ func NewZoneCmd(role string, extras ...*cobra.Command) *cobra.Command {
 	}
 	nsec.AddCommand(nsecGenerate, nsecShow)
 
-	c.AddCommand(list, nsec, sign, reload, bump, write, freeze, thaw)
+	c.AddCommand(list, nsec, sign, resign, reload, bump, write, freeze, thaw)
 	// Role-independent extras attached to every zone tree. Each is built
 	// fresh so the command pointer is unique per NewZoneCmd invocation.
 	c.AddCommand(newZoneReadFakeCmd(), newZoneUpdateCmd(role), newZoneDsyncCmd(role))

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"sort"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -19,21 +18,6 @@ import (
 
 // sig0TTL is the TTL used for SIG(0) records in signed messages.
 const sig0TTL uint32 = 300
-
-// signerStaleRRSIGsDropped counts how many RRSIGs SignRRset has dropped
-// because their signing key was no longer in the active key set. The
-// counter is intended to surface key-state-related events: outside of
-// rollovers it should stay flat; a non-zero rate means SOMETHING changed
-// the active set and the stale-RRSIG cleanup is doing its job. Read via
-// SignerStaleRRSIGsDropped().
-var signerStaleRRSIGsDropped uint64
-
-// SignerStaleRRSIGsDropped returns a snapshot of the stale-RRSIG-drop
-// counter. Used by tests and a future observability surface; per-zone
-// breakdown can be added later if needed.
-func SignerStaleRRSIGsDropped() uint64 {
-	return atomic.LoadUint64(&signerStaleRRSIGsDropped)
-}
 
 // cryptoRandIntn returns a random int in [0, n) using crypto/rand.
 func cryptoRandIntn(n int) int {
@@ -192,38 +176,12 @@ func (zd *ZoneData) SignRRset(rrset *core.RRset, name string, dak *DnssecKeys, f
 	resigned := false
 	now := time.Now().UTC()
 
-	// Drop any RRSIG whose signing key is no longer in our active key set.
-	// This happens after a KSK rollover: the previously-active key is now
-	// retired (or removed) and we no longer want its RRSIG covering the
-	// DNSKEY RRset (or any other RRset signed by KSKs/ZSKs). Without this,
-	// stale RRSIGs by retired keys hang around until their validity
-	// expires — long after the keys themselves leave the zone.
-	//
-	// Logged at INFO level (not Debug) and metered so operators can see
-	// in production logs when this fires. Outside of rollover events the
-	// counter should stay flat; a non-zero rate would indicate an
-	// unexpected key-state change worth investigating.
-	activeKeyTags := make(map[uint16]bool, len(signingkeys))
-	for _, key := range signingkeys {
-		activeKeyTags[key.DnskeyRR.KeyTag()] = true
-	}
-	filtered := rrset.RRSIGs[:0]
-	for _, sig := range rrset.RRSIGs {
-		s, ok := sig.(*dns.RRSIG)
-		if !ok || activeKeyTags[s.KeyTag] {
-			filtered = append(filtered, sig)
-			continue
-		}
-		atomic.AddUint64(&signerStaleRRSIGsDropped, 1)
-		lgSigner.Info("dropping RRSIG by non-active key",
-			"zone", zd.ZoneName,
-			"name", s.Header().Name,
-			"rrtype", dns.TypeToString[s.TypeCovered],
-			"keytag", s.KeyTag,
-			"reason", "key no longer in active set (post-rollover or manual state change)")
-		resigned = true // we changed the rrset.RRSIGs; flag as updated
-	}
-	rrset.RRSIGs = filtered
+	// SignRRset is purely additive: it ensures every RRset has an RRSIG
+	// by every currently-active signing key, and drops only RRSIGs that
+	// are expired or near-expiry (via NeedsResigning, evaluated below).
+	// RRSIGs by no-longer-active keys are left in place — replacing them
+	// is a zone-level "replacement" operation that belongs to ResignZone,
+	// not to individual RRset additions.
 
 	for _, key := range signingkeys {
 		shouldSign := true
@@ -458,6 +416,139 @@ func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB) (*DnssecKeys, error) {
 	}
 
 	return dak, nil
+}
+
+// ResignZone re-signs every RRset in the zone from scratch with the
+// currently-active keys. This is the "replacement" counterpart to
+// SignZone's purely additive semantics: SignZone leaves existing
+// RRSIGs alone (it only fills gaps and refreshes near-expiry ones);
+// ResignZone discards each RRset's RRSIGs and rebuilds them by the
+// active key set.
+//
+// Use after toggling key states (active → inactive, retired, removed)
+// when you want the served zone's RRSIG set to match the new active
+// set immediately, rather than waiting for natural expiry.
+//
+// Per-RRset publish atomicity: the strip-and-resign happens on a
+// local copy of each RRset, and the result is published via a single
+// RRtypes.Set call. Readers (queries, AXFR) therefore go from "old
+// RRSIGs" directly to "new RRSIGs" with no observable intermediate
+// state in which the RRset is unsigned. A bulk strip-then-SignZone
+// would have left the entire zone partially unsigned during the
+// sign pass — visible to any concurrent query or zone transfer.
+//
+// Delegations and glue follow the same rules as SignZone: delegation
+// NS RRsets are not signed, glue addresses (A/AAAA at delegation
+// names) are not signed.
+//
+// Returns the count of RRSIGs written by the final pass.
+func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
+	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+		return 0, fmt.Errorf("ResignZone: zone %s should not be signed here (neither online-signing nor inline-signing)", zd.ZoneName)
+	}
+	if zd.HasError(DnssecError) {
+		return 0, fmt.Errorf("ResignZone: zone %s has DNSSEC error: %s", zd.ZoneName, zd.ErrorMsg)
+	}
+
+	dak, err := zd.EnsureActiveDnssecKeys(kdb)
+	if err != nil {
+		lgSigner.Error("ResignZone: failed to ensure active DNSSEC keys", "zone", zd.ZoneName, "err", err)
+		return 0, err
+	}
+
+	if !zd.Options[OptBlackLies] {
+		if err := zd.GenerateNsecChain(kdb); err != nil {
+			return 0, err
+		}
+	}
+
+	var clamp *ClampParams
+	if zd.DnssecPolicy != nil {
+		clamp, err = ClampParamsForZone(kdb, zd.ZoneName, zd.DnssecPolicy, time.Now())
+		if err != nil {
+			lgSigner.Error("ResignZone: ClampParamsForZone failed; refusing to sign", "zone", zd.ZoneName, "err", err)
+			return 0, fmt.Errorf("ResignZone: ClampParamsForZone for zone %s: %w", zd.ZoneName, err)
+		}
+	}
+
+	if err := zd.PublishDnskeyRRs(dak); err != nil {
+		return 0, err
+	}
+
+	names, err := zd.GetOwnerNames()
+	if err != nil {
+		return 0, err
+	}
+	sort.Strings(names)
+
+	var delegations []string
+	for _, name := range names {
+		if name == zd.ZoneName {
+			continue
+		}
+		owner, err := zd.GetOwner(name)
+		if err != nil {
+			return 0, err
+		}
+		if owner == nil {
+			continue
+		}
+		if _, exist := owner.RRtypes.Get(dns.TypeNS); exist {
+			delegations = append(delegations, name)
+		}
+	}
+
+	newrrsigs := 0
+	for _, name := range names {
+		owner, err := zd.GetOwner(name)
+		if err != nil {
+			return 0, err
+		}
+		if owner == nil {
+			continue
+		}
+		for _, rrt := range owner.RRtypes.Keys() {
+			if rrt == dns.TypeRRSIG {
+				continue
+			}
+			if rrt == dns.TypeNS && name != zd.ZoneName {
+				continue // delegation NS — not signed
+			}
+			if rrt == dns.TypeA || rrt == dns.TypeAAAA {
+				var isglue bool
+				for _, del := range delegations {
+					if strings.HasSuffix(name, del) {
+						isglue = true
+						break
+					}
+				}
+				if isglue {
+					continue
+				}
+			}
+
+			// Work on a local copy. The published RRset stays unchanged
+			// until we Set the new one back in a single atomic store, so
+			// readers never observe an unsigned intermediate state.
+			rrset := owner.RRtypes.GetOnlyRRSet(rrt)
+			rrset.RRSIGs = nil
+			resigned, err := zd.SignRRset(&rrset, zd.ZoneName, dak, true, clamp)
+			if err != nil {
+				lgSigner.Error("ResignZone: SignRRset failed",
+					"zone", zd.ZoneName, "name", name,
+					"rrtype", dns.TypeToString[rrt], "err", err)
+				return newrrsigs, err
+			}
+			owner.RRtypes.Set(rrt, rrset)
+			if resigned {
+				newrrsigs++
+			}
+		}
+	}
+
+	lgSigner.Info("ResignZone completed",
+		"zone", zd.ZoneName, "rrsigs_written", newrrsigs)
+	return newrrsigs, nil
 }
 
 // XXX: MaybesignRRset should report on whether it actually signed anything


### PR DESCRIPTION
## Summary
Splits two unrelated behaviors that were tangled in \`zone sign\`:

- **\`zone sign\`** — additive: cover gaps with currently-active keys, refresh near-expiry RRSIGs. Now leaves RRSIGs by no-longer-active keys alone.
- **\`zone resign\`** — replacement (new command): rebuild every RRset's RRSIGs from the currently-active key set. Use after toggling key states when the served zone should immediately reflect the new active set.

## Why the split

Triggered by observation: after marking SNOVA ZSK \`active → inactive\` and toggling SQIsign ZSK \`created → active\`, \`zone sign --force\` left the zone signed by both ZSKs. The previous code had a stale-by-key drop block inside \`SignRRset\` doing partial replacement semantics under an additive verb. Cleaner separation: each verb does one thing.

## Atomicity

\`ResignZone\` walks the zone like \`SignZone\` and processes one RRset at a time: read → strip RRSIGs on local copy → \`SignRRset(force=true)\` → atomic \`RRtypes.Set\`. The published RRset goes directly from "old RRSIGs" to "new RRSIGs" with no unsigned-window state. A bulk-strip-then-SignZone variant would have left the zone partially unsigned for the duration of the pass — visible to concurrent queries and AXFR.

## Changes

- \`v2/sign.go\`:
  - New \`ResignZone(kdb)\` method (per-RRset replacement).
  - Removed stale-by-key drop block from \`SignRRset\` (~30 lines).
  - Removed dead \`signerStaleRRSIGsDropped\` counter + \`SignerStaleRRSIGsDropped()\` accessor + unused \`sync/atomic\` import.
- \`v2/apihandler_zone.go\`: new \`"resign-zone"\` command alongside \`"sign-zone"\`.
- \`v2/cli/zone_cmds.go\`: new \`zone resign\` subcommand; help text distinguishes the two verbs.

## Test plan
- [ ] \`tdns-cli auth zone --help\` lists both \`sign\` (additive) and \`resign\` (replacement)
- [ ] Multi-key zone: mark one ZSK inactive, run \`tdns-cli auth zone sign\` — old RRSIGs by inactive key remain (expected per new semantics)
- [ ] Same zone: run \`tdns-cli auth zone resign\` — RRSIGs by inactive key are gone, only active-key RRSIGs cover RRsets
- [ ] During \`resign\` of a large zone, AXFR/queries never see an RRset without RRSIGs (atomicity check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `resign` command to perform complete zone re-signing operations via CLI and API.
  * Updated `sign` command to use purely additive signing behavior—new signatures are added while existing signatures from retired keys are preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->