### PR TITLE
logging: run SetupLogging before ParseConfig

### DIFF
--- a/docs/2026-05-27-early-logging-setup.md
+++ b/docs/2026-05-27-early-logging-setup.md
@@ -1,0 +1,247 @@
+# Early logging setup
+
+Date: 2026-05-27
+Status: PLAN — implementation in branch `early-logging-setup`.
+
+## Motivation
+
+`tdns.SetupLogging` currently runs *after* `conf.ParseConfig`, which
+means every `lg.Info` / `lg.Warn` / `lg.Error` call issued from
+inside `ParseConfig` (or any hook it fires —
+`PostParseConfigHook`, `PostValidateConfigHook`) goes to slog's
+default handler. The file handler is not yet wired, so on NetBSD
+daemons (where stderr is typically discarded) those log lines are
+**lost**.
+
+Workarounds for this have leaked into the codebase. The clearest
+example is `RegisterShadowMpConfigParser` in
+`tdns-mp/v2/shadow_mp_config.go`, which deliberately stashes its
+result on the config and defers all logging to a separate
+`EmitShadowMpComparison` that runs *after* `SetupLogging`. Other
+parse-time errors are silently downgraded to `fmt.Errorf` returns or
+disappear into stderr.
+
+This is a real cost: every parse-time validation, hook, or
+sanity-check has to navigate the chicken-and-egg of "I'd like to
+log this, but I can't yet."
+
+## The chicken-and-egg
+
+- `SetupLogging` needs the `log:` section of the config file.
+- `log:` is parsed by `ParseConfig`.
+- `ParseConfig` (today) calls `lg.Debug`/`lg.Warn` internally, plus
+  fires hooks that want to log.
+
+The dependency cycle is only apparent. `log:` is a leaf section
+with three fields (`file`, `level`, `subsystems`). Nothing else in
+the config file influences how logging is set up. So we can parse
+just the `log:` subtree of the config file *first*, set up
+logging, then run the full `ParseConfig` with logging live.
+
+## Design
+
+### New ordering inside `MainInit`
+
+```
+flag.Parse()                                  # already there: sets conf.Internal.CfgFile
+SetupLogging(conf.Internal.CfgFile)           # NEW: reads only log: section
+err := conf.ParseConfig(false)                # now runs with logging live
+... rest of MainInit ...
+```
+
+### `SetupLogging` signature change
+
+Before:
+
+```go
+func SetupLogging(logfile string, logConf LogConf) error
+```
+
+After:
+
+```go
+func SetupLogging(cfgfile string) (LogConf, error)
+```
+
+It now reads the config file itself, extracts the `log:` subtree,
+applies it, and returns the parsed `LogConf` so callers can stash
+it if they wish. (For the single caller in `MainInit`, the later
+full `ParseConfig` will re-populate `Conf.Log` from the same input,
+so no explicit stashing is needed.)
+
+### Focused parser
+
+```go
+type rawLogConfig struct {
+    Log *LogConf `yaml:"log"`
+}
+
+func parseLogConfFromFile(cfgfile string) (LogConf, error) {
+    data, err := os.ReadFile(cfgfile)
+    if err != nil {
+        return LogConf{}, fmt.Errorf("read config %q: %w", cfgfile, err)
+    }
+    var raw rawLogConfig
+    if err := yaml.Unmarshal(data, &raw); err != nil {
+        return LogConf{}, fmt.Errorf("parse log section of %q: %w", cfgfile, err)
+    }
+    if raw.Log == nil {
+        return LogConf{}, fmt.Errorf(
+            "no log: section found at the top level of %q\n\n"+
+                "  The log: block is REQUIRED and MUST live at the top level\n"+
+                "  of the main config file. It cannot be hidden inside an\n"+
+                "  included file — SetupLogging runs before include\n"+
+                "  resolution, so an included log: block would be invisible\n"+
+                "  and logging would silently fall back to defaults.\n\n"+
+                "  Move the log: block into %q and retry.",
+            cfgfile, cfgfile)
+    }
+    if raw.Log.File == "" {
+        return LogConf{}, fmt.Errorf(
+            "log.file is empty in %q (log: section was found but log.file is required)",
+            cfgfile)
+    }
+    return *raw.Log, nil
+}
+```
+
+This parser does **not** call `processConfigFile` — it does not
+resolve `!include` directives or templates. The `log:` block MUST
+live at the top level of the main config file; if the early parse
+doesn't find it there, startup fails with the explicit error above.
+
+Rationale: silently falling back to defaults when the `log:` block
+hides in an include would mean a misconfiguration produces no
+logging *and* no error — exactly the failure mode we are trying to
+eliminate. The hard-fail is loud, the message tells the operator
+exactly what's wrong, and the constraint matches existing
+operational convention.
+
+The `LogConf` field is `*LogConf` (pointer) specifically so we can
+distinguish "no `log:` section at all" from "`log:` section present
+but with zero-valued fields." A non-pointer field would yaml-decode
+to a zero `LogConf{}` in either case, hiding the difference.
+
+### Viper removal in this path
+
+The current code reads `log.file` from viper:
+
+```go
+logfile := viper.GetString("log.file")
+err = SetupLogging(logfile, Conf.Log)
+```
+
+`viper.GetString` is the only viper call in the `MainInit` startup
+path that we can remove cheaply. The new `SetupLogging` reads
+directly from the YAML file via `yaml.Unmarshal`, so the path no
+longer depends on viper at all. This is a small but concrete step
+toward the broader viper-removal direction
+(see `tdns-mp/docs/2026-05-26-viper-removal-analysis.md`).
+
+The `viper.ReadConfig` call inside `ParseConfig` itself is
+unaffected by this change — it remains for non-log keys until the
+broader viper-removal work tackles it.
+
+## Error visibility
+
+There are exactly three error paths during early startup, all
+surfaced to stderr+exit because logging is not yet live:
+
+1. **Config file missing / unreadable / not valid YAML.** Print to
+   stderr and exit non-zero.
+2. **`log:` block missing from top level of config file** (the case
+   the focused parser explicitly handles). Print the multi-line
+   "log: is mandatory" message to stderr and exit non-zero. No
+   silent fallback to defaults.
+3. **`log:` block present but `log.file` empty.** Print to stderr
+   and exit non-zero.
+
+```go
+if err != nil {
+    fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+    os.Exit(1)
+}
+```
+
+All three are irreducible edges — logging cannot exist yet, so
+stderr is the only output channel. But they are *concrete and
+loud*: every one of them tells the operator exactly which thing to
+fix. Compared to today, where a misconfigured `log:` block can
+silently produce a daemon with no logging, this is a strict
+improvement.
+
+Everything after these three pre-conditions has logging live.
+Errors during `ParseConfig`, validation, hooks all land in the
+logfile as normal `lg.Error` / `lg.Warn` calls. The stash-and-defer
+pattern in `RegisterShadowMpConfigParser` can be deleted; hooks can
+log freely.
+
+## Reload path
+
+`conf.ParseConfig(true)` is called from `Shutdowner` / SIGHUP. The
+proposal does not change reload semantics — `SetupLogging` is not
+re-invoked on reload today, and this change preserves that. If a
+future change wants `log:` modifications to take effect on reload,
+it can call `parseLogConfFromFile` from the reload path too. Out
+of scope here.
+
+## CLI tools
+
+CLI binaries that go through `SetupCliLogging` (writes to stderr)
+are unaffected — this design only touches the `SetupLogging`
+codepath used by daemons.
+
+CLI binaries that use `MainInit` are affected positively: they get
+the same earlier-logging behavior.
+
+## Migration risks
+
+- **Single caller in tdns/v2** (`main_initfuncs.go:138`). Easy to
+  update.
+- **No callers in tdns-mp.** tdns-mp's `MainInit` delegates to
+  `tdns.MainInit` for logging setup, so the change is transparent
+  to tdns-mp.
+- **Sibling repos that vendor or duplicate `SetupLogging`**
+  (`tdns-fast-roller-mldsa44/v2/logging.go`). Out of scope for
+  this branch — those repos handle their own logging-setup
+  refactor when they catch up.
+- **Behavior change: `lg.Debug("MainInit starting", ...)` now
+  appears in the logfile** instead of being lost. That's the whole
+  point, but it does mean operators may see one new debug line
+  per startup. Not a regression.
+
+## Knock-on benefits
+
+After this lands:
+
+- The MP config cutover's Bite 8 can simply return errors from the
+  `PostParseConfigHook` instead of the stash-and-defer dance. The
+  `EmitShadowMpComparison`/`MpConfigParseErr` machinery becomes
+  pure cleanup.
+- `Shutdowner` no longer needs to double-output (`lgConfig.Info` +
+  `fmt.Printf`) during early errors — `lgConfig.Info` works.
+- Any future parse-time hook in tdns or downstream packages can
+  log normally.
+
+## Scope
+
+- New: `parseLogConfFromFile` in `logging.go`.
+- Changed: `SetupLogging` signature + body.
+- Changed: `MainInit` in `main_initfuncs.go` — reorder, drop viper
+  call.
+- Removed: nothing yet. (Bite 8 of the MP cutover removes the
+  stash-and-defer in tdns-mp once this lands.)
+
+Estimated diff: ~50-80 lines.
+
+## Verification
+
+1. `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make` — all tdns
+   binaries build clean.
+2. `cd tdns-mp/cmd && GOROOT=/opt/local/lib/go make` — tdns-mp
+   builds clean against the new signature (the call chain goes
+   through `tdns.MainInit`, so tdns-mp doesn't see the signature
+   directly).
+3. Operator test: start a daemon, confirm `log:` section is honored
+   identically to before, confirm a deliberately-broken config
+   reports the error to stderr (instead of failing silently).

--- a/v2/logging.go
+++ b/v2/logging.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -26,17 +27,65 @@ var (
 	logWriter       io.Writer // the underlying lumberjack (or stdout) writer
 )
 
+// parseLogConfFromFile reads the supplied config file and extracts ONLY the
+// top-level log: section. It does not resolve !include directives or any
+// other config structure — the log: block must live at the top level of
+// the main config file. Returns an explicit error if the log: section is
+// missing or log.file is empty, so misconfiguration cannot silently fall
+// back to default behaviour.
+//
+// See tdns/docs/2026-05-27-early-logging-setup.md for design rationale.
+func parseLogConfFromFile(cfgfile string) (LogConf, error) {
+	data, err := os.ReadFile(cfgfile)
+	if err != nil {
+		return LogConf{}, fmt.Errorf("read config %q: %w", cfgfile, err)
+	}
+	// Pointer field: distinguishes "no log: section at all" from
+	// "log: section present but zero-valued".
+	var raw struct {
+		Log *LogConf `yaml:"log"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return LogConf{}, fmt.Errorf("parse log section of %q: %w", cfgfile, err)
+	}
+	if raw.Log == nil {
+		return LogConf{}, fmt.Errorf(
+			"no log: section found at the top level of %q\n\n"+
+				"  The log: block is REQUIRED and MUST live at the top level\n"+
+				"  of the main config file. It cannot be hidden inside an\n"+
+				"  included file — SetupLogging runs before include\n"+
+				"  resolution, so an included log: block would be invisible\n"+
+				"  and logging would silently fall back to defaults.\n\n"+
+				"  Move the log: block into %q and retry.",
+			cfgfile, cfgfile)
+	}
+	if raw.Log.File == "" {
+		return LogConf{}, fmt.Errorf(
+			"log.file is empty in %q (log: section found but log.file is required)",
+			cfgfile)
+	}
+	return *raw.Log, nil
+}
+
 // SetupLogging configures the slog-based logging system with lumberjack rotation.
 // It also bridges the old log package so that existing log.Printf calls flow
 // through slog to the same output.
-func SetupLogging(logfile string, logConf LogConf) error {
-	if logfile == "" {
-		return fmt.Errorf("log file not specified (key log.file)")
+//
+// Reads the log: section directly from the supplied config file so it can be
+// called BEFORE ParseConfig — that way ParseConfig and its hooks have a live
+// logger to write to. Returns the parsed LogConf so callers can stash it if
+// desired (the full ParseConfig will re-populate Conf.Log from the same input,
+// so a caller that drops the return value is fine).
+func SetupLogging(cfgfile string) (LogConf, error) {
+	logConf, err := parseLogConfFromFile(cfgfile)
+	if err != nil {
+		return LogConf{}, err
 	}
+
 	// H27: Validate log file path
-	logfile = filepath.Clean(logfile)
+	logfile := filepath.Clean(logConf.File)
 	if strings.Contains(logfile, "..") {
-		return fmt.Errorf("log file path must not contain directory traversal: %s", logfile)
+		return LogConf{}, fmt.Errorf("log file path must not contain directory traversal: %s", logfile)
 	}
 
 	lj := &lumberjack.Logger{
@@ -72,7 +121,7 @@ func SetupLogging(logfile string, logConf LogConf) error {
 		SetSubsystemLevel(name, ParseLogLevel(levelStr))
 	}
 
-	return nil
+	return logConf, nil
 }
 
 // SetupCliLogging sets up logging for CLI commands.

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
 	flag "github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
 var engineWg sync.WaitGroup
@@ -116,7 +115,6 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 			flag.PrintDefaults()
 		}
 	}
-	lgConfig.Debug("MainInit starting", "defaultcfg", defaultcfg, "cfgfile", conf.Internal.CfgFile)
 	// Defensive: catch an unset Globals.App.Type. Every binary's
 	// main() must set this before calling MainInit.
 	if Globals.App.Type == 0 {
@@ -130,17 +128,22 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 		fmt.Printf("*** TDNS %s version %s mode of operation: %q (verbose: %t, debug: %t)\n",
 			Globals.App.Name, Globals.App.Version, AppTypeToString[Globals.App.Type], Globals.Verbose, Globals.Debug)
 	}
-	err := conf.ParseConfig(false) // false = initial config, not reload
+	// Set up logging BEFORE ParseConfig so the parse and its hooks have
+	// a live logger. SetupLogging reads the log: block directly from the
+	// config file (it doesn't resolve includes) and hard-fails if the
+	// log: block isn't at the top level — preventing silent fallback to
+	// defaults. See tdns/docs/2026-05-27-early-logging-setup.md.
+	logConf, err := SetupLogging(conf.Internal.CfgFile)
+	if err != nil {
+		return fmt.Errorf("error setting up logging: %w", err)
+	}
+	lgConfig.Debug("MainInit starting", "defaultcfg", defaultcfg, "cfgfile", conf.Internal.CfgFile)
+	if Globals.App.Type != AppTypeCli || Globals.Verbose {
+		fmt.Printf("Logging to file: %s\n", logConf.File)
+	}
+	err = conf.ParseConfig(false) // false = initial config, not reload
 	if err != nil {
 		return fmt.Errorf("error parsing config %q: %v", conf.Internal.CfgFile, err)
-	}
-	logfile := viper.GetString("log.file")
-	err = SetupLogging(logfile, Conf.Log)
-	if err != nil {
-		return fmt.Errorf("error setting up logging: %v", err)
-	}
-	if Globals.App.Type != AppTypeCli || Globals.Verbose {
-		fmt.Printf("Logging to file: %s\n", logfile)
 	}
 	switch Globals.App.Type {
 	case AppTypeAuth, AppTypeAgent, AppTypeScanner:

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -143,7 +143,7 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	}
 	err = conf.ParseConfig(false) // false = initial config, not reload
 	if err != nil {
-		return fmt.Errorf("error parsing config %q: %v", conf.Internal.CfgFile, err)
+		return fmt.Errorf("error parsing config %q: %w", conf.Internal.CfgFile, err)
 	}
 	switch Globals.App.Type {
 	case AppTypeAuth, AppTypeAgent, AppTypeScanner:
@@ -151,7 +151,7 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 		if kdb == nil {
 			err = conf.InitializeKeyDB()
 			if err != nil {
-				return fmt.Errorf("error initializing KeyDB: %v", err)
+				return fmt.Errorf("error initializing KeyDB: %w", err)
 			}
 		}
 	default:
@@ -159,7 +159,7 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	}
 	err = Globals.Validate()
 	if err != nil {
-		return fmt.Errorf("error validating TDNS globals: %v", err)
+		return fmt.Errorf("error validating TDNS globals: %w", err)
 	}
 	if Globals.App.Type != AppTypeCli || Globals.Verbose {
 		fmt.Printf("TDNS %s version %s starting.\n", Globals.App.Name, Globals.App.Version)
@@ -191,7 +191,7 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	// It's only registered if zones are configured (TDNS-internal check).
 	// Note: .server. queries are automatically handled by createAuthDnsHandler() as a fallback before returning REFUSED.
 	if err := RegisterDefaultQueryHandlers(conf); err != nil {
-		return fmt.Errorf("failed to register default query handlers: %v", err)
+		return fmt.Errorf("failed to register default query handlers: %w", err)
 	}
 	// Create all channels unconditionally to simplify code and reduce conditional complexity.
 	// Channels containing pointers have minimal memory overhead, so unused channels are acceptable.
@@ -221,7 +221,7 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	// Parse all configured zones
 	all_zones, _, err := conf.ParseZones(ctx, false) // false = initial load, not reload
 	if err != nil {
-		return fmt.Errorf("error parsing zones: %v", err)
+		return fmt.Errorf("error parsing zones: %w", err)
 	}
 	// Provide the complete zone list to engines that need cross-zone post-initialization
 	conf.Internal.AllZones = all_zones


### PR DESCRIPTION
## Summary

- `SetupLogging` now runs *before* `ParseConfig`, reading the `log:`
  block directly from the config file via a focused `yaml.Unmarshal`.
- Eliminates the chicken-and-egg where parse-time errors and hooks
  (like `PostParseConfigHook`) had no live logger to write to.
- Drops the only `viper.GetString` call from the `MainInit` startup
  path — step toward the broader viper-removal direction.

## Behaviour change

The `log:` block MUST live at the top level of the main config file
(the focused parser does not resolve `!include` directives). If it's
missing — or missing `log.file` — startup hard-fails with an explicit
operator-facing message. No silent fallback to defaults.

This formalises existing operational convention; no operator config
should need to move anything.

## Knock-on benefit

After this lands, the MP config cutover's Bite 8
([tdns-mp branch `mp-config-cutover`](https://github.com/johanix/tdns-mp/tree/mp-config-cutover))
can delete the stash-and-defer machinery in
`shadow_mp_config.go` — hooks return errors directly and they land in
the logfile.

## Signature change

```
before: SetupLogging(logfile string, logConf LogConf) error
after:  SetupLogging(cfgfile string) (LogConf, error)
```

Only one caller in `tdns/v2` (`main_initfuncs.go`). tdns-mp goes
through `tdns.MainInit`, so the signature change is invisible to it.
Sibling repos with their own `SetupLogging`
(`tdns-fast-roller-mldsa44`) are out of scope.

## Test plan

- [ ] tdns binaries build clean (verified locally — 5 binaries)
- [ ] tdns-mp binaries build clean against this branch (verified
      locally — 5 binaries)
- [ ] Start a daemon with a valid config — confirm `log:` honored
      identically to before, confirm `lgConfig.Debug("MainInit
      starting", ...)` now lands in logfile
- [ ] Start a daemon with `log:` section deleted — confirm
      multi-line "log: is mandatory" message on stderr, exit
      non-zero
- [ ] Start a daemon with `log:` present but `log.file: ""` —
      confirm "log.file is empty" message on stderr, exit non-zero
- [ ] Start a daemon with config file that doesn't exist — confirm
      "read config" error on stderr, exit non-zero

Design doc: [docs/2026-05-27-early-logging-setup.md](docs/2026-05-27-early-logging-setup.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Logging configuration is now centralized in the application config file instead of requiring separate parameters.
  * Logging initialization occurs earlier in the startup sequence for improved visibility of initialization errors.
  * Added security validation for log file paths to prevent directory traversal issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->