### PR TITLE
parseconfig: include filename + line context in returned YAML parse errors

### DIFF
--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -65,7 +65,8 @@ func processConfigFile(file string, baseDir string, depth int) (map[string]inter
 	var config map[string]interface{}
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		// On parse error, show context around the reported line to help diagnose
-		// (e.g. tabs, wrong indentation, stray colons)
+		// (e.g. tabs, wrong indentation, stray colons). Both log it (server-side
+		// detail) AND fold it into the returned error so callers over RPC see it.
 		errStr := err.Error()
 		var lineNum int
 		if idx := strings.Index(errStr, "line "); idx >= 0 {
@@ -78,6 +79,7 @@ func processConfigFile(file string, baseDir string, depth int) (map[string]inter
 				fmt.Sscanf(rest[:end], "%d", &lineNum)
 			}
 		}
+		var contextBuf strings.Builder
 		if lineNum > 0 {
 			lines := strings.Split(string(data), "\n")
 			start := lineNum - 4
@@ -91,25 +93,34 @@ func processConfigFile(file string, baseDir string, depth int) (map[string]inter
 			lgConfig.Error("YAML parse error", "line", lineNum, "contextStart", start+1, "contextEnd", end)
 			for i := start; i < end; i++ {
 				line := lines[i]
+				marker := "  "
+				if i == lineNum-1 {
+					marker = "> "
+				}
 				// Reveal tabs and other problematic chars for the failing line
 				if i == lineNum-1 {
 					reveal := strings.ReplaceAll(line, "\t", "\\t")
 					reveal = strings.ReplaceAll(reveal, "\r", "\\r")
 					if reveal != line {
 						lgConfig.Error("context line", "num", i+1, "line", line, "raw", reveal)
-					} else {
-						lgConfig.Error("context line", "num", i+1, "line", line)
+						fmt.Fprintf(&contextBuf, "  %s%4d: %s\n", marker, i+1, reveal)
+						continue
 					}
+					lgConfig.Error("context line", "num", i+1, "line", line)
 				} else {
 					lgConfig.Error("context line", "num", i+1, "line", line)
 				}
+				fmt.Fprintf(&contextBuf, "  %s%4d: %s\n", marker, i+1, line)
 			}
 		}
 		lgConfig.Debug("error unmarshalling YAML to struct", "file", file)
 		if Globals.Debug {
 			fmt.Printf("Config that we failed to unmarshal:\n%s\n", string(data))
 		}
-		return nil, nil, fmt.Errorf("error parsing YAML: %v", err)
+		if contextBuf.Len() > 0 {
+			return nil, nil, fmt.Errorf("error parsing YAML in %s: %v\n%s(tabs shown as \\t; '>' marks the reported line — actual mistake often on a previous line)", file, err, contextBuf.String())
+		}
+		return nil, nil, fmt.Errorf("error parsing YAML in %s: %v", file, err)
 	}
 
 	// Track included files


### PR DESCRIPTION
## Summary
- Fold filename, line number, and a 6-line context window into the returned YAML parse error so it survives the round-trip back to a CLI caller (previously only `lgConfig.Error` got the detail — invisible to anyone driving via tdns-cli over RPC).
- Mark the reported line with `>` and reveal tabs as `\t` so common indentation typos jump out.
- Include a one-line note that the real mistake is often *above* the reported line — yaml.v3 reports the structure-break point, not the offending indent itself.

## Example
```
error parsing YAML in /etc/tdns/auth-zones.yaml: yaml: line 47: did not find expected key
      44:         zone:
      45:            type:		selfsub
      46:            rrtypes:		[ A, AAAA, MX, TXT, KEY, NS, CDS, CSYNC ]
  >   47: zones:
      48:    - name:		catalog.
      49:      zonefile:		/tmp/catalog..zone
  (tabs shown as \t; '>' marks the reported line — actual mistake often on a previous line)
```

## Test plan
- [x] Build clean (`cd tdns/cmdv2 && make`).
- [x] Validated on NetBSD: a real indentation mistake several lines above the parser-reported line was diagnosable from the returned error text alone, without server log access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for YAML configuration file parsing errors. When configuration parsing fails, users now receive detailed diagnostic information including the specific problematic line clearly marked with a `>` indicator, surrounding context lines, identification of problematic characters (tabs and carriage returns), and the affected config file path for more efficient troubleshooting and resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/johanix/tdns/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->