### PR TITLE
Remove multi-provider config from tdns

### DIFF
--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -137,16 +137,15 @@ type ConfigPost struct {
 }
 
 type ConfigResponse struct {
-	AppName         string
-	Time            time.Time
-	DnsEngine       DnsEngineConf
-	ApiServer       ApiServerConf
-	Identities      []string
-	CombinerOptions map[CombinerOption]bool
-	DBFile          string
-	Msg             string
-	Error           bool
-	ErrorMsg        string
+	AppName    string
+	Time       time.Time
+	DnsEngine  DnsEngineConf
+	ApiServer  ApiServerConf
+	Identities []string
+	DBFile     string
+	Msg        string
+	Error      bool
+	ErrorMsg   string
 }
 
 type DelegationPost struct {

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -268,9 +268,6 @@ func APIconfig(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 			resp.ApiServer = conf.ApiServer
 			resp.Identities = conf.Service.Identities
 			resp.DBFile = conf.Db.File
-			if conf.MultiProvider != nil {
-				resp.CombinerOptions = conf.MultiProvider.CombinerOptions
-			}
 			resp.Msg = fmt.Sprintf("%s: Configuration is ok, boot time: %s, last config reload: %s",
 				Globals.App.Name, Globals.App.ServerBootTime.Format(TimeLayout), Globals.App.ServerConfigTime.Format(TimeLayout))
 

--- a/v2/cli/config_cmds.go
+++ b/v2/cli/config_cmds.go
@@ -99,20 +99,10 @@ func runConfigCmd(role, command string, showVerboseStatus bool) {
 		} else {
 			fmt.Printf("DnsEngine: no auth options configured\n")
 		}
-		if len(resp.CombinerOptions) > 0 {
-			fmt.Printf("Combiner: options:\n")
-			for opt := range resp.CombinerOptions {
-				optName, ok := tdns.CombinerOptionToString[opt]
-				if !ok {
-					optName = fmt.Sprintf("unknown option %d", opt)
-				}
-				fmt.Printf("  %s\n", optName)
-			}
-			if resp.DBFile != "" {
-				fmt.Printf("DB: %s\n", resp.DBFile)
-			} else {
-				fmt.Printf("DB: not configured\n")
-			}
+		if resp.DBFile != "" {
+			fmt.Printf("DB: %s\n", resp.DBFile)
+		} else {
+			fmt.Printf("DB: not configured\n")
 		}
 		if len(resp.Identities) > 0 {
 			fmt.Printf("Identities: %v\n", resp.Identities)

--- a/v2/config.go
+++ b/v2/config.go
@@ -46,7 +46,6 @@ type Config struct {
 	ApiServer      ApiServerConf
 	DnssecPolicies map[string]DnssecPolicyConf
 	MultiSigner    map[string]MultiSignerConf `yaml:"multisigner"`
-	MultiProvider  *MultiProviderConf         `yaml:"multi-provider" mapstructure:"multi-provider"`
 	Catalog        *CatalogConf               `yaml:"catalog" mapstructure:"catalog"`
 	DynamicZones   DynamicZonesConf           `yaml:"dynamiczones" mapstructure:"dynamiczones"`
 	Zones          []ZoneConf                 `yaml:"zones"`
@@ -101,128 +100,6 @@ type KaspConf struct {
 	// Accepts Go duration strings: "1m", "60s", "5m".
 	// Default: "1m".
 	CheckInterval string `yaml:"check_interval" mapstructure:"check_interval"`
-}
-
-// ProviderZoneConf configures a provider-owned zone that the combiner manages.
-// Unlike MP zones (hardcoded RRtype whitelist, apex-only), provider zones use
-// config-driven RRtype restrictions and allow non-apex record owners.
-type ProviderZoneConf struct {
-	Zone           string   `yaml:"zone"`
-	AllowedRRtypes []string `yaml:"allowed-rrtypes" mapstructure:"allowed-rrtypes"`
-}
-
-// MultiProviderConf holds config for multi-provider DNSSEC (RFC 8901).
-// Used by all three MP roles: agent, combiner, and signer.
-// The Role field determines which role-specific fields are relevant.
-// YAML key: "multi-provider:"
-type MultiProviderConf struct {
-	// === Shared fields (all roles) ===
-
-	// Role: "agent", "combiner", or "signer". Determines which fields are active.
-	Role string `yaml:"role"`
-	// Active: master switch for multi-provider mode.
-	// Must be true AND zone must have options: [multi-provider] for MP behavior.
-	Active bool `yaml:"active"`
-	// Identity: this node's identity (FQDN) for transport protocol.
-	Identity string `yaml:"identity"`
-	// LongTermJosePrivKey: path to JOSE private key for secure CHUNK.
-	LongTermJosePrivKey string `yaml:"long_term_jose_priv_key"`
-	// ChunkMode: "edns0" | "query" for outbound NOTIFY(CHUNK).
-	ChunkMode string `yaml:"chunk_mode" mapstructure:"chunk_mode"`
-	// ChunkMaxSize: maximum size (bytes) of each data chunk when fragmenting payloads.
-	// 0 = default (60000). Useful for testing fragmentation with small values.
-	ChunkMaxSize int `yaml:"chunk_max_size" mapstructure:"chunk_max_size"`
-	// Agents: the agent peers (address, JOSE public key, optional API URL).
-	// Used by signer and combiner roles.
-	Agents []*PeerConf `yaml:"agents"`
-	// SyncApi: sync API server config for inbound HELLO/BEAT/PING over HTTPS.
-	// Used by signer and combiner roles.
-	SyncApi struct {
-		Addresses struct {
-			Listen []string
-		}
-		CertFile string `yaml:"cert_file" mapstructure:"cert_file"`
-		KeyFile  string `yaml:"key_file" mapstructure:"key_file"`
-	} `yaml:"sync_api" mapstructure:"sync_api"`
-
-	// === Combiner-specific fields ===
-
-	// CombinerOptions: list of combiner-specific option strings parsed at startup.
-	// Known options: "add-signature".
-	CombinerOptionsStrs []string                `yaml:"combiner-options" mapstructure:"combiner-options"`
-	CombinerOptions     map[CombinerOption]bool `yaml:"-" mapstructure:"-"`
-
-	// ChunkQueryEndpoint: "include" | "none"; required when chunk_mode=query (combiner role).
-	ChunkQueryEndpoint string `yaml:"chunk_query_endpoint" mapstructure:"chunk_query_endpoint"`
-	// Signature: template string for a TXT record injected into combined zones (demo feature).
-	// Supports {identity} and {zone} placeholders.
-	Signature    string `yaml:"signature"`
-	AddSignature bool   `yaml:"add-signature" mapstructure:"add-signature"` // DEPRECATED: use combiner-options: [add-signature]
-	// ProtectedNamespaces: list of domain suffixes that belong to this provider.
-	// NS records from remote agents whose targets fall within any of these namespaces
-	// are rejected (prevents namespace intrusion).
-	ProtectedNamespaces []string `yaml:"protected-namespaces" mapstructure:"protected-namespaces"`
-	// ProviderZones: zones owned by the provider where agents may make targeted edits
-	// (e.g. _signal KEY records). Unlike MP zones, these use config-driven RRtype
-	// restrictions and allow non-apex owners.
-	ProviderZones []ProviderZoneConf `yaml:"provider-zones" mapstructure:"provider-zones"`
-
-	// === Signer-specific fields ===
-
-	// SignerOptions: list of signer-specific option strings parsed at startup.
-	SignerOptionsStrs []string              `yaml:"signer-options" mapstructure:"signer-options"`
-	SignerOptions     map[SignerOption]bool `yaml:"-" mapstructure:"-"`
-
-	// === Agent-specific fields ===
-
-	// AgentOptions: list of agent-specific option strings parsed at startup.
-	AgentOptionsStrs []string             `yaml:"agent-options" mapstructure:"agent-options"`
-	AgentOptions     map[AgentOption]bool `yaml:"-" mapstructure:"-"`
-	// SupportedMechanisms: List of active transport mechanisms (default: ["api", "dns"] if both configured)
-	SupportedMechanisms []string `yaml:"supported_mechanisms" mapstructure:"supported_mechanisms"`
-	Local               struct {
-		Notify      []string
-		Nameservers []string `yaml:"nameservers,omitempty"`
-	}
-	Remote struct {
-		LocateInterval int
-		BeatInterval   uint32
-	}
-	Syncengine struct {
-		Intervals struct {
-			HelloRetry int
-		}
-	}
-	Api LocalAgentApiConf
-	Dns LocalAgentDnsConf
-	// Combiner peer (agent only): address and combiner's JOSE public key path for secure CHUNK
-	Combiner *PeerConf `yaml:"combiner"`
-	// Signer peer (agent only): address and JOSE public key path for KEYSTATE signaling
-	Signer *PeerConf `yaml:"signer"`
-	// AuthorizedPeers: List of agent identities authorized to communicate
-	AuthorizedPeers []string `yaml:"authorized_peers"`
-	// Peers (DEPRECATED): Old format with embedded addresses/keys - use authorized_peers instead
-	Peers map[string]*PeerConf `yaml:"peers"`
-	Xfr   struct {
-		Outgoing struct {
-			Addresses []string `yaml:"addresses,omitempty"`
-			Auth      []string `yaml:"auth,omitempty"`
-		}
-		Incoming struct {
-			Addresses []string `yaml:"addresses,omitempty"`
-			Auth      []string `yaml:"auth,omitempty"`
-		}
-	}
-}
-
-// FindAgent returns the PeerConf for the agent with the given identity, or nil if not found.
-func (c *MultiProviderConf) FindAgent(identity string) *PeerConf {
-	for _, a := range c.Agents {
-		if a.Identity == identity {
-			return a
-		}
-	}
-	return nil
 }
 
 type AppDetails struct {
@@ -441,100 +318,6 @@ type ApiServerConf struct {
 type ApiServerAppConf struct {
 	Addresses []string
 	ApiKey    SensitiveString
-}
-
-// PeerConf holds address and public key path for the other party (agent or combiner).
-type PeerConf struct {
-	Address            string `yaml:"address"`
-	LongTermJosePubKey string `yaml:"long_term_jose_pub_key"`
-	ApiBaseUrl         string `yaml:"api_base_url,omitempty"` // Optional: for API transport (e.g. https://combiner:8085/api/v1)
-	Identity           string `yaml:"identity"`               // Peer identity (FQDN); required for combiner agents, optional for agent combiner
-}
-
-type LocalAgentApiConf struct {
-	Addresses struct {
-		Publish []string
-		Listen  []string
-	}
-	BaseUrl  string
-	Port     uint16
-	CertFile string
-	KeyFile  string
-	CertData string
-	KeyData  string
-}
-
-type LocalAgentDnsConf struct {
-	Addresses struct {
-		Publish []string
-		Listen  []string
-	}
-	BaseUrl     string
-	Port        uint16
-	ControlZone string `yaml:"control_zone" mapstructure:"control_zone"` // Zone used for NOTIFY(CHUNK) QNAMEs in DNS mode (default: agent identity)
-	// Chunk config (same key names as combiner for consistency)
-	ChunkMode          string `yaml:"chunk_mode" mapstructure:"chunk_mode"`                     // "edns0" | "query"; query = store payload, receiver fetches via CHUNK query (default: edns0)
-	ChunkQueryEndpoint string `yaml:"chunk_query_endpoint" mapstructure:"chunk_query_endpoint"` // "include" | "none"; required when chunk_mode=query. include = signal in NOTIFY (EDNS0); none = receiver uses combiner.agents[].address
-	// ChunkMaxSize: maximum size (bytes) of each data chunk when fragmenting payloads via PrepareDistributionChunks.
-	// 0 = default (60000). Useful for testing fragmentation with small values (e.g. 500).
-	ChunkMaxSize int `yaml:"chunk_max_size" mapstructure:"chunk_max_size"`
-	// Message retention times for CHUNK distributions (in seconds)
-	MessageRetention MessageRetentionConf `yaml:"message_retention" mapstructure:"message_retention"`
-}
-
-// MessageRetentionConf defines retention times for different message types in CHUNK distributions.
-// Times are in seconds. Beat and ping messages expire quickly to reduce clutter,
-// while other message types are kept longer for debugging purposes.
-type MessageRetentionConf struct {
-	Beat     int `yaml:"beat" mapstructure:"beat"`         // Beat message retention (default: 30s)
-	Ping     int `yaml:"ping" mapstructure:"ping"`         // Ping message retention (default: 30s)
-	Hello    int `yaml:"hello" mapstructure:"hello"`       // Hello message retention (default: 300s)
-	Sync     int `yaml:"sync" mapstructure:"sync"`         // Sync message retention (default: 300s)
-	Relocate int `yaml:"relocate" mapstructure:"relocate"` // Relocate message retention (default: 300s)
-	Default  int `yaml:"default" mapstructure:"default"`   // Default retention for other types (default: 300s)
-}
-
-// GetRetentionForMessageType returns the retention time in seconds for a given message type.
-// Returns the configured value if set, otherwise returns the appropriate default.
-func (m *MessageRetentionConf) GetRetentionForMessageType(messageType string) int {
-	// Apply defaults if values are not set (0 or negative)
-	const (
-		defaultBeatPing = 30  // 30 seconds for beat and ping
-		defaultOther    = 300 // 5 minutes for other message types
-	)
-
-	switch messageType {
-	case "beat":
-		if m.Beat > 0 {
-			return m.Beat
-		}
-		return defaultBeatPing
-	case "ping":
-		if m.Ping > 0 {
-			return m.Ping
-		}
-		return defaultBeatPing
-	case "hello":
-		if m.Hello > 0 {
-			return m.Hello
-		}
-		return defaultOther
-	case "sync":
-		if m.Sync > 0 {
-			return m.Sync
-		}
-		return defaultOther
-	case "relocate":
-		if m.Relocate > 0 {
-			return m.Relocate
-		}
-		return defaultOther
-	default:
-		if m.Default > 0 {
-			return m.Default
-		}
-		return defaultOther
-	}
 }
 
 type DbConf struct {
@@ -779,14 +562,4 @@ func (conf *Config) ReloadZoneConfig(ctx context.Context) (string, error) {
 	}
 
 	return fmt.Sprintf("Zones reloaded. Before: %v, After: %v", prezones, zonelist), err
-}
-
-// LocalIdentity returns the local node's identity string, regardless of role.
-// Used by sync API handlers (APIhello, APIbeat, APIsyncPing) so they work on
-// agent, combiner, and signer without referencing conf.Agent.Identity directly.
-func (conf *Config) LocalIdentity() string {
-	if conf.MultiProvider != nil {
-		return conf.MultiProvider.Identity
-	}
-	return ""
 }

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -28,6 +28,29 @@ const (
 
 // TODO: Add support for TSIG zone transfers.
 
+// clarifyXfrError turns the opaque miekg/dns "bad xfr rcode: N" transfer
+// error into a human-readable failure that names the rcode, e.g.
+// "inbound zone transfer of dingo.dnago.dungo. from <upstream> failed: REFUSED"
+// instead of "dns: bad xfr rcode: 5". Non-transfer errors pass through
+// unchanged. Applied at the source so every ZoneTransferIn caller (refresh
+// engine, etc.) reports the clear message.
+func clarifyXfrError(zone, upstream string, err error) error {
+	if err == nil {
+		return nil
+	}
+	const marker = "bad xfr rcode: "
+	if i := strings.Index(err.Error(), marker); i >= 0 {
+		if code, perr := strconv.Atoi(strings.TrimSpace(err.Error()[i+len(marker):])); perr == nil {
+			name := dns.RcodeToString[code]
+			if name == "" {
+				name = fmt.Sprintf("rcode %d", code)
+			}
+			return fmt.Errorf("inbound zone transfer of %s from %s failed: %s", zone, upstream, name)
+		}
+	}
+	return err
+}
+
 func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype string) (uint32, error) {
 
 	if upstream == "" {
@@ -52,7 +75,7 @@ func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype string)
 	answerChan, err := transfer.In(msg, upstream)
 	if err != nil {
 		zd.Logger.Printf("Error from transfer.In: %v\n", err)
-		return 0, err
+		return 0, clarifyXfrError(zd.ZoneName, upstream, err)
 	}
 
 	count := 0
@@ -60,7 +83,7 @@ func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype string)
 	for envelope := range answerChan {
 		if envelope.Error != nil {
 			zd.Logger.Printf("ZoneTransfer: zone %s error: %v", zd.ZoneName, envelope.Error)
-			return 0, envelope.Error
+			return 0, clarifyXfrError(zd.ZoneName, upstream, envelope.Error)
 		}
 
 		for _, rr := range envelope.RR {

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -154,30 +154,6 @@ const (
 	OutboundSoaSerialPersist  = "persist"  // outbound = previous outbound serial; bumps written to OutgoingSerials
 )
 
-type CombinerOption uint8
-
-const (
-	CombinerOptAddSignature CombinerOption = iota + 1
-)
-
-var CombinerOptionToString = map[CombinerOption]string{
-	CombinerOptAddSignature: "add-signature",
-}
-
-var StringToCombinerOption = map[string]CombinerOption{
-	"add-signature": CombinerOptAddSignature,
-}
-
-type SignerOption uint8
-
-var SignerOptionToString = map[SignerOption]string{}
-var StringToSignerOption = map[string]SignerOption{}
-
-type AgentOption uint8
-
-var AgentOptionToString = map[AgentOption]string{}
-var StringToAgentOption = map[string]AgentOption{}
-
 type AppType uint8
 
 // Range allocation for AppType across the tdns ecosystem.

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -19,35 +19,6 @@ import (
 
 var engineWg sync.WaitGroup
 
-/*
-// buildChunkQueryEndpoint returns "host:port" for the agent's DNS service so the receiver of a NOTIFY(CHUNK) knows where to send the CHUNK query. Prefers Publish so the combiner can reach the agent.
-func buildChunkQueryEndpoint(conf *Config) string {
-	if conf.MultiProvider == nil {
-		return ""
-	}
-	dns := &conf.MultiProvider.Dns
-	port := dns.Port
-	if port == 0 {
-		port = 53
-	}
-	var host string
-	if len(dns.Addresses.Publish) > 0 {
-		host = strings.TrimSpace(dns.Addresses.Publish[0])
-	}
-	if host == "" && len(dns.Addresses.Listen) > 0 {
-		host = strings.TrimSpace(dns.Addresses.Listen[0])
-	}
-	if host == "" {
-		return ""
-	}
-	// If host already contains a port, use as-is
-	if _, _, err := net.SplitHostPort(host); err == nil {
-		return host
-	}
-	return net.JoinHostPort(host, strconv.Itoa(int(port)))
-}
-*/
-
 // startEngine wraps engine functions in a goroutine with error handling.
 // It logs errors if the engine function returns an error, preventing silent failures.
 func StartEngine(app *AppDetails, name string, engineFunc func() error) {

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -223,25 +223,6 @@ func (conf *Config) ParseConfig(reload bool) error {
 	}
 
 	// Normalize all identity fields (domain names) from config to FQDN form.
-	// Config files may omit trailing dots; wire protocol always uses FQDN.
-	conf.normalizeConfigIdentities()
-
-	// Validate multi-provider.role matches the application type for
-	// tdns-side roles. Downstream packages (tdns-mp, tdns-nm, tdns-es)
-	// validate their own roles in their own config-validation paths.
-	if conf.MultiProvider != nil {
-		expectedRole := map[AppType]string{
-			AppTypeAuth:  "signer",
-			AppTypeAgent: "agent",
-		}
-		if expected, ok := expectedRole[Globals.App.Type]; ok {
-			if conf.MultiProvider.Role != expected {
-				return fmt.Errorf("multi-provider.role=%q does not match app type %s (expected %q)",
-					conf.MultiProvider.Role, Globals.App.Name, expected)
-			}
-		}
-	}
-
 	if err := validateKaspPropagationDelay(conf.Kasp.PropagationDelay); err != nil {
 		return err
 	}
@@ -374,8 +355,6 @@ func (conf *Config) ParseConfig(reload bool) error {
 	case AppTypeAuth, AppTypeAgent:
 		conf.ParseAuthOptions()
 	}
-
-	conf.parseMultiProviderOptions()
 
 	// KDC and KRS configuration parsing has been moved to tdns-nm
 	// See kdc.ParseKdcConfigFromFile() and krs.ParseKrsConfigFromFile()
@@ -743,23 +722,14 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		}
 
 		if Globals.App.Type == AppTypeAgent && zconf.Type == "primary" {
-			if conf.MultiProvider == nil {
-				lgConfig.Error("agent has primary zone but multi-provider config is missing, zone in error state", "zone", zname)
-				zd.SetError(ConfigError, "agent has primary zone %q but multi-provider config is missing", zname)
-				broken_zones = append(broken_zones, zname)
-				continue
-			}
-			// Agent only supports primary zone if it matches its identity
-			if zname != conf.MultiProvider.Identity {
-				lgConfig.Error("primary zone does not match agent identity, zone in error state", "zone", zname, "identity", conf.MultiProvider.Identity)
-				zd.SetError(AgentError, "primary zone does not match agent identity (%q)", conf.MultiProvider.Identity)
-				broken_zones = append(broken_zones, zname)
-				continue
-			} else {
-				// For agent's own zone, ensure required options are set
-				options[OptAllowUpdates] = true
-				options[OptOnlineSigning] = true
-			}
+			// tdns-agent doesn't serve primary zones. MP roles are
+			// hosted by tdns-mp (tdns-mpagent etc.), not by standalone
+			// tdns-agent. A primary zone in a tdns-agent config is a
+			// configuration error.
+			lgConfig.Error("tdns-agent does not support primary zones, zone in error state", "zone", zname)
+			zd.SetError(ConfigError, "tdns-agent does not support primary zones; use tdns-mpagent for multi-provider roles")
+			broken_zones = append(broken_zones, zname)
+			continue
 		}
 
 		// log.Printf("*** ParseZones: 5. Refreshch: %v", conf.Internal.RefreshZoneCh)
@@ -1409,49 +1379,4 @@ func validateGroupPrefix(prefix string, prefixType string) error {
 	}
 
 	return nil
-}
-
-// normalizeConfigIdentities applies dns.Fqdn() to all identity fields (domain names)
-// in the parsed config. This ensures trailing dots are present regardless of whether
-// the YAML config included them.
-func (conf *Config) normalizeConfigIdentities() {
-	// Agent identity and peers
-	if conf.MultiProvider != nil {
-		if conf.MultiProvider.Identity != "" {
-			conf.MultiProvider.Identity = dns.Fqdn(conf.MultiProvider.Identity)
-		}
-		if conf.MultiProvider.Dns.ControlZone != "" {
-			conf.MultiProvider.Dns.ControlZone = dns.Fqdn(conf.MultiProvider.Dns.ControlZone)
-		}
-		if conf.MultiProvider.Combiner != nil && conf.MultiProvider.Combiner.Identity != "" {
-			conf.MultiProvider.Combiner.Identity = dns.Fqdn(conf.MultiProvider.Combiner.Identity)
-		}
-		if conf.MultiProvider.Signer != nil && conf.MultiProvider.Signer.Identity != "" {
-			conf.MultiProvider.Signer.Identity = dns.Fqdn(conf.MultiProvider.Signer.Identity)
-		}
-		for i, p := range conf.MultiProvider.AuthorizedPeers {
-			conf.MultiProvider.AuthorizedPeers[i] = dns.Fqdn(p)
-		}
-		for _, peer := range conf.MultiProvider.Peers {
-			if peer != nil && peer.Identity != "" {
-				peer.Identity = dns.Fqdn(peer.Identity)
-			}
-		}
-	}
-
-	// Multi-provider agent peers and combiner-specific normalization
-	if conf.MultiProvider != nil {
-		for _, agent := range conf.MultiProvider.Agents {
-			if agent != nil && agent.Identity != "" {
-				agent.Identity = dns.Fqdn(agent.Identity)
-			}
-		}
-		if conf.MultiProvider.Role == "combiner" {
-			for i, ns := range conf.MultiProvider.ProtectedNamespaces {
-				conf.MultiProvider.ProtectedNamespaces[i] = dns.Fqdn(ns)
-			}
-			// Provider zone RR type registration removed — handled
-			// by tdns-mp initMPCombiner.
-		}
-	}
 }

--- a/v2/parseoptions.go
+++ b/v2/parseoptions.go
@@ -138,59 +138,6 @@ func (conf *Config) ParseAuthOptions() {
 	conf.DnsEngine.Options = clean
 }
 
-func (conf *Config) parseMultiProviderOptions() {
-	if conf.MultiProvider == nil {
-		return
-	}
-	mp := conf.MultiProvider
-
-	// Combiner options
-	mp.CombinerOptions = map[CombinerOption]bool{}
-	for _, raw := range mp.CombinerOptionsStrs {
-		opt := strings.ToLower(strings.TrimSpace(raw))
-		if opt == "" {
-			continue
-		}
-		if co, ok := StringToCombinerOption[opt]; ok {
-			mp.CombinerOptions[co] = true
-		} else {
-			lg.Warn("unknown combiner option, ignoring", "option", opt)
-		}
-	}
-	// Migrate legacy add-signature field
-	if mp.AddSignature && !mp.CombinerOptions[CombinerOptAddSignature] {
-		mp.CombinerOptions[CombinerOptAddSignature] = true
-	}
-
-	// Signer options
-	mp.SignerOptions = map[SignerOption]bool{}
-	for _, raw := range mp.SignerOptionsStrs {
-		opt := strings.ToLower(strings.TrimSpace(raw))
-		if opt == "" {
-			continue
-		}
-		if so, ok := StringToSignerOption[opt]; ok {
-			mp.SignerOptions[so] = true
-		} else {
-			lg.Warn("unknown signer option, ignoring", "option", opt)
-		}
-	}
-
-	// Agent options
-	mp.AgentOptions = map[AgentOption]bool{}
-	for _, raw := range mp.AgentOptionsStrs {
-		opt := strings.ToLower(strings.TrimSpace(raw))
-		if opt == "" {
-			continue
-		}
-		if ao, ok := StringToAgentOption[opt]; ok {
-			mp.AgentOptions[ao] = true
-		} else {
-			lg.Warn("unknown agent option, ignoring", "option", opt)
-		}
-	}
-}
-
 // parseZoneOptions validates and applies zone-specific option strings, updating zconf.Options and returning a map of enabled ZoneOption flags.
 //
 // It parses and normalizes the options listed in zconf.OptionsStrs, enables recognized options, and ignores unknown or invalid ones.

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -782,14 +782,13 @@ type AgentMgmtPost struct {
 }
 
 type AgentMgmtResponse struct {
-	Identity    AgentId
-	Status      string
-	Time        time.Time
-	AgentConfig MultiProviderConf
-	Msg         string
-	Error       bool
-	ErrorMsg    string
-	Data        interface{} `json:"data,omitempty"` // Generic data field for custom responses
+	Identity AgentId
+	Status   string
+	Time     time.Time
+	Msg      string
+	Error    bool
+	ErrorMsg string
+	Data     interface{} `json:"data,omitempty"` // Generic data field for custom responses
 }
 
 // DnskeyStatus holds the result of DNSKEY change detection (local keys only).


### PR DESCRIPTION
## Summary

Bite 9b step 4 of the MP config cutover. The multi-provider feature
now lives entirely in tdns-mp (under tdns-mpagent, tdns-mpsigner,
tdns-mpcombiner, tdns-mpauditor). Standalone tdns-agent and
tdns-auth lose MP capability with this commit.

## What's deleted

- \`MultiProviderConf\` struct + \`MultiProvider\` field on \`Config\`.
- Sub-types: \`PeerConf\`, \`LocalAgentApiConf\`, \`LocalAgentDnsConf\`,
  \`ProviderZoneConf\`, \`MessageRetentionConf\` (was only used by
  \`LocalAgentDnsConf\`).
- Option enums: \`CombinerOption\`, \`SignerOption\`, \`AgentOption\` +
  the \`StringTo*\` / \`*ToString\` maps + the
  \`CombinerOptAddSignature\` constant.
- \`LocalIdentity()\` accessor on \`*Config\`.
- \`parseMultiProviderOptions()\` and its call from \`ParseConfig\`.
- \`normalizeConfigIdentities()\` (body was entirely MP fields).
- \`ConfigResponse.CombinerOptions\` + populator + tdns-cli rendering.
- \`AgentMgmtResponse.AgentConfig\` (dead field on tdns side; never
  read or written).
- Multi-provider role-match validation in \`ParseConfig\`.
- Some commented-out dead code.

## Behavioural changes

- **tdns-agent with a primary zone is now unconditionally an error**.
  Was previously allowed if \`multi-provider.identity\` matched the
  zone name. Use \`tdns-mpagent\` for multi-provider agent roles.
- **\`tdns-cli config status\` no longer renders combiner options.**
  Use \`tdns-mpcli combiner config status [-v]\` instead.
- **Standalone \`tdns-auth\` no longer accepts \`multi-provider:\`** in
  its config. Use \`tdns-mpsigner\` for the multi-provider signer.

## What's preserved

- The \`OptMultiProvider\` zone option — tdns-mp marks zones with it
  to identify MP zones. It's a zone-level flag, not a config field.

## Strict ordering requirement

This PR is the tdns half of Bite 9b. The tdns-mp half is on
[tdns-mp PR #31](https://github.com/johanix/tdns-mp/pull/31)
(branch \`mp-config-cutover\`, commits \`04b7229\` through \`0801d9c\`).

Both halves must land for the cutover to be complete. **This PR
should merge first**, so that tdns-mp can then bump its tdns version
pin to a tdns commit that has the deletes applied. Without that
ordering, an updated tdns-mp would temporarily target a tdns
version where \`tdns.MultiProvider\` still exists (harmless, but
muddier).

## Test plan

- [x] Local build clean: all 5 tdns binaries (tdns-auth, tdns-agent,
      tdns-imr, tdns-cli, dog) compile.
- [x] Local build clean: all 5 tdns-mp binaries (tdns-mpagent,
      tdns-mpsigner, tdns-mpcombiner, tdns-mpauditor, tdns-mpcli)
      compile against this tdns via the local \`replace\` directive.
- [ ] **NetBSD VM testing on operator's lab**: bites 1-9a already
      tested clean. Bite 9b additionally needs:
  - [ ] tdns-mpsigner, tdns-mpcombiner, tdns-mpagent, tdns-mpauditor
        all start cleanly with realistic configs.
  - [ ] \`tdns-mpcli combiner config status\` and \`-v\` produce sensible
        output.
  - [ ] A tdns-agent config containing a \`primary\` zone produces the
        new "tdns-agent does not support primary zones" error.

## Plan reference

Full execution plan in
[tdns-mp/docs/2026-05-28-bite-9b-plan.md](https://github.com/johanix/tdns-mp/blob/mp-config-cutover/docs/2026-05-28-bite-9b-plan.md).
Findings carry stable IDs (B9b-N) that map to the deletes here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved clarity of DNS zone transfer error messages with more descriptive feedback.

* **Configuration Changes**
  * Simplified configuration response structure by removing combiner options field.
  * Agent role no longer supports primary zone configuration.
  * Removed multi-provider and agent-specific configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->