### PR TITLE
cli: annotate algorithms listing with config-driven profiles

### DIFF
--- a/cmdv2/cli/algorithms.sample.yaml
+++ b/cmdv2/cli/algorithms.sample.yaml
@@ -1,0 +1,115 @@
+# algorithms.yaml — algorithm enrichment data for tdns-cli.
+#
+# Install as /etc/tdns/algorithms.yaml and pull it into tdns-cli.yaml:
+#
+#   include:
+#      - /etc/tdns/algorithms.yaml
+#
+# This data is consumed ONLY by the `tdns-cli ... keystore <sig0|dnssec>
+# algorithms` listing, to annotate the algorithms a server reports as
+# supported. It is intentionally separated from the host-local CLI
+# config (API keys, addresses, ...) so it can be shared and
+# version-controlled on its own.
+#
+# Keyed by the algorithm NAME the server reports. Entries that match no
+# server-supported algorithm are ignored; supported algorithms with no
+# entry here simply print "-" in the enrichment columns. The set of
+# supported algorithms always comes from the server — nothing here
+# changes that.
+#
+# Fields (all optional; omit what you don't know — a missing field shows
+# as "-"):
+#   description     free-form note
+#   publickeybytes  DNSKEY/KEY public key size, bytes
+#   signaturebytes  RRSIG/SIG signature size, bytes (typical; see notes
+#                   for variable-length schemes)
+#   secretkeybytes  stored private key size, bytes
+#   securitylevel   NIST PQ security level (1/3/5); omit for classical
+#   maturity        final | draft | candidate | builtin
+#   signingcost     cost of signing,    relative to ED25519 (= 1)
+#   validationcost  cost of validation, relative to ED25519 (= 1)
+#
+# ED25519 is the cost reference (signingcost = validationcost = 1). The
+# PQ signing/validation costs are intentionally left unset below — fill
+# them in with your own measurements, relative to ED25519, as you
+# benchmark each algorithm on your reference hardware. Example:
+#
+#   MLDSA44:
+#      signingcost:     5
+#      validationcost:  2
+
+algorithms:
+   ED25519:
+      description:     "Edwards-curve DSA; classical, cost reference"
+      publickeybytes:  32
+      signaturebytes:  64
+      secretkeybytes:  32
+      maturity:        builtin
+      signingcost:     1
+      validationcost:  1
+
+   MLDSA44:
+      description:     "ML-DSA-44 (FIPS 204), lattice"
+      publickeybytes:  1312
+      signaturebytes:  2420
+      secretkeybytes:  2560
+      securitylevel:   1
+      maturity:        final
+      # signingcost:     <measure relative to ED25519>
+      # validationcost:  <measure relative to ED25519>
+
+   SLHDSA128S:
+      description:     "SLH-DSA-SHA2-128s (FIPS 205), hash-based; tiny keys, large slow signatures"
+      publickeybytes:  32
+      signaturebytes:  7856
+      secretkeybytes:  64
+      securitylevel:   1
+      maturity:        final
+
+   FALCON512:
+      description:     "Falcon-512 (FIPS 206 draft), lattice; signature is variable-length, <= 752"
+      publickeybytes:  897
+      signaturebytes:  752
+      secretkeybytes:  1281
+      securitylevel:   1
+      maturity:        draft
+
+   MAYO1:
+      description:     "MAYO-1 (NIST onramp), oil-and-vinegar; seed-sized secret key"
+      publickeybytes:  1420
+      signaturebytes:  454
+      secretkeybytes:  24
+      securitylevel:   1
+      maturity:        candidate
+
+   SNOVA24_5_4:
+      description:     "SNOVA-24_5_4 (NIST onramp), oil-and-vinegar"
+      publickeybytes:  1016
+      signaturebytes:  248
+      secretkeybytes:  48
+      securitylevel:   1
+      maturity:        candidate
+
+   SQISIGN1:
+      description:     "SQIsign-I (NIST onramp), isogeny; very small keys and signatures, slow"
+      publickeybytes:  65
+      signaturebytes:  148
+      secretkeybytes:  353
+      securitylevel:   1
+      maturity:        candidate
+
+   QRUOV1:
+      description:     "QR-UOV-I q=31 L=3 (NIST onramp), oil-and-vinegar; large public key"
+      publickeybytes:  23641
+      signaturebytes:  157
+      secretkeybytes:  32
+      securitylevel:   1
+      maturity:        candidate
+
+   MAYO2:
+      description:     "MAYO-2 (NIST onramp), oil-and-vinegar; larger pubkey / smaller sig than MAYO-1"
+      publickeybytes:  4912
+      signaturebytes:  186
+      secretkeybytes:  24
+      securitylevel:   1
+      maturity:        candidate

--- a/cmdv2/cli/root.go
+++ b/cmdv2/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -109,6 +110,41 @@ func initConfig() {
 		cfgFileUsed = viper.ConfigFileUsed()
 	} else {
 		log.Fatalf("Could not load config %s: Error: %v", viper.ConfigFileUsed(), err)
+	}
+
+	// Expand any top-level "include:" directives. viper has no native
+	// include support, so we merge each listed file in turn. This is a
+	// single-level (non-recursive) shim: an included file's own
+	// "include:" is not processed. Relative paths resolve against the
+	// main config file's directory. Used e.g. to pull algorithm
+	// enrichment data in from a shareable /etc/tdns/algorithms.yaml,
+	// keeping it out of this host-local, secret-bearing config.
+	for _, inc := range viper.GetStringSlice("include") {
+		incPath := inc
+		if !filepath.IsAbs(incPath) {
+			incPath = filepath.Join(filepath.Dir(cfgFileUsed), incPath)
+		}
+		// A missing included file is not fatal — it is treated as an
+		// optional overlay (mirrors the LocalConfig handling below), so
+		// e.g. an as-yet-uninstalled /etc/tdns/algorithms.yaml just
+		// leaves the CLI without that enrichment. A present-but-broken
+		// include is still a hard error.
+		if _, err := os.Stat(incPath); err != nil {
+			if os.IsNotExist(err) {
+				if tdns.Globals.Verbose {
+					fmt.Fprintln(os.Stderr, "Skipping missing included config:", incPath)
+				}
+				continue
+			}
+			log.Fatalf("Error stat(%s): %v", incPath, err)
+		}
+		viper.SetConfigFile(incPath)
+		if err := viper.MergeInConfig(); err != nil {
+			log.Fatalf("Could not merge included config %s: Error: %v", incPath, err)
+		}
+		if tdns.Globals.Verbose {
+			fmt.Fprintln(os.Stderr, "Merged included config:", incPath)
+		}
 	}
 
 	LocalConfig = viper.GetString("cli.localconfig")

--- a/cmdv2/cli/tdns-cli.sample.yaml
+++ b/cmdv2/cli/tdns-cli.sample.yaml
@@ -1,3 +1,10 @@
+# Pull in shareable, non-secret algorithm enrichment data (key/signature
+# sizes, relative costs, maturity) kept separate from this host-local,
+# secret-bearing config. Consumed by `tdns-cli ... keystore <sig0|dnssec>
+# algorithms`. See algorithms.sample.yaml.
+include:
+   - /etc/tdns/algorithms.yaml
+
 apiservers:
    - name:              tdns-server
      baseurl:           https://127.0.0.1:8989/api/v1

--- a/v2/cli/algorithm_profiles.go
+++ b/v2/cli/algorithm_profiles.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/viper"
+)
+
+// algorithmProfile is optional, CLI-side descriptive metadata about a
+// DNSSEC/SIG(0) algorithm: key and signature sizes, relative cost,
+// maturity, and a free-form note. It exists purely to *annotate* the
+// `keystore ... algorithms` listing during PQ algorithm experimentation
+// — it never feeds name<->codepoint resolution or what a server reports
+// as supported (that stays server-authoritative).
+//
+// Profiles are read from the optional "algorithms" map in the CLI
+// config, keyed by algorithm name. The data is deliberately kept out of
+// the (host-local, secret-bearing) main CLI config and pulled in from a
+// shareable file such as /etc/tdns/algorithms.yaml via an "include:".
+//
+// Every field is optional. A zero value means "not provided" and is
+// rendered as "-" in the listing; because no real key/signature size or
+// cost is legitimately zero, that convention is unambiguous here.
+type algorithmProfile struct {
+	Description    string `mapstructure:"description"`
+	PublicKeyBytes int    `mapstructure:"publickeybytes"`
+	SignatureBytes int    `mapstructure:"signaturebytes"`
+	SecretKeyBytes int    `mapstructure:"secretkeybytes"`
+	SecurityLevel  int    `mapstructure:"securitylevel"` // NIST PQ level 1/3/5; 0 = unspecified
+	Maturity       string `mapstructure:"maturity"`      // final | draft | candidate | builtin
+	SigningCost    int    `mapstructure:"signingcost"`    // relative to ED25519 (= 1); 0 = unknown
+	ValidationCost int    `mapstructure:"validationcost"` // relative to ED25519 (= 1); 0 = unknown
+}
+
+// loadAlgorithmProfiles returns the "algorithms" enrichment map from the
+// (already include-expanded) CLI config, or nil if none is configured.
+//
+// viper lower-cases all config keys, so the returned map is keyed by the
+// lower-cased algorithm name; callers must look up with
+// strings.ToLower(name). Malformed config is non-fatal — enrichment is
+// optional, so we warn and fall back to the bare listing.
+func loadAlgorithmProfiles() map[string]algorithmProfile {
+	if !viper.IsSet("algorithms") {
+		return nil
+	}
+	var profiles map[string]algorithmProfile
+	if err := viper.UnmarshalKey("algorithms", &profiles); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: ignoring malformed 'algorithms' config section: %v\n", err)
+		return nil
+	}
+	return profiles
+}
+
+// algIntCol renders an optional integer profile field for the listing:
+// 0 (unset) becomes "-".
+func algIntCol(n int) string {
+	if n == 0 {
+		return "-"
+	}
+	return strconv.Itoa(n)
+}
+
+// algStrCol renders an optional string profile field for the listing:
+// "" (unset) becomes "-".
+func algStrCol(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/v2/cli/algorithms.go
+++ b/v2/cli/algorithms.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"text/tabwriter"
 
 	tdns "github.com/johanix/tdns/v2"
 	algregistry "github.com/johanix/tdns/v2/algorithms"
@@ -110,19 +111,48 @@ func resolveServerAlgorithm(role, name string, use algUse) (uint8, error) {
 }
 
 // printServerAlgorithms lists the algorithms role's server supports for
-// the given use, one per line as "NAME (codepoint N)".
+// the given use. The set of algorithms is server-authoritative; if the
+// CLI config carries an "algorithms" enrichment map (see
+// [algorithmProfile]), each entry is annotated with key/signature sizes,
+// relative cost, etc. With no enrichment configured it falls back to the
+// original compact "NAME codepoint" listing.
 func printServerAlgorithms(role string, use algUse) error {
 	algs, err := fetchServerAlgorithms(role)
 	if err != nil {
 		return err
 	}
+	profiles := loadAlgorithmProfiles()
 	fmt.Printf("Algorithms supported by the %s server:\n", role)
-	for _, a := range algs {
-		if use.permits(a) {
-			fmt.Printf("  %-16s %d\n", a.Name, a.Number)
+
+	if len(profiles) == 0 {
+		for _, a := range algs {
+			if use.permits(a) {
+				fmt.Printf("  %-16s %d\n", a.Name, a.Number)
+			}
 		}
+		return nil
 	}
-	return nil
+
+	// Enriched table. Sizes are in bytes; SIGN/VRFY are signing/
+	// validation cost relative to ED25519 (= 1); "-" means the profile
+	// did not specify the field.
+	fmt.Println("  (sizes in bytes; SIGN/VRFY = signing/validation cost relative to ED25519=1; '-' = unspecified)")
+	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "  NAME\tCP\tPUBKEY\tSIG\tSECKEY\tLVL\tSIGN\tVRFY\tMATURITY\tDESCRIPTION")
+	for _, a := range algs {
+		if !use.permits(a) {
+			continue
+		}
+		// viper lower-cases config keys, so the profile map is keyed by
+		// the lower-cased algorithm name.
+		p := profiles[strings.ToLower(a.Name)]
+		fmt.Fprintf(tw, "  %s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			a.Name, a.Number,
+			algIntCol(p.PublicKeyBytes), algIntCol(p.SignatureBytes), algIntCol(p.SecretKeyBytes),
+			algIntCol(p.SecurityLevel), algIntCol(p.SigningCost), algIntCol(p.ValidationCost),
+			algStrCol(p.Maturity), algStrCol(p.Description))
+	}
+	return tw.Flush()
 }
 
 func serverAlgNames(algs []algregistry.AlgorithmInfo, use algUse) []string {


### PR DESCRIPTION
## What

`tdns-cli ... keystore <sig0|dnssec> algorithms` now enriches the server's algorithm list with the data that actually drives PQ-algorithm choice — **key/signature/secret-key sizes, relative signing & validation cost, security level, maturity, and a description** — instead of just name + codepoint.

```
Algorithms supported by the auth server:
  (sizes in bytes; SIGN/VRFY = signing/validation cost relative to ED25519=1; '-' = unspecified)
  NAME         CP   PUBKEY  SIG   SECKEY  LVL  SIGN  VRFY  MATURITY   DESCRIPTION
  ED25519      15   32      64    32      -    1     1     builtin    Edwards-curve DSA; classical, cost reference
  MLDSA44      199  1312    2420  2560    1    -     -     final      ML-DSA-44 (FIPS 204), lattice
  ...
  MAYO2        206  4912    186   24      1    -     -     candidate  MAYO-2 (NIST onramp), ...
```

## Design

- **Config-driven, not baked into the server.** The data is curated and frequently re-tuned (costs are measured, machine-dependent), so it lives in operator config: a new optional `algorithms:` map keyed by algorithm name. It's pure presentation annotation — the supported set stays **server-authoritative**; config never feeds name↔codepoint resolution.
- **Separable from secrets.** Meant to live in its own `/etc/tdns/algorithms.yaml`, pulled into `tdns-cli.yaml` via `include:`. Since `tdns-cli` loads config through plain viper (not the server-side include-aware parser), a small **single-level include shim** in `initConfig` expands a top-level `include:` list via `viper.MergeInConfig`. Missing included files are skipped (optional overlay), mirroring the existing `LocalConfig` handling.
- **Costs relative to ED25519 (= 1).** All profile fields optional; unset → `-`. No profiles configured → falls back to the original compact `name codepoint` listing. No registration-API change, no wire change, no server change.

## Files

- `v2/cli/algorithm_profiles.go` (new) — `algorithmProfile` type + loader + render helpers
- `v2/cli/algorithms.go` — enriched `tabwriter` table in `printServerAlgorithms`
- `cmdv2/cli/root.go` — include-expansion shim
- `cmdv2/cli/algorithms.sample.yaml` (new) — accurate sizes for all current algorithms; ED25519 as the 1/1 reference; PQ costs left as measurement TODOs
- `cmdv2/cli/tdns-cli.sample.yaml` — adds the `include:` directive

## Verification

- `go vet` + `go build` of `tdns-cli` — clean.
- Standalone harness against the real `algorithms.sample.yaml`: include merges, 9 profiles load, viper lower-cases keys (so the `strings.ToLower(name)` lookup is correct), MAYO2 + ED25519 resolve correctly; table layout rendered (above).
- Not exercised: the live `algorithms` command's server round-trip (`fetchServerAlgorithms`, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including external configuration files in CLI config using a top-level `include:` directive.
  * Enhanced algorithm display to show detailed metadata (key sizes, security levels, signing costs, maturity) when algorithm profiles are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->