### PR TITLE
auth, imr: register MAYO-2 (codepoint 206)

### DIFF
--- a/cmdv2/auth/go.mod
+++ b/cmdv2/auth/go.mod
@@ -10,7 +10,7 @@ replace (
 )
 
 require (
-	github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f
+	github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4
 	github.com/johanix/tdns/v2 v2.0.0-00010101000000-000000000000
 	github.com/mattn/go-sqlite3 v1.14.28
 )

--- a/cmdv2/auth/go.sum
+++ b/cmdv2/auth/go.sum
@@ -147,6 +147,8 @@ github.com/johanix/dns v0.0.0-20260608092609-2a28f8f1484d h1:rkhMXetTV0gTQPj0Wj6
 github.com/johanix/dns v0.0.0-20260608092609-2a28f8f1484d/go.mod h1:hBcNfObhP6OL8tg/LRRiRxqToCk64JmTahUFw2q39GM=
 github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f h1:C6yDbPWfXJ0el5lEJE8vRUzEXPcbJcvwWluU+lJEUWA=
 github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
+github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4 h1:LIlj2KkhUAzt5IW3r/wMbvY87DRe7nt8OWkaCWUYc20=
+github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/cmdv2/auth/pq_algorithms_liboqs.go
+++ b/cmdv2/auth/pq_algorithms_liboqs.go
@@ -16,6 +16,7 @@ package main
 import (
 	"github.com/johanix/dnssec-algorithms/falcon512"
 	"github.com/johanix/dnssec-algorithms/mayo1"
+	"github.com/johanix/dnssec-algorithms/mayo2"
 	"github.com/johanix/dnssec-algorithms/snova24_5_4"
 
 	algs "github.com/johanix/tdns/v2/algorithms"
@@ -25,4 +26,5 @@ func init() {
 	algs.Register(201, falcon512.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(206, mayo2.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }

--- a/cmdv2/imr/go.mod
+++ b/cmdv2/imr/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f
+	github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4
 	github.com/johanix/tdns/v2 v2.0.0-00010101000000-000000000000
 	github.com/johanix/tdns/v2/cli v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.8.1

--- a/cmdv2/imr/go.sum
+++ b/cmdv2/imr/go.sum
@@ -155,6 +155,8 @@ github.com/johanix/dns v0.0.0-20260608092609-2a28f8f1484d h1:rkhMXetTV0gTQPj0Wj6
 github.com/johanix/dns v0.0.0-20260608092609-2a28f8f1484d/go.mod h1:hBcNfObhP6OL8tg/LRRiRxqToCk64JmTahUFw2q39GM=
 github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f h1:C6yDbPWfXJ0el5lEJE8vRUzEXPcbJcvwWluU+lJEUWA=
 github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
+github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4 h1:LIlj2KkhUAzt5IW3r/wMbvY87DRe7nt8OWkaCWUYc20=
+github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/cmdv2/imr/pq_algorithms_liboqs.go
+++ b/cmdv2/imr/pq_algorithms_liboqs.go
@@ -16,6 +16,7 @@ package main
 import (
 	"github.com/johanix/dnssec-algorithms/falcon512"
 	"github.com/johanix/dnssec-algorithms/mayo1"
+	"github.com/johanix/dnssec-algorithms/mayo2"
 	"github.com/johanix/dnssec-algorithms/snova24_5_4"
 
 	algs "github.com/johanix/tdns/v2/algorithms"
@@ -25,4 +26,5 @@ func init() {
 	algs.Register(201, falcon512.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(206, mayo2.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }


### PR DESCRIPTION
Wires the **MAYO-2** liboqs algorithm into `tdns-auth` and `tdns-imr`, alongside the existing Falcon-512 (201), MAYO-1 (202) and SNOVA-24_5_4 (203), behind the existing `liboqs` build tag.

MAYO-2 is a NIST onramp level-1 parameter set that trades a larger public key (4912 B) for a much smaller signature (186 B) vs MAYO-1 — useful data point for the PQ algorithm comparison work.

## Changes
- `cmdv2/auth/pq_algorithms_liboqs.go`, `cmdv2/imr/pq_algorithms_liboqs.go` — add the `mayo2` import + `algs.Register(206, mayo2.New(), {ForSIG0: true, ForDNSSEC: true})`.
- `go.mod` / `go.sum` in both app modules — bump `dnssec-algorithms` to the commit adding the `mayo2` subpackage (`...1644011b330f` → `...d1839edda8e4`).

`cmdv2/agent` is intentionally left unchanged.

## Verification
- `go vet` + `go build -tags liboqs` of both apps — clean.
- Both binaries link the `mayo2.(*Impl)` method set and the compiled-in `Register(206, …)`.
- The auth server's live `keystore ... algorithms` listing reports `MAYO2  206`.

Depends on the MAYO-2 subpackage in [johanix/dnssec-algorithms#4](https://github.com/johanix/dnssec-algorithms/pull/4) (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the mayo2 post-quantum cryptographic algorithm (ID 206) with SIG0 and DNSSEC capabilities when built with liboqs support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->