### PR TITLE
auth, imr, cli: register MAYO-3/5, Falcon-1024, SNOVA-37_17_2/25_8_3 + QR-UOV rename

### DIFF
--- a/cmdv2/auth/go.mod
+++ b/cmdv2/auth/go.mod
@@ -10,7 +10,7 @@ replace (
 )
 
 require (
-	github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4
+	github.com/johanix/dnssec-algorithms v0.0.0-20260610050337-d454ac920e5f
 	github.com/johanix/tdns/v2 v2.0.0-00010101000000-000000000000
 	github.com/mattn/go-sqlite3 v1.14.28
 )

--- a/cmdv2/auth/go.sum
+++ b/cmdv2/auth/go.sum
@@ -149,6 +149,8 @@ github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f h1:C6yDb
 github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
 github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4 h1:LIlj2KkhUAzt5IW3r/wMbvY87DRe7nt8OWkaCWUYc20=
 github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
+github.com/johanix/dnssec-algorithms v0.0.0-20260610050337-d454ac920e5f h1:crEQO7w59Kjyc8LOETXxg474SeSXz8O2o3IKFFPUvhk=
+github.com/johanix/dnssec-algorithms v0.0.0-20260610050337-d454ac920e5f/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/cmdv2/auth/pq_algorithms_liboqs.go
+++ b/cmdv2/auth/pq_algorithms_liboqs.go
@@ -14,10 +14,15 @@
 package main
 
 import (
+	"github.com/johanix/dnssec-algorithms/falcon1024"
 	"github.com/johanix/dnssec-algorithms/falcon512"
 	"github.com/johanix/dnssec-algorithms/mayo1"
 	"github.com/johanix/dnssec-algorithms/mayo2"
+	"github.com/johanix/dnssec-algorithms/mayo3"
+	"github.com/johanix/dnssec-algorithms/mayo5"
 	"github.com/johanix/dnssec-algorithms/snova24_5_4"
+	"github.com/johanix/dnssec-algorithms/snova25_8_3"
+	"github.com/johanix/dnssec-algorithms/snova37_17_2"
 
 	algs "github.com/johanix/tdns/v2/algorithms"
 )
@@ -27,4 +32,9 @@ func init() {
 	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(206, mayo2.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(207, mayo3.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(208, mayo5.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(209, falcon1024.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(210, snova37_17_2.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(211, snova25_8_3.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }

--- a/cmdv2/auth/pq_algorithms_qruov.go
+++ b/cmdv2/auth/pq_algorithms_qruov.go
@@ -16,11 +16,11 @@
 package main
 
 import (
-	"github.com/johanix/dnssec-algorithms/qruov1"
+	"github.com/johanix/dnssec-algorithms/qruov_q31_l3"
 
 	algs "github.com/johanix/tdns/v2/algorithms"
 )
 
 func init() {
-	algs.Register(205, qruov1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(205, qruov_q31_l3.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }

--- a/cmdv2/cli/algorithms.sample.yaml
+++ b/cmdv2/cli/algorithms.sample.yaml
@@ -53,7 +53,7 @@ algorithms:
       publickeybytes:  1312
       signaturebytes:  2420
       secretkeybytes:  2560
-      securitylevel:   1
+      securitylevel:   2
       maturity:        final
       # signingcost:     <measure relative to ED25519>
       # validationcost:  <measure relative to ED25519>
@@ -98,7 +98,7 @@ algorithms:
       securitylevel:   1
       maturity:        candidate
 
-   QRUOV1:
+   QRUOV_Q31_L3:
       description:     "QR-UOV-I q=31 L=3 (NIST onramp), oil-and-vinegar; large public key"
       publickeybytes:  23641
       signaturebytes:  157
@@ -111,5 +111,45 @@ algorithms:
       publickeybytes:  4912
       signaturebytes:  186
       secretkeybytes:  24
+      securitylevel:   1
+      maturity:        candidate
+
+   MAYO3:
+      description:     "MAYO-3 (NIST onramp), oil-and-vinegar; level-3 parameter set"
+      publickeybytes:  2986
+      signaturebytes:  681
+      secretkeybytes:  32
+      securitylevel:   3
+      maturity:        candidate
+
+   MAYO5:
+      description:     "MAYO-5 (NIST onramp), oil-and-vinegar; level-5 parameter set"
+      publickeybytes:  5554
+      signaturebytes:  964
+      secretkeybytes:  40
+      securitylevel:   5
+      maturity:        candidate
+
+   FALCON1024:
+      description:     "Falcon-1024 (FIPS 206 draft), lattice; level-5, variable-length sig <= 1462"
+      publickeybytes:  1793
+      signaturebytes:  1462
+      secretkeybytes:  2305
+      securitylevel:   5
+      maturity:        draft
+
+   SNOVA37_17_2:
+      description:     "SNOVA-37_17_2 (NIST onramp), oil-and-vinegar; smallest signature (124 B), larger public key"
+      publickeybytes:  9842
+      signaturebytes:  124
+      secretkeybytes:  48
+      securitylevel:   1
+      maturity:        candidate
+
+   SNOVA25_8_3:
+      description:     "SNOVA-25_8_3 (NIST onramp), oil-and-vinegar; small signature, modest public key"
+      publickeybytes:  2320
+      signaturebytes:  165
+      secretkeybytes:  48
       securitylevel:   1
       maturity:        candidate

--- a/cmdv2/cli/main.go
+++ b/cmdv2/cli/main.go
@@ -29,7 +29,13 @@ func init() {
 	algs.RegisterMetadata(202, "MAYO1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.RegisterMetadata(203, "SNOVA24_5_4", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.RegisterMetadata(204, "SQISIGN1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
-	algs.RegisterMetadata(205, "QRUOV1", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(205, "QRUOV_Q31_L3", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(206, "MAYO2", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(207, "MAYO3", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(208, "MAYO5", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(209, "FALCON1024", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(210, "SNOVA37_17_2", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.RegisterMetadata(211, "SNOVA25_8_3", algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }
 
 func main() {

--- a/cmdv2/imr/go.mod
+++ b/cmdv2/imr/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4
+	github.com/johanix/dnssec-algorithms v0.0.0-20260610050337-d454ac920e5f
 	github.com/johanix/tdns/v2 v2.0.0-00010101000000-000000000000
 	github.com/johanix/tdns/v2/cli v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.8.1

--- a/cmdv2/imr/go.sum
+++ b/cmdv2/imr/go.sum
@@ -157,6 +157,8 @@ github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f h1:C6yDb
 github.com/johanix/dnssec-algorithms v0.0.0-20260608095153-1644011b330f/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
 github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4 h1:LIlj2KkhUAzt5IW3r/wMbvY87DRe7nt8OWkaCWUYc20=
 github.com/johanix/dnssec-algorithms v0.0.0-20260609201107-d1839edda8e4/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
+github.com/johanix/dnssec-algorithms v0.0.0-20260610050337-d454ac920e5f h1:crEQO7w59Kjyc8LOETXxg474SeSXz8O2o3IKFFPUvhk=
+github.com/johanix/dnssec-algorithms v0.0.0-20260610050337-d454ac920e5f/go.mod h1:6VauTodNzFC0Ck6uxxnnhOA+JvTdU4ZtkEr0u72ZVfc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/cmdv2/imr/pq_algorithms_liboqs.go
+++ b/cmdv2/imr/pq_algorithms_liboqs.go
@@ -14,10 +14,15 @@
 package main
 
 import (
+	"github.com/johanix/dnssec-algorithms/falcon1024"
 	"github.com/johanix/dnssec-algorithms/falcon512"
 	"github.com/johanix/dnssec-algorithms/mayo1"
 	"github.com/johanix/dnssec-algorithms/mayo2"
+	"github.com/johanix/dnssec-algorithms/mayo3"
+	"github.com/johanix/dnssec-algorithms/mayo5"
 	"github.com/johanix/dnssec-algorithms/snova24_5_4"
+	"github.com/johanix/dnssec-algorithms/snova25_8_3"
+	"github.com/johanix/dnssec-algorithms/snova37_17_2"
 
 	algs "github.com/johanix/tdns/v2/algorithms"
 )
@@ -27,4 +32,9 @@ func init() {
 	algs.Register(202, mayo1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(203, snova24_5_4.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 	algs.Register(206, mayo2.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(207, mayo3.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(208, mayo5.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(209, falcon1024.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(210, snova37_17_2.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(211, snova25_8_3.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }

--- a/cmdv2/imr/pq_algorithms_qruov.go
+++ b/cmdv2/imr/pq_algorithms_qruov.go
@@ -22,11 +22,11 @@
 package main
 
 import (
-	"github.com/johanix/dnssec-algorithms/qruov1"
+	"github.com/johanix/dnssec-algorithms/qruov_q31_l3"
 
 	algs "github.com/johanix/tdns/v2/algorithms"
 )
 
 func init() {
-	algs.Register(205, qruov1.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
+	algs.Register(205, qruov_q31_l3.New(), algs.Capabilities{ForSIG0: true, ForDNSSEC: true})
 }


### PR DESCRIPTION
Registers the five new liboqs-backed algorithms in **tdns-auth** and **tdns-imr** (behind the existing `liboqs` build tag) and folds in the downstream QR-UOV rename + the ML-DSA-44 level fix.

## New registrations (codepoints 207–211)
| codepoint | name | NIST cat | sig / pubkey |
|---|---|---|---|
| 207 | MAYO3 | 3 | 681 / 2986 |
| 208 | MAYO5 | 5 | 964 / 5554 |
| 209 | FALCON1024 | 5 | ≤1462 / 1793 |
| 210 | SNOVA37_17_2 | 1 | 124 / 9842 |
| 211 | SNOVA25_8_3 | 1 | 165 / 2320 |

Added to `pq_algorithms_liboqs.go` in auth and imr, and to the CLI's `RegisterMetadata` list (`cmdv2/cli/main.go`) — which also gains **MAYO2 (206)**, previously missing.

## QR-UOV rename (downstream of [dnssec-algorithms#6](https://github.com/johanix/dnssec-algorithms/pull/6))
- `qruov1` → `qruov_q31_l3` (import + `Register`), DNS name `QRUOV1` → `QRUOV_Q31_L3` (registration + CLI metadata + `algorithms.yaml` key).

## Dependency
- `dnssec-algorithms` bumped in auth/imr (`…d1839edda8e4` → `…d454ac920e5f`) — the commit carrying both the rename and the five new packages.

## algorithms.sample.yaml
- Profiles (sizes / level / maturity) for the five new algorithms.
- QRUOV key renamed.
- **ML-DSA-44 `securitylevel` 1 → 2** (ML-DSA-44 is NIST Category 2).

Companion PR for the `algorithms` listing display (family grouping + description wrapping) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for six new post-quantum signature algorithms (Mayo 2/3/5, Falcon 1024, and Snova variants) for DNSSEC and SIG0 operations.

* **Improvements**
  * Updated the QR-UOV post-quantum algorithm to use an optimized implementation variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->