### PR TITLE
cli: group algorithms listing by family + wrap long descriptions

### DIFF
--- a/v2/cli/algorithm_profiles.go
+++ b/v2/cli/algorithm_profiles.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -31,8 +32,8 @@ type algorithmProfile struct {
 	PublicKeyBytes int    `mapstructure:"publickeybytes"`
 	SignatureBytes int    `mapstructure:"signaturebytes"`
 	SecretKeyBytes int    `mapstructure:"secretkeybytes"`
-	SecurityLevel  int    `mapstructure:"securitylevel"` // NIST PQ level 1/3/5; 0 = unspecified
-	Maturity       string `mapstructure:"maturity"`      // final | draft | candidate | builtin
+	SecurityLevel  int    `mapstructure:"securitylevel"`  // NIST PQ level 1/3/5; 0 = unspecified
+	Maturity       string `mapstructure:"maturity"`       // final | draft | candidate | builtin
 	SigningCost    int    `mapstructure:"signingcost"`    // relative to ED25519 (= 1); 0 = unknown
 	ValidationCost int    `mapstructure:"validationcost"` // relative to ED25519 (= 1); 0 = unknown
 }
@@ -72,4 +73,51 @@ func algStrCol(s string) string {
 		return "-"
 	}
 	return s
+}
+
+// algorithmFamily returns the family grouping key for an algorithm name:
+// the leading run before the first digit or underscore (MAYO1 -> "MAYO",
+// SNOVA24_5_4 -> "SNOVA", FALCON1024 -> "FALCON", QRUOV_Q31_L3 ->
+// "QRUOV"). Used to sort the listing so related parameter sets group
+// together; it is display-only and does not affect codepoints.
+func algorithmFamily(name string) string {
+	i := strings.IndexFunc(name, func(r rune) bool {
+		return (r >= '0' && r <= '9') || r == '_'
+	})
+	if i <= 0 {
+		return name
+	}
+	return name[:i]
+}
+
+// descWrapWidth bounds the DESCRIPTION column so a long note wraps onto
+// continuation rows instead of stretching the whole table.
+const descWrapWidth = 60
+
+// wrapText word-wraps s into lines no longer than width. A single word
+// longer than width gets its own (overlong) line rather than being
+// split. Returns nil for empty s.
+func wrapText(s string, width int) []string {
+	if s == "" {
+		return nil
+	}
+	var lines []string
+	var b strings.Builder
+	for _, w := range strings.Fields(s) {
+		switch {
+		case b.Len() == 0:
+			b.WriteString(w)
+		case b.Len()+1+len(w) > width:
+			lines = append(lines, b.String())
+			b.Reset()
+			b.WriteString(w)
+		default:
+			b.WriteByte(' ')
+			b.WriteString(w)
+		}
+	}
+	if b.Len() > 0 {
+		lines = append(lines, b.String())
+	}
+	return lines
 }

--- a/v2/cli/algorithms.go
+++ b/v2/cli/algorithms.go
@@ -121,36 +121,71 @@ func printServerAlgorithms(role string, use algUse) error {
 	if err != nil {
 		return err
 	}
+
+	// Filter to the requested capability, then group related parameter
+	// sets together: order by algorithm family (MAYO*, SNOVA*, FALCON*,
+	// ...), families by their lowest codepoint, and members by codepoint
+	// within a family. This is display-only — codepoints are unchanged
+	// and stay authoritative on the wire.
+	var rows []algregistry.AlgorithmInfo
+	for _, a := range algs {
+		if use.permits(a) {
+			rows = append(rows, a)
+		}
+	}
+	familyMin := map[string]uint8{}
+	for _, a := range rows {
+		if f := algorithmFamily(a.Name); familyMin[f] == 0 || a.Number < familyMin[f] {
+			familyMin[f] = a.Number
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		fi, fj := algorithmFamily(rows[i].Name), algorithmFamily(rows[j].Name)
+		if fi != fj {
+			if familyMin[fi] != familyMin[fj] {
+				return familyMin[fi] < familyMin[fj]
+			}
+			return fi < fj
+		}
+		return rows[i].Number < rows[j].Number
+	})
+
 	profiles := loadAlgorithmProfiles()
 	fmt.Printf("Algorithms supported by the %s server:\n", role)
 
 	if len(profiles) == 0 {
-		for _, a := range algs {
-			if use.permits(a) {
-				fmt.Printf("  %-16s %d\n", a.Name, a.Number)
-			}
+		for _, a := range rows {
+			fmt.Printf("  %-16s %d\n", a.Name, a.Number)
 		}
 		return nil
 	}
 
 	// Enriched table. Sizes are in bytes; SIGN/VRFY are signing/
 	// validation cost relative to ED25519 (= 1); "-" means the profile
-	// did not specify the field.
+	// did not specify the field. A long DESCRIPTION wraps onto
+	// continuation rows so it cannot stretch the table.
 	fmt.Println("  (sizes in bytes; SIGN/VRFY = signing/validation cost relative to ED25519=1; '-' = unspecified)")
 	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
 	fmt.Fprintln(tw, "  NAME\tCP\tPUBKEY\tSIG\tSECKEY\tLVL\tSIGN\tVRFY\tMATURITY\tDESCRIPTION")
-	for _, a := range algs {
-		if !use.permits(a) {
-			continue
-		}
+	for _, a := range rows {
 		// viper lower-cases config keys, so the profile map is keyed by
 		// the lower-cased algorithm name.
 		p := profiles[strings.ToLower(a.Name)]
+		desc := wrapText(p.Description, descWrapWidth)
+		firstLine, contLines := "", []string(nil)
+		if len(desc) > 0 {
+			firstLine, contLines = desc[0], desc[1:]
+		}
 		fmt.Fprintf(tw, "  %s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			a.Name, a.Number,
 			algIntCol(p.PublicKeyBytes), algIntCol(p.SignatureBytes), algIntCol(p.SecretKeyBytes),
 			algIntCol(p.SecurityLevel), algIntCol(p.SigningCost), algIntCol(p.ValidationCost),
-			algStrCol(p.Maturity), algStrCol(p.Description))
+			algStrCol(p.Maturity), algStrCol(firstLine))
+		// Continuation rows: nine empty leading cells so the wrapped
+		// text lands under the DESCRIPTION column.
+		for _, line := range contLines {
+			fmt.Fprintf(tw, "  %s%s\n", strings.Repeat("\t", 9), line)
+		}
 	}
 	return tw.Flush()
 }


### PR DESCRIPTION
Display-only improvements to `tdns-cli ... keystore <sig0|dnssec> algorithms`. **No codepoint or wire changes** — codepoints stay authoritative; this only changes how the listing is rendered.

## 1. Group by family
The listing printed in raw server (codepoint) order, scattering related parameter sets. Now it groups by algorithm **family** (MAYO\*, SNOVA\*, FALCON\*, …) — families ordered by their lowest codepoint, members by codepoint within a family — so FALCON512/FALCON1024, all MAYO sets, and all SNOVA sets sit together regardless of their assigned numbers.

## 2. Wrap long descriptions
A long DESCRIPTION used to stretch the whole table. It now wraps at 60 columns onto continuation rows aligned under the DESCRIPTION column.

Preview (with a fully-populated `algorithms.yaml`):
```
  NAME          CP   PUBKEY  SIG   SECKEY  LVL  SIGN  VRFY  MATURITY   DESCRIPTION
  FALCON512     201  897     752   1281    1    -     -     draft      Falcon-512 (FIPS 206 draft), lattice; signature is
                                                                       variable-length, <= 752
  FALCON1024    209  ...
  MAYO1         202  ...
  MAYO2         206  ...
  MAYO3         207  ...
  ...
```

New helpers `algorithmFamily` and `wrapText` in `algorithm_profiles.go`; `printServerAlgorithms` pre-filters, sorts by family, and renders with wrapping.

Companion PR #253 adds the algorithm registrations these rows describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)