### PR TITLE
CLI: classical algorithm enrichment + a measured cost example

### DIFF
--- a/cmdv2/cli/algorithms.measured-arm64.example.yaml
+++ b/cmdv2/cli/algorithms.measured-arm64.example.yaml
@@ -1,51 +1,29 @@
-# algorithms.yaml — algorithm enrichment data for tdns-cli.
+# algorithms.measured-arm64.example.yaml
 #
-# Install as /etc/tdns/algorithms.yaml and pull it into tdns-cli.yaml:
+# A WORKED EXAMPLE of algorithms.yaml with signingcost / validationcost
+# filled in from a real benchmark run. This is NOT a drop-in config for
+# your deployment — the costs were measured on ONE machine and the
+# relative multipliers shift across architectures (AVX2 on x86 vs NEON
+# on arm64, RSA bignum performance, etc.).
 #
-#   include:
-#      - /etc/tdns/algorithms.yaml
+# Measured with: go run ./cmd/algbench   (dnssec-algorithms repo)
+#   Host:     Apple Silicon (arm64), macOS
+#   Run:      -n 50, RSA at 2048-bit
+#   Reference: ED25519 (signingcost = validationcost = 1)
 #
-# This data is consumed ONLY by the `tdns-cli ... keystore <sig0|dnssec>
-# algorithms` listing, to annotate the algorithms a server reports as
-# supported. It is intentionally separated from the host-local CLI
-# config (API keys, addresses, ...) so it can be shared and
-# version-controlled on its own.
+# To get numbers for YOUR reference hardware, run cmd/algbench there and
+# paste its output into your own algorithms.yaml. The canonical template
+# (algorithms.sample.yaml) intentionally leaves these costs unset.
 #
-# Structure:
-#   algorithms.display     listing presentation knobs (optional)
-#   algorithms.profiles    per-algorithm enrichment, keyed by the
-#                          algorithm NAME the server reports
+# What survives across hardware is the *shape*, not the exact factors:
+#   - RSA: slow to sign, fast to verify
+#   - SLH-DSA: hash-based, extremely slow signing
+#   - SQIsign: isogeny, slow sign and (relatively) slow verify
+#   - ML-DSA / MAYO / Falcon: lattice / oil-and-vinegar, modest cost
 #
-# Profiles keyed by a NAME matching no server-supported algorithm are
-# ignored; supported algorithms with no entry simply print "-" in the
-# enrichment columns. The set of supported algorithms always comes from
-# the server — nothing here changes that.
-#
-# Profile fields (all optional; omit what you don't know — a missing
-# field shows as "-"):
-#   description     free-form note
-#   publickeybytes  DNSKEY/KEY public key size, bytes
-#   signaturebytes  RRSIG/SIG signature size, bytes (typical; see notes
-#                   for variable-length schemes)
-#   secretkeybytes  stored private key size, bytes
-#   securitylevel   NIST PQ security level (1/3/5); omit for classical
-#   maturity        final | draft | candidate | builtin
-#   signingcost     cost of signing,    relative to ED25519 (= 1)
-#   validationcost  cost of validation, relative to ED25519 (= 1)
-#
-# ED25519 is the cost reference (signingcost = validationcost = 1). The
-# PQ signing/validation costs are intentionally left unset below — fill
-# them in with your own measurements, relative to ED25519, as you
-# benchmark each algorithm on your reference hardware. Example:
-#
-#   MLDSA44:
-#      signingcost:     5
-#      validationcost:  2
+# Field meanings are documented in algorithms.sample.yaml.
 
 algorithms:
-   # Presentation knobs for the listing. descriptionwidth bounds the
-   # DESCRIPTION column so a long note wraps onto continuation rows
-   # instead of stretching the whole table (default 50).
    display:
       descriptionwidth:  50
 
@@ -65,6 +43,8 @@ algorithms:
          signaturebytes:  64
          secretkeybytes:  32
          maturity:        builtin
+         signingcost:     1.1
+         validationcost:  1.3
 
       ECDSAP384SHA384:
          description:     "ECDSA P-384 with SHA-384 (RFC 6605); classical"
@@ -72,6 +52,8 @@ algorithms:
          signaturebytes:  96
          secretkeybytes:  48
          maturity:        builtin
+         signingcost:     7.9
+         validationcost:  11
 
       RSASHA256:
          description:     "RSA with SHA-256 (RFC 5702); classical. Sizes shown for a 2048-bit key (variable)"
@@ -79,6 +61,8 @@ algorithms:
          signaturebytes:  256
          secretkeybytes:  1192
          maturity:        builtin
+         signingcost:     53
+         validationcost:  0.9
 
       RSASHA512:
          description:     "RSA with SHA-512 (RFC 5702); classical. Sizes shown for a 2048-bit key (variable)"
@@ -86,6 +70,8 @@ algorithms:
          signaturebytes:  256
          secretkeybytes:  1192
          maturity:        builtin
+         signingcost:     53
+         validationcost:  0.8
 
       MLDSA44:
          description:     "ML-DSA-44 (FIPS 204), lattice"
@@ -94,8 +80,8 @@ algorithms:
          secretkeybytes:  2560
          securitylevel:   2
          maturity:        final
-         # signingcost:     <measure relative to ED25519>
-         # validationcost:  <measure relative to ED25519>
+         signingcost:     3.1
+         validationcost:  1.9
 
       SLHDSA128S:
          description:     "SLH-DSA-SHA2-128s (FIPS 205), hash-based; tiny keys, large slow signatures"
@@ -104,6 +90,8 @@ algorithms:
          secretkeybytes:  64
          securitylevel:   1
          maturity:        final
+         signingcost:     7946
+         validationcost:  4.1
 
       FALCON512:
          description:     "Falcon-512 (FIPS 206 draft), lattice; signature is variable-length, <= 752"
@@ -112,6 +100,8 @@ algorithms:
          secretkeybytes:  1281
          securitylevel:   1
          maturity:        draft
+         signingcost:     7.4
+         validationcost:  0.7
 
       MAYO1:
          description:     "MAYO-1 (NIST onramp), oil-and-vinegar; seed-sized secret key"
@@ -120,6 +110,8 @@ algorithms:
          secretkeybytes:  24
          securitylevel:   1
          maturity:        candidate
+         signingcost:     6.9
+         validationcost:  1.4
 
       SNOVA24_5_4:
          description:     "SNOVA-24_5_4 (NIST onramp), oil-and-vinegar"
@@ -128,6 +120,8 @@ algorithms:
          secretkeybytes:  48
          securitylevel:   1
          maturity:        candidate
+         signingcost:     21
+         validationcost:  4.1
 
       SQISIGN1:
          description:     "SQIsign-I (NIST onramp), isogeny; very small keys and signatures, slow"
@@ -136,6 +130,8 @@ algorithms:
          secretkeybytes:  353
          securitylevel:   1
          maturity:        candidate
+         signingcost:     2237
+         validationcost:  62
 
       QRUOV_Q31_L3:
          description:     "QR-UOV-I q=31 L=3 (NIST onramp), oil-and-vinegar; large public key"
@@ -144,6 +140,8 @@ algorithms:
          secretkeybytes:  32
          securitylevel:   1
          maturity:        candidate
+         signingcost:     76
+         validationcost:  34
 
       MAYO2:
          description:     "MAYO-2 (NIST onramp), oil-and-vinegar; larger pubkey / smaller sig than MAYO-1"
@@ -152,6 +150,8 @@ algorithms:
          secretkeybytes:  24
          securitylevel:   1
          maturity:        candidate
+         signingcost:     5
+         validationcost:  0.9
 
       MAYO3:
          description:     "MAYO-3 (NIST onramp), oil-and-vinegar; level-3 parameter set"
@@ -160,6 +160,8 @@ algorithms:
          secretkeybytes:  32
          securitylevel:   3
          maturity:        candidate
+         signingcost:     18
+         validationcost:  3.7
 
       MAYO5:
          description:     "MAYO-5 (NIST onramp), oil-and-vinegar; level-5 parameter set"
@@ -168,6 +170,8 @@ algorithms:
          secretkeybytes:  40
          securitylevel:   5
          maturity:        candidate
+         signingcost:     37
+         validationcost:  7.7
 
       FALCON1024:
          description:     "Falcon-1024 (FIPS 206 draft), lattice; level-5, variable-length sig <= 1462"
@@ -176,6 +180,8 @@ algorithms:
          secretkeybytes:  2305
          securitylevel:   5
          maturity:        draft
+         signingcost:     15
+         validationcost:  1.3
 
       SNOVA37_17_2:
          description:     "SNOVA-37_17_2 (NIST onramp), oil-and-vinegar; smallest signature (124 B), larger public key"
@@ -184,6 +190,8 @@ algorithms:
          secretkeybytes:  48
          securitylevel:   1
          maturity:        candidate
+         signingcost:     34
+         validationcost:  11
 
       SNOVA25_8_3:
          description:     "SNOVA-25_8_3 (NIST onramp), oil-and-vinegar; small signature, modest public key"
@@ -192,3 +200,5 @@ algorithms:
          secretkeybytes:  48
          securitylevel:   1
          maturity:        candidate
+         signingcost:     15
+         validationcost:  2.7


### PR DESCRIPTION
Enriches the `tdns-cli ... keystore <sig0|dnssec> algorithms` listing data.

## `algorithms.sample.yaml` — add the classical built-ins
Profiles existed for the PQ algorithms and ED25519, but the other classical algorithms a server reports were missing. Added:

| Algorithm | pubkey | sig | seckey | notes |
|---|---|---|---|---|
| ECDSAP256SHA256 | 64 | 64 | 32 | exact (RFC 6605) |
| ECDSAP384SHA384 | 96 | 96 | 48 | exact (RFC 6605) |
| RSASHA256 | 260 | 256 | 1192 | 2048-bit key, variable (RFC 5702) |
| RSASHA512 | 260 | 256 | 1192 | 2048-bit key, variable (RFC 5702) |

`signingcost`/`validationcost` are intentionally left unset in the canonical sample — they are hardware-specific and meant to be measured per deployment.

## `algorithms.measured-arm64.example.yaml` — a worked example (new)
A complete enrichment file with every profile's `signingcost`/`validationcost` filled in from a real benchmark run (the new `cmd/algbench` in `johanix/dnssec-algorithms`, ED25519 = 1), on an Apple Silicon arm64 host.

**Explicitly not a drop-in config.** Relative multipliers shift across architectures (AVX2 on x86 vs NEON on arm64, RSA bignum perf, …). It illustrates the *shape* — RSA slow-sign/fast-verify, SLH-DSA extremely slow signing, SQIsign slow signing with relatively slow (but far cheaper than its own signing) verify — rather than prescribing values. Run `algbench` on your reference hardware to get authoritative numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)