### PR TITLE
imr: DNSKEY transport policy enum + transport-selection design (WIP/scratch)

### DIFF
--- a/cmdv2/cli/algorithms.measured-netbsd-x86.example.yaml
+++ b/cmdv2/cli/algorithms.measured-netbsd-x86.example.yaml
@@ -1,0 +1,218 @@
+# algorithms.measured-netbsd-x86.example.yaml
+#
+# A WORKED EXAMPLE of algorithms.yaml with signingcost / validationcost
+# filled in from a real benchmark run. This is NOT a drop-in config for
+# your deployment — the costs were measured on ONE machine and the
+# relative multipliers shift across architectures and across whether the
+# PQ C libraries were built with CPU-specific optimization (AVX2, etc.)
+# or as generic reference code.
+#
+# Measured with: go run ./cmd/algbench   (dnssec-algorithms repo)
+#   Host:     NetBSD VM on an Intel i9-12900 (godev101)
+#   Run:      -n 50, RSA at 2048-bit
+#   Reference: ED25519 (signingcost = validationcost = 1)
+#
+# Compare with algorithms.measured-arm64.example.yaml: the shape is the
+# same, but several PQ signing costs are much higher here — most
+# strikingly FALCON512 (119x vs 7.4x) and SLHDSA128S (40423x vs 7946x).
+#
+# This is NOT a missing-CPU-feature artifact: the host (a NetBSD/Xen
+# guest on an i9-12900H) does expose AVX2/FMA/AES/SHA to the guest. The
+# inflated PQ signing costs come from the C libraries being built as
+# generic / reference code rather than with the AVX2 signing paths
+# enabled — e.g. qruovc here builds the QR-UOV *ref* (non-vectorized)
+# platform by design, and the liboqs/sqisign builds were not compiled
+# with -march tuning. Rebuilding those with the optimized code paths
+# would very probably narrow the gap; the numbers below reflect the
+# library builds as currently installed on this host, not an upper
+# bound on the algorithms.
+#
+# SLHDSA128S signing here is ~1.6 SECONDS per signature: usable only for
+# offline signing of rarely-changing RRsets, never online — and that
+# holds regardless of build flags (hash-based signing is intrinsically
+# slow).
+#
+# To get numbers for YOUR reference hardware, run cmd/algbench there.
+# The canonical template (algorithms.sample.yaml) leaves these unset.
+#
+# Field meanings are documented in algorithms.sample.yaml.
+
+algorithms:
+   display:
+      descriptionwidth:  50
+
+   profiles:
+      ED25519:
+         description:     "Edwards-curve DSA (RFC 8080); classical, cost reference"
+         publickeybytes:  32
+         signaturebytes:  64
+         secretkeybytes:  32
+         maturity:        builtin
+         signingcost:     1
+         validationcost:  1
+
+      ECDSAP256SHA256:
+         description:     "ECDSA P-256 with SHA-256 (RFC 6605); classical, widely deployed"
+         publickeybytes:  64
+         signaturebytes:  64
+         secretkeybytes:  32
+         maturity:        builtin
+         signingcost:     1.4
+         validationcost:  1.1
+
+      ECDSAP384SHA384:
+         description:     "ECDSA P-384 with SHA-384 (RFC 6605); classical"
+         publickeybytes:  96
+         signaturebytes:  96
+         secretkeybytes:  48
+         maturity:        builtin
+         signingcost:     6.9
+         validationcost:  8.2
+
+      RSASHA256:
+         description:     "RSA with SHA-256 (RFC 5702); classical. Sizes shown for a 2048-bit key (variable)"
+         publickeybytes:  260
+         signaturebytes:  256
+         secretkeybytes:  1192
+         maturity:        builtin
+         signingcost:     39
+         validationcost:  0.8
+
+      RSASHA512:
+         description:     "RSA with SHA-512 (RFC 5702); classical. Sizes shown for a 2048-bit key (variable)"
+         publickeybytes:  260
+         signaturebytes:  256
+         secretkeybytes:  1192
+         maturity:        builtin
+         signingcost:     40
+         validationcost:  0.7
+
+      MLDSA44:
+         description:     "ML-DSA-44 (FIPS 204), lattice"
+         publickeybytes:  1312
+         signaturebytes:  2420
+         secretkeybytes:  2560
+         securitylevel:   2
+         maturity:        final
+         signingcost:     2.6
+         validationcost:  1.3
+
+      SLHDSA128S:
+         description:     "SLH-DSA-SHA2-128s (FIPS 205), hash-based; tiny keys, large slow signatures"
+         publickeybytes:  32
+         signaturebytes:  7856
+         secretkeybytes:  64
+         securitylevel:   1
+         maturity:        final
+         signingcost:     40423
+         validationcost:  18
+
+      FALCON512:
+         description:     "Falcon-512 (FIPS 206 draft), lattice; signature is variable-length, <= 752"
+         publickeybytes:  897
+         signaturebytes:  752
+         secretkeybytes:  1281
+         securitylevel:   1
+         maturity:        draft
+         signingcost:     119
+         validationcost:  0.4
+
+      MAYO1:
+         description:     "MAYO-1 (NIST onramp), oil-and-vinegar; seed-sized secret key"
+         publickeybytes:  1420
+         signaturebytes:  454
+         secretkeybytes:  24
+         securitylevel:   1
+         maturity:        candidate
+         signingcost:     25
+         validationcost:  2.1
+
+      SNOVA24_5_4:
+         description:     "SNOVA-24_5_4 (NIST onramp), oil-and-vinegar"
+         publickeybytes:  1016
+         signaturebytes:  248
+         secretkeybytes:  48
+         securitylevel:   1
+         maturity:        candidate
+         signingcost:     59
+         validationcost:  17
+
+      SQISIGN1:
+         description:     "SQIsign-I (NIST onramp), isogeny; very small keys and signatures, slow"
+         publickeybytes:  65
+         signaturebytes:  148
+         secretkeybytes:  353
+         securitylevel:   1
+         maturity:        candidate
+         signingcost:     3296
+         validationcost:  122
+
+      QRUOV_Q31_L3:
+         description:     "QR-UOV-I q=31 L=3 (NIST onramp), oil-and-vinegar; large public key"
+         publickeybytes:  23641
+         signaturebytes:  157
+         secretkeybytes:  32
+         securitylevel:   1
+         maturity:        candidate
+         signingcost:     100
+         validationcost:  37
+
+      MAYO2:
+         description:     "MAYO-2 (NIST onramp), oil-and-vinegar; larger pubkey / smaller sig than MAYO-1"
+         publickeybytes:  4912
+         signaturebytes:  186
+         secretkeybytes:  24
+         securitylevel:   1
+         maturity:        candidate
+         signingcost:     19
+         validationcost:  0.8
+
+      MAYO3:
+         description:     "MAYO-3 (NIST onramp), oil-and-vinegar; level-3 parameter set"
+         publickeybytes:  2986
+         signaturebytes:  681
+         secretkeybytes:  32
+         securitylevel:   3
+         maturity:        candidate
+         signingcost:     68
+         validationcost:  5.4
+
+      MAYO5:
+         description:     "MAYO-5 (NIST onramp), oil-and-vinegar; level-5 parameter set"
+         publickeybytes:  5554
+         signaturebytes:  964
+         secretkeybytes:  40
+         securitylevel:   5
+         maturity:        candidate
+         signingcost:     162
+         validationcost:  11
+
+      FALCON1024:
+         description:     "Falcon-1024 (FIPS 206 draft), lattice; level-5, variable-length sig <= 1462"
+         publickeybytes:  1793
+         signaturebytes:  1462
+         secretkeybytes:  2305
+         securitylevel:   5
+         maturity:        draft
+         signingcost:     259
+         validationcost:  1.1
+
+      SNOVA37_17_2:
+         description:     "SNOVA-37_17_2 (NIST onramp), oil-and-vinegar; smallest signature (124 B), larger public key"
+         publickeybytes:  9842
+         signaturebytes:  124
+         secretkeybytes:  48
+         securitylevel:   1
+         maturity:        candidate
+         signingcost:     59
+         validationcost:  8.2
+
+      SNOVA25_8_3:
+         description:     "SNOVA-25_8_3 (NIST onramp), oil-and-vinegar; small signature, modest public key"
+         publickeybytes:  2320
+         signaturebytes:  165
+         secretkeybytes:  48
+         securitylevel:   1
+         maturity:        candidate
+         signingcost:     29
+         validationcost:  6.6

--- a/cmdv2/imr/tdns-imr.sample.yaml
+++ b/cmdv2/imr/tdns-imr.sample.yaml
@@ -18,12 +18,30 @@ imrengine:
       # - query-for-transport-tlsa
 
 # DNSSEC algorithm numbers whose DNSKEY/RRSIG payloads are large for UDP.
+# Consulted ONLY when dnskey_query_transport is "use_ds_signal" (the default).
 # When a referral DS RRset contains any listed algorithm, the IMR fetches
-# the child zone's DNSKEY over TCP from the start (do53-tcp), not UDP with
-# TC fallback. RSASHA512 (10) is a stand-in where ML-DSA-44 is unavailable.
-# Inspect counters: tdns-cli imr stats large-ksk
+# the child zone's DNSKEY over a non-UDP transport from the start, not UDP
+# with TC fallback. RSASHA512 (10) is a stand-in where ML-DSA-44 is
+# unavailable. Inspect counters: tdns-cli imr stats large-ksk
+#
+# dnskey_query_transport selects how the IMR picks a transport for DNSKEY
+# queries. DNSKEY queries are ~0.1% of traffic and exempt from a server's
+# probabilistic transport-weight distribution, so the chosen transport
+# bypasses those weights (it still honors the server's advertised
+# capabilities, preferring doq > dot > doh > tcp). Values:
+#    force_udp        - disable this feature; follow normal probabilistic
+#                       transport selection even for large-KSK zones.
+#    use_ds_signal    - (default) bypass to the best transport only when the
+#                       parent DS uses a large_algorithms algorithm.
+#    try_encrypted    - bypass for ALL DNSKEY queries; prefer encrypted,
+#                       fall back to TCP, never UDP. Avoids having to keep
+#                       large_algorithms current as PQ algorithms proliferate.
+#    force_encrypted  - bypass for ALL DNSKEY queries; encrypted only, fail
+#                       the query if the server advertises no encrypted
+#                       transport.
 dnssec:
    large_algorithms: [ 10 ]
+   dnskey_query_transport: use_ds_signal
 
 log:
    file:                /var/log/tdns/tdns-imr.log

--- a/docs/2026-06-12-transport-selection-policy.md
+++ b/docs/2026-06-12-transport-selection-policy.md
@@ -1,0 +1,363 @@
+# Transport Selection Policy for the IMR
+
+**Date**: 2026-06-12
+**Status**: DESIGN + IMPLEMENTATION PLAN
+**Component**: tdns-imr resolver (`tdns/v2`)
+
+Supersedes the reasoning in (kept for the trail, marked superseded):
+- `tdns-project/docs/2026-06-12-part3-ds-transport-signaling.md`
+- `tdns-project/docs/2026-06-12-dnskey-transport-upgrade-analysis.md`
+- `tdns-project/docs/2026-06-12-dnskey-probabilistic-bypass-summary.md`
+
+---
+
+## 1. Motivation
+
+Three forces converge on "which transport should the IMR use for an
+outgoing query":
+
+1. **Large responses.** Post-quantum DNSKEY RRsets exceed the ~1232-byte
+   UDP ceiling; we want them off UDP to avoid truncate-then-retry. This
+   is draft-johani-dnsop-dnssec-alg-split Part 3.
+
+2. **Privacy.** An end user (stub) may want the IMR's upstream queries
+   carried over an encrypted transport (DoT/DoQ). Today this is the PR
+   (Privacy Requested) EDNS(0) flag, bit 12.
+
+3. **Server-advertised capability.** Auth servers signal which
+   transports they support (and at what weights) via SVCB/TSYNC. The IMR
+   distributes queries across those transports.
+
+The current code expresses these with two separate, blunt mechanisms:
+
+- `requireEncrypted bool` — threaded through the whole resolution path,
+  sourced from the PR flag. All-or-nothing: "encrypted only, or
+  SERVFAIL".
+- `dnskeyTransport` enum (added 2026-06-12) — DNSKEY-specific, four
+  values, bypasses probabilistic selection.
+
+These overlap (`force_encrypted` in the DNSKEY enum is the same
+capability as `requireEncrypted`) and they are spelled differently. The
+large-response intent and the privacy intent **want different
+fallbacks** (TCP vs UDP), which neither mechanism captures.
+
+This document unifies them into one **transport-selection policy** that
+applies to any qtype, composes cleanly with a per-query end-user signal,
+and leaves room for a future richer signal (EDNS(0) option).
+
+---
+
+## 2. The policy vocabulary
+
+A single enum, `TransportPolicy`, with six values:
+
+| value | consults signals | prefers encrypted | fallback floor | forbids |
+|-------|:---------------:|:----------------:|:--------------:|---------|
+| `none` | no | no | UDP/53 | (nothing) — ignores discovered transports entirely |
+| `use_transport_signal` | yes | no (weighted) | UDP | — |
+| `use_ds_signal` | yes | (meta) | (escalates) | — |
+| `encrypted_or_udp` | yes | yes | **UDP** | — |
+| `encrypted_or_tcp` | yes | yes | **TCP** | UDP |
+| `encrypted_or_fail` | yes | yes | (none) | UDP **and** TCP |
+
+Two of these are *decision rules* ("meta" values), the rest are
+*targets*:
+
+- **`none`** — apply no policy. Ignore SVCB/TSYNC-discovered transports;
+  query plain UDP/53 (with the intrinsic TC→TCP fallback that Do53
+  always has). This is the deliberate opt-out and, crucially, the
+  **measurement control arm** (see §5).
+
+- **`use_transport_signal`** — honor the server's advertised transports,
+  distributed by whatever mechanism the IMR currently implements
+  (today: deterministic weighted hash per qname; tomorrow possibly
+  query-count or byte-count based — the policy name names the *intent*,
+  not the mechanism). This reproduces today's default behavior.
+
+- **`use_ds_signal`** — DNSKEY-specific meta-value: if the cached parent
+  DS uses a large algorithm (`dnssec.large_algorithms`), escalate this
+  query to `encrypted_or_tcp`; otherwise behave as
+  `use_transport_signal`.
+
+- **`encrypted_or_udp`** — prefer an encrypted transport; if none is
+  available, fall back all the way to UDP. Best-effort privacy:
+  availability wins over privacy. This is the right *default-level*
+  choice for a privacy-leaning resolver.
+
+- **`encrypted_or_tcp`** — prefer an encrypted transport; if none is
+  available, fall back to TCP, but **never UDP**. This is the
+  large-response floor: the whole point is to escape UDP truncation, so
+  UDP is not an acceptable fallback even when encryption is unavailable.
+
+- **`encrypted_or_fail`** — encrypted transport or nothing: if the
+  server advertises no encrypted transport, fail the query with
+  SERVFAIL + EDE `EDEPrivacyRequestedUnavailable`. This is exactly
+  today's `requireEncrypted == true` behavior.
+
+### Why `try_encrypted` was split
+
+An earlier iteration had a single `try_encrypted` with an implicit
+fallback. It conflated two distinct intents that want **opposite**
+fallbacks:
+
+- privacy (best-effort) → fall back to **UDP** (`encrypted_or_udp`)
+- large-response → fall back to **TCP**, never UDP (`encrypted_or_tcp`)
+
+Naming the fallback target in the value removes the ambiguity at the
+point of configuration.
+
+---
+
+## 3. Config schema
+
+```yaml
+transport_selection:
+   default: use_transport_signal   # IMR's disposition absent a per-query signal
+   dnskey:  use_ds_signal          # qtype override: large DS → encrypted_or_tcp
+   # future: key: ..., tlsa: ..., etc.
+```
+
+Resolution of the **config policy** for a query of type Q:
+
+1. If `transport_selection.<qtype>` is set for Q, use it.
+2. Else use `transport_selection.default`.
+3. If neither is set, the default is `use_transport_signal` (today's
+   behavior, backward compatible).
+
+**Allowed values per level:**
+
+- `default` and per-qtype keys: `none`, `use_transport_signal`,
+  `encrypted_or_udp`, `encrypted_or_tcp`, `encrypted_or_fail`.
+- per-qtype keys additionally: `use_ds_signal` (only meaningful for
+  qtypes whose parent publishes a DS — in practice DNSKEY). Rejected
+  at parse time under `default`.
+
+### Migration from the current keys
+
+The `dnssec.large_algorithms` list stays (it is what `use_ds_signal`
+consults). The `dnssec.dnskey_query_transport` key added earlier today
+is **renamed and relocated** into `transport_selection.dnskey`, with the
+value vocabulary updated:
+
+| old `dnssec.dnskey_query_transport` | new `transport_selection.dnskey` |
+|-------------------------------------|----------------------------------|
+| `force_udp` | `use_transport_signal` (or `none` to ignore signals) |
+| `use_ds_signal` | `use_ds_signal` |
+| `try_encrypted` | `encrypted_or_tcp` (DNSKEY wants TCP floor) |
+| `force_encrypted` | `encrypted_or_fail` |
+
+Per project policy (no backwards compatibility, operator migrates own
+config): the old key is removed, not dual-parsed.
+
+---
+
+## 4. Composition with the per-query end-user signal
+
+The config policy is the IMR's disposition **in the absence of** an
+explicit per-query signal. A present signal (today: PR flag; tomorrow:
+an EDNS(0) option) can only **raise the bar for that query, never lower
+it**. The IMR issues queries on behalf of the end user; ignoring a
+signalled requirement makes no sense, but a stub also cannot ask the IMR
+to be *less* careful than its configured floor.
+
+Model the effective policy on **two independent axes** rather than one
+linear lattice (because `encrypted_or_udp` and `encrypted_or_tcp` are
+not comparable on a single "strictness" scale):
+
+- **encryption requirement** ∈ {none, prefer, require}
+  - `none`/`use_transport_signal` → none
+  - `encrypted_or_udp`/`encrypted_or_tcp` → prefer
+  - `encrypted_or_fail` → require
+- **UDP allowed** ∈ {yes, no}
+  - `none`/`use_transport_signal`/`encrypted_or_udp` → yes
+  - `encrypted_or_tcp`/`encrypted_or_fail` → no
+
+A signal raises an axis; it never lowers it. The effective policy is
+recomposed from the raised axes:
+
+| encryption req. | UDP allowed | effective policy |
+|-----------------|-------------|------------------|
+| none | yes | (config as-is: none / use_transport_signal) |
+| prefer | yes | encrypted_or_udp |
+| prefer | no | encrypted_or_tcp |
+| require | (n/a) | encrypted_or_fail |
+
+`use_ds_signal` is resolved to its target (`encrypted_or_tcp` on large
+DS, else `use_transport_signal`) **before** composition, so the signal
+composes against the resolved target.
+
+### Worked examples
+
+- Config `default: encrypted_or_udp`, query arrives with a privacy
+  "force" signal → encryption axis raised none→require →
+  **`encrypted_or_fail`** for that query.
+- Config `dnskey: use_ds_signal`, large parent DS → resolves to
+  `encrypted_or_tcp` (UDP-forbidden). Same query *also* carries a "force"
+  signal → encryption axis raised prefer→require, UDP-forbidden already
+  set → **`encrypted_or_fail`**.
+- Config `default: none`, query with a privacy "force" signal →
+  baseline `none` is overridable; encryption axis raised →
+  **`encrypted_or_fail`**. (`none` governs the IMR's own disposition,
+  not its obedience to an explicit request.)
+- Config `default: encrypted_or_fail`, query with **no** signal → stays
+  `encrypted_or_fail` (config floor; signal absence cannot lower it).
+
+### Today's signal mapping (PR flag)
+
+The PR flag is a single bit: present means "encrypted required, no
+cleartext fallback". So today:
+
+- `PR == true` → signal contributes **encryption=require**.
+- `PR == false` → no signal contribution.
+
+This reproduces current behavior exactly (PR → `encrypted_or_fail`).
+When the richer EDNS(0) option lands (able to express
+prefer-with-fallback, choose UDP vs TCP floor, etc.), only the
+"decode signal → axis contributions" step changes; the composition and
+resolution machinery is untouched.
+
+---
+
+## 5. `none` as the measurement control arm
+
+`none` is not merely a debug escape hatch — it is the **A/B control**
+for proving the whole feature works. Run the IMR with
+`default: none` for a window and record (UDP query count, truncations).
+Then run with `use_transport_signal` + `use_ds_signal` and record
+(truncations, DoT/DoQ counts). The hypothesis the feature exists to
+validate:
+
+```
+truncations(policy)  <<  truncations(none)
+DoT/DoQ(policy)       >>  0
+```
+
+This pairs with the existing large-KSK counters
+(`tdns-cli imr stats large-ksk`: DS-encountered, DNSKEY-lookups,
+bypassed). Because `none` must produce a clean baseline, it has to
+**genuinely suppress** discovered transports (query UDP/53 even when the
+server is known to speak DoT), not merely "not prefer" them.
+
+Implication: `none` is a real branch in `candidateTransports` /
+`prioritizeServers`, not just "encryption not required".
+
+---
+
+## 6. Implementation plan
+
+The guiding principle is **preserve-then-generalize**: keep current
+behavior bit-exact at each step, introduce the enum alongside the
+existing `requireEncrypted bool`, derive the bool from the enum, then
+remove the bool once every consumer reads the enum. Build + test green
+at every step.
+
+### Step 0 — Vocabulary + config (no behavior change)
+
+- Define `TransportPolicy` (string enum) + the six constants. Rename the
+  existing `DNSKEYTransportPolicy` type to `TransportPolicy`; keep the
+  DNSKEY constants but rename to the new vocabulary
+  (`encrypted_or_tcp`, `encrypted_or_fail`, `use_ds_signal`,
+  `use_transport_signal`, `encrypted_or_udp`, `none`).
+- Predicate methods on the enum (the lattice lives here, nowhere else):
+  - `ConsultsSignals() bool` — false only for `none`.
+  - `PrefersEncrypted() bool` — true for the three `encrypted_or_*`.
+  - `RequiresEncrypted() bool` — true only for `encrypted_or_fail`.
+  - `AllowsUDP() bool` — false for `encrypted_or_tcp`, `encrypted_or_fail`.
+  - `AllowsCleartextFallback() bool` — false only for `encrypted_or_fail`.
+- New config struct `TransportSelectionConf { Default string; Dnskey string; ... }`
+  under `Config` (top-level `transport_selection:`).
+- `parseTransportPolicy(string) (TransportPolicy, error)` +
+  per-level validation (`use_ds_signal` rejected under `default`).
+- Derived `Internal.TransportSelection` holding resolved
+  `map[uint16]TransportPolicy` (per-qtype) + a default.
+- Remove `dnssec.dnskey_query_transport`; move semantics to
+  `transport_selection.dnskey`.
+- **Verify**: config round-trips; `parseTransportPolicy` unit tests for
+  all six values, default, bad value, `use_ds_signal`-under-default
+  rejection.
+
+### Step 1 — Per-query effective-policy chokepoint
+
+- `effectivePolicy(qname string, qtype uint16, signal SignalReq) TransportPolicy`:
+  1. config policy = lookup(qtype) else default.
+  2. if `use_ds_signal`: resolve to `encrypted_or_tcp` (large cached DS)
+     or `use_transport_signal`.
+  3. compose with `signal` on the two axes (§4); recompose to a value.
+- `SignalReq` decoded from `msgoptions`: today `PR==true →
+  {encryption: require}`. One decode function, isolated.
+- **Verify**: table-driven test of the §4 composition matrix, including
+  the four worked examples.
+
+### Step 2 — Wire the enum into resolution (alongside the bool)
+
+- Change `IterativeDNSQuery` / `IterativeDNSQueryWithLoopDetection` /
+  `prioritizeServers` / `candidateTransports` to accept a
+  `TransportPolicy` instead of (or initially in addition to)
+  `requireEncrypted bool`.
+- Transitional: compute `requireEncrypted := policy.RequiresEncrypted()`
+  and leave existing downstream checks untouched. This keeps the diff
+  small and behavior identical while the signature changes propagate.
+- `candidateTransports`:
+  - `none` → `[Do53]` only, ignore `server.Transports`.
+  - `PrefersEncrypted()` → encrypted tuples first; UDP tuple included
+    only if `AllowsUDP()`, TCP tuple included if `!AllowsUDP()` and
+    `AllowsCleartextFallback()`.
+  - `RequiresEncrypted()` → encrypted tuples only (today's
+    `requireEncrypted` filter).
+  - else (`use_transport_signal`) → unchanged weighted behavior.
+- **Verify**: existing `prioritizeServers`/`candidateTransports` tests
+  still pass; add cases for `none`, `encrypted_or_udp`,
+  `encrypted_or_tcp`.
+
+### Step 3 — Fold DNSKEY bypass into the unified path
+
+- Replace `dnskeyTransportBypass` / `preferredDNSKEYTransport` usage in
+  `tryServer` with the policy resolved by `effectivePolicy`. The
+  "bypass probabilistic weights for DNSKEY" behavior becomes: when the
+  effective policy is `encrypted_or_tcp`/`encrypted_or_fail`, the tuple
+  generation already excludes UDP and prefers encrypted — no separate
+  bypass needed. Keep the per-(addr,transport) dedup.
+- Keep telemetry (`noteDSEncountered`, `noteDNSKEYLookup`,
+  large-ksk counters) — rename "forcedTCP" counter to "bypassed" /
+  "off-udp" to match the generalized meaning.
+- **Verify**: the DNSKEY tests from earlier today, adapted to the new
+  vocabulary; large-DS query still goes off-UDP.
+
+### Step 4 — Retire `requireEncrypted bool`
+
+- Once every consumer reads the policy, remove the transitional bool and
+  the `requireEncrypted` parameter. Cache-admission checks (skip cached
+  data that arrived over cleartext) read
+  `policy.RequiresEncrypted()` (or `!AllowsCleartextFallback()`)
+  instead.
+- **Verify**: full `tdns/v2` test suite (minus the two pre-existing
+  `TestGlobalStuffValidate*` URL failures); manual `dog`/`tdns-cli`
+  sanity against a lab IMR if available.
+
+### Step 5 — Sample config + docs
+
+- Update `cmdv2/imr/tdns-imr.sample.yaml`: replace the `dnssec`
+  `dnskey_query_transport` block with a `transport_selection:` block,
+  documenting all six values and the default.
+- Mark the three superseded docs with a "superseded by this doc" note.
+- Update memory file `project_part3_ds_signaling.md`.
+
+### Risk notes
+
+- `requireEncrypted` touches ~15 sites incl. cache admission; Step 4 is
+  the riskiest. Preserve-then-generalize keeps each step behavior-exact.
+- `none` must be a genuine branch (suppress discovered transports), or
+  the measurement baseline is invalid (§5).
+- The two-axis composition (not a linear lattice) is the subtle part;
+  Step 1's table-driven test is the guard.
+
+---
+
+## 7. Open questions (none blocking)
+
+- A future EDNS(0) privacy option's exact wire format and how it encodes
+  prefer-vs-require and UDP-vs-TCP floor — out of scope here; the
+  `SignalReq` decode chokepoint isolates it.
+- Whether other qtypes (KEY, TLSA) want their own `transport_selection`
+  entries in practice — the schema allows it; we add them when a use
+  case appears.

--- a/v2/cli/imr_stats_large_ksk.go
+++ b/v2/cli/imr_stats_large_ksk.go
@@ -33,13 +33,13 @@ func printLargeKskImrMetrics(m tdns.LargeKskImrMetrics) {
 	}
 
 	fmt.Printf("DNSKEY lookups:                     %d\n", m.DNSKEYLookupTotal)
-	fmt.Printf("  forced TCP from start (do53-tcp):  %d (%s)\n",
-		m.DNSKEYLookupForcedTCP, pct(m.DNSKEYLookupForcedTCP, m.DNSKEYLookupTotal))
+	fmt.Printf("  bypassed probabilistic (tcp/enc):  %d (%s)\n",
+		m.DNSKEYLookupBypassed, pct(m.DNSKEYLookupBypassed, m.DNSKEYLookupTotal))
 	var normal uint64
-	if m.DNSKEYLookupForcedTCP <= m.DNSKEYLookupTotal {
-		normal = m.DNSKEYLookupTotal - m.DNSKEYLookupForcedTCP
+	if m.DNSKEYLookupBypassed <= m.DNSKEYLookupTotal {
+		normal = m.DNSKEYLookupTotal - m.DNSKEYLookupBypassed
 	}
-	fmt.Printf("  normal (UDP / encrypted / other):  %d (%s)\n",
+	fmt.Printf("  normal (probabilistic selection):  %d (%s)\n",
 		normal, pct(normal, m.DNSKEYLookupTotal))
 }
 

--- a/v2/config.go
+++ b/v2/config.go
@@ -64,7 +64,22 @@ type DnssecConf struct {
 	// LargeAlgorithms lists DNSSEC algorithm numbers whose DNSKEY/RRSIG sizes
 	// are large for UDP. The IMR may query child DNSKEY over TCP when parent
 	// DS uses one; the signer warns if one signs the bulk of a zone.
+	// Consulted ONLY when DNSKEYTransport is "use_ds_signal".
 	LargeAlgorithms []uint8 `yaml:"large_algorithms" mapstructure:"large_algorithms"`
+
+	// DNSKEYTransport selects how the IMR chooses a transport for DNSKEY
+	// queries. DNSKEY queries are ~0.1% of traffic and exempt from a server's
+	// probabilistic transport-weight distribution, so the chosen transport
+	// bypasses those weights (it still honors the server's advertised
+	// capabilities). Values:
+	//   "force_udp"       - disable Part 3; follow normal probabilistic selection.
+	//   "use_ds_signal"   - (default) bypass to best transport only when the
+	//                       cached parent DS uses a LargeAlgorithms algorithm.
+	//   "try_encrypted"   - bypass for all DNSKEY; prefer encrypted, fall back
+	//                       to TCP, never UDP.
+	//   "force_encrypted" - bypass for all DNSKEY; encrypted only, fail the
+	//                       query if the server advertises no encrypted transport.
+	DNSKEYTransport string `yaml:"dnskey_query_transport" mapstructure:"dnskey_query_transport"`
 }
 
 // KaspConf holds Key and Signing Policy parameters for the signer.
@@ -433,6 +448,10 @@ type InternalConf struct {
 
 	// LargeAlgorithms is the derived lookup set from Dnssec.LargeAlgorithms.
 	LargeAlgorithms map[uint8]bool
+
+	// DNSKEYTransport is the validated policy derived from
+	// Dnssec.DNSKEYTransport. Defaults to DNSKEYTransportUseDSSignal.
+	DNSKEYTransport DNSKEYTransportPolicy
 
 	// PostParseZonesHook is called after ParseZones completes during
 	// reload (SIGHUP or "config reload-zones"). Set by MP apps to

--- a/v2/dnslookup.go
+++ b/v2/dnslookup.go
@@ -1099,9 +1099,9 @@ func (imr *Imr) IterativeDNSQueryWithLoopDetection(ctx context.Context, qname st
 	}
 	// if Globals.Debug { fmt.Printf("IterativeDNSQuery: message after AddOTSToMessage: %s", m.String()) }
 
-	forceTCP := imr.dnskeyQueryForceTCP(qname, qtype)
+	dnskeyBypass := imr.dnskeyTransportBypass(qname, qtype)
 	if qtype == dns.TypeDNSKEY {
-		imr.noteDNSKEYLookup(forceTCP)
+		imr.noteDNSKEYLookup(dnskeyBypass)
 	}
 
 	// If PR flag is set, verify at least one server has encrypted transports available
@@ -1154,6 +1154,12 @@ func (imr *Imr) IterativeDNSQueryWithLoopDetection(ctx context.Context, qname st
 		lastErr          error
 		attempts         int
 	)
+	// When the DNSKEY transport policy bypasses probabilistic selection, every
+	// tuple for a given (server, addr) resolves to the SAME preferred transport.
+	// prioritizeServers still emits one tuple per advertised transport, so dedup
+	// by resolved (addr, transport) to avoid re-querying an identical path that
+	// just failed.
+	dnskeyAttempted := map[cache.AddrXport]bool{}
 	for attempt := 0; attempt < 2; attempt++ {
 		zoneName, zone, prioritized = imr.prioritizeServers(qname, serverMap, requireEncrypted)
 		if Globals.Debug {
@@ -1170,6 +1176,18 @@ func (imr *Imr) IterativeDNSQueryWithLoopDetection(ctx context.Context, qname st
 			addr := tuple.Addr
 			nsname := tuple.NSName
 			transport := tuple.Transport
+
+			if dnskeyBypass {
+				// All tuples for this (server, addr) collapse to the same
+				// preferred transport; skip the ones we've already tried.
+				eff := imr.preferredDNSKEYTransport(server)
+				key := cache.AddrXport{Addr: addr, Transport: eff}
+				if dnskeyAttempted[key] {
+					continue
+				}
+				dnskeyAttempted[key] = true
+			}
+
 			lastNS, lastAddr, lastTransport = nsname, addr, transport
 			attempts++
 
@@ -1178,7 +1196,7 @@ func (imr *Imr) IterativeDNSQueryWithLoopDetection(ctx context.Context, qname st
 					addr, nsname, core.TransportToString[transport], server.Alpn, qname, dns.TypeToString[qtype])
 			}
 
-			r, _, wireTransport, err := imr.tryServer(ctx, server, addr, transport, m, qname, qtype, forceTCP)
+			r, _, wireTransport, err := imr.tryServer(ctx, server, addr, transport, m, qname, qtype, dnskeyBypass)
 			lastTransport = wireTransport
 			if err != nil {
 				lastErr = err
@@ -1840,10 +1858,19 @@ func buildQuery(qname string, qtype uint16) (*dns.Msg, error) {
 // tryServer executes one query attempt for an explicit (server, addr,
 // transport) tuple selected upstream by prioritizeServers. It records the
 // outcome against the server's per-(addr, transport) backoff map.
-func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr string, t core.Transport, m *dns.Msg, qname string, qtype uint16, forceTCP bool) (*dns.Msg, time.Duration, core.Transport, error) {
+func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr string, t core.Transport, m *dns.Msg, qname string, qtype uint16, dnskeyBypass bool) (*dns.Msg, time.Duration, core.Transport, error) {
 	eff := t
-	if forceTCP && t == core.TransportDo53 {
-		eff = core.TransportDo53TCP
+	if dnskeyBypass {
+		// DNSKEY transport policy bypasses this server's probabilistic
+		// transport weights and picks the best advertised transport instead.
+		// Returns 0 only under force_encrypted when the server has no
+		// encrypted transport; in that case we must fail rather than fall
+		// back to cleartext.
+		pref := imr.preferredDNSKEYTransport(server)
+		if pref == 0 {
+			return nil, 0, t, fmt.Errorf("dnssec.dnskey_query_transport=force_encrypted but server %s advertises no encrypted transport", server.Name)
+		}
+		eff = pref
 	}
 
 	select {

--- a/v2/imr_large_ksk_metrics.go
+++ b/v2/imr_large_ksk_metrics.go
@@ -17,11 +17,11 @@ import (
 )
 
 var (
-	imrDSEncounteredTotal    atomic.Uint64
-	imrDSEncounteredLarge    atomic.Uint64
-	imrDSDLargeRRByAlg       [256]atomic.Uint64
-	imrDNSKEYLookupTotal     atomic.Uint64
-	imrDNSKEYLookupForcedTCP atomic.Uint64
+	imrDSEncounteredTotal   atomic.Uint64
+	imrDSEncounteredLarge   atomic.Uint64
+	imrDSDLargeRRByAlg      [256]atomic.Uint64
+	imrDNSKEYLookupTotal    atomic.Uint64
+	imrDNSKEYLookupBypassed atomic.Uint64
 )
 
 // LargeKskDSAlgCount holds the number of individual DS RRs seen for one
@@ -37,7 +37,11 @@ type LargeKskImrMetrics struct {
 	DSEncounteredLarge    uint64
 	DSDLargeRRByAlgorithm []LargeKskDSAlgCount
 	DNSKEYLookupTotal     uint64
-	DNSKEYLookupForcedTCP uint64
+	// DNSKEYLookupBypassed counts DNSKEY lookups that bypassed the server's
+	// probabilistic transport selection per the dnskey_query_transport policy.
+	// The transport actually chosen may be do53-tcp OR an encrypted transport
+	// (DoQ/DoT/DoH) depending on the server's advertised capabilities.
+	DNSKEYLookupBypassed uint64
 }
 
 // DNSSECAlgorithmLabel returns a human-readable algorithm name with number.
@@ -50,10 +54,10 @@ func DNSSECAlgorithmLabel(alg uint8) string {
 
 func LargeKskImrMetricsSnapshot() LargeKskImrMetrics {
 	m := LargeKskImrMetrics{
-		DSEncounteredTotal:    imrDSEncounteredTotal.Load(),
-		DSEncounteredLarge:    imrDSEncounteredLarge.Load(),
-		DNSKEYLookupTotal:     imrDNSKEYLookupTotal.Load(),
-		DNSKEYLookupForcedTCP: imrDNSKEYLookupForcedTCP.Load(),
+		DSEncounteredTotal:   imrDSEncounteredTotal.Load(),
+		DSEncounteredLarge:   imrDSEncounteredLarge.Load(),
+		DNSKEYLookupTotal:    imrDNSKEYLookupTotal.Load(),
+		DNSKEYLookupBypassed: imrDNSKEYLookupBypassed.Load(),
 	}
 	for alg := range imrDSDLargeRRByAlg {
 		if c := imrDSDLargeRRByAlg[alg].Load(); c > 0 {
@@ -74,7 +78,7 @@ func resetLargeKskImrMetricsForTest() {
 	imrDSEncounteredTotal.Store(0)
 	imrDSEncounteredLarge.Store(0)
 	imrDNSKEYLookupTotal.Store(0)
-	imrDNSKEYLookupForcedTCP.Store(0)
+	imrDNSKEYLookupBypassed.Store(0)
 	for i := range imrDSDLargeRRByAlg {
 		imrDSDLargeRRByAlg[i].Store(0)
 	}
@@ -102,7 +106,7 @@ func (imr *Imr) noteDSEncountered(dsRRs []dns.RR) {
 func (imr *Imr) noteDNSKEYLookup(bypassed bool) {
 	imrDNSKEYLookupTotal.Add(1)
 	if bypassed {
-		imrDNSKEYLookupForcedTCP.Add(1)
+		imrDNSKEYLookupBypassed.Add(1)
 	}
 }
 

--- a/v2/imr_large_ksk_metrics.go
+++ b/v2/imr_large_ksk_metrics.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"sync/atomic"
 
+	cache "github.com/johanix/tdns/v2/cache"
+	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
 )
 
@@ -97,17 +99,51 @@ func (imr *Imr) noteDSEncountered(dsRRs []dns.RR) {
 	}
 }
 
-func (imr *Imr) noteDNSKEYLookup(forceTCP bool) {
+func (imr *Imr) noteDNSKEYLookup(bypassed bool) {
 	imrDNSKEYLookupTotal.Add(1)
-	if forceTCP {
+	if bypassed {
 		imrDNSKEYLookupForcedTCP.Add(1)
 	}
 }
 
-// dnskeyQueryForceTCP returns true when a cached parent DS RRset signals a large
-// child KSK algorithm and the IMR should fetch the child DNSKEY over TCP.
-func (imr *Imr) dnskeyQueryForceTCP(qname string, qtype uint16) bool {
-	if imr == nil || imr.Cache == nil || qtype != dns.TypeDNSKEY {
+// dnskeyPolicy returns the effective DNSKEY transport policy, treating the
+// empty zero value as the default (use_ds_signal).
+func (imr *Imr) dnskeyPolicy() DNSKEYTransportPolicy {
+	if imr == nil || imr.dnskeyTransport == "" {
+		return DNSKEYTransportUseDSSignal
+	}
+	return imr.dnskeyTransport
+}
+
+// dnskeyTransportBypass reports whether this DNSKEY query should bypass the
+// server's probabilistic transport-weight selection and instead use the best
+// available transport (resolved per-server by preferredDNSKEYTransport).
+//
+// DNSKEY queries are ~0.1% of traffic, so forcing them off the probabilistic
+// distribution does not meaningfully disturb a server's load shape.
+//
+//   - force_udp:       never bypass.
+//   - use_ds_signal:   bypass only when the cached parent DS uses a large alg.
+//   - try/force_encrypted: always bypass.
+func (imr *Imr) dnskeyTransportBypass(qname string, qtype uint16) bool {
+	if imr == nil || qtype != dns.TypeDNSKEY {
+		return false
+	}
+	switch imr.dnskeyPolicy() {
+	case DNSKEYTransportForceUDP:
+		return false
+	case DNSKEYTransportTryEncrypted, DNSKEYTransportForceEncrypted:
+		return true
+	case DNSKEYTransportUseDSSignal:
+		return imr.dnskeyDSSignalsLarge(qname)
+	}
+	return false
+}
+
+// dnskeyDSSignalsLarge reports whether a cached parent DS RRset for qname uses
+// a large child KSK algorithm.
+func (imr *Imr) dnskeyDSSignalsLarge(qname string) bool {
+	if imr == nil || imr.Cache == nil {
 		return false
 	}
 	ds := imr.Cache.Get(qname, dns.TypeDS)
@@ -119,9 +155,48 @@ func (imr *Imr) dnskeyQueryForceTCP(qname string, qtype uint16) bool {
 		if !ok || !imr.isLargeAlgorithm(d.Algorithm) {
 			continue
 		}
-		lgDns.Info("large-alg DS observed; will query child DNSKEY over TCP",
+		lgDns.Info("large-alg DS observed; will bypass UDP for child DNSKEY",
 			"zone", qname, "alg", d.Algorithm)
 		return true
+	}
+	return false
+}
+
+// preferredDNSKEYTransport picks the transport for a DNSKEY query that has been
+// selected to bypass probabilistic transport weights. It honors the server's
+// advertised capabilities (server.Transports) but ignores the weights. The
+// preference order is DoQ > DoT > DoH > TCP.
+//
+// Returns 0 (no transport) when the policy is force_encrypted and the server
+// advertises no encrypted transport; the caller must fail the query in that
+// case rather than fall back to cleartext.
+func (imr *Imr) preferredDNSKEYTransport(server *cache.AuthServer) core.Transport {
+	order := []core.Transport{core.TransportDoQ, core.TransportDoT, core.TransportDoH}
+	for _, pref := range order {
+		if serverAdvertises(server, pref) {
+			return pref
+		}
+	}
+
+	if imr.dnskeyPolicy() == DNSKEYTransportForceEncrypted {
+		// No encrypted transport available: signal failure (no fallback).
+		return 0
+	}
+
+	// Non-encrypted fallback: plain TCP, never UDP.
+	return core.TransportDo53TCP
+}
+
+// serverAdvertises reports whether the server lists transport t in its
+// advertised Transports.
+func serverAdvertises(server *cache.AuthServer, t core.Transport) bool {
+	if server == nil {
+		return false
+	}
+	for _, a := range server.Transports {
+		if a == t {
+			return true
+		}
 	}
 	return false
 }

--- a/v2/imrengine.go
+++ b/v2/imrengine.go
@@ -56,6 +56,10 @@ type Imr struct {
 	TLSADiscovery            *cache.DiscoveryTracker
 	// largeAlgs is copied from conf.Internal.LargeAlgorithms at init.
 	largeAlgs map[uint8]bool
+	// dnskeyTransport is the DNSKEY-query transport policy, copied from
+	// conf.Internal.DNSKEYTransport at init. The empty zero value behaves
+	// as DNSKEYTransportUseDSSignal.
+	dnskeyTransport DNSKEYTransportPolicy
 }
 
 func (imr *Imr) isLargeAlgorithm(alg uint8) bool {
@@ -154,7 +158,8 @@ func (conf *Config) InitImrEngine(quiet bool) error {
 			conf.Imr.Tuning.Discovery.RetryAfterFailure,
 			conf.Imr.Tuning.Discovery.MaxFailures,
 		),
-		largeAlgs: conf.Internal.LargeAlgorithms,
+		largeAlgs:       conf.Internal.LargeAlgorithms,
+		dnskeyTransport: conf.Internal.DNSKEYTransport,
 	}
 
 	if conf.Imr.Logging.Enabled {

--- a/v2/large_ksk.go
+++ b/v2/large_ksk.go
@@ -34,6 +34,37 @@ func buildLargeAlgorithmSet(algs []uint8) map[uint8]bool {
 	return m
 }
 
+// DNSKEYTransportPolicy selects how the IMR chooses a transport for DNSKEY
+// queries. See DnssecConf.DNSKEYTransport for the semantics of each value.
+type DNSKEYTransportPolicy string
+
+const (
+	DNSKEYTransportForceUDP       DNSKEYTransportPolicy = "force_udp"
+	DNSKEYTransportUseDSSignal    DNSKEYTransportPolicy = "use_ds_signal"
+	DNSKEYTransportTryEncrypted   DNSKEYTransportPolicy = "try_encrypted"
+	DNSKEYTransportForceEncrypted DNSKEYTransportPolicy = "force_encrypted"
+)
+
+// parseDNSKEYTransportPolicy validates the configured dnskey_query_transport
+// value. An empty value defaults to use_ds_signal (the backward-compatible
+// DS-driven behavior).
+func parseDNSKEYTransportPolicy(s string) (DNSKEYTransportPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return DNSKEYTransportUseDSSignal, nil
+	case string(DNSKEYTransportForceUDP):
+		return DNSKEYTransportForceUDP, nil
+	case string(DNSKEYTransportUseDSSignal):
+		return DNSKEYTransportUseDSSignal, nil
+	case string(DNSKEYTransportTryEncrypted):
+		return DNSKEYTransportTryEncrypted, nil
+	case string(DNSKEYTransportForceEncrypted):
+		return DNSKEYTransportForceEncrypted, nil
+	default:
+		return "", fmt.Errorf("unknown dnssec.dnskey_query_transport %q (valid: force_udp, use_ds_signal, try_encrypted, force_encrypted)", s)
+	}
+}
+
 // IsLargeAlgorithm reports whether alg is listed in dnssec.large_algorithms.
 func (conf *Config) IsLargeAlgorithm(alg uint8) bool {
 	if conf == nil || conf.Internal.LargeAlgorithms == nil {

--- a/v2/large_ksk_test.go
+++ b/v2/large_ksk_test.go
@@ -107,16 +107,10 @@ func TestLargeKskImrMetrics(t *testing.T) {
 	}
 }
 
-func TestImrDnskeyQueryForceTCP(t *testing.T) {
-	imr := &Imr{largeAlgs: map[uint8]bool{dns.RSASHA512: true}}
-	if imr.dnskeyQueryForceTCP("example.com.", dns.TypeA) {
-		t.Fatal("non-DNSKEY query must not force TCP")
-	}
-	if imr.dnskeyQueryForceTCP("example.com.", dns.TypeDNSKEY) {
-		t.Fatal("no cached DS must not force TCP")
-	}
-
-	qname := "example.com."
+// cacheWithLargeDS returns an RRset cache seeded with a large-algorithm parent
+// DS for qname.
+func cacheWithLargeDS(t *testing.T, qname string) *cache.RRsetCacheT {
+	t.Helper()
 	logger := log.New(os.Stderr, "", 0)
 	rrcache := cache.NewRRsetCache(logger, false, false)
 	ds := &dns.DS{
@@ -139,8 +133,96 @@ func TestImrDnskeyQueryForceTCP(t *testing.T) {
 			RRs:    []dns.RR{ds},
 		},
 	})
-	imr.Cache = rrcache
-	if !imr.dnskeyQueryForceTCP(qname, dns.TypeDNSKEY) {
-		t.Fatal("cached large-alg parent DS must force TCP for child DNSKEY")
+	return rrcache
+}
+
+func TestParseDNSKEYTransportPolicy(t *testing.T) {
+	cases := map[string]DNSKEYTransportPolicy{
+		"":                DNSKEYTransportUseDSSignal, // empty -> default
+		"use_ds_signal":   DNSKEYTransportUseDSSignal,
+		"FORCE_UDP":       DNSKEYTransportForceUDP, // case-insensitive
+		"try_encrypted":   DNSKEYTransportTryEncrypted,
+		"force_encrypted": DNSKEYTransportForceEncrypted,
+	}
+	for in, want := range cases {
+		got, err := parseDNSKEYTransportPolicy(in)
+		if err != nil {
+			t.Fatalf("parse(%q) err = %v", in, err)
+		}
+		if got != want {
+			t.Fatalf("parse(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if _, err := parseDNSKEYTransportPolicy("bogus"); err == nil {
+		t.Fatal("parse(bogus) should error")
+	}
+}
+
+func TestDnskeyTransportBypass(t *testing.T) {
+	qname := "example.com."
+
+	// use_ds_signal: bypass only when cached DS is large.
+	imr := &Imr{largeAlgs: map[uint8]bool{dns.RSASHA512: true}}
+	if imr.dnskeyTransportBypass(qname, dns.TypeA) {
+		t.Fatal("non-DNSKEY query must never bypass")
+	}
+	if imr.dnskeyTransportBypass(qname, dns.TypeDNSKEY) {
+		t.Fatal("use_ds_signal with no cached DS must not bypass")
+	}
+	imr.Cache = cacheWithLargeDS(t, qname)
+	if !imr.dnskeyTransportBypass(qname, dns.TypeDNSKEY) {
+		t.Fatal("use_ds_signal with large cached DS must bypass")
+	}
+
+	// force_udp: never bypass, even with a large DS.
+	imrUDP := &Imr{
+		largeAlgs:       map[uint8]bool{dns.RSASHA512: true},
+		dnskeyTransport: DNSKEYTransportForceUDP,
+		Cache:           cacheWithLargeDS(t, qname),
+	}
+	if imrUDP.dnskeyTransportBypass(qname, dns.TypeDNSKEY) {
+		t.Fatal("force_udp must never bypass")
+	}
+
+	// try_encrypted / force_encrypted: always bypass DNSKEY, DS irrelevant.
+	for _, pol := range []DNSKEYTransportPolicy{DNSKEYTransportTryEncrypted, DNSKEYTransportForceEncrypted} {
+		i := &Imr{dnskeyTransport: pol} // no cache, no large algs
+		if !i.dnskeyTransportBypass(qname, dns.TypeDNSKEY) {
+			t.Fatalf("%s must bypass for DNSKEY regardless of DS", pol)
+		}
+		if i.dnskeyTransportBypass(qname, dns.TypeA) {
+			t.Fatalf("%s must not bypass non-DNSKEY", pol)
+		}
+	}
+}
+
+func TestPreferredDNSKEYTransport(t *testing.T) {
+	mkServer := func(ts ...core.Transport) *cache.AuthServer {
+		s := cache.NewAuthServer("ns.example.")
+		s.Transports = ts
+		return s
+	}
+
+	// Prefers DoQ over DoT over DoH.
+	imr := &Imr{dnskeyTransport: DNSKEYTransportTryEncrypted}
+	if got := imr.preferredDNSKEYTransport(mkServer(core.TransportDo53, core.TransportDoT, core.TransportDoQ)); got != core.TransportDoQ {
+		t.Fatalf("want DoQ, got %v", got)
+	}
+	if got := imr.preferredDNSKEYTransport(mkServer(core.TransportDo53, core.TransportDoT)); got != core.TransportDoT {
+		t.Fatalf("want DoT, got %v", got)
+	}
+
+	// try_encrypted with no encrypted transport falls back to TCP.
+	if got := imr.preferredDNSKEYTransport(mkServer(core.TransportDo53)); got != core.TransportDo53TCP {
+		t.Fatalf("try_encrypted no-encrypted want TCP, got %v", got)
+	}
+
+	// force_encrypted with no encrypted transport returns 0 (fail).
+	imrForce := &Imr{dnskeyTransport: DNSKEYTransportForceEncrypted}
+	if got := imrForce.preferredDNSKEYTransport(mkServer(core.TransportDo53)); got != 0 {
+		t.Fatalf("force_encrypted no-encrypted want 0, got %v", got)
+	}
+	if got := imrForce.preferredDNSKEYTransport(mkServer(core.TransportDo53, core.TransportDoT)); got != core.TransportDoT {
+		t.Fatalf("force_encrypted with DoT want DoT, got %v", got)
 	}
 }

--- a/v2/large_ksk_test.go
+++ b/v2/large_ksk_test.go
@@ -102,8 +102,8 @@ func TestLargeKskImrMetrics(t *testing.T) {
 	if LargeAlgDSMetrics() != 2 {
 		t.Fatalf("LargeAlgDSMetrics = %d, want 2 large DS RRs", LargeAlgDSMetrics())
 	}
-	if m.DNSKEYLookupTotal != 2 || m.DNSKEYLookupForcedTCP != 1 {
-		t.Fatalf("DNSKEY metrics = %+v, want total=2 forced=1", m)
+	if m.DNSKEYLookupTotal != 2 || m.DNSKEYLookupBypassed != 1 {
+		t.Fatalf("DNSKEY metrics = %+v, want total=2 bypassed=1", m)
 	}
 }
 

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -228,6 +228,12 @@ func (conf *Config) ParseConfig(reload bool) error {
 	}
 	conf.Internal.LargeAlgorithms = buildLargeAlgorithmSet(conf.Dnssec.LargeAlgorithms)
 
+	dnskeyXport, err := parseDNSKEYTransportPolicy(conf.Dnssec.DNSKEYTransport)
+	if err != nil {
+		return err
+	}
+	conf.Internal.DNSKEYTransport = dnskeyXport
+
 	// Normalize service.transport.type (default: none)
 	if conf.Service.Transport.Type == "" {
 		conf.Service.Transport.Type = "none"

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -209,6 +209,12 @@ func (conf *Config) ParseConfig(reload bool) error {
 		}
 	}
 
+	// Reset raw fields that derive an internal default when omitted, so a
+	// reload after the operator removes the YAML key reverts to the default
+	// instead of preserving the previously-decoded value (mapstructure leaves
+	// absent keys untouched).
+	conf.Dnssec.DNSKEYTransport = ""
+
 	// Decode the entire config at once
 	if err := decoder.Decode(configMap); err != nil {
 		errMsg := err.Error()


### PR DESCRIPTION
Scratch WIP branch capturing today's IMR transport-selection work for later review. **Not intended to merge as-is** — the shipped enum will be renamed/replaced when the design doc's broader vocabulary is implemented.

## Shipped (working, tested) code

Generalizes Part 3 (draft-johani-dnsop-dnssec-alg-split) DNSKEY transport selection:

- New `dnssec.dnskey_query_transport` enum: `force_udp` | `use_ds_signal` (default) | `try_encrypted` | `force_encrypted`.
- Replaces the boolean DS→TCP forcing with a policy that can upgrade to **DoT/DoQ** (not just TCP) and offers a **catch-all** alternative to maintaining `dnssec.large_algorithms` as the PQ algorithm list grows.
- **Probabilistic bypass**: DNSKEY queries (~0.1% of traffic) are exempt from a server's transport-weight load distribution, so the chosen transport ignores the weights while still honoring the server's advertised capabilities (DoQ > DoT > DoH > TCP).
- `dnskeyTransportBypass` (per-query decision) + `preferredDNSKEYTransport` (per-server pick); `force_encrypted` fails the query with SERVFAIL+EDE when the server has no encrypted transport.
- Query-loop dedup by resolved `(addr, transport)` since all of a server's tuples collapse to one preferred transport.
- Tests: enum parsing, bypass across all four policies, transport-preference order + force_encrypted fail path.
- `cmdv2/imr/tdns-imr.sample.yaml` documents the setting.

## Design only (for later implementation)

`docs/2026-06-12-transport-selection-policy.md` — unifies the DNSKEY-specific enum and the existing PR-driven `requireEncrypted` into one per-qtype **transport_selection** policy:

- Six values: `none`, `use_transport_signal`, `use_ds_signal`, `encrypted_or_udp`, `encrypted_or_tcp`, `encrypted_or_fail`.
- Per-qtype config schema (`transport_selection: {default:, dnskey:, …}`).
- Two-axis composition (encryption-requirement × udp-allowed) with the end-user privacy signal, which can only **raise** the bar per query, never lower it.
- `none` as the A/B **measurement control arm**.
- Step-plan for the `requireEncrypted bool → enum` migration (preserve-then-generalize).

## Also

- Adds `cmdv2/cli/algorithms.measured-netbsd-x86.example.yaml`.

## Build / test

- `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make` — clean.
- `go test ./v2` green except two pre-existing, unrelated `TestGlobalStuffValidate*` failures (BaseUri URL parsing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable DNSKEY query transport selection with four policies (force UDP, use DS signal, try encrypted, force encrypted) for improved DNSSEC validation.
  * Implemented intelligent transport preference for DNSKEY queries based on parent DS signaling for large key algorithms.

* **Tests**
  * Added tests for DNSKEY transport policy parsing and selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->