### PR TITLE
dnssec: ZSK rollover step 0 — manual trigger, active_at heal, active_seq counter

### DIFF
--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -181,6 +181,19 @@ keybootstrap:
 # zones reference (dnssec.policies:), and the key/signing policy for the
 # KeyStateWorker (dnssec.kasp:).
 dnssec:
+   # DNSSEC completeness mode (deployment-wide, RFC 4035 §2.2):
+   #   strict  (default) - a ZSK algorithm rollover keeps the old-algorithm
+   #                       key signing through the drain window (maintained
+   #                       double-signature); zones stay §4035-conformant.
+   #   relaxed           - alg-split regime: the old key drops at the switch
+   #                       (drain only, no maintained double-signature). Sound
+   #                       because completeness binds the signer, not the
+   #                       validator. Needed for the cheap PQ ZSK-alg roll.
+   # NOT per-zone/per-policy: it is a property of which validators must be
+   # satisfied, constant across a policy transition. Unknown value = hard
+   # config error.
+   completeness: strict
+
    # Algorithm NAMES treated as "large" for IMR DNSKEY-over-TCP and signer
    # warnings. RSASHA512 is a stand-in where ML-DSA-44 is unavailable. Names,
    # not codepoints: non-standardized PQ codepoints are assigned per

--- a/v2/apihandler_rollover.go
+++ b/v2/apihandler_rollover.go
@@ -98,6 +98,26 @@ func APIRolloverAsap(conf *Config) func(w http.ResponseWriter, r *http.Request) 
 		lock.Lock()
 		defer lock.Unlock()
 
+		// ZSK asap: no parent-DS coordination, so "earliest" is just now —
+		// the next KeyStateWorker tick rolls if a standby ZSK exists. Set
+		// the manual request and return; the worker handles the rest
+		// (including the "due but no standby yet" wait, since the request
+		// persists until the roll commits).
+		if strings.EqualFold(req.KeyType, "ZSK") {
+			now := time.Now()
+			if err := SetZskManualRolloverRequest(kdb, zone, now, now); err != nil {
+				lgApi.Warn("rollover/asap: SetZskManualRolloverRequest failed", "zone", zone, "err", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(RolloverAsapResponse{
+				Zone:        zone,
+				RequestedAt: now.UTC().Format(time.RFC3339),
+				Earliest:    now.UTC().Format(time.RFC3339),
+			})
+			return
+		}
+
 		// asap is a write operation; refuse cleanly if a rollover is
 		// already underway. ComputeEarliestRollover itself does not
 		// gate on this (so that ComputeRolloverWhen can project past
@@ -181,6 +201,16 @@ func APIRolloverCancel(conf *Config) func(w http.ResponseWriter, r *http.Request
 		lock := AcquireRolloverLock(zone)
 		lock.Lock()
 		defer lock.Unlock()
+
+		if strings.EqualFold(req.KeyType, "ZSK") {
+			if err := ClearZskManualRolloverRequest(kdb, zone); err != nil {
+				lgApi.Warn("rollover/cancel: ClearZskManualRolloverRequest failed", "zone", zone, "err", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(RolloverCancelResponse{Zone: zone, Cleared: true})
+			return
+		}
 
 		if err := ClearManualRolloverRequest(kdb, zone); err != nil {
 			lgApi.Warn("rollover/cancel: ClearManualRolloverRequest failed", "zone", zone, "err", err)

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -611,12 +611,20 @@ Online-only: scheduling against a stopped daemon is meaningless
 			tdns.Globals.App.Type = tdns.AppTypeCli
 			z := dns.Fqdn(tdns.Globals.Zonename)
 
+			if autoRolloverFlags.kskOnly && autoRolloverFlags.zskOnly {
+				cliFatalf("flags --ksk and --zsk are mutually exclusive")
+			}
+			keytype := "KSK"
+			if autoRolloverFlags.zskOnly {
+				keytype = "ZSK"
+			}
+
 			api, err := GetApiClient("auth", true)
 			if err != nil {
 				cliFatalf("error getting API client: %v", err)
 			}
 			status, body, err := api.RequestNG("POST", "/rollover/asap",
-				tdns.RolloverAsapRequest{Zone: z}, true)
+				tdns.RolloverAsapRequest{Zone: z, KeyType: keytype}, true)
 			if err != nil {
 				cliFatalf("error calling rollover/asap: %v", err)
 			}
@@ -630,9 +638,13 @@ Online-only: scheduling against a stopped daemon is meaningless
 			if err := json.Unmarshal(body, &resp); err != nil {
 				cliFatalf("error parsing rollover/asap response: %v", err)
 			}
-			fmt.Printf("scheduled manual rollover for zone %s\n", resp.Zone)
+			fmt.Printf("scheduled manual %s rollover for zone %s\n", keytype, resp.Zone)
 			fmt.Printf("  earliest          %s\n", formatRolloverTime(resp.Earliest))
-			fmt.Printf("  from active keyid %d to %d\n", resp.FromKeyID, resp.ToKeyID)
+			// ZSK response carries no from/to keyid (the standby is picked
+			// by the worker at roll time); only print it for KSK.
+			if keytype == "KSK" {
+				fmt.Printf("  from active keyid %d to %d\n", resp.FromKeyID, resp.ToKeyID)
+			}
 		},
 	}
 	c.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone")
@@ -655,19 +667,27 @@ manual_rollover_* row isn't being read by anything).`,
 			tdns.Globals.App.Type = tdns.AppTypeCli
 			z := dns.Fqdn(tdns.Globals.Zonename)
 
+			if autoRolloverFlags.kskOnly && autoRolloverFlags.zskOnly {
+				cliFatalf("flags --ksk and --zsk are mutually exclusive")
+			}
+			keytype := "KSK"
+			if autoRolloverFlags.zskOnly {
+				keytype = "ZSK"
+			}
+
 			api, err := GetApiClient("auth", true)
 			if err != nil {
 				cliFatalf("error getting API client: %v", err)
 			}
 			status, body, err := api.RequestNG("POST", "/rollover/cancel",
-				tdns.RolloverCancelRequest{Zone: z}, true)
+				tdns.RolloverCancelRequest{Zone: z, KeyType: keytype}, true)
 			if err != nil {
 				cliFatalf("error calling rollover/cancel: %v", err)
 			}
 			if status != http.StatusOK {
 				cliFatalf("unexpected status %d from rollover/cancel: %s", status, strings.TrimSpace(string(body)))
 			}
-			fmt.Printf("cleared manual rollover request for zone %s\n", z)
+			fmt.Printf("cleared manual %s rollover request for zone %s\n", keytype, z)
 		},
 	}
 	c.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone")
@@ -1256,12 +1276,19 @@ func printRolloverKeyTable(keys []tdns.RolloverKeyEntry, verbose bool, kskTable 
 			}
 		}
 	} else {
+		// active_seq leads the ZSK table, matching the KSK layout, so a
+		// ZSK roll is visible the same way (the active key's number ticks
+		// up each roll).
 		if verbose {
-			rows = append(rows, "keyid|alg|state|active_at|next_roll")
+			rows = append(rows, "active_seq|keyid|alg|state|active_at|next_roll")
 		} else {
-			rows = append(rows, "keyid|state|active_at|next_roll")
+			rows = append(rows, "active_seq|keyid|state|active_at|next_roll")
 		}
 		for _, k := range keys {
+			seqStr := "-"
+			if k.ActiveSeq != nil {
+				seqStr = fmt.Sprintf("%d", *k.ActiveSeq)
+			}
 			at := formatStateSinceCol(k)
 			nextRoll := formatZskNextRollCol(k)
 			if verbose {
@@ -1269,9 +1296,9 @@ func printRolloverKeyTable(keys []tdns.RolloverKeyEntry, verbose bool, kskTable 
 				if algStr == "" {
 					algStr = "-"
 				}
-				rows = append(rows, fmt.Sprintf("%d|%s|%s|%s|%s", k.KeyID, algStr, k.State, at, nextRoll))
+				rows = append(rows, fmt.Sprintf("%s|%d|%s|%s|%s|%s", seqStr, k.KeyID, algStr, k.State, at, nextRoll))
 			} else {
-				rows = append(rows, fmt.Sprintf("%d|%s|%s|%s", k.KeyID, k.State, at, nextRoll))
+				rows = append(rows, fmt.Sprintf("%s|%d|%s|%s|%s", seqStr, k.KeyID, k.State, at, nextRoll))
 			}
 		}
 	}

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -870,6 +870,9 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 		if len(s.ZSKs) > 0 {
 			fmt.Println()
 			printRolloverKeyTable(s.ZSKs, verbose, false)
+			if s.HiddenRemovedZskCount > 0 {
+				fmt.Printf("  ... %d older removed key(s) not shown\n", s.HiddenRemovedZskCount)
+			}
 		}
 	}
 
@@ -1280,9 +1283,9 @@ func printRolloverKeyTable(keys []tdns.RolloverKeyEntry, verbose bool, kskTable 
 		// ZSK roll is visible the same way (the active key's number ticks
 		// up each roll).
 		if verbose {
-			rows = append(rows, "active_seq|keyid|alg|state|active_at|next_roll")
+			rows = append(rows, "active_seq|keyid|alg|state|state_since|next_roll")
 		} else {
-			rows = append(rows, "active_seq|keyid|state|active_at|next_roll")
+			rows = append(rows, "active_seq|keyid|state|state_since|next_roll")
 		}
 		for _, k := range keys {
 			seqStr := "-"

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -1283,9 +1283,9 @@ func printRolloverKeyTable(keys []tdns.RolloverKeyEntry, verbose bool, kskTable 
 		// ZSK roll is visible the same way (the active key's number ticks
 		// up each roll).
 		if verbose {
-			rows = append(rows, "active_seq|keyid|alg|state|state_since|next_roll")
+			rows = append(rows, "active_seq|keyid|alg|state|state_since|next_transition")
 		} else {
-			rows = append(rows, "active_seq|keyid|state|state_since|next_roll")
+			rows = append(rows, "active_seq|keyid|state|state_since|next_transition")
 		}
 		for _, k := range keys {
 			seqStr := "-"
@@ -1327,40 +1327,23 @@ func printZskRolloverSummary(s *tdns.RolloverStatus) {
 		return
 	}
 
-	var activeKey *tdns.RolloverKeyEntry
+	// Zone-level summary only: zsk.lifetime (not in the per-key table) and
+	// whether a propagated standby is ready to roll into. The active key's
+	// active_at / next-transition timing lives in the key table below, so it
+	// is not repeated here (avoids the redundant header lines).
 	standbyReady := false
 	for i := range s.ZSKs {
-		switch s.ZSKs[i].State {
-		case tdns.DnskeyStateActive:
-			if activeKey == nil {
-				activeKey = &s.ZSKs[i]
-			}
-		case tdns.DnskeyStateStandby:
+		if s.ZSKs[i].State == tdns.DnskeyStateStandby {
 			standbyReady = true
+			break
 		}
 	}
 
 	fmt.Printf("  zsk.lifetime                 %s\n", lifetimeStr)
-	if activeKey == nil {
-		fmt.Println("  active ZSK                   none")
-	} else {
-		fmt.Printf("  active ZSK                   keyid %d\n", activeKey.KeyID)
-		if activeKey.StateSince != "" {
-			if t, err := time.Parse(time.RFC3339, activeKey.StateSince); err == nil {
-				fmt.Printf("  active_at                    %s\n", formatTimeWithDelta(t))
-				next := t.Add(lifetime)
-				fmt.Printf("  next roll (scheduled)        %s\n", formatTimeWithDelta(next))
-			} else {
-				fmt.Println("  active_at                    unknown")
-			}
-		} else {
-			fmt.Println("  active_at                    unknown (not stamped yet)")
-		}
-	}
 	if standbyReady {
-		fmt.Println("  standby ZSK                  ready")
+		fmt.Println("  standby                      ready (a due roll can proceed)")
 	} else {
-		fmt.Println("  standby ZSK                  not ready")
+		fmt.Println("  standby                      none (a due roll will wait for one)")
 	}
 }
 

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -1358,11 +1358,18 @@ func formatStateSinceCol(k tdns.RolloverKeyEntry) string {
 }
 
 func formatZskNextRollCol(k tdns.RolloverKeyEntry) string {
-	if k.State != tdns.DnskeyStateActive || k.NextTransitionAt == "" {
-		return "-"
+	// Show the engine's next-transition time for ANY state that has one
+	// (active→retired, standby→active-on-roll, published→standby,
+	// retired→removed) — not just the active key. The `state` column tells
+	// the operator which transition the time refers to. Falls back to the
+	// engine's note when there is a transition but no concrete time.
+	if k.NextTransitionAt != "" {
+		if t, err := time.Parse(time.RFC3339, k.NextTransitionAt); err == nil {
+			return formatTimeWithDelta(t)
+		}
 	}
-	if t, err := time.Parse(time.RFC3339, k.NextTransitionAt); err == nil {
-		return formatTimeWithDelta(t)
+	if k.NextTransitionNote != "" {
+		return k.NextTransitionNote
 	}
 	return "-"
 }

--- a/v2/completeness_mode_test.go
+++ b/v2/completeness_mode_test.go
@@ -1,0 +1,38 @@
+package tdns
+
+import "testing"
+
+// Step 1: the global dnssec.completeness knob. Verifies parse/validate
+// (good values, default, bad value rejected). The behavior it gates
+// (relaxed ZSK alg roll / strict refusal) lands with step 2.
+func TestResolveCompletenessMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", CompletenessStrict, false},           // default
+		{"strict", CompletenessStrict, false},     // explicit
+		{"STRICT", CompletenessStrict, false},     // case-insensitive
+		{" relaxed ", CompletenessRelaxed, false}, // trimmed
+		{"relaxed", CompletenessRelaxed, false},
+		{"loose", "", true}, // unknown → hard error
+		{"true", "", true},  // not a bool
+	}
+	for _, c := range cases {
+		got, err := resolveCompletenessMode(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("resolveCompletenessMode(%q): expected error, got %q", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("resolveCompletenessMode(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("resolveCompletenessMode(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/v2/config.go
+++ b/v2/config.go
@@ -86,7 +86,25 @@ type DnssecConf struct {
 	// Kasp is the Key and Signing Policy controlling the KeyStateWorker.
 	// YAML: dnssec.kasp:.
 	Kasp KaspConf `yaml:"kasp" mapstructure:"kasp"`
+
+	// Completeness selects the signer's RFC 4035 §2.2 completeness mode,
+	// deployment-wide (NOT per-zone/per-policy — see the algorithm-rollover
+	// design doc §4.4). "strict" (default) honors completeness: a ZSK
+	// algorithm rollover keeps the old-algorithm key signing through the
+	// drain window (maintained double-signature). "relaxed" (alg-split
+	// regime) drops the old key at the switch (drain only, no maintained
+	// double-signature) — sound because completeness binds the signer, not
+	// the validator. The mode also selects the standby-counting discipline
+	// for a ZSK roll (role-only vs per-(role,algorithm)). Empty = strict.
+	// YAML: dnssec.completeness:.
+	Completeness string `yaml:"completeness" mapstructure:"completeness"`
 }
+
+// DNSSEC completeness modes (Conf.Internal.Completeness / dnssec.completeness).
+const (
+	CompletenessStrict  = "strict"
+	CompletenessRelaxed = "relaxed"
+)
 
 // KaspConf holds Key and Signing Policy parameters for the signer.
 // Controls the KeyStateWorker's automatic key state transitions and standby key maintenance.
@@ -460,6 +478,12 @@ type InternalConf struct {
 	// kskAlg -> set of permitted zskAlgs. nil/empty means no mixed pair is
 	// allowed (only same-algorithm KSK/ZSK policies pass).
 	SplitAlgorithms map[uint8]map[uint8]bool
+
+	// Completeness is the resolved DNSSEC completeness mode from
+	// Dnssec.Completeness ("strict" | "relaxed"), defaulted to "strict".
+	// Read by the algorithm-rollover reconcile (step 2) to decide whether a
+	// ZSK algorithm roll runs relaxed or is refused under strict.
+	Completeness string
 
 	// PostParseZonesHook is called after ParseZones completes during
 	// reload (SIGHUP or "config reload-zones"). Set by MP apps to

--- a/v2/db.go
+++ b/v2/db.go
@@ -170,6 +170,9 @@ func dbMigrateSchema(db *sql.DB) {
 		{"DnssecKeyStore", "published_at", "ALTER TABLE DnssecKeyStore ADD COLUMN published_at TEXT DEFAULT ''"},
 		{"DnssecKeyStore", "active_at", "ALTER TABLE DnssecKeyStore ADD COLUMN active_at TEXT DEFAULT ''"},
 		{"DnssecKeyStore", "retired_at", "ALTER TABLE DnssecKeyStore ADD COLUMN retired_at TEXT DEFAULT ''"},
+		// ZSK active_seq: monotonic per-key roll counter (operator feedback),
+		// MAX(active_seq)+1 over the zone's ZSK rows, stamped at standby→active.
+		{"DnssecKeyStore", "active_seq", "ALTER TABLE DnssecKeyStore ADD COLUMN active_seq INTEGER"},
 		{"Sig0KeyStore", "parent_state", "ALTER TABLE Sig0KeyStore ADD COLUMN parent_state INTEGER DEFAULT 0"},
 		// Rollover overhaul phase 2: softfail-state columns on RolloverZoneState.
 		// All NULL/0-default so existing testbed rows remain valid post-migration.

--- a/v2/db_schema.go
+++ b/v2/db_schema.go
@@ -79,6 +79,7 @@ comment		  TEXT,
 published_at              TEXT DEFAULT '',
 active_at                 TEXT DEFAULT '',
 retired_at                TEXT DEFAULT '',
+active_seq                INTEGER,
 UNIQUE (zonename, keyid)
 )`,
 
@@ -104,6 +105,17 @@ UNIQUE (zonename, keyid)
 		active_seq           INTEGER,
 		last_rollover_error  TEXT,
 		PRIMARY KEY (zone, keyid)
+	)`,
+
+	// ZskRolloverState holds per-zone manual ZSK-rollover requests (the
+	// `auto-rollover asap --zsk` / `cancel --zsk` mechanism). ZSK rollover
+	// has no parent-DS coordination, so unlike RolloverZoneState (KSK) this
+	// carries only the manual-request fields. Separate table to avoid
+	// entangling ZSK state with the KSK rollover-phase machine.
+	"ZskRolloverState": `CREATE TABLE IF NOT EXISTS 'ZskRolloverState' (
+		zone                          TEXT NOT NULL PRIMARY KEY,
+		manual_rollover_requested_at  TEXT,
+		manual_rollover_earliest      TEXT
 	)`,
 
 	"RolloverZoneState": `CREATE TABLE IF NOT EXISTS 'RolloverZoneState' (

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -1177,6 +1177,10 @@ type DnssecKeyWithTimestamps struct {
 	PublishedAt *time.Time
 	ActiveAt    *time.Time
 	RetiredAt   *time.Time
+	// ActiveSeq is the per-key "n-th active in this zone's history" counter
+	// (DnssecKeyStore.active_seq), nil when never stamped. For ZSK this is
+	// the operator-facing roll counter; KSK uses RolloverKeyState instead.
+	ActiveSeq *int
 }
 
 // GetDnssecKeysByState returns all DNSSEC keys in a given state, with lifecycle timestamps.
@@ -1186,10 +1190,10 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 	var args []interface{}
 
 	if zone == "" {
-		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, '') FROM DnssecKeyStore WHERE state=?`
+		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, ''), active_seq FROM DnssecKeyStore WHERE state=?`
 		args = []interface{}{state}
 	} else {
-		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, '') FROM DnssecKeyStore WHERE zonename=? AND state=?`
+		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, ''), active_seq FROM DnssecKeyStore WHERE zonename=? AND state=?`
 		args = []interface{}{zone, state}
 	}
 
@@ -1203,7 +1207,8 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 	for rows.Next() {
 		var zonename, algorithm, st, keyrr, publishedAtStr, activeAtStr, retiredAtStr string
 		var keyid, flags int
-		if err := rows.Scan(&zonename, &keyid, &flags, &algorithm, &st, &keyrr, &publishedAtStr, &activeAtStr, &retiredAtStr); err != nil {
+		var activeSeq sql.NullInt64
+		if err := rows.Scan(&zonename, &keyid, &flags, &algorithm, &st, &keyrr, &publishedAtStr, &activeAtStr, &retiredAtStr, &activeSeq); err != nil {
 			return nil, fmt.Errorf("GetDnssecKeysByState: scan failed: %w", err)
 		}
 
@@ -1235,6 +1240,10 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 			if t, err := time.Parse(time.RFC3339, retiredAtStr); err == nil {
 				entry.RetiredAt = &t
 			}
+		}
+		if activeSeq.Valid {
+			v := int(activeSeq.Int64)
+			entry.ActiveSeq = &v
 		}
 
 		entries = append(entries, entry)
@@ -1394,6 +1403,22 @@ func (kdb *KeyDB) RolloverKey(zonename string, keytype string, tx *Tx) (uint16, 
 		DnskeyStateActive, now, zonename, standbyKey.KeyTag)
 	if txErr != nil {
 		return 0, 0, fmt.Errorf("standby→active transition failed: %w", txErr)
+	}
+
+	// Stamp the ZSK active_seq counter (operator-facing "n-th active ZSK")
+	// in the same transaction as active_at, so a roll visibly increments it.
+	// KSK active_seq lives in RolloverKeyState (stamped by AtomicRollover),
+	// not here — RolloverKey is the ZSK roll path.
+	if keytype == "ZSK" {
+		seq, serr := nextZskActiveSeqTx(tx, zonename)
+		if serr != nil {
+			txErr = serr
+			return 0, 0, fmt.Errorf("zsk active_seq: %w", serr)
+		}
+		if serr := setZskActiveSeqTx(tx, zonename, standbyKey.KeyTag, seq); serr != nil {
+			txErr = serr
+			return 0, 0, fmt.Errorf("stamp zsk active_seq: %w", serr)
+		}
 	}
 
 	// active → retired (set retired_at)

--- a/v2/ksk_rollover_zone_state.go
+++ b/v2/ksk_rollover_zone_state.go
@@ -993,6 +993,17 @@ func StateSinceForDnssecKey(kdb *KeyDB, zone string, k *DnssecKeyWithTimestamps)
 		if k.RetiredAt != nil {
 			return *k.RetiredAt
 		}
+	case DnskeyStateRemoved:
+		// ZSKs have no RolloverKeyState row, so the generic
+		// rollover_state_at fallback below returns zero and the status
+		// table would show "-" for a removed ZSK. retired_at (preserved on
+		// the DnssecKeyStore row through removal — the retired→removed
+		// transition stamps no new timestamp) is the best available
+		// "state since" for a removed ZSK. KSK removed keys still resolve
+		// via rollover_state_at below.
+		if k.Flags&dns.SEP == 0 && k.RetiredAt != nil {
+			return *k.RetiredAt
+		}
 	case DnskeyStateActive:
 		if k.Flags&dns.SEP == 0 && k.ActiveAt != nil {
 			return *k.ActiveAt

--- a/v2/ksk_rollover_zone_state.go
+++ b/v2/ksk_rollover_zone_state.go
@@ -1016,6 +1016,15 @@ func StateSinceForDnssecKey(kdb *KeyDB, zone string, k *DnssecKeyWithTimestamps)
 			return *k.ActiveAt
 		}
 	case DnskeyStateStandby:
+		// ZSKs have no RolloverKeyState row and DnssecKeyStore has no
+		// standby_at column (the published→standby transition stamps
+		// nothing). Use published_at as the state-since: for a ZSK the
+		// published→standby gap is just propagation_delay, so published_at
+		// is effectively "standby since". KSKs fall through to the
+		// RolloverKeyState lookups below.
+		if k.Flags&dns.SEP == 0 && k.PublishedAt != nil {
+			return *k.PublishedAt
+		}
 		// Genuine standby (post-C18): the key reached propagated-
 		// standby state. RolloverKeyState.standby_at is the
 		// transition moment.

--- a/v2/large_ksk.go
+++ b/v2/large_ksk.go
@@ -87,6 +87,21 @@ func buildSplitAlgorithmSet(in map[string][]string) map[uint8]map[uint8]bool {
 	return out
 }
 
+// resolveCompletenessMode validates dnssec.completeness and returns the
+// canonical mode. Empty defaults to "strict" (the conservative,
+// §4035-conformant choice). An unrecognized value is a hard config error —
+// a typo here silently changing signing semantics would be dangerous.
+func resolveCompletenessMode(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", CompletenessStrict:
+		return CompletenessStrict, nil
+	case CompletenessRelaxed:
+		return CompletenessRelaxed, nil
+	default:
+		return "", fmt.Errorf("invalid dnssec.completeness %q (want %q or %q)", s, CompletenessStrict, CompletenessRelaxed)
+	}
+}
+
 // validateSplitAlgorithm enforces the KSK/ZSK split-algorithm gate. Same
 // algorithm always passes. A differing pair must be listed in the allowlist
 // (kskAlg -> permitted zskAlgs); otherwise it is rejected (fail closed).

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -266,6 +266,10 @@ type RolloverWhenGateEntry struct {
 // scheduled rollover.
 type RolloverAsapRequest struct {
 	Zone string `json:"zone"`
+	// KeyType selects which role to roll: "" or "KSK" (default) = KSK,
+	// "ZSK" = ZSK. ZSK uses the lighter ZskRolloverState manual-request
+	// path (no parent-DS coordination).
+	KeyType string `json:"keytype,omitempty"`
 }
 
 type RolloverAsapResponse struct {
@@ -279,6 +283,8 @@ type RolloverAsapResponse struct {
 // Request/response types for POST /api/v1/rollover/cancel.
 type RolloverCancelRequest struct {
 	Zone string `json:"zone"`
+	// KeyType: "" / "KSK" (default) = KSK, "ZSK" = ZSK.
+	KeyType string `json:"keytype,omitempty"`
 }
 
 type RolloverCancelResponse struct {

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -120,6 +120,9 @@ type RolloverStatus struct {
 	// by active_seq, most recent first).
 	HiddenRemovedKskCount int                `json:"hiddenRemovedKskCount,omitempty"`
 	ZSKs                  []RolloverKeyEntry `json:"zsks"`
+	// HiddenRemovedZskCount is the ZSK analog of HiddenRemovedKskCount:
+	// removed ZSKs beyond the display cap, omitted from ZSKs.
+	HiddenRemovedZskCount int `json:"hiddenRemovedZskCount,omitempty"`
 
 	// Policy summary. Verbose mode shows this; compact mode hides it.
 	Policy *PolicySummary `json:"policy,omitempty"`

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -1214,6 +1214,11 @@ func (conf *Config) parseDnssecConfig() error {
 	}
 	conf.Internal.LargeAlgorithms = largeAlgs
 	conf.Internal.SplitAlgorithms = buildSplitAlgorithmSet(conf.Dnssec.SplitAlgorithms)
+	mode, err := resolveCompletenessMode(conf.Dnssec.Completeness)
+	if err != nil {
+		return err
+	}
+	conf.Internal.Completeness = mode
 
 	conf.Internal.DnssecPolicies = make(map[string]DnssecPolicy)
 	for name, dp := range conf.Dnssec.Policies {

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -83,7 +83,9 @@ func ComputeRolloverStatus(kdb *KeyDB, zone string, pol *DnssecPolicy, checkInte
 	var hiddenRemoved int
 	out.KSKs, hiddenRemoved = loadRolloverKeyEntries(kdb, zone, true)
 	out.HiddenRemovedKskCount = hiddenRemoved
-	out.ZSKs, _ = loadRolloverKeyEntries(kdb, zone, false)
+	var hiddenRemovedZsk int
+	out.ZSKs, hiddenRemovedZsk = loadRolloverKeyEntries(kdb, zone, false)
+	out.HiddenRemovedZskCount = hiddenRemovedZsk
 
 	if err := populateDSKeyidsForStatus(kdb, zone, out); err != nil {
 		return nil, fmt.Errorf("ComputeRolloverStatus: %w", err)
@@ -606,7 +608,12 @@ func loadRolloverKeyEntries(kdb *KeyDB, zone string, wantSEP bool) ([]RolloverKe
 			}
 			batch = append(batch, rolloverKeyEntryFromKeystoreKey(kdb, zone, k, wantSEP))
 		}
-		if st == DnskeyStateRemoved && wantSEP {
+		// Cap + sort removed keys for BOTH roles (KSK and ZSK): show only
+		// the most-recent rolloverStatusRemovedDisplayCap by active_seq
+		// (descending; keys without a seq sink to the bottom), the rest
+		// summarized as a hidden count. Also makes the removed rows read in
+		// seq order rather than keytag order.
+		if st == DnskeyStateRemoved {
 			sort.SliceStable(batch, func(i, j int) bool {
 				si := rolloverActiveSeqSortKey(batch[i].ActiveSeq)
 				sj := rolloverActiveSeqSortKey(batch[j].ActiveSeq)

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -646,14 +646,21 @@ func rolloverKeyEntryFromKeystoreKey(kdb *KeyDB, zone string, k *DnssecKeyWithTi
 	if ts := StateSinceForDnssecKey(kdb, zone, k); !ts.IsZero() {
 		entry.StateSince = ts.UTC().Format(time.RFC3339)
 	}
-	seq, err := RolloverKeyActiveSeq(kdb, zone, k.KeyTag)
-	if err != nil {
-		// Don't fail the whole status response over one key's lookup
-		// — partial status is still useful — but log so the failure
-		// isn't invisible.
-		lgSigner.Debug("rolloverKeyEntryFromKeystoreKey: RolloverKeyActiveSeq failed", "zone", zone, "keyid", k.KeyTag, "err", err)
-	} else if seq >= 0 {
-		v := seq
+	if wantSEP {
+		// KSK active_seq lives in RolloverKeyState.
+		seq, err := RolloverKeyActiveSeq(kdb, zone, k.KeyTag)
+		if err != nil {
+			// Don't fail the whole status response over one key's lookup
+			// — partial status is still useful — but log so the failure
+			// isn't invisible.
+			lgSigner.Debug("rolloverKeyEntryFromKeystoreKey: RolloverKeyActiveSeq failed", "zone", zone, "keyid", k.KeyTag, "err", err)
+		} else if seq >= 0 {
+			v := seq
+			entry.ActiveSeq = &v
+		}
+	} else if k.ActiveSeq != nil {
+		// ZSK active_seq lives in DnssecKeyStore (loaded into the key).
+		v := *k.ActiveSeq
 		entry.ActiveSeq = &v
 	}
 	if msg, err := LoadLastRolloverError(kdb, zone, k.KeyTag); err != nil {

--- a/v2/zsk_rollover.go
+++ b/v2/zsk_rollover.go
@@ -8,19 +8,194 @@ package tdns
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/miekg/dns"
 )
 
-// zskRollDue reports whether an active ZSK has lived past policy.ZSK.Lifetime.
-func zskRollDue(now time.Time, activeAt *time.Time, lifetimeSec uint32) bool {
+// zskRollDue reports whether a ZSK roll is due, and whether it was triggered
+// manually. A roll is due when either:
+//  1. an operator `asap --zsk` request's earliest moment has been reached
+//     (manualEarliest, RFC3339; "" when none), OR
+//  2. the active ZSK has lived past policy.ZSK.Lifetime (scheduled cadence).
+//
+// Manual takes precedence and bypasses the lifetime gate (operator override).
+func zskRollDue(now time.Time, activeAt *time.Time, lifetimeSec uint32, manualEarliest string) (due bool, manual bool) {
+	if s := strings.TrimSpace(manualEarliest); s != "" {
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			if !now.Before(t) {
+				return true, true
+			}
+		} else {
+			lgSigner.Warn("zsk rollover: invalid manual_rollover_earliest", "value", manualEarliest, "err", err)
+		}
+	}
 	if lifetimeSec == 0 || activeAt == nil {
-		return false
+		return false, false
 	}
 	lifetime := time.Duration(lifetimeSec) * time.Second
-	return now.Sub(*activeAt) >= lifetime
+	return now.Sub(*activeAt) >= lifetime, false
+}
+
+// healZskActiveSeqAndActiveAt stamps a missing active_at (and active_seq) on
+// the active ZSK, so the lifetime-driven roll becomes decidable
+// (zskRollDue reads ActiveAt) and the operator-facing roll counter has a
+// value. The ZSK analog of healBootstrapActiveAt (KSK). Simpler: ZSK state
+// lives directly in DnssecKeyStore, so this is a direct stamp — no
+// RolloverKeyState. First-observation semantics: stamp `now` only when the
+// field is currently NULL (never overwrite a real timestamp, or every
+// restart would push the roll forward).
+func healZskActiveAt(kdb *KeyDB, zone string, activeZSK *DnssecKeyWithTimestamps) {
+	if activeZSK == nil {
+		return
+	}
+	needAt := activeZSK.ActiveAt == nil
+	needSeq := activeZSK.ActiveSeq == nil
+	if !needAt && !needSeq {
+		return
+	}
+	tx, err := kdb.Begin("healZskActiveAt")
+	if err != nil {
+		lgSigner.Warn("zsk rollover: heal begin tx failed", "zone", zone, "keyid", activeZSK.KeyTag, "err", err)
+		return
+	}
+	commit := false
+	defer func() {
+		if commit {
+			tx.Commit()
+		} else {
+			tx.Rollback()
+		}
+	}()
+	if needAt {
+		now := time.Now().UTC().Format(time.RFC3339)
+		if _, err := tx.Exec(`UPDATE DnssecKeyStore SET active_at=? WHERE zonename=? AND keyid=? AND (active_at IS NULL OR active_at='')`,
+			now, zone, int(activeZSK.KeyTag)); err != nil {
+			lgSigner.Warn("zsk rollover: heal active_at failed", "zone", zone, "keyid", activeZSK.KeyTag, "err", err)
+			return
+		}
+	}
+	if needSeq {
+		seq, serr := nextZskActiveSeqTx(tx, zone)
+		if serr != nil {
+			lgSigner.Warn("zsk rollover: heal active_seq compute failed", "zone", zone, "keyid", activeZSK.KeyTag, "err", serr)
+			return
+		}
+		if _, err := tx.Exec(`UPDATE DnssecKeyStore SET active_seq=? WHERE zonename=? AND keyid=? AND active_seq IS NULL`,
+			seq, zone, int(activeZSK.KeyTag)); err != nil {
+			lgSigner.Warn("zsk rollover: heal active_seq failed", "zone", zone, "keyid", activeZSK.KeyTag, "err", err)
+			return
+		}
+	}
+	commit = true
+	lgSigner.Info("zsk rollover: healed active ZSK state", "zone", zone, "keyid", activeZSK.KeyTag,
+		"healed_active_at", needAt, "healed_active_seq", needSeq)
+}
+
+// nextZskActiveSeqTx returns the next ZSK active_seq for a zone:
+// MAX(active_seq)+1 over the zone's ZSK rows (flags=256) in DnssecKeyStore,
+// or 0 if no ZSK has ever been active. This is the operator-facing
+// "n-th active ZSK in this zone's history" counter — the ZSK analog of
+// the KSK active_seq in RolloverKeyState, but sourced from DnssecKeyStore
+// since ZSK rollover keeps no RolloverKeyState rows.
+//
+// Purge semantics: MAX+1 survives normal purges (retired→removed and
+// policy-cleanup delete the OLDEST, lowest-seq keys, never the newest, so
+// MAX stays held by the most-recent key). It resets only when ALL ZSK rows
+// are deleted (`clear`), which is the intended "wipe and start over."
+func nextZskActiveSeqTx(tx *Tx, zone string) (int, error) {
+	var max sql.NullInt64
+	// flags=256 = real ZSK (ZONE bit set, SEP clear), matching how the rest
+	// of zsk_rollover.go identifies ZSKs. KSK/CSK (flags=257) are excluded,
+	// so the ZSK and KSK active_seq counters are independent.
+	err := tx.QueryRow(
+		`SELECT MAX(active_seq) FROM DnssecKeyStore WHERE zonename=? AND CAST(flags AS INTEGER)=256`,
+		zone).Scan(&max)
+	if err != nil {
+		return 0, err
+	}
+	if !max.Valid {
+		return 0, nil
+	}
+	return int(max.Int64) + 1, nil
+}
+
+// setZskActiveSeqTx stamps active_seq for one ZSK on an existing TX.
+func setZskActiveSeqTx(tx *Tx, zone string, keyid uint16, seq int) error {
+	_, err := tx.Exec(`UPDATE DnssecKeyStore SET active_seq=? WHERE zonename=? AND keyid=?`,
+		seq, zone, int(keyid))
+	return err
+}
+
+// ZskManualRollover holds the per-zone manual ZSK-rollover request read
+// from ZskRolloverState. Earliest is "" when no request is pending.
+type ZskManualRollover struct {
+	RequestedAt string
+	Earliest    string
+}
+
+// EnsureZskRolloverRow creates the per-zone ZskRolloverState row if absent.
+func EnsureZskRolloverRow(kdb *KeyDB, zone string) error {
+	zone = strings.TrimSpace(zone)
+	if zone == "" {
+		return fmt.Errorf("EnsureZskRolloverRow: empty zone")
+	}
+	_, err := kdb.DB.Exec(
+		`INSERT INTO ZskRolloverState (zone) VALUES (?) ON CONFLICT(zone) DO NOTHING`, zone)
+	return err
+}
+
+// SetZskManualRolloverRequest stamps a manual ZSK-rollover request. Mirrors
+// the KSK SetManualRolloverRequest, on ZskRolloverState.
+func SetZskManualRolloverRequest(kdb *KeyDB, zone string, requestedAt, earliest time.Time) error {
+	if err := EnsureZskRolloverRow(kdb, zone); err != nil {
+		return err
+	}
+	_, err := kdb.DB.Exec(`UPDATE ZskRolloverState
+SET manual_rollover_requested_at = ?,
+    manual_rollover_earliest = ?
+WHERE zone = ?`,
+		requestedAt.UTC().Format(time.RFC3339),
+		earliest.UTC().Format(time.RFC3339),
+		zone)
+	return err
+}
+
+// ClearZskManualRolloverRequest nulls the manual-request columns. Called by
+// `cancel --zsk` and after a manual ZSK roll commits.
+func ClearZskManualRolloverRequest(kdb *KeyDB, zone string) error {
+	_, err := kdb.DB.Exec(`UPDATE ZskRolloverState
+SET manual_rollover_requested_at = NULL,
+    manual_rollover_earliest = NULL
+WHERE zone = ?`, zone)
+	return err
+}
+
+// LoadZskManualRollover returns the pending manual ZSK-rollover request for a
+// zone (zero value when none / no row).
+func LoadZskManualRollover(kdb *KeyDB, zone string) (ZskManualRollover, error) {
+	zone = strings.TrimSpace(zone)
+	var requestedAt, earliest sql.NullString
+	err := kdb.DB.QueryRow(
+		`SELECT manual_rollover_requested_at, manual_rollover_earliest FROM ZskRolloverState WHERE zone = ?`,
+		zone).Scan(&requestedAt, &earliest)
+	if err == sql.ErrNoRows {
+		return ZskManualRollover{}, nil
+	}
+	if err != nil {
+		return ZskManualRollover{}, err
+	}
+	out := ZskManualRollover{}
+	if requestedAt.Valid {
+		out.RequestedAt = requestedAt.String
+	}
+	if earliest.Valid {
+		out.Earliest = earliest.String
+	}
+	return out, nil
 }
 
 // zskRemovalMargin is the hold time before a retired ZSK may be removed:
@@ -85,7 +260,35 @@ func rolloverZskForZone(ctx context.Context, conf *Config, kdb *KeyDB, zd *ZoneD
 		return nil
 	}
 
-	if !zskRollDue(now, activeZSK.ActiveAt, pol.ZSK.Lifetime) {
+	// Self-heal a missing active_at / active_seq so the roll is decidable
+	// and the operator-facing counter has a value. Re-read the active ZSK
+	// afterward if anything was stamped.
+	if activeZSK.ActiveAt == nil || activeZSK.ActiveSeq == nil {
+		healZskActiveAt(kdb, zone, activeZSK)
+		delete(kdb.KeystoreDnskeyCache, zone+"+"+DnskeyStateActive)
+		activeKeys, err = GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
+		if err != nil {
+			return fmt.Errorf("re-list active keys after heal: %w", err)
+		}
+		activeZSK = nil
+		for i := range activeKeys {
+			if activeKeys[i].Flags == 256 {
+				activeZSK = &activeKeys[i]
+				break
+			}
+		}
+		if activeZSK == nil {
+			return nil
+		}
+	}
+
+	manual, err := LoadZskManualRollover(kdb, zone)
+	if err != nil {
+		return fmt.Errorf("load manual zsk request: %w", err)
+	}
+
+	due, isManual := zskRollDue(now, activeZSK.ActiveAt, pol.ZSK.Lifetime, manual.Earliest)
+	if !due {
 		return nil
 	}
 
@@ -101,7 +304,11 @@ func rolloverZskForZone(ctx context.Context, conf *Config, kdb *KeyDB, zd *ZoneD
 		}
 	}
 	if !haveStandby {
-		lgSigner.Warn("zsk rollover: roll due but no standby ZSK available", "zone", zone, "active_keyid", activeZSK.KeyTag)
+		// Roll is due but no standby yet. Do NOT clear a manual request
+		// here — it must persist until the roll actually commits, so the
+		// trigger fires when a standby appears (e.g. a fresh key still
+		// propagating). Just wait for the next tick.
+		lgSigner.Warn("zsk rollover: roll due but no standby ZSK available", "zone", zone, "active_keyid", activeZSK.KeyTag, "manual", isManual)
 		return nil
 	}
 
@@ -109,7 +316,14 @@ func rolloverZskForZone(ctx context.Context, conf *Config, kdb *KeyDB, zd *ZoneD
 	if err != nil {
 		return fmt.Errorf("RolloverKey: %w", err)
 	}
-	lgSigner.Info("zsk rollover: completed", "zone", zone, "old_active", oldActive, "new_active", newActive)
+	// Clear the manual request only after the roll has committed (mirrors
+	// the KSK path: clear on fire, not on the no-standby no-op above).
+	if isManual {
+		if cerr := ClearZskManualRolloverRequest(kdb, zone); cerr != nil {
+			lgSigner.Warn("zsk rollover: clear manual request failed", "zone", zone, "err", cerr)
+		}
+	}
+	lgSigner.Info("zsk rollover: completed", "zone", zone, "old_active", oldActive, "new_active", newActive, "manual", isManual)
 	triggerResign(conf, zd.ZoneName)
 	return nil
 }

--- a/v2/zsk_rollover_step0_test.go
+++ b/v2/zsk_rollover_step0_test.go
@@ -273,6 +273,57 @@ func TestZskRemovedDisplayParity(t *testing.T) {
 	}
 }
 
+// Display: a standby ZSK gets a state_since (from published_at, since ZSKs
+// have no standby_at) and a next_transition (promote-on-roll = active_at +
+// lifetime), not blank. Covers the renderer un-gating + the standby
+// state_since fix.
+func TestZskStandbyStateSinceAndNextTransition(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	seedActiveZSK(t, kdb, true) // one active, one standby
+
+	// A real standby arrives via published→standby, so published_at is set.
+	// The test seed creates it directly in standby, so stamp published_at to
+	// mirror production (it is what state_since resolves from for a ZSK).
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := kdb.DB.Exec(`UPDATE DnssecKeyStore SET published_at=? WHERE zonename=? AND state=? AND CAST(flags AS INTEGER)=256`,
+		now, zskTestZone, DnskeyStateStandby); err != nil {
+		t.Fatalf("stamp standby published_at: %v", err)
+	}
+
+	// Build status entries the way ComputeRolloverStatus does.
+	out := &RolloverStatus{}
+	out.ZSKs, _ = loadRolloverKeyEntries(kdb, zskTestZone, false)
+
+	// Standby must have a non-empty state_since (sourced from published_at).
+	var standby *RolloverKeyEntry
+	for i := range out.ZSKs {
+		if out.ZSKs[i].State == DnskeyStateStandby {
+			standby = &out.ZSKs[i]
+		}
+	}
+	if standby == nil {
+		t.Fatalf("no standby ZSK entry; got %+v", out.ZSKs)
+	}
+	if standby.StateSince == "" {
+		t.Fatalf("standby ZSK state_since is empty; want published_at")
+	}
+
+	// Next-transition: with an active ZSK present and a 15m lifetime, the
+	// standby should be marked promote-on-roll with a concrete time.
+	pol := &DnssecPolicy{Mode: DnssecPolicyModeKSKZSK}
+	pol.ZSK.Lifetime = uint32((15 * time.Minute).Seconds())
+	populateZskNextTransitions(out, kdb, zskTestZone, pol, time.Minute)
+
+	for i := range out.ZSKs {
+		if out.ZSKs[i].State == DnskeyStateStandby {
+			standby = &out.ZSKs[i]
+		}
+	}
+	if standby.NextTransition == "" || standby.NextTransitionAt == "" {
+		t.Fatalf("standby ZSK next_transition not populated: %+v", *standby)
+	}
+}
+
 func zskActiveSeqOf(t *testing.T, kdb *KeyDB, keyid uint16) *int {
 	t.Helper()
 	for _, st := range []string{DnskeyStateActive, DnskeyStateRetired, DnskeyStateStandby} {

--- a/v2/zsk_rollover_step0_test.go
+++ b/v2/zsk_rollover_step0_test.go
@@ -1,0 +1,240 @@
+package tdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Step 0 (ZSK rollover robustness parity) tests: manual asap/cancel request,
+// roll-due manual override, active_at self-heal, and the active_seq counter.
+// Driven against a real on-disk KeyDB via newTestKeyDB (sign_reconcile_test.go).
+
+const zskTestZone = "zsk-step0.example."
+
+// seedActiveZSK generates one active + (optionally) one standby ZSK so the
+// roll path has something to work with. Returns the active keyid.
+func seedActiveZSK(t *testing.T, kdb *KeyDB, withStandby bool) uint16 {
+	t.Helper()
+	pkc, _, err := kdb.GenerateKeypair(zskTestZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("generate active ZSK: %v", err)
+	}
+	if withStandby {
+		if _, _, err := kdb.GenerateKeypair(zskTestZone, "test", DnskeyStateStandby, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil); err != nil {
+			t.Fatalf("generate standby ZSK: %v", err)
+		}
+	}
+	return pkc.KeyId
+}
+
+// T0.1 — manual asap request persists and reads back; cancel clears it.
+func TestZskManualRequestPersistAndCancel(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	now := time.Now()
+
+	if m, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m.Earliest != "" {
+		t.Fatalf("no request yet: got (%+v, %v)", m, err)
+	}
+	if err := SetZskManualRolloverRequest(kdb, zskTestZone, now, now); err != nil {
+		t.Fatalf("SetZskManualRolloverRequest: %v", err)
+	}
+	m, err := LoadZskManualRollover(kdb, zskTestZone)
+	if err != nil || m.Earliest == "" || m.RequestedAt == "" {
+		t.Fatalf("after set: got (%+v, %v), want both fields populated", m, err)
+	}
+	if err := ClearZskManualRolloverRequest(kdb, zskTestZone); err != nil {
+		t.Fatalf("ClearZskManualRolloverRequest: %v", err)
+	}
+	if m, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m.Earliest != "" {
+		t.Fatalf("after clear: got (%+v, %v), want empty", m, err)
+	}
+}
+
+// T0.2 — roll-due returns true (manual) when a manual request is set even
+// though the lifetime has not elapsed; false otherwise.
+func TestZskRollDueManualOverride(t *testing.T) {
+	now := time.Now()
+	justActive := now.Add(-1 * time.Minute) // far younger than lifetime
+	lifetime := uint32((24 * time.Hour).Seconds())
+
+	// No manual request, young key: not due.
+	if due, manual := zskRollDue(now, &justActive, lifetime, ""); due || manual {
+		t.Fatalf("young key, no manual: got due=%v manual=%v, want false,false", due, manual)
+	}
+	// Manual request with earliest in the past: due (manual), despite young key.
+	past := now.Add(-1 * time.Second).UTC().Format(time.RFC3339)
+	if due, manual := zskRollDue(now, &justActive, lifetime, past); !due || !manual {
+		t.Fatalf("manual override: got due=%v manual=%v, want true,true", due, manual)
+	}
+	// Manual request with earliest in the future: not yet due.
+	future := now.Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	if due, manual := zskRollDue(now, &justActive, lifetime, future); due || manual {
+		t.Fatalf("future manual: got due=%v manual=%v, want false,false", due, manual)
+	}
+	// Lifetime elapsed, no manual: due (scheduled, not manual).
+	old := now.Add(-48 * time.Hour)
+	if due, manual := zskRollDue(now, &old, lifetime, ""); !due || manual {
+		t.Fatalf("lifetime elapsed: got due=%v manual=%v, want true,false", due, manual)
+	}
+	// lifetime 0 = never, no manual: not due.
+	if due, _ := zskRollDue(now, &old, 0, ""); due {
+		t.Fatalf("lifetime 0: got due=%v, want false", due)
+	}
+}
+
+// T0.3 — a manual ZSK roll (RolloverKey) with a standby present swaps
+// standby→active / active→retired. With no standby it errors (no key loss).
+func TestZskRolloverKeySwapAndNoStandby(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	oldActive := seedActiveZSK(t, kdb, true)
+
+	old, neu, err := kdb.RolloverKey(zskTestZone, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("RolloverKey: %v", err)
+	}
+	if old != oldActive {
+		t.Fatalf("old active = %d, want %d", old, oldActive)
+	}
+	// old key now retired, new key active.
+	retired, _ := GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateRetired)
+	if len(retired) != 1 || retired[0].KeyTag != old {
+		t.Fatalf("expected retired key %d, got %+v", old, retired)
+	}
+	active, _ := GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateActive)
+	if len(active) != 1 || active[0].KeyTag != neu {
+		t.Fatalf("expected active key %d, got %+v", neu, active)
+	}
+
+	// No standby remains → a second roll must error (and not lose the active).
+	if _, _, err := kdb.RolloverKey(zskTestZone, "ZSK", nil); err == nil {
+		t.Fatalf("expected error rolling with no standby")
+	}
+	active, _ = GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateActive)
+	if len(active) != 1 {
+		t.Fatalf("active key lost after failed roll: %+v", active)
+	}
+}
+
+// T0.4 — persistence across a no-standby tick is the engine's responsibility
+// (rolloverZskForZone does NOT clear on the no-standby no-op). Here we assert
+// the helper-level contract that a manual request set with no standby is not
+// auto-cleared by reading it back (the worker only clears after a committed
+// roll). This complements the engine wiring in rolloverZskForZone.
+func TestZskManualRequestSurvivesNoStandby(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	seedActiveZSK(t, kdb, false) // active only, no standby
+	now := time.Now()
+	if err := SetZskManualRolloverRequest(kdb, zskTestZone, now, now); err != nil {
+		t.Fatalf("set request: %v", err)
+	}
+	// Simulate what the worker reads: request is present and due.
+	m, err := LoadZskManualRollover(kdb, zskTestZone)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	due, manual := zskRollDue(now, nil, 0, m.Earliest)
+	if !due || !manual {
+		t.Fatalf("manual due with no active_at: got due=%v manual=%v, want true,true", due, manual)
+	}
+	// The request must still be present (worker would NOT clear it without a
+	// standby to roll to).
+	if m2, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m2.Earliest == "" {
+		t.Fatalf("request must persist with no standby: got (%+v, %v)", m2, err)
+	}
+}
+
+// T0.5 — active_at self-heal: an active ZSK with NULL active_at gets stamped;
+// a real active_at is not overwritten.
+func TestZskActiveAtSelfHeal(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	keyid := seedActiveZSK(t, kdb, false)
+
+	// Force active_at NULL (GenerateKeypair into active stamps active_at; clear it).
+	if _, err := kdb.DB.Exec(`UPDATE DnssecKeyStore SET active_at=NULL, active_seq=NULL WHERE zonename=? AND keyid=?`, zskTestZone, int(keyid)); err != nil {
+		t.Fatalf("null active_at: %v", err)
+	}
+	active, _ := GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateActive)
+	if len(active) != 1 || active[0].ActiveAt != nil {
+		t.Fatalf("precondition: want one active ZSK with nil active_at, got %+v", active)
+	}
+
+	healZskActiveAt(kdb, zskTestZone, &active[0])
+
+	active, _ = GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateActive)
+	if active[0].ActiveAt == nil {
+		t.Fatalf("active_at not healed")
+	}
+	if active[0].ActiveSeq == nil {
+		t.Fatalf("active_seq not healed")
+	}
+	stampedAt := *active[0].ActiveAt
+
+	// Re-heal must NOT overwrite the now-real active_at.
+	healZskActiveAt(kdb, zskTestZone, &active[0])
+	active, _ = GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateActive)
+	if active[0].ActiveAt == nil || !active[0].ActiveAt.Equal(stampedAt) {
+		t.Fatalf("re-heal overwrote active_at: was %v now %v", stampedAt, active[0].ActiveAt)
+	}
+}
+
+// T0.6 — active_seq increments by one per roll; KSK keys are not counted in
+// the ZSK seq (independent counters).
+func TestZskActiveSeqCounter(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// Seed an active ZSK + standby, plus a KSK (must not affect ZSK seq).
+	seedActiveZSK(t, kdb, true)
+	if _, _, err := kdb.GenerateKeypair(zskTestZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK: %v", err)
+	}
+
+	// First roll: the promoted ZSK gets active_seq from MAX(seq)+1. No ZSK has
+	// a seq yet (GenerateKeypair doesn't stamp it), so first promotion = 0.
+	_, neu, err := kdb.RolloverKey(zskTestZone, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("roll 1: %v", err)
+	}
+	seq1 := zskActiveSeqOf(t, kdb, neu)
+	if seq1 == nil {
+		t.Fatalf("roll 1: new active ZSK has no active_seq")
+	}
+
+	// Add another standby and roll again; seq must increment.
+	if _, _, err := kdb.GenerateKeypair(zskTestZone, "test", DnskeyStateStandby, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil); err != nil {
+		t.Fatalf("generate standby 2: %v", err)
+	}
+	_, neu2, err := kdb.RolloverKey(zskTestZone, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("roll 2: %v", err)
+	}
+	seq2 := zskActiveSeqOf(t, kdb, neu2)
+	if seq2 == nil {
+		t.Fatalf("roll 2: new active ZSK has no active_seq")
+	}
+	if *seq2 != *seq1+1 {
+		t.Fatalf("seq did not increment: roll1=%d roll2=%d", *seq1, *seq2)
+	}
+
+	// The KSK must not have a ZSK-counter value bleeding into it (independent).
+	ksks, _ := GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateActive)
+	for _, k := range ksks {
+		if k.Flags == 257 && k.ActiveSeq != nil {
+			t.Fatalf("KSK got a ZSK active_seq: %+v", k)
+		}
+	}
+}
+
+func zskActiveSeqOf(t *testing.T, kdb *KeyDB, keyid uint16) *int {
+	t.Helper()
+	for _, st := range []string{DnskeyStateActive, DnskeyStateRetired, DnskeyStateStandby} {
+		keys, _ := GetDnssecKeysByState(kdb, zskTestZone, st)
+		for i := range keys {
+			if keys[i].KeyTag == keyid {
+				return keys[i].ActiveSeq
+			}
+		}
+	}
+	return nil
+}

--- a/v2/zsk_rollover_step0_test.go
+++ b/v2/zsk_rollover_step0_test.go
@@ -258,15 +258,19 @@ func TestZskRemovedDisplayParity(t *testing.T) {
 		t.Fatalf("first shown removed ZSK seq = %v, want 4", zsks[0].ActiveSeq)
 	}
 	// state_since resolves (non-empty) for a removed ZSK via retired_at.
-	zd := testZone(t, zskTestZone, zskTestZone+" IN SOA . . 1 1 1 1 1\n")
-	zd.KeyDB = kdb
-	k := &DnssecKeyWithTimestamps{ZoneName: zskTestZone, KeyTag: zsks[0].KeyID, Flags: 256, State: DnskeyStateRemoved}
-	// reload the full key (with retired_at) for the state-since check
-	removed, _ := GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateRemoved)
+	// Reload the full key (with retired_at) for the state-since check.
+	removed, err := GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateRemoved)
+	if err != nil {
+		t.Fatalf("load removed ZSKs: %v", err)
+	}
+	var k *DnssecKeyWithTimestamps
 	for i := range removed {
 		if removed[i].KeyTag == zsks[0].KeyID {
 			k = &removed[i]
 		}
+	}
+	if k == nil {
+		t.Fatalf("removed ZSK keyid %d not found in state query", zsks[0].KeyID)
 	}
 	if ts := StateSinceForDnssecKey(kdb, zskTestZone, k); ts.IsZero() {
 		t.Fatalf("removed ZSK state_since is zero; want retired_at")

--- a/v2/zsk_rollover_step0_test.go
+++ b/v2/zsk_rollover_step0_test.go
@@ -226,6 +226,53 @@ func TestZskActiveSeqCounter(t *testing.T) {
 	}
 }
 
+// Display parity: a removed ZSK shows a state_since timestamp (sourced from
+// retired_at, since ZSKs have no RolloverKeyState row), not blank; and the
+// removed-key display cap + hidden count apply to ZSKs like KSKs.
+func TestZskRemovedDisplayParity(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// Create several removed ZSKs with retired_at set, distinct active_seq.
+	for i := 0; i < 5; i++ {
+		pkc, _, err := kdb.GenerateKeypair(zskTestZone, "test", DnskeyStateRemoved, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil)
+		if err != nil {
+			t.Fatalf("generate removed ZSK %d: %v", i, err)
+		}
+		ts := time.Now().Add(time.Duration(-i) * time.Hour).UTC().Format(time.RFC3339)
+		if _, err := kdb.DB.Exec(`UPDATE DnssecKeyStore SET retired_at=?, active_seq=? WHERE zonename=? AND keyid=?`,
+			ts, i, zskTestZone, int(pkc.KeyId)); err != nil {
+			t.Fatalf("stamp removed ZSK %d: %v", i, err)
+		}
+	}
+
+	zsks, hidden := loadRolloverKeyEntries(kdb, zskTestZone, false)
+	// Cap: only rolloverStatusRemovedDisplayCap shown, rest hidden.
+	if len(zsks) != rolloverStatusRemovedDisplayCap {
+		t.Fatalf("shown removed ZSKs = %d, want %d", len(zsks), rolloverStatusRemovedDisplayCap)
+	}
+	if hidden != 5-rolloverStatusRemovedDisplayCap {
+		t.Fatalf("hidden removed ZSKs = %d, want %d", hidden, 5-rolloverStatusRemovedDisplayCap)
+	}
+	// Shown keys are the highest active_seq (most recent), descending.
+	if zsks[0].ActiveSeq == nil || *zsks[0].ActiveSeq != 4 {
+		t.Fatalf("first shown removed ZSK seq = %v, want 4", zsks[0].ActiveSeq)
+	}
+	// state_since resolves (non-empty) for a removed ZSK via retired_at.
+	zd := testZone(t, zskTestZone, zskTestZone+" IN SOA . . 1 1 1 1 1\n")
+	zd.KeyDB = kdb
+	k := &DnssecKeyWithTimestamps{ZoneName: zskTestZone, KeyTag: zsks[0].KeyID, Flags: 256, State: DnskeyStateRemoved}
+	// reload the full key (with retired_at) for the state-since check
+	removed, _ := GetDnssecKeysByState(kdb, zskTestZone, DnskeyStateRemoved)
+	for i := range removed {
+		if removed[i].KeyTag == zsks[0].KeyID {
+			k = &removed[i]
+		}
+	}
+	if ts := StateSinceForDnssecKey(kdb, zskTestZone, k); ts.IsZero() {
+		t.Fatalf("removed ZSK state_since is zero; want retired_at")
+	}
+}
+
 func zskActiveSeqOf(t *testing.T, kdb *KeyDB, keyid uint16) *int {
 	t.Helper()
 	for _, st := range []string{DnskeyStateActive, DnskeyStateRetired, DnskeyStateStandby} {

--- a/v2/zsk_rollover_step0_test.go
+++ b/v2/zsk_rollover_step0_test.go
@@ -34,7 +34,7 @@ func TestZskManualRequestPersistAndCancel(t *testing.T) {
 	kdb := newTestKeyDB(t)
 	now := time.Now()
 
-	if m, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m.Earliest != "" {
+	if m, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m.Earliest != "" || m.RequestedAt != "" {
 		t.Fatalf("no request yet: got (%+v, %v)", m, err)
 	}
 	if err := SetZskManualRolloverRequest(kdb, zskTestZone, now, now); err != nil {
@@ -47,7 +47,7 @@ func TestZskManualRequestPersistAndCancel(t *testing.T) {
 	if err := ClearZskManualRolloverRequest(kdb, zskTestZone); err != nil {
 		t.Fatalf("ClearZskManualRolloverRequest: %v", err)
 	}
-	if m, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m.Earliest != "" {
+	if m, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m.Earliest != "" || m.RequestedAt != "" {
 		t.Fatalf("after clear: got (%+v, %v), want empty", m, err)
 	}
 }
@@ -140,7 +140,7 @@ func TestZskManualRequestSurvivesNoStandby(t *testing.T) {
 	}
 	// The request must still be present (worker would NOT clear it without a
 	// standby to roll to).
-	if m2, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m2.Earliest == "" {
+	if m2, err := LoadZskManualRollover(kdb, zskTestZone); err != nil || m2.Earliest == "" || m2.RequestedAt == "" {
 		t.Fatalf("request must persist with no standby: got (%+v, %v)", m2, err)
 	}
 }

--- a/v2/zsk_rollover_test.go
+++ b/v2/zsk_rollover_test.go
@@ -10,16 +10,18 @@ func TestZskRollDue(t *testing.T) {
 	activeAt := now.Add(-48 * time.Hour)
 	lifetime := uint32((24 * time.Hour).Seconds())
 
-	if !zskRollDue(now, &activeAt, lifetime) {
-		t.Fatal("expected roll due when active age exceeds lifetime")
+	// Lifetime-driven cases (no manual request). The manual-override cases
+	// are covered by TestZskRollDueManualOverride.
+	if due, manual := zskRollDue(now, &activeAt, lifetime, ""); !due || manual {
+		t.Fatalf("expected scheduled roll due (true,false), got (%v,%v)", due, manual)
 	}
-	if zskRollDue(now, &activeAt, 0) {
+	if due, _ := zskRollDue(now, &activeAt, 0, ""); due {
 		t.Fatal("lifetime 0 must never roll")
 	}
-	if zskRollDue(now, nil, lifetime) {
+	if due, _ := zskRollDue(now, nil, lifetime, ""); due {
 		t.Fatal("nil active_at must not roll")
 	}
-	if zskRollDue(now, &now, lifetime) {
+	if due, _ := zskRollDue(now, &now, lifetime, ""); due {
 		t.Fatal("fresh active key must not roll")
 	}
 }


### PR DESCRIPTION
Bring automated ZSK rollover up to KSK-level robustness. This is **step 0** of the algorithm-rollover plan (`tdns/docs/2026-06-17-algorithm-rollover-evaluation.md`, §8.1) — the prerequisite that must work before any algorithm-rollover logic. **No alg-roll logic here.**

## What this adds

- **Manual trigger** — `auto-rollover asap/cancel --zsk`, backed by a new per-zone `ZskRolloverState` table. `zskRollDue` honors a manual request (overrides the lifetime gate). The request persists until the roll **commits** (not cleared on a no-standby no-op), so it fires when a standby appears.
- **`active_at` self-heal** — an active ZSK with NULL `active_at` is stamped (first-observation), so the roll becomes decidable. ZSK analog of KSK `healBootstrapActiveAt`. Fixes zones stuck with `active_at` unset (observed live on the testbed).
- **`active_seq` counter** — monotonic per-key roll counter on a new `DnssecKeyStore.active_seq` column (`MAX(seq)+1` over the zone's ZSK rows, stamped at standby→active in `RolloverKey`). Survives normal purges (oldest removed first); resets only on `clear`. Shown in `auto-rollover status` (ZSK key table `active_seq` column — KSK parity).

## Mechanics

- Schema: `active_seq` column (CREATE + idempotent `ALTER TABLE` migration) + `ZskRolloverState` table.
- API: `RolloverAsap/CancelRequest` gain `KeyType` (default KSK; ZSK routes to the lighter no-parent-DS path, earliest = now).
- CLI: `--zsk` on `asap`/`cancel` (mirrors the existing `status --zsk`).

## Tests

T0.1–T0.6 (`zsk_rollover_step0_test.go`): manual request persist/cancel, manual-override due, roll swap + no-standby, persistence across no-standby, `active_at` heal, `active_seq` increment + role independence. Pre-existing `TestZskRollDue` updated for the new signature. `go test -race` green; full build green.

Note: the two `TestGlobalStuffValidate*` failures in the package are pre-existing on `main` (BaseUri/URL validation, unrelated to this change), verified via a clean main worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-zone ZSK manual rollover scheduling/cancellation via API, including an optional key-type selector.
  * CLI `auto-rollover` now targets the selected key type consistently and updates output accordingly.

* **Improvements**
  * ZSK status output now tracks active sequence and reports additional hidden-removed entries.
  * Added DNSSEC `completeness` configuration (`strict` default, `relaxed`).

* **Bug Fixes**
  * Corrected “state since” display for removed non-SEP keys in status output.

* **Tests**
  * Expanded ZSK rollover/manual request, healing, sequencing, and completeness-mode parsing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->