### PR TITLE
dnssec: relaxed-mode ZSK algorithm rollover (step 2) + status polish + reload fix

### DIFF
--- a/docs/2026-06-17-algorithm-rollover-evaluation.md
+++ b/docs/2026-06-17-algorithm-rollover-evaluation.md
@@ -8,10 +8,14 @@ for relaxed-mode ZSK algorithm rollover. Progress (2026-06-21):
   (merge commit b4c59a2d). Testbed-confirmed on cpt.p.axfr.net.
 - STEP 1 (global dnssec.completeness knob): DONE — same PR #261. Knob
   parses + is exposed on Conf.Internal; not yet read (that is step 2).
-- STEP 2 (the actual relaxed-mode ZSK ALGORITHM roll): NOT STARTED. This
-  is where the real logic lives — role-only standby counting, the sweep
-  fix, the FIFO ORDER BY fix, change-policy, and the KSK/CSK/both-role/
-  re-entrancy refusals.
+- STEP 2 (the actual relaxed-mode ZSK ALGORITHM roll): DONE — branch
+  feat/zsk-alg-rollover-step2 (not yet merged). Role-only standby
+  counting + youngest-surplus cap, the relaxed sweep skip, the FIFO
+  ORDER BY fix, change-policy (CLI `auto-rollover policy-change`), the
+  KSK/CSK/both-role/strict/re-entrancy refusals, and the status
+  alg-transition line — all built, with the §8.4 test matrix green under
+  `go test -race`. Testbed validation operator-gated. See §8.3 for the
+  as-built record.
 
 Remaining §6 open items (CSK handling, multi-ds vs double-signature,
 strict-mode alg rollover, large-zone secondary propagation) are LATER
@@ -819,7 +823,47 @@ Verify: T2 (§8.4) + a parse test (good/bad values, default).
 
 ### 8.3 Step 2 — relaxed-mode ZSK alg roll
 
-STATUS: NOT STARTED. This is the next chunk and the highest-risk of the
+STATUS: DONE (branch feat/zsk-alg-rollover-step2; build + `go test ./...
+-race` green, both auth+cli binaries link; only the two pre-existing
+TestGlobalStuffValidate* BaseUri/URL failures remain, unrelated).
+As-built:
+  - FIFO fix: `GetDnssecKeysByState` now `ORDER BY published_at ASC,
+    keyid ASC` (global; all callers consume as a set, none depended on
+    the prior unspecified order). Makes ZSK standby promotion FIFO.
+  - `reconcileActiveKeyAlgorithms` (sign.go) is mode-aware:
+    KSK mismatch (either mode) → REFUSE (error); ZSK mismatch + strict →
+    REFUSE; ZSK mismatch + relaxed → no-op (FIFO carries it). The
+    standby/published algorithm-based deletion is SKIPPED for same-role
+    ZSK keys in relaxed mode (kept for KSK / strict). CSK still
+    early-returns (refused at entry). Refusals are errors so a background
+    re-sign cannot run the unsafe swap (entry-layer front door + reconcile
+    backstop, per the resolved decision).
+  - Role-only standby counting + cap (key_state_worker.go): relaxed-mode
+    ZSK maintainer counts by role only (`countKeysForMaintain` roleOnly);
+    `capStandbyZsksByCount` deletes the youngest surplus standby ZSK (by
+    published_at, any algorithm), sharing the one role-total count so
+    generate and cap never oscillate. `countKeysByFlagsAndAlg` renamed →
+    `countKeysForMaintain`.
+  - change-policy (apihandler_zone.go `changeZonePolicy`, command
+    "change-policy"; CLI `auto-rollover policy-change -z -p`): reuses the
+    set-policy override-write + rebind + SignZone path (D3 — relaxed
+    reconcile no-ops the swap). Entry guards BEFORE any override write:
+    CSK → refuse; both-role → refuse; KSK-only → refuse; re-entrancy via
+    the fuller drain-window predicate `zskAlgRollInFlight` (standby/active/
+    retired ZSK of an alg ≠ target) → refuse; strict-mode ZSK change →
+    refuse. CLI help spells out the two-command (policy-change then
+    `asap --zsk`) workflow.
+  - Status: `RolloverStatus.AlgTransition` (`AlgTransitionInfo`) populated
+    from the shared `zskAlgRollInFlight` predicate; CLI header shows
+    `alg rollover: ZSK X → Y (in progress), N of M on new alg`.
+  - Tests (zsk_alg_rollover_test.go + sign_reconcile_test.go split):
+    T1, T2, T2b, T2c, T2d (pre-promotion + drain-window), T-timing, T3,
+    T3b, T4, T4b, T4c, T5, T6, T7, T8, T9 — all green under -race. The old
+    immediate-retire TestReconcileActiveKeyAlgorithms is replaced by
+    strict-refuse + same-alg-noop variants.
+  Actuals: ~310 source + ~470 test LOC. Testbed validation operator-gated.
+
+(Original plan, retained as the build spec.) The highest-risk of the
 three (MED–HIGH): it touches reconcileActiveKeyAlgorithms (the §2
 bogus-zone path is one wrong branch away) and carries the heaviest test
 matrix. Builds on the now-merged steps 0+1 (the manual trigger, the

--- a/v2/apihandler_rollover.go
+++ b/v2/apihandler_rollover.go
@@ -350,9 +350,13 @@ func APIRolloverWhen(conf *Config) func(w http.ResponseWriter, r *http.Request) 
 
 		// keytype selects the schedule: "" / "KSK" = the parent-DS-gated KSK
 		// schedule (default); "ZSK" = the zone-local ZSK schedule.
+		role := "KSK"
+		if strings.EqualFold(r.URL.Query().Get("keytype"), "ZSK") {
+			role = "ZSK"
+		}
 		var out *RolloverWhenResponse
 		var err error
-		if strings.EqualFold(r.URL.Query().Get("keytype"), "ZSK") {
+		if role == "ZSK" {
 			out, err = ComputeZskRolloverWhen(kdb, zone, pol, time.Now())
 		} else {
 			out, err = ComputeRolloverWhen(kdb, zone, pol, time.Now())
@@ -360,9 +364,10 @@ func APIRolloverWhen(conf *Config) func(w http.ResponseWriter, r *http.Request) 
 		if err != nil {
 			// The compute functions only return top-level errors for an empty
 			// zone (already handled above). Defensive: surface any remaining
-			// case as a Note rather than an HTTP error.
+			// case as a Note rather than an HTTP error. Carry the requested
+			// role so the CLI renders the right header even on this path.
 			lgApi.Debug("rollover/when: compute returned error", "zone", zone, "err", err)
-			_ = json.NewEncoder(w).Encode(RolloverWhenResponse{Zone: zone, Note: err.Error()})
+			_ = json.NewEncoder(w).Encode(RolloverWhenResponse{Zone: zone, Role: role, Note: err.Error()})
 			return
 		}
 		_ = json.NewEncoder(w).Encode(out)

--- a/v2/apihandler_rollover.go
+++ b/v2/apihandler_rollover.go
@@ -348,12 +348,20 @@ func APIRolloverWhen(conf *Config) func(w http.ResponseWriter, r *http.Request) 
 			pol = zd.DnssecPolicy
 		}
 
-		out, err := ComputeRolloverWhen(kdb, zone, pol, time.Now())
+		// keytype selects the schedule: "" / "KSK" = the parent-DS-gated KSK
+		// schedule (default); "ZSK" = the zone-local ZSK schedule.
+		var out *RolloverWhenResponse
+		var err error
+		if strings.EqualFold(r.URL.Query().Get("keytype"), "ZSK") {
+			out, err = ComputeZskRolloverWhen(kdb, zone, pol, time.Now())
+		} else {
+			out, err = ComputeRolloverWhen(kdb, zone, pol, time.Now())
+		}
 		if err != nil {
-			// ComputeRolloverWhen only returns top-level errors for
-			// empty zone (already handled above). Defensive: surface
-			// any remaining case as a Note rather than HTTP error.
-			lgApi.Debug("rollover/when: ComputeRolloverWhen returned error", "zone", zone, "err", err)
+			// The compute functions only return top-level errors for an empty
+			// zone (already handled above). Defensive: surface any remaining
+			// case as a Note rather than an HTTP error.
+			lgApi.Debug("rollover/when: compute returned error", "zone", zone, "err", err)
 			_ = json.NewEncoder(w).Encode(RolloverWhenResponse{Zone: zone, Note: err.Error()})
 			return
 		}

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -434,9 +434,9 @@ func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, erro
 	// In relaxed mode the reconcile no-ops the synchronous swap, so SignZone
 	// here only adds RRSIGs by the (unchanged) active keys + re-stages the
 	// pipeline; no old-alg active ZSK is retired. ---
-	oldName := zd.DnssecPolicyName
 	zd.mu.Lock()
 	oldPol := zd.DnssecPolicy
+	oldName := zd.DnssecPolicyName
 	zd.DnssecPolicy = &pol
 	zd.DnssecPolicyName = policyName
 	zd.mu.Unlock()

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -406,10 +406,16 @@ func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, erro
 			zd.ZoneName, dns.AlgorithmToString[curKSKAlg], dns.AlgorithmToString[pol.KSKAlgorithm])
 	}
 
-	// Re-entrancy: refuse if a ZSK alg roll is already in flight (fuller
-	// drain-window predicate). This covers both the pre-promotion phase and the
-	// drain window (D4's blind spot), and the back-to-original-alg sub-case.
-	if inflight, err := zskAlgRollInFlight(kdb, zd.ZoneName, pol.ZSKAlgorithm); err != nil {
+	// Re-entrancy: refuse if a ZSK alg roll is already in flight. "In flight" is
+	// measured against the zone's CURRENTLY-BOUND ZSK algorithm (curZSKAlg), NOT
+	// the incoming target: before any roll, every ZSK is on the bound algorithm,
+	// so there is nothing in flight and this first change-policy proceeds. A
+	// genuine mid-roll has ZSKs of an algorithm other than the bound policy's
+	// (standby/active/retired) — that is what we refuse a second change-policy
+	// on. This also catches the back-to-original sub-case: mid fastroll→mayo1
+	// (bound=mayo1) the still-draining old ED25519 ZSKs are ≠ the bound MAYO1, so
+	// a change-policy back to ED25519 is correctly refused while they drain.
+	if inflight, err := zskAlgRollInFlight(kdb, zd.ZoneName, curZSKAlg); err != nil {
 		return "", fmt.Errorf("change-policy: checking in-flight roll for zone %s: %w", zd.ZoneName, err)
 	} else if inflight.InFlight {
 		return "", fmt.Errorf("change-policy: a ZSK algorithm rollover is already in progress for zone %s (%s→%s); wait for it to complete, or cancel it with \"auto-rollover cancel -z %s --zsk\" before changing course",

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -96,6 +96,13 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 				resp.ErrorMsg = err.Error()
 			}
 
+		case "change-policy":
+			resp.Msg, err = changeZonePolicy(zd, kdb, zp.Policy)
+			if err != nil {
+				resp.Error = true
+				resp.ErrorMsg = err.Error()
+			}
+
 		case "generate-nsec":
 			err := zd.GenerateNsecChain(kdb)
 			if err != nil {
@@ -324,6 +331,139 @@ func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) 
 	if algChanged {
 		fmt.Fprintf(&b, "\nNOTE #2: to clean up keys and signatures from the previous policy use \"... keystore dnssec policy-cleanup -z %s\" (note that this may break DNSSEC validation).", zd.ZoneName)
 	}
+	return b.String(), nil
+}
+
+// changeZonePolicy binds a zone toward a new DNSSEC policy for a gradual,
+// relaxed-mode ZSK ALGORITHM rollover. Unlike set-policy (which retires the
+// old-alg key synchronously — the unsafe §2 swap for an algorithm change),
+// change-policy only sets the algorithm of FUTURE-generated keys: it writes the
+// ZonePolicyOverride target + rebinds zd.DnssecPolicy, then the existing FIFO
+// ZSK pipeline drains in order. `auto-rollover asap -z <zone> --zsk` is the
+// throttle. The relaxed reconcile (sign.go) no-ops the synchronous retire, so
+// reusing set-policy's path is safe (D3).
+//
+// Entry-layer safety gates, all validated BEFORE any override write or rebind
+// so the zone is never left half-changed:
+//   - CSK target: refused (a CSK alg change is parent-coordinated engine work,
+//     not built; the reconcile early-returns on CSK and never sees it).
+//   - both-role target (KSK alg AND ZSK alg differ): refused — roll one role at
+//     a time (§4.1).
+//   - re-entrancy: a ZSK alg roll already in flight (fuller drain-window
+//     predicate): refused.
+//   - KSK-only alg target / strict mode: deferred to the reconcile, which
+//     refuses (defensive backstop) — but we surface a clean error here too.
+func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) {
+	policyName = strings.TrimSpace(policyName)
+	if policyName == "" {
+		return "", fmt.Errorf("change-policy: no policy specified")
+	}
+	confMu.RLock()
+	pol, ok := Conf.Internal.DnssecPolicies[policyName]
+	confMu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("change-policy: DNSSEC policy %q does not exist", policyName)
+	}
+	if pol.Error != "" {
+		return "", fmt.Errorf("change-policy: DNSSEC policy %q is broken: %s", policyName, pol.Error)
+	}
+	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+		return "", fmt.Errorf("change-policy: zone %s is not signed (neither online-signing nor inline-signing)", zd.ZoneName)
+	}
+
+	// Capture the current (source) policy algorithms/mode.
+	zd.mu.Lock()
+	cur := zd.DnssecPolicy
+	zd.mu.Unlock()
+	var curKSKAlg, curZSKAlg uint8
+	if cur != nil {
+		curKSKAlg, curZSKAlg = cur.KSKAlgorithm, cur.ZSKAlgorithm
+	}
+
+	// --- Entry guards (before any override write / rebind) ---
+
+	// CSK target (or current zone in CSK mode): an algorithm change to/within a
+	// CSK is parent-coordinated and not built. The reconcile early-returns on
+	// CSK, so this MUST be caught here.
+	if pol.Mode == DnssecPolicyModeCSK || (cur != nil && cur.Mode == DnssecPolicyModeCSK) {
+		return "", fmt.Errorf("change-policy: CSK algorithm rollover not implemented for zone %s (a CSK is SEP-flagged with a parent DS — route via the engine, not yet built)", zd.ZoneName)
+	}
+
+	kskChanged := curKSKAlg != pol.KSKAlgorithm
+	zskChanged := curZSKAlg != pol.ZSKAlgorithm
+
+	// Both-role target: roll one role at a time (§4.1).
+	if kskChanged && zskChanged {
+		return "", fmt.Errorf("change-policy: policy %q changes BOTH the KSK (%s→%s) and ZSK (%s→%s) algorithm for zone %s; roll one role at a time (issue two policy changes in sequence)",
+			policyName,
+			dns.AlgorithmToString[curKSKAlg], dns.AlgorithmToString[pol.KSKAlgorithm],
+			dns.AlgorithmToString[curZSKAlg], dns.AlgorithmToString[pol.ZSKAlgorithm], zd.ZoneName)
+	}
+
+	// KSK-only algorithm change: not implemented (parent-coordinated engine).
+	if kskChanged {
+		return "", fmt.Errorf("change-policy: KSK algorithm rollover not implemented for zone %s (%s→%s); route via the auto-rollover engine — not yet built",
+			zd.ZoneName, dns.AlgorithmToString[curKSKAlg], dns.AlgorithmToString[pol.KSKAlgorithm])
+	}
+
+	// Re-entrancy: refuse if a ZSK alg roll is already in flight (fuller
+	// drain-window predicate). This covers both the pre-promotion phase and the
+	// drain window (D4's blind spot), and the back-to-original-alg sub-case.
+	if inflight, err := zskAlgRollInFlight(kdb, zd.ZoneName, pol.ZSKAlgorithm); err != nil {
+		return "", fmt.Errorf("change-policy: checking in-flight roll for zone %s: %w", zd.ZoneName, err)
+	} else if inflight.InFlight {
+		return "", fmt.Errorf("change-policy: a ZSK algorithm rollover is already in progress for zone %s (%s→%s); wait for it to complete, or cancel it with \"auto-rollover cancel -z %s --zsk\" before changing course",
+			zd.ZoneName, dns.AlgorithmToString[inflight.FromAlg], dns.AlgorithmToString[inflight.ToAlg], zd.ZoneName)
+	}
+
+	// Strict mode: a ZSK alg change is not implemented (the reconcile refuses).
+	// Surface it here cleanly before touching anything. A same-algorithm /
+	// timing-only change is always allowed (no roll happens).
+	if zskChanged && Conf.Internal.Completeness != CompletenessRelaxed {
+		return "", fmt.Errorf("change-policy: strict-mode ZSK algorithm rollover not implemented for zone %s (%s→%s); set dnssec.completeness: relaxed to roll the ZSK algorithm gradually",
+			zd.ZoneName, dns.AlgorithmToString[curZSKAlg], dns.AlgorithmToString[pol.ZSKAlgorithm])
+	}
+
+	// --- Bind the target: reuse set-policy's override-write + rebind + sign.
+	// In relaxed mode the reconcile no-ops the synchronous swap, so SignZone
+	// here only adds RRSIGs by the (unchanged) active keys + re-stages the
+	// pipeline; no old-alg active ZSK is retired. ---
+	oldName := zd.DnssecPolicyName
+	zd.mu.Lock()
+	oldPol := zd.DnssecPolicy
+	zd.DnssecPolicy = &pol
+	zd.DnssecPolicyName = policyName
+	zd.mu.Unlock()
+
+	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm)
+
+	if _, err := zd.SignZone(kdb, true); err != nil {
+		zd.mu.Lock()
+		zd.DnssecPolicy = oldPol
+		zd.DnssecPolicyName = oldName
+		zd.mu.Unlock()
+		return "", fmt.Errorf("change-policy: re-sign zone %s: %w", zd.ZoneName, err)
+	}
+
+	if err := SetZonePolicyOverride(kdb, zd.ZoneName, policyName); err != nil {
+		return "", fmt.Errorf("change-policy: zone bound but persisting the override failed (the change will not survive restart): %w", err)
+	}
+
+	var b strings.Builder
+	if oldName != "" && oldName != policyName {
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy bound from %q to %q.\n", zd.ZoneName, oldName, policyName)
+	} else {
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy bound to %q.\n", zd.ZoneName, policyName)
+	}
+	if zskChanged {
+		fmt.Fprintf(&b, "ZSK algorithm will roll %s → %s GRADUALLY: future-generated ZSKs carry the new algorithm and the existing keys drain in FIFO order.\n",
+			dns.AlgorithmToString[curZSKAlg], dns.AlgorithmToString[pol.ZSKAlgorithm])
+		fmt.Fprintf(&b, "This command does NOT perform the roll. It advances on the normal ZSK cadence, or run \"auto-rollover asap -z %s --zsk\" to promote the next standby now (repeat to accelerate).\n", zd.ZoneName)
+	} else {
+		b.WriteString("Algorithms unchanged; new policy timings take effect. No algorithm roll is triggered.\n")
+	}
+	b.WriteString("WARNING: the policy change is stored in the keystore, not the zone config.\n")
+	fmt.Fprintf(&b, "NOTE: update the zone's dnssec_policy in YAML to make %q the permanent policy.", policyName)
 	return b.String(), nil
 }
 

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -941,6 +941,13 @@ func printStateTable(s *tdns.RolloverStatus) {
 	if s.Policy != nil {
 		left = append(left, kv{"policy:", policyHeaderValue(s.Policy)})
 	}
+	if t := s.AlgTransition; t != nil {
+		v := fmt.Sprintf("%s %s → %s  (in progress)", t.Role, t.FromAlg, t.ToAlg)
+		if t.Total > 0 {
+			v += fmt.Sprintf(", %d of %d on new alg", t.Done, t.Total)
+		}
+		left = append(left, kv{"alg rollover:", v})
+	}
 	if s.Phase != "" && s.Phase != "idle" {
 		left = append(left, kv{"phase:", s.Phase})
 	}
@@ -1599,8 +1606,9 @@ Differs from 'reset' (which clears last_rollover_error for one keyid).`,
 // today; others accept the flags as no-ops so an operator can copy a
 // command line between subcommands without "unknown flag" errors.
 var autoRolloverFlags struct {
-	kskOnly bool
-	zskOnly bool
+	kskOnly    bool
+	zskOnly    bool
+	policyName string
 }
 
 // newAutoRolloverCmd returns the parent command holding the auto-rollover
@@ -1631,10 +1639,70 @@ func newAutoRolloverCmd(_ string) *cobra.Command {
 		newAutoRolloverWhenCmd(),
 		newAutoRolloverAsapCmd(),
 		newAutoRolloverCancelCmd(),
+		newAutoRolloverPolicyChangeCmd(),
 		newAutoRolloverStatusCmd(),
 		newAutoRolloverResetCmd(),
 		newAutoRolloverUnstickCmd(),
 		newAutoRolloverValidateCmd(),
 	)
+	return c
+}
+
+// newAutoRolloverPolicyChangeCmd binds a zone toward a new DNSSEC policy for a
+// gradual, relaxed-mode ZSK ALGORITHM rollover. It only sets the algorithm of
+// future-generated keys (writes the policy override + rebinds); it does NOT
+// perform the roll. `auto-rollover asap -z <zone> --zsk` is the throttle.
+func newAutoRolloverPolicyChangeCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "policy-change",
+		Short: "Bind a zone to a new DNSSEC policy for a gradual ZSK algorithm rollover",
+		Long: `Bind a zone toward a new DNSSEC policy so its ZSK algorithm rolls over
+GRADUALLY. Unlike "zone set-policy" (which retires the old key
+synchronously — unsafe for an algorithm change), this only sets the
+algorithm of FUTURE-generated ZSKs: the existing FIFO key pipeline drains
+in order, oldest first.
+
+This command does NOT perform the roll. After binding, the algorithm
+rolls on the normal ZSK cadence — OR run
+
+  auto-rollover asap -z <zone> --zsk
+
+to promote the next standby now (repeat to accelerate through the
+already-propagated old-alg standbys to the new algorithm).
+
+Requires dnssec.completeness: relaxed. A KSK / CSK / both-role algorithm
+change, or a second policy-change while a roll is in flight, is refused.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			PrepArgs(cmd, "zonename")
+			tdns.Globals.App.Type = tdns.AppTypeCli
+			if strings.TrimSpace(autoRolloverFlags.policyName) == "" {
+				cliFatalf("flag --policy is required")
+			}
+			z := dns.Fqdn(tdns.Globals.Zonename)
+
+			api, err := GetApiClient("auth", true)
+			if err != nil {
+				cliFatalf("error getting API client: %v", err)
+			}
+			cr, err := SendZoneCommand(api, tdns.ZonePost{
+				Command: "change-policy",
+				Zone:    z,
+				Policy:  strings.TrimSpace(autoRolloverFlags.policyName),
+			})
+			if err != nil {
+				cliFatalf("error from %q: %s", cr.AppName, err.Error())
+			}
+			if cr.Error {
+				cliFatalf("%s", cr.ErrorMsg)
+			}
+			if cr.Msg != "" {
+				fmt.Printf("%s\n", cr.Msg)
+			}
+		},
+	}
+	c.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone")
+	c.Flags().StringVarP(&autoRolloverFlags.policyName, "policy", "p", "", "Target DNSSEC policy name")
+	_ = c.MarkFlagRequired("zone")
+	_ = c.MarkFlagRequired("policy")
 	return c
 }

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -398,10 +398,14 @@ func newAutoRolloverWhenCmd() *cobra.Command {
 	var offline bool
 	c := &cobra.Command{
 		Use:   "when",
-		Short: "Compute the earliest moment a KSK rollover could safely fire (no state change)",
-		Long: `Asks the running daemon to compute ComputeEarliestRollover (§8.5) and
-prints the result. Side-effect free; does not request a rollover. Use
-'auto-rollover asap' to actually schedule one.
+		Short: "Compute the earliest moment a rollover could safely fire (no state change)",
+		Long: `Asks the running daemon when the next rollover will fire and the
+earliest it could fire if requested. Side-effect free; does not request
+a rollover. Use 'auto-rollover asap' to actually schedule one.
+
+Reports the KSK schedule by default (parent-DS gated). Use --zsk for the
+ZSK schedule (zone-local, no parent gates — bounded only by standby
+readiness), or --ksk to be explicit. The two flags are mutually exclusive.
 
 Default mode talks to the daemon's API server (no daemon config needed
 on the CLI host). Use --offline to compute locally against the keystore
@@ -412,11 +416,19 @@ config file so the CLI can find db.file and the zone's policy.`,
 			tdns.Globals.App.Type = tdns.AppTypeCli
 			z := dns.Fqdn(tdns.Globals.Zonename)
 
+			if autoRolloverFlags.kskOnly && autoRolloverFlags.zskOnly {
+				cliFatalf("flags --ksk and --zsk are mutually exclusive")
+			}
+			keytype := "KSK"
+			if autoRolloverFlags.zskOnly {
+				keytype = "ZSK"
+			}
+
 			if offline {
-				runWhenOffline(z)
+				runWhenOffline(z, keytype)
 				return
 			}
-			runWhenOnline(z)
+			runWhenOnline(z, keytype)
 		},
 	}
 	c.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone")
@@ -427,12 +439,12 @@ config file so the CLI can find db.file and the zone's policy.`,
 
 // runWhenOnline is the default path: GET /api/v1/rollover/when via
 // the configured API client. No daemon config loaded on the CLI host.
-func runWhenOnline(z string) {
+func runWhenOnline(z, keytype string) {
 	api, err := GetApiClient("auth", true)
 	if err != nil {
 		cliFatalf("error getting API client: %v", err)
 	}
-	endpoint := "/rollover/when?zone=" + z
+	endpoint := "/rollover/when?zone=" + z + "&keytype=" + keytype
 	// "when" is observational; the daemon always returns 200 with a
 	// structured response (any caveats land in resp.Note). Non-2xx
 	// here would mean network-level failure, in which case the API
@@ -450,14 +462,19 @@ func runWhenOnline(z string) {
 
 // runWhenOffline preserves the legacy direct-DB path for postmortem
 // use when the daemon is down.
-func runWhenOffline(z string) {
+func runWhenOffline(z, keytype string) {
 	kdb, _, pol, err := openKeystoreForCli()
 	if err != nil {
 		cliFatalf("error: %v", err)
 	}
 	defer kdb.DB.Close()
 
-	resp, err := tdns.ComputeRolloverWhen(kdb, z, pol, time.Now())
+	var resp *tdns.RolloverWhenResponse
+	if keytype == "ZSK" {
+		resp, err = tdns.ComputeZskRolloverWhen(kdb, z, pol, time.Now())
+	} else {
+		resp, err = tdns.ComputeRolloverWhen(kdb, z, pol, time.Now())
+	}
 	if err != nil {
 		cliFatalf("%s", err.Error())
 	}
@@ -510,11 +527,21 @@ func printRolloverPolicyWarnings(warns []string) bool {
 // time. During in-progress rollovers, both lines reflect projected
 // times for the rollover after the current one completes.
 func renderRolloverWhen(resp *tdns.RolloverWhenResponse) {
+	role := resp.Role
+	if role == "" {
+		role = "KSK" // legacy daemon / unset
+	}
+	// The "asap" command needs --zsk for the ZSK schedule.
+	asapHint := "request via \"asap\" cmd"
+	if role == "ZSK" {
+		asapHint = "request via \"asap --zsk\" cmd"
+	}
+
 	if printRolloverPolicyErrors(resp.PolicyErrors) {
 		// Schedule output is meaningless while the policy is violated.
 		// Suppress remaining lines except the bare zone header so the
 		// operator still sees which zone they queried.
-		fmt.Printf("KSK rollover schedule for zone %s: blocked\n", resp.Zone)
+		fmt.Printf("%s rollover schedule for zone %s: blocked\n", role, resp.Zone)
 		return
 	}
 	// Warnings don't block — render schedule below the warning header.
@@ -522,9 +549,9 @@ func renderRolloverWhen(resp *tdns.RolloverWhenResponse) {
 
 	// Case 1 / waiting-for-parent: render the structured blocker
 	// instead of the schedule view. The schedule has no meaningful
-	// EarliestPossible in this state.
+	// EarliestPossible in this state. (KSK only — a ZSK has no parent gate.)
 	if resp.Status == "waiting-for-parent" && resp.Blocker != nil {
-		fmt.Printf("KSK rollover for zone %s: not currently possible.\n", resp.Zone)
+		fmt.Printf("%s rollover for zone %s: not currently possible.\n", role, resp.Zone)
 		fmt.Printf("  Reason: %s\n", resp.Blocker.Reason)
 		if resp.Blocker.Cause != "" {
 			fmt.Printf("  Cause:  %s\n", resp.Blocker.Cause)
@@ -546,14 +573,19 @@ func renderRolloverWhen(resp *tdns.RolloverWhenResponse) {
 		// still has the operator anchor.
 		currentTime = time.Now().UTC().Format("15:04:05 UTC (Mon Jan 2 2006)")
 	}
-	fmt.Printf("KSK rollover schedule for zone %s  Current time: %s\n", resp.Zone, currentTime)
+	fmt.Printf("%s rollover schedule for zone %s  Current time: %s\n", role, resp.Zone, currentTime)
 	if resp.InProgress {
 		fmt.Println("  (current rollover in progress; times below project the rollover after it completes)")
 	}
 
 	keyidPair := ""
-	if resp.FromKeyID != 0 || resp.ToKeyID != 0 {
+	switch {
+	case resp.FromKeyID != 0 && resp.ToKeyID != 0:
 		keyidPair = fmt.Sprintf("active keyid %d --> %d", resp.FromKeyID, resp.ToKeyID)
+	case resp.FromKeyID != 0:
+		// No promotion target yet (e.g. ZSK with no standby) — show the active
+		// keyid without a misleading "--> 0".
+		keyidPair = fmt.Sprintf("active keyid %d", resp.FromKeyID)
 	}
 
 	// Pad the time-with-delta to the wider of the two time strings.
@@ -570,7 +602,7 @@ func renderRolloverWhen(resp *tdns.RolloverWhenResponse) {
 	fmt.Printf("  next scheduled       %-*s  %s\n", timeColWidth, nextStr, keyidPair)
 	earliestLine := fmt.Sprintf("  earliest possible    %-*s  %s", timeColWidth, earliestStr, keyidPair)
 	if resp.EarliestPossible != "" && !resp.InProgress {
-		earliestLine += "  (request via \"asap\" cmd)"
+		earliestLine += "  (" + asapHint + ")"
 	}
 	fmt.Println(earliestLine)
 

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -868,7 +868,12 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 	}
 
 	if showZSK {
-		fmt.Println()
+		// Separate from a preceding KSK section. When ZSK is the first/only
+		// section, the global header's trailing blank is the separator — adding
+		// one here too would double the gap.
+		if showKSK {
+			fmt.Println()
+		}
 		if currentTimePrinted {
 			fmt.Printf("ZSK rollover state for zone %s\n", s.Zone)
 		} else {
@@ -903,7 +908,18 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 func printZoneGlobalHeader(s *tdns.RolloverStatus, verbose bool) {
 	printed := false
 	if s.Policy != nil {
-		fmt.Printf("Current policy: %s\n", policyHeaderValue(s.Policy))
+		// Non-verbose: name + per-role algorithms on the one line. Verbose: the
+		// algorithms are in the detail table just below, so the line carries
+		// only the policy name (no redundant "(KSK …, ZSK …)" suffix).
+		if verbose {
+			name := s.Policy.Name
+			if name == "" {
+				name = "(unnamed)"
+			}
+			fmt.Printf("Current policy: %s\n", name)
+		} else {
+			fmt.Printf("Current policy: %s\n", policyHeaderValue(s.Policy))
+		}
 		printed = true
 	}
 	if t := s.AlgTransition; t != nil {
@@ -962,7 +978,6 @@ func printPolicyDetail(p *tdns.PolicySummary) {
 		}
 	}
 
-	fmt.Println("policy:")
 	rows := make([]string, 0, depth)
 	for i := 0; i < depth; i++ {
 		fields := make([]string, 0, 8)

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -938,17 +938,21 @@ func printPolicyDetail(p *tdns.PolicySummary) {
 		kskAlg = p.Algorithm
 	}
 
-	// Four category columns, each a list of "label: value" cells filled
-	// top-down; columnize aligns them into a grid.
-	cols := [4][]string{
-		{cell("ksk.algorithm", kskAlg), cell("ksk.lifetime", p.KskLifetime)},
-		{cell("zsk.algorithm", zskAlg), cell("zsk.lifetime", p.ZskLifetime)},
+	// Each of the four category columns is a list of (label, value) cells
+	// filled top-down. Emitting label and value as SEPARATE columnize columns
+	// (8 columns total, not 4) makes columnize align every label column AND
+	// every value column independently — so the values line up instead of
+	// wobbling with the label width.
+	type cell struct{ label, value string }
+	cols := [4][]cell{
+		{{"ksk.algorithm", kskAlg}, {"ksk.lifetime", p.KskLifetime}},
+		{{"zsk.algorithm", zskAlg}, {"zsk.lifetime", p.ZskLifetime}},
 		{
-			cell("rollover.ds-publish-delay", p.DsPublishDelay),
-			cell("rollover.max-attempts", fmt.Sprintf("%d", p.MaxAttemptsBeforeBackoff)),
-			cell("rollover.softfail-delay", p.SoftfailDelay),
+			{"rollover.ds-publish-delay", p.DsPublishDelay},
+			{"rollover.max-attempts", fmt.Sprintf("%d", p.MaxAttemptsBeforeBackoff)},
+			{"rollover.softfail-delay", p.SoftfailDelay},
 		},
-		{cell("clamping.margin", p.ClampingMargin)},
+		{{"clamping.margin", p.ClampingMargin}},
 	}
 
 	depth := 0
@@ -961,11 +965,14 @@ func printPolicyDetail(p *tdns.PolicySummary) {
 	fmt.Println("policy:")
 	rows := make([]string, 0, depth)
 	for i := 0; i < depth; i++ {
-		fields := make([]string, 4)
+		fields := make([]string, 0, 8)
 		for c := 0; c < 4; c++ {
-			if i < len(cols[c]) {
-				fields[c] = cols[c][i]
+			var label, value string
+			if i < len(cols[c]) && strings.TrimSpace(cols[c][i].value) != "" {
+				label = cols[c][i].label + ":"
+				value = cols[c][i].value
 			}
+			fields = append(fields, label, value)
 		}
 		rows = append(rows, strings.Join(fields, "|"))
 	}
@@ -973,15 +980,6 @@ func printPolicyDetail(p *tdns.PolicySummary) {
 	for _, line := range strings.Split(formatted, "\n") {
 		fmt.Printf("  %s\n", strings.TrimRight(line, " "))
 	}
-}
-
-// cell formats a "label: value" policy cell, or "" when the value is empty so
-// the slot collapses without printing a dangling label.
-func cell(label, value string) string {
-	if strings.TrimSpace(value) == "" {
-		return ""
-	}
-	return label + ": " + value
 }
 
 // policyHeaderValue renders the one-line policy summary for the status

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -839,8 +839,10 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 	// Zone-global header: the effective policy and any in-flight algorithm
 	// rollover are facts about the ZONE, not about the KSK specifically, so
 	// they print once at the top — visible whether the operator views both
-	// roles, only KSK (--ksk), or only ZSK (--zsk).
-	printZoneGlobalHeader(s)
+	// roles, only KSK (--ksk), or only ZSK (--zsk). In verbose mode the full
+	// policy detail follows here too (an expansion of the policy line), rather
+	// than tacked on at the end of the report.
+	printZoneGlobalHeader(s, verbose)
 
 	currentTime := formatRolloverTimeAbsolute(s.CurrentTime)
 
@@ -889,30 +891,16 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 	// for one or two keys); a dedicated section reads better and
 	// gives the message room to breathe.
 	printRolloverKeyErrors(s, showKSK, showZSK, verbose)
-
-	if verbose && s.Policy != nil && (showKSK || showZSK) {
-		fmt.Println()
-		fmt.Println("  policy:")
-		fmt.Printf("    name                         %s\n", s.Policy.Name)
-		fmt.Printf("    algorithm                    %s\n", s.Policy.Algorithm)
-		fmt.Printf("    ksk.lifetime                 %s\n", s.Policy.KskLifetime)
-		if s.Policy.ZskLifetime != "" {
-			fmt.Printf("    zsk.lifetime                 %s\n", s.Policy.ZskLifetime)
-		}
-		fmt.Printf("    rollover.ds-publish-delay    %s\n", s.Policy.DsPublishDelay)
-		fmt.Printf("    rollover.max-attempts        %d\n", s.Policy.MaxAttemptsBeforeBackoff)
-		fmt.Printf("    rollover.softfail-delay      %s\n", s.Policy.SoftfailDelay)
-		if s.Policy.ClampingMargin != "" {
-			fmt.Printf("    clamping.margin              %s\n", s.Policy.ClampingMargin)
-		}
-	}
 }
 
 // printZoneGlobalHeader prints the zone-wide facts that belong above BOTH the
 // KSK and ZSK sections: the effective policy (name + per-role algorithms) and
 // any in-flight ZSK algorithm rollover. These are properties of the zone, not
 // of a particular key role, so they show regardless of --ksk / --zsk filtering.
-func printZoneGlobalHeader(s *tdns.RolloverStatus) {
+// In verbose mode the full policy detail (an expansion of the policy line) is
+// printed here too — the name already appears in the policy line above, so the
+// detail block drops it and lays the rest out compactly in columns.
+func printZoneGlobalHeader(s *tdns.RolloverStatus, verbose bool) {
 	printed := false
 	if s.Policy != nil {
 		fmt.Printf("Current policy: %s\n", policyHeaderValue(s.Policy))
@@ -928,9 +916,72 @@ func printZoneGlobalHeader(s *tdns.RolloverStatus) {
 		fmt.Println(line)
 		printed = true
 	}
+	if verbose && s.Policy != nil {
+		printPolicyDetail(s.Policy)
+		printed = true
+	}
 	if printed {
 		fmt.Println()
 	}
+}
+
+// printPolicyDetail renders the verbose policy expansion compactly in columns,
+// grouped by category: KSK | ZSK | rollover | clamping. The policy name is
+// omitted (it is already in the "Current policy:" line). Both per-role
+// algorithms are shown — a policy is a zone-wide description, not role-filtered,
+// so the KSK and ZSK algorithm both belong here even under --ksk / --zsk.
+func printPolicyDetail(p *tdns.PolicySummary) {
+	kskAlg := p.KSKAlgorithm
+	zskAlg := p.ZSKAlgorithm
+	if kskAlg == "" && zskAlg == "" {
+		// CSK / legacy single-algorithm policy.
+		kskAlg = p.Algorithm
+	}
+
+	// Four category columns, each a list of "label: value" cells filled
+	// top-down; columnize aligns them into a grid.
+	cols := [4][]string{
+		{cell("ksk.algorithm", kskAlg), cell("ksk.lifetime", p.KskLifetime)},
+		{cell("zsk.algorithm", zskAlg), cell("zsk.lifetime", p.ZskLifetime)},
+		{
+			cell("rollover.ds-publish-delay", p.DsPublishDelay),
+			cell("rollover.max-attempts", fmt.Sprintf("%d", p.MaxAttemptsBeforeBackoff)),
+			cell("rollover.softfail-delay", p.SoftfailDelay),
+		},
+		{cell("clamping.margin", p.ClampingMargin)},
+	}
+
+	depth := 0
+	for _, c := range cols {
+		if len(c) > depth {
+			depth = len(c)
+		}
+	}
+
+	fmt.Println("policy:")
+	rows := make([]string, 0, depth)
+	for i := 0; i < depth; i++ {
+		fields := make([]string, 4)
+		for c := 0; c < 4; c++ {
+			if i < len(cols[c]) {
+				fields[c] = cols[c][i]
+			}
+		}
+		rows = append(rows, strings.Join(fields, "|"))
+	}
+	formatted := columnize.SimpleFormat(rows)
+	for _, line := range strings.Split(formatted, "\n") {
+		fmt.Printf("  %s\n", strings.TrimRight(line, " "))
+	}
+}
+
+// cell formats a "label: value" policy cell, or "" when the value is empty so
+// the slot collapses without printing a dangling label.
+func cell(label, value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return label + ": " + value
 }
 
 // policyHeaderValue renders the one-line policy summary for the status

--- a/v2/cli/ksk_rollover_cli.go
+++ b/v2/cli/ksk_rollover_cli.go
@@ -835,6 +835,13 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 		// rollover-engine state explicit before the rest of the report.
 		fmt.Println()
 	}
+
+	// Zone-global header: the effective policy and any in-flight algorithm
+	// rollover are facts about the ZONE, not about the KSK specifically, so
+	// they print once at the top — visible whether the operator views both
+	// roles, only KSK (--ksk), or only ZSK (--zsk).
+	printZoneGlobalHeader(s)
+
 	currentTime := formatRolloverTimeAbsolute(s.CurrentTime)
 
 	// Track whether the current-time anchor has been printed yet, so
@@ -901,6 +908,31 @@ func renderRolloverStatus(s *tdns.RolloverStatus, verbose, showKSK, showZSK bool
 	}
 }
 
+// printZoneGlobalHeader prints the zone-wide facts that belong above BOTH the
+// KSK and ZSK sections: the effective policy (name + per-role algorithms) and
+// any in-flight ZSK algorithm rollover. These are properties of the zone, not
+// of a particular key role, so they show regardless of --ksk / --zsk filtering.
+func printZoneGlobalHeader(s *tdns.RolloverStatus) {
+	printed := false
+	if s.Policy != nil {
+		fmt.Printf("Current policy: %s\n", policyHeaderValue(s.Policy))
+		printed = true
+	}
+	if t := s.AlgTransition; t != nil {
+		// ASCII "->" (not the Unicode arrow); spell out "algorithm"; describe
+		// the count as published ZSKs (the live keys in the DNSKEY RRset).
+		line := fmt.Sprintf("Algorithm rollover: %s %s -> %s  (in progress)", t.Role, t.FromAlg, t.ToAlg)
+		if t.Total > 0 {
+			line += fmt.Sprintf(", %d of %d published ZSKs on new algorithm", t.Done, t.Total)
+		}
+		fmt.Println(line)
+		printed = true
+	}
+	if printed {
+		fmt.Println()
+	}
+}
+
 // policyHeaderValue renders the one-line policy summary for the status
 // header: the effective policy name plus its per-role algorithms, e.g.
 //
@@ -933,21 +965,10 @@ func printStateTable(s *tdns.RolloverStatus) {
 	type kv struct{ label, value string }
 	var left, right []kv
 
-	// Left column: this zone's current intent + DS state.
+	// Left column: this zone's current intent + DS state. (The effective
+	// policy and any in-flight algorithm rollover are zone-global facts and
+	// print in printZoneGlobalHeader, above both role sections.)
 	left = append(left, kv{"status:", s.Headline + " — " + headlinePhraseFor(s.Headline, s.Phase)})
-	// Effective policy + per-role algorithms, always shown (not just -v):
-	// an operator must be able to see which policy/algorithms the engine
-	// is following, and an algorithm transition is invisible without it.
-	if s.Policy != nil {
-		left = append(left, kv{"policy:", policyHeaderValue(s.Policy)})
-	}
-	if t := s.AlgTransition; t != nil {
-		v := fmt.Sprintf("%s %s → %s  (in progress)", t.Role, t.FromAlg, t.ToAlg)
-		if t.Total > 0 {
-			v += fmt.Sprintf(", %d of %d on new alg", t.Done, t.Total)
-		}
-		left = append(left, kv{"alg rollover:", v})
-	}
 	if s.Phase != "" && s.Phase != "idle" {
 		left = append(left, kv{"phase:", s.Phase})
 	}

--- a/v2/db.go
+++ b/v2/db.go
@@ -307,7 +307,7 @@ func NewKeyDB(dbfile string, force bool, options map[AuthOption]string) (*KeyDB,
 		}
 	}
 	dbSetupTables(db)
-	return &KeyDB{
+	kdb := &KeyDB{
 		DB:                  db,
 		DBFile:              dbfile,
 		KeystoreSig0Cache:   make(map[string]*Sig0ActiveKeys),
@@ -315,8 +315,9 @@ func NewKeyDB(dbfile string, force bool, options map[AuthOption]string) (*KeyDB,
 		KeystoreDnskeyCache: make(map[string]*DnssecKeys),
 		UpdateQ:             make(chan UpdateRequest),
 		KeyBootstrapperQ:    make(chan KeyBootstrapperRequest, 10),
-		Options:             options,
-	}, nil
+	}
+	kdb.SetOptions(options)
+	return kdb, nil
 }
 
 func NewSig0StoreT() *Sig0StoreT {

--- a/v2/delegation_sync.go
+++ b/v2/delegation_sync.go
@@ -399,10 +399,8 @@ func (zd *ZoneData) SyncZoneDelegationViaUpdate(kdb *KeyDB, syncstate Delegation
 
 	// Check the parent-update option to determine whether to use replace or delta mode
 	updateMode := UpdateModeDelta // default
-	if kdb.Options != nil {
-		if mode, exists := kdb.Options[AuthOptParentUpdate]; exists {
-			updateMode = mode
-		}
+	if mode, exists := kdb.AuthOption(AuthOptParentUpdate); exists {
+		updateMode = mode
 	}
 
 	var m *dns.Msg

--- a/v2/key_state_worker.go
+++ b/v2/key_state_worker.go
@@ -273,23 +273,46 @@ func maintainStandbyKeys(conf *Config, kdb *KeyDB, standbyZskCount, standbyKskCo
 			continue
 		}
 
-		maintainStandbyKeysForType(kdb, zoneName, zd.DnssecPolicy.ZSKAlgorithm, "ZSK", 256, standbyZskCount)
+		// RELAXED completeness counts standby ZSKs by ROLE only (algorithm-
+		// agnostic): N old-alg standbys satisfy the count, so an algorithm
+		// change generates nothing eagerly — the gradual FIFO roll mints the
+		// new algorithm only when the count actually drops (a standby was
+		// promoted). STRICT keeps per-(role,algorithm) counting (the maintained
+		// double-signature shape). See the algorithm-rollover plan §8.3 / D5.
+		relaxed := Conf.Internal.Completeness == CompletenessRelaxed
+		maintainStandbyKeysForType(kdb, zoneName, zd.DnssecPolicy.ZSKAlgorithm, "ZSK", 256, standbyZskCount, relaxed)
+
+		// In relaxed mode, cap the standby-ZSK TOTAL (any algorithm) at
+		// standbyZskCount: with the algorithm-based deletion skipped, an
+		// asap-faster-than-drain or stray extra could otherwise bloat the
+		// DNSKEY RRset. Keep the oldest standbyZskCount (FIFO, by published_at),
+		// delete the youngest surplus, NEVER by algorithm. Shares the same
+		// role-total count as the maintainer above so the two never oscillate.
+		if relaxed {
+			capStandbyZsksByCount(kdb, zoneName, standbyZskCount)
+		}
 
 		if standbyKskCount > 0 && (zd.DnssecPolicy == nil || zd.DnssecPolicy.Rollover.Method == RolloverMethodNone) {
-			maintainStandbyKeysForType(kdb, zoneName, zd.DnssecPolicy.KSKAlgorithm, "KSK", 257, standbyKskCount)
+			// KSK is always per-(role,algorithm): relaxed mode's role-only
+			// discipline is a ZSK-roll property (the ZSK signs the whole zone);
+			// a KSK algorithm change is refused, not gradually rolled, here.
+			maintainStandbyKeysForType(kdb, zoneName, zd.DnssecPolicy.KSKAlgorithm, "KSK", 257, standbyKskCount, false)
 		}
 	}
 }
 
 // maintainStandbyKeysForType checks and maintains standby key count for a
-// specific key type (ZSK or KSK) in a zone.
-func maintainStandbyKeysForType(kdb *KeyDB, zoneName string, alg uint8, keytype string, expectedFlags uint16, standbyKeyCount int) {
+// specific key type (ZSK or KSK) in a zone. When roleOnly is true (relaxed-mode
+// ZSK), the standby/published pipeline counts are by ROLE (flags) only, not by
+// (role, algorithm): N old-algorithm standbys satisfy the count and nothing is
+// generated. When false (strict, or any KSK), counts are per-(role, algorithm).
+func maintainStandbyKeysForType(kdb *KeyDB, zoneName string, alg uint8, keytype string, expectedFlags uint16, standbyKeyCount int, roleOnly bool) {
 	standbyKeys, err := GetDnssecKeysByState(kdb, zoneName, DnskeyStateStandby)
 	if err != nil {
 		lgSigner.Error("KeyStateWorker: error getting standby keys", "zone", zoneName, "keytype", keytype, "err", err)
 		return
 	}
-	standbyCount := countKeysByFlagsAndAlg(standbyKeys, expectedFlags, alg)
+	standbyCount := countKeysForMaintain(standbyKeys, expectedFlags, alg, roleOnly)
 
 	if standbyCount >= standbyKeyCount {
 		return
@@ -300,7 +323,7 @@ func maintainStandbyKeysForType(kdb *KeyDB, zoneName string, alg uint8, keytype 
 		lgSigner.Error("KeyStateWorker: error getting published keys", "zone", zoneName, "keytype", keytype, "err", err)
 		return
 	}
-	publishedCount := countKeysByFlagsAndAlg(publishedKeys, expectedFlags, alg)
+	publishedCount := countKeysForMaintain(publishedKeys, expectedFlags, alg, roleOnly)
 
 	if publishedCount > 0 {
 		lgSigner.Debug("KeyStateWorker: keys in pipeline, not generating", "zone", zoneName, "keytype", keytype, "published", publishedCount)
@@ -320,14 +343,53 @@ func maintainStandbyKeysForType(kdb *KeyDB, zoneName string, alg uint8, keytype 
 	}
 }
 
-// countKeysByFlagsAndAlg counts keys matching flags and algorithm.
-// ZSK: flags=256, KSK/CSK: flags=257.
-func countKeysByFlagsAndAlg(keys []DnssecKeyWithTimestamps, expectedFlags uint16, alg uint8) int {
+// capStandbyZsksByCount enforces the relaxed-mode standby-ZSK total cap: if more
+// than standbyZskCount standby ZSKs (flags=256, any algorithm) exist, delete the
+// YOUNGEST surplus (highest published_at), keeping the oldest standbyZskCount.
+// GetDnssecKeysByState returns standbys ordered published_at ASC, so the oldest
+// (furthest through propagation, next to promote) are kept and only the tail is
+// removed. Removal here is safe: a standby key has never signed, so there are no
+// RRSIGs to orphan — its only footprint is the DNSKEY RRset. This shares the
+// role-total count with maintainStandbyKeysForType(roleOnly=true), so generate
+// and cap agree and never oscillate.
+func capStandbyZsksByCount(kdb *KeyDB, zoneName string, standbyZskCount int) {
+	standbyKeys, err := GetDnssecKeysByState(kdb, zoneName, DnskeyStateStandby)
+	if err != nil {
+		lgSigner.Error("KeyStateWorker: cap: error getting standby keys", "zone", zoneName, "err", err)
+		return
+	}
+	var zsks []DnssecKeyWithTimestamps
+	for _, k := range standbyKeys {
+		if k.Flags == 256 {
+			zsks = append(zsks, k)
+		}
+	}
+	if len(zsks) <= standbyZskCount {
+		return
+	}
+	for _, k := range zsks[standbyZskCount:] {
+		lgSigner.Info("KeyStateWorker: relaxed cap: removing youngest surplus standby ZSK",
+			"zone", zoneName, "keyid", k.KeyTag, "have", len(zsks), "cap", standbyZskCount,
+			"alg", dns.AlgorithmToString[k.Algorithm])
+		if err := UpdateDnssecKeyState(kdb, zoneName, k.KeyTag, DnskeyStateRemoved); err != nil {
+			lgSigner.Error("KeyStateWorker: cap: remove surplus standby ZSK failed", "zone", zoneName, "keyid", k.KeyTag, "err", err)
+		}
+	}
+}
+
+// countKeysForMaintain counts keys for the standby maintainer. With roleOnly it
+// matches by flags (role) only — algorithm-agnostic, the relaxed-mode ZSK shape;
+// otherwise it matches flags AND algorithm (strict / KSK).
+func countKeysForMaintain(keys []DnssecKeyWithTimestamps, expectedFlags uint16, alg uint8, roleOnly bool) int {
 	count := 0
 	for _, k := range keys {
-		if k.Flags == expectedFlags && k.Algorithm == alg {
-			count++
+		if k.Flags != expectedFlags {
+			continue
 		}
+		if !roleOnly && k.Algorithm != alg {
+			continue
+		}
+		count++
 	}
 	return count
 }

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -1189,11 +1189,19 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 	var query string
 	var args []interface{}
 
+	// ORDER BY published_at ASC, keyid ASC makes the result deterministic and
+	// FIFO by propagation age (oldest-published first). This is REQUIRED for
+	// correct ZSK rollover: RolloverKey promotes the first standby returned
+	// here, so without an explicit order promotion is arbitrary (SQLite row
+	// order is unspecified) — fatal to an algorithm roll, where an old-alg
+	// standby must promote before a younger new-alg one. NULL published_at
+	// sorts first (an unpublished key precedes published ones); standby keys
+	// always have published_at, so the promotion pick is unaffected.
 	if zone == "" {
-		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, ''), active_seq FROM DnssecKeyStore WHERE state=?`
+		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, ''), active_seq FROM DnssecKeyStore WHERE state=? ORDER BY published_at ASC, keyid ASC`
 		args = []interface{}{state}
 	} else {
-		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, ''), active_seq FROM DnssecKeyStore WHERE zonename=? AND state=?`
+		query = `SELECT zonename, keyid, flags, algorithm, state, COALESCE(keyrr, ''), COALESCE(published_at, ''), COALESCE(active_at, ''), COALESCE(retired_at, ''), active_seq FROM DnssecKeyStore WHERE zonename=? AND state=? ORDER BY published_at ASC, keyid ASC`
 		args = []interface{}{zone, state}
 	}
 

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -246,7 +246,11 @@ type AlgTransitionInfo struct {
 // InProgress=true is the operator-facing signal that the times
 // reflect projection rather than current schedule.
 type RolloverWhenResponse struct {
-	Zone             string                  `json:"zone"`
+	Zone string `json:"zone"`
+	// Role is the key role this schedule is for: "KSK" (parent-DS gated) or
+	// "ZSK" (zone-local, no parent gates). Drives the renderer's header and
+	// whether a gates section applies. Empty is treated as "KSK".
+	Role             string                  `json:"role,omitempty"`
 	CurrentTime      string                  `json:"currentTime,omitempty"`      // RFC3339 UTC, server's wallclock
 	NextScheduled    string                  `json:"nextScheduled,omitempty"`    // RFC3339 UTC
 	EarliestPossible string                  `json:"earliestPossible,omitempty"` // RFC3339 UTC

--- a/v2/messages_rollover.go
+++ b/v2/messages_rollover.go
@@ -124,6 +124,12 @@ type RolloverStatus struct {
 	// removed ZSKs beyond the display cap, omitted from ZSKs.
 	HiddenRemovedZskCount int `json:"hiddenRemovedZskCount,omitempty"`
 
+	// AlgTransition is set when a ZSK algorithm rollover is in flight (an
+	// active/standby/retired ZSK whose algorithm ≠ the effective-policy ZSK
+	// algorithm — the same drain-window predicate the change-policy re-entrancy
+	// guard uses). nil when no roll is in progress.
+	AlgTransition *AlgTransitionInfo `json:"algTransition,omitempty"`
+
 	// Policy summary. Verbose mode shows this; compact mode hides it.
 	Policy *PolicySummary `json:"policy,omitempty"`
 
@@ -215,6 +221,18 @@ type PolicySummary struct {
 	MaxAttemptsBeforeBackoff int    `json:"maxAttemptsBeforeBackoff"`
 	SoftfailDelay            string `json:"softfailDelay"`
 	ClampingMargin           string `json:"clampingMargin,omitempty"`
+}
+
+// AlgTransitionInfo describes an in-flight ZSK algorithm rollover for the
+// status header line: e.g. "ZSK alg rollover: ED25519 → MAYO5 (in progress)".
+// FromAlg/ToAlg are algorithm names; Done/Total are a coarse progress count
+// (target-alg ZSKs / all live ZSK pipeline members).
+type AlgTransitionInfo struct {
+	Role    string `json:"role"` // currently always "ZSK"
+	FromAlg string `json:"fromAlg"`
+	ToAlg   string `json:"toAlg"`
+	Done    int    `json:"done"`
+	Total   int    `json:"total"`
 }
 
 // RolloverWhenResponse is returned by GET /api/v1/rollover/when.

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -408,13 +408,14 @@ func (conf *Config) ParseConfig(reload bool) error {
 				return err
 			}
 		} else if conf.Internal.KeyDB != nil {
-			// Refresh the live KeyDB's Options from the freshly-parsed config so
+			// Refresh the live KeyDB's options from the freshly-parsed config so
 			// a reloaded option (e.g. minimal-responses) takes effect without a
 			// restart. The KeyDB is built once at startup and reused across
-			// reloads, but the query responder reads kdb.Options — without this,
-			// reload updated only conf.DnsEngine.Options (the presentation) while
-			// the responder kept the stale startup map.
-			conf.Internal.KeyDB.Options = conf.DnsEngine.Options
+			// reloads, but the query responder reads them — without this, reload
+			// updated only conf.DnsEngine.Options (the presentation) while the
+			// responder kept the stale startup map. SetOptions swaps the map
+			// atomically, so the per-query lock-free readers are race-free.
+			conf.Internal.KeyDB.SetOptions(conf.DnsEngine.Options)
 			if err := applyOutboundSoaSerial(conf.Internal.KeyDB, conf.DnsEngine.OutboundSoaSerial); err != nil {
 				return err
 			}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -408,6 +408,13 @@ func (conf *Config) ParseConfig(reload bool) error {
 				return err
 			}
 		} else if conf.Internal.KeyDB != nil {
+			// Refresh the live KeyDB's Options from the freshly-parsed config so
+			// a reloaded option (e.g. minimal-responses) takes effect without a
+			// restart. The KeyDB is built once at startup and reused across
+			// reloads, but the query responder reads kdb.Options — without this,
+			// reload updated only conf.DnsEngine.Options (the presentation) while
+			// the responder kept the stale startup map.
+			conf.Internal.KeyDB.Options = conf.DnsEngine.Options
 			if err := applyOutboundSoaSerial(conf.Internal.KeyDB, conf.DnsEngine.OutboundSoaSerial); err != nil {
 				return err
 			}

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -594,27 +594,11 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	// apex glue on positive answers. Referrals and NXDOMAIN/NODATA paths are
 	// unaffected (their authority/additional sections are still required).
 	minimalResponses := false
-	var minRespRaw string
-	var minRespPresent bool
 	if kdb != nil && kdb.Options != nil {
-		minRespRaw, minRespPresent = kdb.Options[AuthOptMinimalResponses]
-		if minRespPresent && minRespRaw == "true" {
+		if v, ok := kdb.Options[AuthOptMinimalResponses]; ok && v == "true" {
 			minimalResponses = true
 		}
 	}
-	// TEMP DIAGNOSTIC (minimal-responses not suppressing NS+glue): log the value
-	// actually resolved at query time, plus why. Logged at Info so it is visible
-	// at the deployed log level. Remove once root-caused.
-	lgHandler.Info("minimal-responses resolved",
-		"zone", zd.ZoneName, "minimalResponses", minimalResponses,
-		"kdbNil", kdb == nil, "optsNil", kdb != nil && kdb.Options == nil,
-		"present", minRespPresent, "rawValue", minRespRaw,
-		"optionCount", func() int {
-			if kdb != nil && kdb.Options != nil {
-				return len(kdb.Options)
-			}
-			return 0
-		}())
 
 	// Get DNSSEC keys if KeyDB is available and zone has DNSSEC enabled
 	var dak *DnssecKeys

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -594,11 +594,27 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	// apex glue on positive answers. Referrals and NXDOMAIN/NODATA paths are
 	// unaffected (their authority/additional sections are still required).
 	minimalResponses := false
+	var minRespRaw string
+	var minRespPresent bool
 	if kdb != nil && kdb.Options != nil {
-		if v, ok := kdb.Options[AuthOptMinimalResponses]; ok && v == "true" {
+		minRespRaw, minRespPresent = kdb.Options[AuthOptMinimalResponses]
+		if minRespPresent && minRespRaw == "true" {
 			minimalResponses = true
 		}
 	}
+	// TEMP DIAGNOSTIC (minimal-responses not suppressing NS+glue): log the value
+	// actually resolved at query time, plus why. Logged at Info so it is visible
+	// at the deployed log level. Remove once root-caused.
+	lgHandler.Info("minimal-responses resolved",
+		"zone", zd.ZoneName, "minimalResponses", minimalResponses,
+		"kdbNil", kdb == nil, "optsNil", kdb != nil && kdb.Options == nil,
+		"present", minRespPresent, "rawValue", minRespRaw,
+		"optionCount", func() int {
+			if kdb != nil && kdb.Options != nil {
+				return len(kdb.Options)
+			}
+			return 0
+		}())
 
 	// Get DNSSEC keys if KeyDB is available and zone has DNSSEC enabled
 	var dak *DnssecKeys

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -594,8 +594,8 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	// apex glue on positive answers. Referrals and NXDOMAIN/NODATA paths are
 	// unaffected (their authority/additional sections are still required).
 	minimalResponses := false
-	if kdb != nil && kdb.Options != nil {
-		if v, ok := kdb.Options[AuthOptMinimalResponses]; ok && v == "true" {
+	if kdb != nil {
+		if v, ok := kdb.AuthOption(AuthOptMinimalResponses); ok && v == "true" {
 			minimalResponses = true
 		}
 	}

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -78,6 +78,23 @@ func ComputeRolloverStatus(kdb *KeyDB, zone string, pol *DnssecPolicy, checkInte
 	if pol != nil {
 		populateAttemptTiming(out, row, pol)
 		out.Policy = policySummary(pol)
+
+		// Surface an in-flight ZSK algorithm rollover in the header (shares the
+		// drain-window predicate with the change-policy re-entrancy guard). Only
+		// meaningful for KSK-ZSK mode; a CSK has no separate ZSK algorithm.
+		if pol.Mode == DnssecPolicyModeKSKZSK && pol.ZSKAlgorithm != 0 {
+			if st, err := zskAlgRollInFlight(kdb, zone, pol.ZSKAlgorithm); err != nil {
+				lgRollover.Debug("ComputeRolloverStatus: zskAlgRollInFlight failed", "zone", zone, "err", err)
+			} else if st.InFlight {
+				out.AlgTransition = &AlgTransitionInfo{
+					Role:    "ZSK",
+					FromAlg: dns.AlgorithmToString[st.FromAlg],
+					ToAlg:   dns.AlgorithmToString[st.ToAlg],
+					Done:    st.Done,
+					Total:   st.Total,
+				}
+			}
+		}
 	}
 
 	var hiddenRemoved int

--- a/v2/rollover_api_funcs.go
+++ b/v2/rollover_api_funcs.go
@@ -330,6 +330,7 @@ func ComputeRolloverWhen(kdb *KeyDB, zone string, pol *DnssecPolicy, now time.Ti
 	}
 	out := &RolloverWhenResponse{
 		Zone:        zone,
+		Role:        "KSK",
 		CurrentTime: now.UTC().Format(time.RFC3339),
 	}
 

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -400,17 +400,18 @@ func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB) (*DnssecKeys, error) {
 		return nil, err
 	}
 
-	// Reconcile the active key algorithms against the policy: retire any
-	// active key whose algorithm the policy no longer wants, so the
-	// generate-if-missing logic below replaces it with one of the policy's
-	// algorithm. Retired keys keep their DNSKEY published and their RRSIGs
-	// valid until the KeyStateWorker removes them, so the zone stays
-	// validatable (a graceful, zone-side algorithm change). On a no-op (keys
-	// already match the policy) this returns without changes — idempotent,
-	// safe on every sign/re-sign.
-	if retired, err := zd.reconcileActiveKeyAlgorithms(kdb, dak); err != nil {
+	// Reconcile the active key algorithms against the policy. An active-key
+	// algorithm mismatch is REFUSED with an error (a KSK mismatch in either
+	// mode, a ZSK mismatch under strict completeness) — never the legacy
+	// synchronous retire, which is the unsafe path for an algorithm change. A
+	// relaxed-mode ZSK mismatch is a no-op (the gradual roll carries it). The
+	// boolean return reports only whether non-active leftover keys
+	// (standby/published of a wrong algorithm) were removed, in which case we
+	// re-fetch the active set. On a same-algorithm zone this is an idempotent
+	// no-op, safe on every sign/re-sign.
+	if removed, err := zd.reconcileActiveKeyAlgorithms(kdb, dak); err != nil {
 		return nil, err
-	} else if retired {
+	} else if removed {
 		dak, err = zd.refreshActiveDnssecKeys(kdb, "after algorithm reconcile")
 		if err != nil {
 			return nil, err

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -268,25 +268,36 @@ func (zd *ZoneData) refreshActiveDnssecKeys(kdb *KeyDB, context string) (*Dnssec
 	return dak, nil
 }
 
-// reconcileActiveKeyAlgorithms retires active keys whose algorithm the zone's
-// policy no longer wants, so the caller's generate-if-missing logic replaces
-// them with keys of the policy's algorithm. It returns true if it retired any
-// key (the caller must then re-fetch the active set).
+// reconcileActiveKeyAlgorithms reconciles active keys against the zone's policy
+// algorithm. For a SAME-algorithm policy (the common case) it is a no-op. For an
+// algorithm MISMATCH the behavior is mode-aware (dnssec.completeness):
 //
-// Scope: KSK-ZSK mode only. CSK mode (Mode==csk) is left untouched — it is not
-// enforced elsewhere in the signing path, so reconciling it here would create
-// inconsistency. Retiring (not deleting) keeps the old DNSKEY published and its
-// RRSIGs valid until the KeyStateWorker removes it: a graceful algorithm change.
+//   - ZSK mismatch, RELAXED mode: do NOT retire the wrong-alg active ZSK. The
+//     gradual FIFO ZSK roll (change-policy binds the new alg → newly-generated
+//     keys carry it → standbys drain in order, asap is the throttle) carries
+//     the transition. Retiring here would be the unsafe synchronous swap.
+//   - ZSK mismatch, STRICT mode: REFUSE. Strict-mode algorithm rollover
+//     (maintained whole-zone double-signature) is not implemented; running the
+//     legacy synchronous retire would produce an unsafe zone.
+//   - KSK mismatch, EITHER mode: REFUSE. A KSK algorithm rollover must go
+//     through the parent-coordinated engine (standby DS gate); the legacy
+//     immediate retire here bypasses the gate and bogus-zones the parent DS
+//     chain. Not yet built — refuse rather than run the unsafe swap.
 //
-// Safety: a KSK rollover is strictly same-algorithm and maintains the
-// "exactly one active KSK" invariant, so an active KSK whose algorithm differs
-// from the policy can only be a genuine policy change, never an in-flight
-// rollover. We still skip retirement while a rollover is in progress, as a
-// defensive guard.
+// CSK mode (Mode==csk) early-returns: it never reaches the key loops, so a CSK
+// algorithm change is refused at the ENTRY layer (change-policy/set-policy), not
+// here. See the algorithm-rollover plan §8.3.
+//
+// It returns true if it retired/removed any key (the caller must then re-fetch
+// the active set). Refusals are returned as errors so a background re-sign can
+// never silently run the unsafe swap — the entry layer is the front door, this
+// is the backstop.
 func (zd *ZoneData) reconcileActiveKeyAlgorithms(kdb *KeyDB, dak *DnssecKeys) (bool, error) {
 	if zd.DnssecPolicy == nil || zd.DnssecPolicy.Mode == DnssecPolicyModeCSK {
 		return false, nil
 	}
+
+	relaxed := Conf.Internal.Completeness == CompletenessRelaxed
 
 	rolloverInProgress := false
 	if row, err := LoadRolloverZoneRow(kdb, zd.ZoneName); err != nil {
@@ -295,54 +306,46 @@ func (zd *ZoneData) reconcileActiveKeyAlgorithms(kdb *KeyDB, dak *DnssecKeys) (b
 		rolloverInProgress = row.RolloverInProgress
 	}
 
-	retiredAny := false
-	retire := func(keyid uint16, role string, have, want uint8) error {
-		lgSigner.Info("retiring active DNSSEC key: algorithm no longer matches policy",
-			"zone", zd.ZoneName, "keyid", keyid, "role", role,
-			"have", dns.AlgorithmToString[have], "want", dns.AlgorithmToString[want])
-		if err := UpdateDnssecKeyState(kdb, zd.ZoneName, keyid, DnskeyStateRetired); err != nil {
-			return fmt.Errorf("reconcile: retire %s %d for zone %s: %w", role, keyid, zd.ZoneName, err)
-		}
-		retiredAny = true
-		return nil
-	}
-
+	// KSK algorithm mismatch is REFUSED in both modes — a KSK alg rollover is
+	// parent-coordinated engine work (not yet built), and the legacy immediate
+	// retire below would bypass the standby DS gate and bogus the parent chain.
 	for _, ksk := range dak.KSKs {
-		if ksk.DnskeyRR.Algorithm == zd.DnssecPolicy.KSKAlgorithm {
-			continue
-		}
-		if rolloverInProgress {
-			lgSigner.Warn("active KSK algorithm differs from policy but a rollover is in progress; deferring retirement",
-				"zone", zd.ZoneName, "keyid", ksk.KeyId)
-			continue
-		}
-		if err := retire(ksk.KeyId, "KSK", ksk.DnskeyRR.Algorithm, zd.DnssecPolicy.KSKAlgorithm); err != nil {
-			return retiredAny, err
+		if ksk.DnskeyRR.Algorithm != zd.DnssecPolicy.KSKAlgorithm {
+			return false, fmt.Errorf("KSK algorithm rollover not implemented for zone %s (active KSK %d is %s, policy wants %s); route via the auto-rollover engine — not yet built",
+				zd.ZoneName, ksk.KeyId, dns.AlgorithmToString[ksk.DnskeyRR.Algorithm], dns.AlgorithmToString[zd.DnssecPolicy.KSKAlgorithm])
 		}
 	}
 
-	// Only real ZSKs (flags=256). A KSK reused as CSK (flags=257) is handled by
-	// the KSK loop above, not here.
+	// ZSK algorithm mismatch: refuse in strict mode; no-op in relaxed mode (the
+	// gradual roll carries it). A matching ZSK falls through to the leftover
+	// sweep below unchanged.
 	for _, zsk := range dak.ZSKs {
-		if zsk.DnskeyRR.Flags != 256 {
+		if zsk.DnskeyRR.Flags != 256 { // KSK-reused-as-CSK handled by the KSK loop
 			continue
 		}
 		if zsk.DnskeyRR.Algorithm == zd.DnssecPolicy.ZSKAlgorithm {
 			continue
 		}
-		if err := retire(zsk.KeyId, "ZSK", zsk.DnskeyRR.Algorithm, zd.DnssecPolicy.ZSKAlgorithm); err != nil {
-			return retiredAny, err
+		if !relaxed {
+			return false, fmt.Errorf("strict-mode ZSK algorithm rollover not implemented for zone %s (active ZSK %d is %s, policy wants %s); set dnssec.completeness: relaxed to roll the ZSK algorithm gradually",
+				zd.ZoneName, zsk.KeyId, dns.AlgorithmToString[zsk.DnskeyRR.Algorithm], dns.AlgorithmToString[zd.DnssecPolicy.ZSKAlgorithm])
 		}
+		lgSigner.Info("relaxed mode: active ZSK algorithm differs from policy; leaving it for the gradual FIFO roll (not retiring)",
+			"zone", zd.ZoneName, "keyid", zsk.KeyId,
+			"have", dns.AlgorithmToString[zsk.DnskeyRR.Algorithm], "want", dns.AlgorithmToString[zd.DnssecPolicy.ZSKAlgorithm])
 	}
 
-	// Standby and published keys of a wrong algorithm are leftovers from a
-	// prior policy (e.g. a standby ZSK from the previous algorithm). They never
-	// signed the zone — only active keys sign — so there are no RRSIGs by them
-	// to orphan; their only footprint is being published in the DNSKEY RRset.
-	// Remove them outright so they drop out of the RRset immediately. Algorithm
-	// uniquely identifies a leftover: a legitimate same-algorithm rollover
-	// pipeline key always matches the policy algorithm, so this never touches
-	// one. (KSK case still respects the rollover-in-progress guard.)
+	retiredAny := false
+
+	// Standby and published keys of a wrong algorithm are normally leftovers
+	// from a prior policy — they never signed, so removing them is safe and
+	// drops them out of the DNSKEY RRset. BUT in relaxed mode an old-alg
+	// standby/published ZSK during a roll is a legitimate FIFO member, not a
+	// leftover: deleting it by algorithm would break the gradual drain. So in
+	// relaxed mode SKIP the algorithm-based deletion for same-role ZSK keys
+	// (the standby total-count cap in maintainStandbyKeys is the relaxed-mode
+	// bloat valve instead). KSK leftovers are still removed (respecting the
+	// rollover-in-progress guard); strict mode is unchanged.
 	for _, state := range []string{DnskeyStateStandby, DnskeyStatePublished} {
 		keys, err := GetDnssecKeysByState(kdb, zd.ZoneName, state)
 		if err != nil {
@@ -357,6 +360,10 @@ func (zd *ZoneData) reconcileActiveKeyAlgorithms(kdb *KeyDB, dak *DnssecKeys) (b
 				want = zd.DnssecPolicy.ZSKAlgorithm
 			}
 			if k.Algorithm == want {
+				continue
+			}
+			if role == "ZSK" && relaxed {
+				// Legitimate old-alg FIFO member during a relaxed roll.
 				continue
 			}
 			if role == "KSK" && rolloverInProgress {

--- a/v2/sign_reconcile_test.go
+++ b/v2/sign_reconcile_test.go
@@ -156,6 +156,58 @@ func TestReconcileActiveZSKWrongAlgStrictRefuses(t *testing.T) {
 	}
 }
 
+// A wrong-algorithm active KSK is REFUSED in BOTH completeness modes — a KSK
+// algorithm rollover is parent-coordinated engine work (not yet built), and the
+// legacy immediate retire would bypass the standby DS gate and bogus the parent
+// chain (the §2 path). The reconcile must error and leave the KSK active.
+func TestReconcileActiveKSKWrongAlgRefuses(t *testing.T) {
+	for _, mode := range []string{CompletenessStrict, CompletenessRelaxed} {
+		t.Run(mode, func(t *testing.T) {
+			withCompleteness(t, mode)
+			kdb := newTestKeyDB(t)
+			zd := &ZoneData{
+				ZoneName: "example.",
+				Options:  map[ZoneOption]bool{OptOnlineSigning: true},
+				DnssecPolicy: &DnssecPolicy{
+					Mode:         DnssecPolicyModeKSKZSK,
+					KSKAlgorithm: dns.ED25519,   // policy wants ED25519 KSK
+					ZSKAlgorithm: dns.RSASHA256, // matching ZSK so only the KSK mismatches
+				},
+				Logger: log.New(os.Stderr, "", 0),
+			}
+
+			// Wrong-alg active KSK (RSASHA256, policy wants ED25519) + matching ZSK.
+			if _, _, err := kdb.GenerateKeypair(zd.ZoneName, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.RSASHA256, "KSK", nil); err != nil {
+				t.Fatalf("generate KSK: %v", err)
+			}
+			if _, _, err := kdb.GenerateKeypair(zd.ZoneName, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.RSASHA256, "ZSK", nil); err != nil {
+				t.Fatalf("generate ZSK: %v", err)
+			}
+
+			dak, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
+			if err != nil {
+				t.Fatalf("GetDnssecKeys: %v", err)
+			}
+			removed, err := zd.reconcileActiveKeyAlgorithms(kdb, dak)
+			if err == nil {
+				t.Fatal("KSK alg mismatch must be refused with an error (both modes)")
+			}
+			if removed {
+				t.Fatal("refusal must not remove/retire any key")
+			}
+
+			// The wrong-alg KSK is STILL active (no synchronous swap).
+			dak2, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
+			if err != nil {
+				t.Fatalf("GetDnssecKeys after refused reconcile: %v", err)
+			}
+			if len(dak2.KSKs) != 1 || dak2.KSKs[0].DnskeyRR.Algorithm != dns.RSASHA256 {
+				t.Fatalf("wrong-alg KSK must remain active after refusal, got %d KSK(s)", len(dak2.KSKs))
+			}
+		})
+	}
+}
+
 // Same-algorithm reconcile is a no-op in both modes (the common case): no
 // mismatch, no error, no key change.
 func TestReconcileActiveKeysSameAlgNoop(t *testing.T) {

--- a/v2/sign_reconcile_test.go
+++ b/v2/sign_reconcile_test.go
@@ -92,10 +92,23 @@ func newTestKeyDB(t *testing.T) *KeyDB {
 	return kdb
 }
 
-func TestReconcileActiveKeyAlgorithms(t *testing.T) {
+// withCompleteness sets the global completeness mode for the duration of a test
+// and restores it on cleanup. The reconcile reads Conf.Internal.Completeness.
+func withCompleteness(t *testing.T, mode string) {
+	t.Helper()
+	prev := Conf.Internal.Completeness
+	Conf.Internal.Completeness = mode
+	t.Cleanup(func() { Conf.Internal.Completeness = prev })
+}
+
+// STRICT mode: a wrong-algorithm active ZSK is REFUSED (strict-mode algorithm
+// rollover is not implemented), not retired. This replaces the old
+// immediate-retire assertion — under the relaxed-mode design the synchronous
+// swap is exactly the unsafe §2 path and is gated off in both modes.
+func TestReconcileActiveZSKWrongAlgStrictRefuses(t *testing.T) {
+	withCompleteness(t, CompletenessStrict)
 	kdb := newTestKeyDB(t)
 
-	// Policy wants KSK=ED25519, ZSK=RSASHA256 (both built-in; no liboqs).
 	zd := &ZoneData{
 		ZoneName: "example.",
 		Options:  map[ZoneOption]bool{OptOnlineSigning: true},
@@ -107,8 +120,7 @@ func TestReconcileActiveKeyAlgorithms(t *testing.T) {
 		Logger: log.New(os.Stderr, "", 0),
 	}
 
-	// Seed an active KSK that matches the policy and an active ZSK that does
-	// NOT (ED25519 instead of RSASHA256) — the wrong-algorithm leftover.
+	// Matching active KSK + wrong-alg active ZSK (ED25519, policy wants RSASHA256).
 	if _, _, err := kdb.GenerateKeypair(zd.ZoneName, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
 		t.Fatalf("generate KSK: %v", err)
 	}
@@ -121,20 +133,17 @@ func TestReconcileActiveKeyAlgorithms(t *testing.T) {
 		t.Fatalf("GetDnssecKeys: %v", err)
 	}
 	retired, err := zd.reconcileActiveKeyAlgorithms(kdb, dak)
-	if err != nil {
-		t.Fatalf("reconcile: %v", err)
+	if err == nil {
+		t.Fatal("strict-mode ZSK alg mismatch should be refused with an error")
 	}
-	if !retired {
-		t.Fatal("reconcile should have retired the wrong-algorithm ZSK")
+	if retired {
+		t.Fatal("refusal must not retire any key")
 	}
 
-	// The matching KSK stays active; the wrong-alg ZSK is gone from active.
+	// The wrong-alg ZSK is STILL active (no synchronous swap happened).
 	dak2, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
 	if err != nil {
-		t.Fatalf("GetDnssecKeys after reconcile: %v", err)
-	}
-	if len(dak2.KSKs) != 1 || dak2.KSKs[0].DnskeyRR.Algorithm != dns.ED25519 {
-		t.Fatalf("active KSKs = %d (want 1 ED25519)", len(dak2.KSKs))
+		t.Fatalf("GetDnssecKeys after refused reconcile: %v", err)
 	}
 	realZSKs := 0
 	for _, z := range dak2.ZSKs {
@@ -142,16 +151,46 @@ func TestReconcileActiveKeyAlgorithms(t *testing.T) {
 			realZSKs++
 		}
 	}
-	if realZSKs != 0 {
-		t.Fatalf("wrong-alg ZSK should have been retired, still %d active real ZSK(s)", realZSKs)
+	if realZSKs != 1 {
+		t.Fatalf("wrong-alg ZSK must remain active after a refusal, got %d real ZSK(s)", realZSKs)
 	}
+}
 
-	// Idempotency: a second reconcile against the now-correct active set
-	// (only the matching KSK active) retires nothing.
-	if again, err := zd.reconcileActiveKeyAlgorithms(kdb, dak2); err != nil {
-		t.Fatalf("reconcile (2nd): %v", err)
-	} else if again {
-		t.Fatal("second reconcile should be a no-op (no thrashing)")
+// Same-algorithm reconcile is a no-op in both modes (the common case): no
+// mismatch, no error, no key change.
+func TestReconcileActiveKeysSameAlgNoop(t *testing.T) {
+	for _, mode := range []string{CompletenessStrict, CompletenessRelaxed} {
+		t.Run(mode, func(t *testing.T) {
+			withCompleteness(t, mode)
+			kdb := newTestKeyDB(t)
+			zd := &ZoneData{
+				ZoneName: "example.",
+				Options:  map[ZoneOption]bool{OptOnlineSigning: true},
+				DnssecPolicy: &DnssecPolicy{
+					Mode:         DnssecPolicyModeKSKZSK,
+					KSKAlgorithm: dns.ED25519,
+					ZSKAlgorithm: dns.RSASHA256,
+				},
+				Logger: log.New(os.Stderr, "", 0),
+			}
+			if _, _, err := kdb.GenerateKeypair(zd.ZoneName, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+				t.Fatalf("generate KSK: %v", err)
+			}
+			if _, _, err := kdb.GenerateKeypair(zd.ZoneName, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.RSASHA256, "ZSK", nil); err != nil {
+				t.Fatalf("generate ZSK: %v", err)
+			}
+			dak, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
+			if err != nil {
+				t.Fatalf("GetDnssecKeys: %v", err)
+			}
+			changed, err := zd.reconcileActiveKeyAlgorithms(kdb, dak)
+			if err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+			if changed {
+				t.Fatal("same-alg reconcile should be a no-op")
+			}
+		})
 	}
 }
 
@@ -159,6 +198,11 @@ func TestReconcileActiveKeyAlgorithms(t *testing.T) {
 // removed by the reconcile too — otherwise they keep appearing in the DNSKEY
 // RRset. They never signed, so removal is safe (no orphan RRSIGs).
 func TestReconcileRemovesNonActiveWrongAlgKeys(t *testing.T) {
+	// STRICT mode: the algorithm-based standby/published deletion is the strict
+	// shape (relaxed skips it for same-role ZSK keys — see the relaxed-mode
+	// tests). The active keys here all match the policy, so the active loops
+	// pass and only the sweep acts.
+	withCompleteness(t, CompletenessStrict)
 	kdb := newTestKeyDB(t)
 	zd := &ZoneData{
 		ZoneName: "example.",

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -716,7 +717,11 @@ type KeyDB struct {
 	Ctx                 string
 	UpdateQ             chan UpdateRequest
 	KeyBootstrapperQ    chan KeyBootstrapperRequest
-	Options             map[AuthOption]string
+	// options holds the parsed DnsEngine auth options. It is read on the hot
+	// query path (QueryResponder, per request) and replaced wholesale on config
+	// reload, so it is stored behind an atomic.Pointer for lock-free reads and a
+	// race-free swap. Access via AuthOption()/SetOptions(), never directly.
+	options atomic.Pointer[map[AuthOption]string]
 	// OutboundSoaSerial is the resolved mode for outbound SOA serials:
 	// OutboundSoaSerialKeep / OutboundSoaSerialUnixtime / OutboundSoaSerialPersist.
 	// Sourced from DnsEngineConf.OutboundSoaSerial at parse, defaulted to
@@ -728,6 +733,26 @@ type KeyDB struct {
 // tdns-mp and can no longer access the unexported kdb.mu.
 func (kdb *KeyDB) Lock()   { kdb.mu.Lock() }
 func (kdb *KeyDB) Unlock() { kdb.mu.Unlock() }
+
+// SetOptions replaces the auth-option map atomically (config reload). A nil map
+// is normalized to an empty one so readers never observe a nil dereference.
+func (kdb *KeyDB) SetOptions(opts map[AuthOption]string) {
+	if opts == nil {
+		opts = map[AuthOption]string{}
+	}
+	kdb.options.Store(&opts)
+}
+
+// AuthOption returns the value for an auth option and whether it is set, reading
+// the current option map without a lock.
+func (kdb *KeyDB) AuthOption(key AuthOption) (string, bool) {
+	m := kdb.options.Load()
+	if m == nil {
+		return "", false
+	}
+	v, ok := (*m)[key]
+	return v, ok
+}
 
 type Tx struct {
 	*sql.Tx

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -734,13 +734,17 @@ type KeyDB struct {
 func (kdb *KeyDB) Lock()   { kdb.mu.Lock() }
 func (kdb *KeyDB) Unlock() { kdb.mu.Unlock() }
 
-// SetOptions replaces the auth-option map atomically (config reload). A nil map
-// is normalized to an empty one so readers never observe a nil dereference.
+// SetOptions replaces the auth-option map atomically (config reload). It stores
+// a private COPY of opts, not the caller's map, so the stored map can never be
+// mutated out from under a concurrent lock-free reader even if the caller later
+// changes its own map. A nil map yields an empty one so readers never observe a
+// nil dereference.
 func (kdb *KeyDB) SetOptions(opts map[AuthOption]string) {
-	if opts == nil {
-		opts = map[AuthOption]string{}
+	cp := make(map[AuthOption]string, len(opts))
+	for k, v := range opts {
+		cp[k] = v
 	}
-	kdb.options.Store(&opts)
+	kdb.options.Store(&cp)
 }
 
 // AuthOption returns the value for an auth option and whether it is set, reading

--- a/v2/zsk_alg_rollover_test.go
+++ b/v2/zsk_alg_rollover_test.go
@@ -680,3 +680,71 @@ func TestT8NoMaintainedDoubleSignature(t *testing.T) {
 		t.Fatal("retired old-alg ZSK must stay retired (no maintained double-signature)")
 	}
 }
+
+// ComputeZskRolloverWhen: with a standby present the schedule is "ready" with
+// next = active_at + ZSK.Lifetime and earliest = now; with no standby it is
+// "waiting-for-standby" with no earliest. Role is always "ZSK".
+func TestComputeZskRolloverWhen(t *testing.T) {
+	pol := &DnssecPolicy{Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.ED25519}
+	pol.ZSK.Lifetime = uint32((15 * time.Minute).Seconds())
+	now := time.Now()
+
+	// With standby: ready.
+	kdb := newTestKeyDB(t)
+	active := genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	if _, err := kdb.DB.Exec(`UPDATE DnssecKeyStore SET active_at=? WHERE zonename=? AND keyid=?`,
+		now.Add(-10*time.Minute).UTC().Format(time.RFC3339), algZone, int(active)); err != nil {
+		t.Fatalf("stamp active_at: %v", err)
+	}
+	standby := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	r, err := ComputeZskRolloverWhen(kdb, algZone, pol, now)
+	if err != nil {
+		t.Fatalf("ComputeZskRolloverWhen: %v", err)
+	}
+	if r.Role != "ZSK" {
+		t.Fatalf("role = %q, want ZSK", r.Role)
+	}
+	if r.Status != "ready" {
+		t.Fatalf("status = %q, want ready", r.Status)
+	}
+	if r.FromKeyID != active || r.ToKeyID != standby {
+		t.Fatalf("from/to = %d/%d, want %d/%d", r.FromKeyID, r.ToKeyID, active, standby)
+	}
+	if r.NextScheduled == "" || r.EarliestPossible == "" {
+		t.Fatalf("ready schedule must have next + earliest: %+v", r)
+	}
+	// next scheduled = active_at + lifetime = now - 10m + 15m = now + 5m.
+	wantNext := now.Add(-10 * time.Minute).Add(15 * time.Minute).UTC().Format(time.RFC3339)
+	if r.NextScheduled != wantNext {
+		t.Fatalf("next scheduled = %q, want %q (active_at + lifetime)", r.NextScheduled, wantNext)
+	}
+
+	// No standby: waiting-for-standby, no earliest.
+	kdb2 := newTestKeyDB(t)
+	a2 := genZSK(t, kdb2, DnskeyStateActive, dns.ED25519)
+	if _, err := kdb2.DB.Exec(`UPDATE DnssecKeyStore SET active_at=? WHERE zonename=? AND keyid=?`,
+		now.Add(-10*time.Minute).UTC().Format(time.RFC3339), algZone, int(a2)); err != nil {
+		t.Fatalf("stamp active_at: %v", err)
+	}
+	r2, err := ComputeZskRolloverWhen(kdb2, algZone, pol, now)
+	if err != nil {
+		t.Fatalf("ComputeZskRolloverWhen (no standby): %v", err)
+	}
+	if r2.Status != "waiting-for-standby" || r2.EarliestPossible != "" {
+		t.Fatalf("no-standby: status=%q earliest=%q, want waiting-for-standby / empty", r2.Status, r2.EarliestPossible)
+	}
+
+	// A pending manual asap in the future pushes earliest out to that time.
+	future := now.Add(30 * time.Minute)
+	if err := SetZskManualRolloverRequest(kdb, algZone, now, future); err != nil {
+		t.Fatalf("SetZskManualRolloverRequest: %v", err)
+	}
+	r3, err := ComputeZskRolloverWhen(kdb, algZone, pol, now)
+	if err != nil {
+		t.Fatalf("ComputeZskRolloverWhen (manual): %v", err)
+	}
+	wantEarliest := future.UTC().Format(time.RFC3339)
+	if r3.EarliestPossible != wantEarliest {
+		t.Fatalf("manual earliest = %q, want %q", r3.EarliestPossible, wantEarliest)
+	}
+}

--- a/v2/zsk_alg_rollover_test.go
+++ b/v2/zsk_alg_rollover_test.go
@@ -1,0 +1,625 @@
+package tdns
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Step 2 (relaxed-mode ZSK algorithm rollover) test matrix, §8.4:
+// T1, T2, T2b, T2c, T2d, T-timing, T3, T3b, T4, T4b, T4c, T5, T6, T7, T8, T9.
+// Driven against a real on-disk KeyDB via newTestKeyDB (sign_reconcile_test.go)
+// and the package-global Conf (withCompleteness sets the mode per test).
+
+const algZone = "zsk-alg.example."
+
+// algTestZone builds a minimal signing ZoneData with a bound KSK-ZSK policy.
+func algTestZone(ksk, zsk uint8) *ZoneData {
+	return &ZoneData{
+		ZoneName: algZone,
+		Options:  map[ZoneOption]bool{OptOnlineSigning: true},
+		DnssecPolicy: &DnssecPolicy{
+			Mode:         DnssecPolicyModeKSKZSK,
+			KSKAlgorithm: ksk,
+			ZSKAlgorithm: zsk,
+		},
+		DnssecPolicyName: "base",
+		Logger:           log.New(os.Stderr, "", 0),
+	}
+}
+
+// stampPublishedAt sets published_at on a standby ZSK so FIFO ordering is
+// deterministic (GenerateKeypair directly into standby does not set it).
+func stampPublishedAt(t *testing.T, kdb *KeyDB, keyid uint16, at time.Time) {
+	t.Helper()
+	if _, err := kdb.DB.Exec(`UPDATE DnssecKeyStore SET published_at=? WHERE zonename=? AND keyid=?`,
+		at.UTC().Format(time.RFC3339), algZone, int(keyid)); err != nil {
+		t.Fatalf("stamp published_at on %d: %v", keyid, err)
+	}
+}
+
+func genZSK(t *testing.T, kdb *KeyDB, state string, alg uint8) uint16 {
+	t.Helper()
+	pkc, _, err := kdb.GenerateKeypair(algZone, "test", state, dns.TypeDNSKEY, alg, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("generate ZSK (%s, %s): %v", state, dns.AlgorithmToString[alg], err)
+	}
+	return pkc.KeyId
+}
+
+func countStandbyZSKs(t *testing.T, kdb *KeyDB) int {
+	t.Helper()
+	keys, err := GetDnssecKeysByState(kdb, algZone, DnskeyStateStandby)
+	if err != nil {
+		t.Fatalf("list standby: %v", err)
+	}
+	n := 0
+	for _, k := range keys {
+		if k.Flags == 256 {
+			n++
+		}
+	}
+	return n
+}
+
+func countPublishedZSKs(t *testing.T, kdb *KeyDB) int {
+	t.Helper()
+	keys, err := GetDnssecKeysByState(kdb, algZone, DnskeyStatePublished)
+	if err != nil {
+		t.Fatalf("list published: %v", err)
+	}
+	n := 0
+	for _, k := range keys {
+		if k.Flags == 256 {
+			n++
+		}
+	}
+	return n
+}
+
+// T1 — relaxed-mode reconcile with active ZSK alg ≠ policy alg does NOT retire
+// the active ZSK (the §2 unsafe synchronous swap is gated off).
+func TestT1RelaxedReconcileDoesNotRetireActiveZSK(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.RSASHA256) // policy ZSK = RSASHA256
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK: %v", err)
+	}
+	// Active ZSK is ED25519 — wrong alg vs policy RSASHA256.
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+
+	dak, err := kdb.GetDnssecKeys(algZone, DnskeyStateActive)
+	if err != nil {
+		t.Fatalf("GetDnssecKeys: %v", err)
+	}
+	changed, err := zd.reconcileActiveKeyAlgorithms(kdb, dak)
+	if err != nil {
+		t.Fatalf("relaxed reconcile must not error: %v", err)
+	}
+	if changed {
+		t.Fatal("relaxed reconcile must not retire the wrong-alg active ZSK")
+	}
+	// The old-alg ZSK is still active.
+	active, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateActive)
+	found := false
+	for _, k := range active {
+		if k.Flags == 256 && k.Algorithm == dns.ED25519 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("old-alg active ZSK should remain active (carried by the FIFO roll)")
+	}
+}
+
+// T9 — reload mid-roll: the relaxed reconcile is invoked again (as a zone reload
+// re-sign would) while the active ZSK is still old-alg; the T1 invariant holds
+// (no retire) across the repeated call.
+func TestT9RelaxedReconcileIdempotentMidRoll(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.RSASHA256)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+
+	for i := 0; i < 3; i++ {
+		dak, _ := kdb.GetDnssecKeys(algZone, DnskeyStateActive)
+		if changed, err := zd.reconcileActiveKeyAlgorithms(kdb, dak); err != nil || changed {
+			t.Fatalf("reload %d: changed=%v err=%v (want no-op)", i, changed, err)
+		}
+	}
+	active, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateActive)
+	realZSKs := 0
+	for _, k := range active {
+		if k.Flags == 256 {
+			realZSKs++
+		}
+	}
+	if realZSKs != 1 {
+		t.Fatalf("active ZSK count after 3 reloads = %d, want 1 (never retired)", realZSKs)
+	}
+}
+
+// T3 — role-only count: standby_zsk_count=2, two OLD-alg standbys present, policy
+// ZSK alg changed to NEW. The maintainer generates NOTHING (role-only count sees
+// 2 ≥ 2), and the two old-alg standbys are untouched.
+func TestT3RoleOnlyCountGeneratesNothing(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	// policy ZSK = MAYO would need liboqs; use two built-ins: old=ED25519,
+	// new=RSASHA256. Policy now wants RSASHA256.
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	s1 := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	s2 := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	stampPublishedAt(t, kdb, s1, time.Now().Add(-2*time.Hour))
+	stampPublishedAt(t, kdb, s2, time.Now().Add(-1*time.Hour))
+
+	// New policy ZSK alg = RSASHA256; role-only count of standbys = 2 ≥ 2.
+	maintainStandbyKeysForType(kdb, algZone, dns.RSASHA256, "ZSK", 256, 2, true /*roleOnly*/)
+
+	if n := countStandbyZSKs(t, kdb); n != 2 {
+		t.Fatalf("standby ZSK count = %d, want 2 (nothing generated)", n)
+	}
+	if n := countPublishedZSKs(t, kdb); n != 0 {
+		t.Fatalf("published ZSK count = %d, want 0 (nothing minted)", n)
+	}
+	// Both old-alg standbys still ED25519.
+	keys, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateStandby)
+	for _, k := range keys {
+		if k.Flags == 256 && k.Algorithm != dns.ED25519 {
+			t.Fatalf("standby %d alg %s, want ED25519 (untouched)", k.KeyTag, dns.AlgorithmToString[k.Algorithm])
+		}
+	}
+}
+
+// T3b — generate-on-drain: from T3's state, after one standby is promoted (count
+// drops to 1), the maintainer generates ONE key and it carries the NEW algorithm.
+func TestT3bGenerateOnDrainUsesNewAlg(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	// Only ONE old-alg standby (count dropped to 1 after a promotion).
+	s1 := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	stampPublishedAt(t, kdb, s1, time.Now().Add(-2*time.Hour))
+
+	// Maintainer with new policy alg RSASHA256, standby target 2, role-only.
+	maintainStandbyKeysForType(kdb, algZone, dns.RSASHA256, "ZSK", 256, 2, true)
+
+	// It should have generated exactly one new key, staged to published, NEW alg.
+	pub, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStatePublished)
+	newCount := 0
+	for _, k := range pub {
+		if k.Flags == 256 {
+			newCount++
+			if k.Algorithm != dns.RSASHA256 {
+				t.Fatalf("generated key alg %s, want RSASHA256 (new alg)", dns.AlgorithmToString[k.Algorithm])
+			}
+		}
+	}
+	if newCount != 1 {
+		t.Fatalf("generated %d new keys, want exactly 1", newCount)
+	}
+	// The remaining old-alg standby is untouched.
+	keys, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateStandby)
+	for _, k := range keys {
+		if k.Flags == 256 && k.KeyTag == s1 && k.Algorithm != dns.ED25519 {
+			t.Fatalf("old standby %d changed alg", s1)
+		}
+	}
+}
+
+// T4 — sweep cap: standby_zsk_count=2, THREE standby ZSKs present; the relaxed
+// cap deletes the YOUNGEST one (back to 2), keeps the oldest two regardless of
+// algorithm — never deletes by algorithm. Maintainer + cap agree (no oscillation).
+func TestT4SweepCapDeletesYoungestSurplus(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	// Three standbys: two old-alg (oldest), one new-alg (youngest).
+	old1 := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	old2 := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	young := genZSK(t, kdb, DnskeyStateStandby, dns.RSASHA256)
+	stampPublishedAt(t, kdb, old1, time.Now().Add(-3*time.Hour))
+	stampPublishedAt(t, kdb, old2, time.Now().Add(-2*time.Hour))
+	stampPublishedAt(t, kdb, young, time.Now().Add(-1*time.Hour))
+
+	capStandbyZsksByCount(kdb, algZone, 2)
+
+	if n := countStandbyZSKs(t, kdb); n != 2 {
+		t.Fatalf("standby ZSK count after cap = %d, want 2", n)
+	}
+	keys, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateStandby)
+	gotTags := map[uint16]bool{}
+	for _, k := range keys {
+		if k.Flags == 256 {
+			gotTags[k.KeyTag] = true
+		}
+	}
+	if !gotTags[old1] || !gotTags[old2] {
+		t.Fatalf("cap deleted an OLD standby; survivors=%v want both old (%d,%d)", gotTags, old1, old2)
+	}
+	if gotTags[young] {
+		t.Fatalf("cap kept the YOUNGEST standby %d; should have deleted it", young)
+	}
+
+	// Maintainer + cap agree: with 2 standbys and target 2, role-only maintainer
+	// generates nothing, cap removes nothing — no oscillation.
+	maintainStandbyKeysForType(kdb, algZone, dns.RSASHA256, "ZSK", 256, 2, true)
+	capStandbyZsksByCount(kdb, algZone, 2)
+	if n := countStandbyZSKs(t, kdb); n != 2 {
+		t.Fatalf("after maintainer+cap re-run, standby count = %d, want stable 2", n)
+	}
+	if p := countPublishedZSKs(t, kdb); p != 0 {
+		t.Fatalf("maintainer generated %d keys when count already met (oscillation)", p)
+	}
+}
+
+// T4b — no out-of-order promotion: an OLDER old-alg standby and a YOUNGER new-alg
+// standby both present; a roll promotes the OLD-alg one (FIFO oldest-first).
+func TestT4bNoOutOfOrderPromotion(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil); err != nil {
+		t.Fatalf("generate active ZSK: %v", err)
+	}
+	oldAlg := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	newAlg := genZSK(t, kdb, DnskeyStateStandby, dns.RSASHA256)
+	stampPublishedAt(t, kdb, oldAlg, time.Now().Add(-2*time.Hour)) // older
+	stampPublishedAt(t, kdb, newAlg, time.Now().Add(-1*time.Hour)) // younger
+
+	_, promoted, err := kdb.RolloverKey(algZone, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("RolloverKey: %v", err)
+	}
+	if promoted != oldAlg {
+		t.Fatalf("promoted %d, want the OLDER old-alg standby %d (FIFO)", promoted, oldAlg)
+	}
+}
+
+// T4c — FIFO ordering fix: with multiple same-role standbys created in a known
+// order, RolloverKey promotes the OLDEST published_at deterministically,
+// independent of insertion order. Asserts the ORDER BY published_at fix.
+func TestT4cFifoOrderingByPublishedAt(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil); err != nil {
+		t.Fatalf("generate active ZSK: %v", err)
+	}
+	// Insert in NON-chronological order: a (newest), b (oldest), c (middle).
+	a := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	b := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	c := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	stampPublishedAt(t, kdb, a, time.Now().Add(-1*time.Hour))
+	stampPublishedAt(t, kdb, b, time.Now().Add(-3*time.Hour)) // oldest
+	stampPublishedAt(t, kdb, c, time.Now().Add(-2*time.Hour))
+
+	_, promoted, err := kdb.RolloverKey(algZone, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("RolloverKey: %v", err)
+	}
+	if promoted != b {
+		t.Fatalf("promoted %d, want the oldest-published standby %d", promoted, b)
+	}
+}
+
+// T5 — full sequence via asap (standby_zsk_count=2): change-policy binds new alg;
+// the maintainer generates nothing; successive RolloverKey (asap) promotes the
+// old-alg standbys FIFO; once they drain the maintainer mints new-alg keys; a
+// further promotion activates a new-alg key. No instant with zero ZSK coverage;
+// FIFO preserved; DNSKEY RRset never exceeds active + 2 standby + draining-retired.
+func TestT5FullSequenceViaAsap(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	const oldA, newA = dns.ED25519, dns.RSASHA256
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, oldA, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, oldA)
+	s1 := genZSK(t, kdb, DnskeyStateStandby, oldA)
+	s2 := genZSK(t, kdb, DnskeyStateStandby, oldA)
+	stampPublishedAt(t, kdb, s1, time.Now().Add(-4*time.Hour))
+	stampPublishedAt(t, kdb, s2, time.Now().Add(-3*time.Hour))
+
+	// change-policy bound new alg (simulated by maintainer/promotions using newA).
+	// 1) maintainer: role-only count = 2, generates nothing.
+	maintainStandbyKeysForType(kdb, algZone, newA, "ZSK", 256, 2, true)
+	if countPublishedZSKs(t, kdb) != 0 || countStandbyZSKs(t, kdb) != 2 {
+		t.Fatalf("step1: expected 2 standby, 0 published; got %d/%d", countStandbyZSKs(t, kdb), countPublishedZSKs(t, kdb))
+	}
+
+	// 2) asap → promote s1 (oldest old-alg).
+	_, p1, err := kdb.RolloverKey(algZone, "ZSK", nil)
+	if err != nil || p1 != s1 {
+		t.Fatalf("asap#1 promoted %d (err %v), want s1=%d", p1, err, s1)
+	}
+	// 3) asap → promote s2.
+	_, p2, err := kdb.RolloverKey(algZone, "ZSK", nil)
+	if err != nil || p2 != s2 {
+		t.Fatalf("asap#2 promoted %d (err %v), want s2=%d", p2, err, s2)
+	}
+	// Now 0 standby → maintainer mints 2 new-alg keys (into published).
+	if countStandbyZSKs(t, kdb) != 0 {
+		t.Fatalf("after draining both standbys, standby count = %d, want 0", countStandbyZSKs(t, kdb))
+	}
+	maintainStandbyKeysForType(kdb, algZone, newA, "ZSK", 256, 2, true)
+	// Move the freshly-generated published keys to standby (the worker's
+	// published→standby transition), stamping published_at oldest-first.
+	pub, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStatePublished)
+	var newKeys []uint16
+	for _, k := range pub {
+		if k.Flags == 256 {
+			newKeys = append(newKeys, k.KeyTag)
+		}
+	}
+	if len(newKeys) != 2 {
+		t.Fatalf("maintainer minted %d new keys, want 2", len(newKeys))
+	}
+	for i, kid := range newKeys {
+		if err := UpdateDnssecKeyState(kdb, algZone, kid, DnskeyStateStandby); err != nil {
+			t.Fatalf("publish→standby %d: %v", kid, err)
+		}
+		stampPublishedAt(t, kdb, kid, time.Now().Add(time.Duration(-2+i)*time.Hour))
+		// Confirm new alg.
+		keys, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateStandby)
+		for _, k := range keys {
+			if k.KeyTag == kid && k.Algorithm != newA {
+				t.Fatalf("new key %d alg %s, want new alg", kid, dns.AlgorithmToString[k.Algorithm])
+			}
+		}
+	}
+
+	// 4) asap → promotes a NEW-alg key; zone now signs new alg.
+	_, p3, err := kdb.RolloverKey(algZone, "ZSK", nil)
+	if err != nil {
+		t.Fatalf("asap#3: %v", err)
+	}
+	active, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateActive)
+	var activeZSKAlg uint8
+	for _, k := range active {
+		if k.Flags == 256 {
+			activeZSKAlg = k.Algorithm
+		}
+	}
+	if activeZSKAlg != newA {
+		t.Fatalf("after asap#3 active ZSK alg = %s, want new alg %s (promoted key %d)",
+			dns.AlgorithmToString[activeZSKAlg], dns.AlgorithmToString[newA], p3)
+	}
+
+	// Invariant: at no checked point were there zero active ZSKs.
+	if len(active) == 0 {
+		t.Fatal("zero active ZSKs at end of sequence")
+	}
+}
+
+// ---- change-policy entry-guard tests (T2, T2b, T2c, T2d) ----
+// These exercise the refusal guards, which return BEFORE SignZone, so they need
+// only a bound current policy + a target in Conf.Internal.DnssecPolicies.
+
+func withPolicies(t *testing.T, policies map[string]DnssecPolicy) {
+	t.Helper()
+	prev := Conf.Internal.DnssecPolicies
+	Conf.Internal.DnssecPolicies = policies
+	t.Cleanup(func() { Conf.Internal.DnssecPolicies = prev })
+}
+
+// T2 — STRICT mode ZSK alg change is refused at the entry, no key change.
+func TestT2StrictModeZskAlgChangeRefused(t *testing.T) {
+	withCompleteness(t, CompletenessStrict)
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519) // current ZSK ED25519
+	withPolicies(t, map[string]DnssecPolicy{
+		"target": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
+	})
+	_, err := changeZonePolicy(zd, kdb, "target")
+	if err == nil {
+		t.Fatal("strict-mode ZSK alg change must be refused")
+	}
+	// No override written.
+	if _, ok, _ := GetZonePolicyOverride(kdb, algZone); ok {
+		t.Fatal("strict refusal must not write an override")
+	}
+}
+
+// T2b — KSK-only and CSK alg changes under RELAXED are refused; no key churn.
+func TestT2bKskAndCskAlgChangeRefused(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+
+	// KSK-only change (ZSK same).
+	zd := algTestZone(dns.ED25519, dns.RSASHA256)
+	withPolicies(t, map[string]DnssecPolicy{
+		"kskroll": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.RSASHA256},
+	})
+	if _, err := changeZonePolicy(zd, kdb, "kskroll"); err == nil {
+		t.Fatal("KSK-only alg change must be refused")
+	}
+	if _, ok, _ := GetZonePolicyOverride(kdb, algZone); ok {
+		t.Fatal("KSK refusal must not write an override")
+	}
+
+	// CSK target.
+	zdCsk := algTestZone(dns.ED25519, dns.RSASHA256)
+	withPolicies(t, map[string]DnssecPolicy{
+		"csk": {Mode: DnssecPolicyModeCSK, Algorithm: dns.RSASHA256, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.RSASHA256},
+	})
+	if _, err := changeZonePolicy(zdCsk, kdb, "csk"); err == nil {
+		t.Fatal("CSK alg change must be refused")
+	}
+}
+
+// T2c — both-role target is rejected at entry before any override write.
+func TestT2cBothRoleChangeRejected(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	withPolicies(t, map[string]DnssecPolicy{
+		"both": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.RSASHA256},
+	})
+	_, err := changeZonePolicy(zd, kdb, "both")
+	if err == nil {
+		t.Fatal("both-role alg change must be rejected")
+	}
+	if _, ok, _ := GetZonePolicyOverride(kdb, algZone); ok {
+		t.Fatal("both-role rejection must not write an override")
+	}
+}
+
+// T2d — re-entrancy: a second change-policy while a ZSK alg roll is in flight is
+// refused, covering both the pre-promotion phase and the drain window (D4's
+// blind spot, where the new-alg key is active and an old-alg ZSK is still
+// retired). Asserts the fuller predicate.
+func TestT2dReentrancyRefused(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+
+	t.Run("pre-promotion", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(dns.ED25519, dns.RSASHA256) // bound policy already RSASHA256
+		// Active ZSK is still old-alg (ED25519) → roll in flight pre-promotion.
+		if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+			t.Fatalf("KSK: %v", err)
+		}
+		genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+		withPolicies(t, map[string]DnssecPolicy{
+			"target": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
+		})
+		if _, err := changeZonePolicy(zd, kdb, "target"); err == nil {
+			t.Fatal("re-entrant change-policy (pre-promotion) must be refused")
+		}
+	})
+
+	t.Run("drain-window", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(dns.ED25519, dns.RSASHA256)
+		if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+			t.Fatalf("KSK: %v", err)
+		}
+		// New-alg ZSK already promoted to active; old-alg ZSK still retired
+		// (draining). active alg == policy alg (D4 reads false), but the fuller
+		// predicate sees the retired old-alg key → still in flight.
+		genZSK(t, kdb, DnskeyStateActive, dns.RSASHA256)
+		genZSK(t, kdb, DnskeyStateRetired, dns.ED25519)
+		withPolicies(t, map[string]DnssecPolicy{
+			"target": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
+		})
+		if _, err := changeZonePolicy(zd, kdb, "target"); err == nil {
+			t.Fatal("re-entrant change-policy (drain window) must be refused")
+		}
+	})
+}
+
+// T7 — override≠YAML but active-alg == bound-policy-alg (a COMPLETED prior
+// change) is NOT treated as in progress (D4 / the fuller predicate both read
+// "not rolling"). zskAlgRollInFlight returns false.
+func TestT7CompletedChangeNotInProgress(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.RSASHA256, "ZSK", nil); err != nil {
+		t.Fatalf("active ZSK: %v", err)
+	}
+	// One retired ZSK of the SAME (current) alg — a normal same-alg roll
+	// remnant, not an algorithm transition.
+	genZSK(t, kdb, DnskeyStateRetired, dns.RSASHA256)
+	st, err := zskAlgRollInFlight(kdb, algZone, dns.RSASHA256)
+	if err != nil {
+		t.Fatalf("zskAlgRollInFlight: %v", err)
+	}
+	if st.InFlight {
+		t.Fatalf("completed same-alg state must not read in-flight: %+v", st)
+	}
+}
+
+// T2 (mode) + T-timing — a same-algorithm, timing-only change is allowed: no
+// roll, no error, no in-flight detection. (We assert the predicate is false and
+// the both-role/KSK/CSK/re-entrancy guards do not fire for a same-alg target.)
+func TestTTimingSameAlgNotARoll(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.RSASHA256, "ZSK", nil); err != nil {
+		t.Fatalf("active ZSK: %v", err)
+	}
+	st, err := zskAlgRollInFlight(kdb, algZone, dns.RSASHA256)
+	if err != nil {
+		t.Fatalf("zskAlgRollInFlight: %v", err)
+	}
+	if st.InFlight {
+		t.Fatal("same-alg zone must not read as an in-flight roll")
+	}
+}
+
+// T6 — change-policy writes the override to the TARGET; a simulated restart
+// (re-resolve via EffectiveDnssecPolicyName, given the YAML config base) rebinds
+// to the target, not the old policy. This is the persistence half of
+// change-policy (the override write) verified independently of the heavy
+// SignZone path the success branch also runs.
+func TestT6OverrideResumesToTargetOnRestart(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	const configBase = "old-policy"
+	const target = "new-policy"
+
+	// Before any change-policy: effective == config base.
+	eff, overridden, err := EffectiveDnssecPolicyName(kdb, algZone, configBase)
+	if err != nil {
+		t.Fatalf("EffectiveDnssecPolicyName (pre): %v", err)
+	}
+	if overridden || eff != configBase {
+		t.Fatalf("pre-override: eff=%q overridden=%v, want %q/false", eff, overridden, configBase)
+	}
+
+	// change-policy's durable effect: write the override to the target.
+	if err := SetZonePolicyOverride(kdb, algZone, target); err != nil {
+		t.Fatalf("SetZonePolicyOverride: %v", err)
+	}
+
+	// Simulated restart: re-resolve from the YAML config base. The override wins.
+	eff, overridden, err = EffectiveDnssecPolicyName(kdb, algZone, configBase)
+	if err != nil {
+		t.Fatalf("EffectiveDnssecPolicyName (post): %v", err)
+	}
+	if !overridden || eff != target {
+		t.Fatalf("post-override: eff=%q overridden=%v, want %q/true (resume toward target)", eff, overridden, target)
+	}
+}
+
+// T8 — relaxed roll does not maintain a whole-zone double-signature: the
+// reconcile never re-activates or refreshes the old-alg ZSK once it has been
+// retired; only the new-alg active key signs. We assert at the key-state level
+// that a retired old-alg ZSK is not promoted back to active by the reconcile.
+func TestT8NoMaintainedDoubleSignature(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.RSASHA256)
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.RSASHA256) // new-alg active
+	oldRetired := genZSK(t, kdb, DnskeyStateRetired, dns.ED25519)
+
+	dak, _ := kdb.GetDnssecKeys(algZone, DnskeyStateActive)
+	if changed, err := zd.reconcileActiveKeyAlgorithms(kdb, dak); err != nil || changed {
+		t.Fatalf("reconcile changed=%v err=%v (want no-op; new-alg active matches policy)", changed, err)
+	}
+	// The old-alg key is still retired (not promoted back to active).
+	retired, _ := GetDnssecKeysByState(kdb, algZone, DnskeyStateRetired)
+	stillRetired := false
+	for _, k := range retired {
+		if k.KeyTag == oldRetired {
+			stillRetired = true
+		}
+	}
+	if !stillRetired {
+		t.Fatal("retired old-alg ZSK must stay retired (no maintained double-signature)")
+	}
+}

--- a/v2/zsk_alg_rollover_test.go
+++ b/v2/zsk_alg_rollover_test.go
@@ -3,6 +3,7 @@ package tdns
 import (
 	"log"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -538,6 +539,62 @@ func TestT7CompletedChangeNotInProgress(t *testing.T) {
 	}
 	if st.InFlight {
 		t.Fatalf("completed same-alg state must not read in-flight: %+v", st)
+	}
+}
+
+// Regression: a FRESH zone whose ZSKs are all on its currently-bound algorithm
+// (active + standby + draining retired, all the same alg — the normal starting
+// state before any roll) must NOT read as a roll-in-flight relative to that
+// bound algorithm. The re-entrancy guard measures against the BOUND alg, not the
+// incoming target; checking against a different target would falsely report
+// "already in progress" on the very first change-policy. (Caught on the testbed
+// rolling fastroll ED25519 → mayo1.)
+func TestReentrancyFreshZoneNotInFlight(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	// Mirror a live fastroll zone: active + standby + a draining retired ZSK,
+	// all ED25519 (the bound alg).
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil); err != nil {
+		t.Fatalf("active ZSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	genZSK(t, kdb, DnskeyStateRetired, dns.ED25519)
+
+	// Against the BOUND alg (ED25519): nothing is in flight — the roll has not
+	// started.
+	if st, err := zskAlgRollInFlight(kdb, algZone, dns.ED25519); err != nil {
+		t.Fatalf("zskAlgRollInFlight(bound): %v", err)
+	} else if st.InFlight {
+		t.Fatalf("fresh same-alg zone must not read in-flight vs its bound alg: %+v", st)
+	}
+
+	// Sanity: against a DIFFERENT alg the predicate trivially trips — which is
+	// exactly why the guard must use the bound alg, not the target.
+	if st, err := zskAlgRollInFlight(kdb, algZone, dns.RSASHA256); err != nil {
+		t.Fatalf("zskAlgRollInFlight(target): %v", err)
+	} else if !st.InFlight {
+		t.Fatal("vs a different alg the predicate should trip (guards the bound-vs-target reasoning)")
+	}
+}
+
+// Regression (end-to-end): changeZonePolicy on a fresh same-alg zone must get
+// PAST the re-entrancy guard (it may fail later in SignZone for lack of real
+// zone data, but it must NOT be refused as "already in progress").
+func TestChangePolicyFreshZonePassesReentrancyGuard(t *testing.T) {
+	withCompleteness(t, CompletenessRelaxed)
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519) // bound fastroll-like: ZSK ED25519
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "ZSK", nil); err != nil {
+		t.Fatalf("active ZSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	withPolicies(t, map[string]DnssecPolicy{
+		"mayoish": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
+	})
+	_, err := changeZonePolicy(zd, kdb, "mayoish")
+	// It will likely error in SignZone (no real zone data), but NOT with the
+	// re-entrancy refusal.
+	if err != nil && strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("fresh zone wrongly refused as already-in-progress: %v", err)
 	}
 }
 

--- a/v2/zsk_rollover.go
+++ b/v2/zsk_rollover.go
@@ -250,6 +250,99 @@ func zskAlgRollInFlight(kdb *KeyDB, zone string, targetZSKAlg uint8) (ZskAlgRoll
 	return out, nil
 }
 
+// ComputeZskRolloverWhen answers "when will / could the ZSK roll" — the ZSK
+// analog of ComputeRolloverWhen (KSK). A ZSK roll has NO parent-DS dimension,
+// so there are no propagation gates: the only precondition is that a standby
+// ZSK exists to promote. The schedule is therefore simple:
+//
+//   - next scheduled = active ZSK's active_at + ZSK.Lifetime (the
+//     lifetime-driven cadence). Absent when ZSK.Lifetime == 0 (never) or no
+//     active ZSK / no active_at.
+//   - earliest possible = now when a standby ZSK is ready (a roll can fire on
+//     the next tick), or the pending manual-asap earliest if later. When no
+//     standby exists the roll is blocked until one reaches standby — reported
+//     via Status="waiting-for-standby" with no Earliest.
+//
+// Soft conditions are surfaced via Note (200-style), mirroring the KSK path.
+func ComputeZskRolloverWhen(kdb *KeyDB, zone string, pol *DnssecPolicy, now time.Time) (*RolloverWhenResponse, error) {
+	zone = dns.Fqdn(strings.TrimSpace(zone))
+	if zone == "." || zone == "" {
+		return nil, fmt.Errorf("ComputeZskRolloverWhen: empty zone")
+	}
+	out := &RolloverWhenResponse{
+		Zone:        zone,
+		Role:        "ZSK",
+		CurrentTime: now.UTC().Format(time.RFC3339),
+	}
+	if pol == nil {
+		out.Note = "zone has no DNSSEC policy"
+		return out, nil
+	}
+	if pol.Mode != DnssecPolicyModeKSKZSK {
+		out.Note = "zone is not in ksk-zsk mode; no separate ZSK rollover"
+		return out, nil
+	}
+
+	activeKeys, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
+	if err != nil {
+		return nil, fmt.Errorf("ComputeZskRolloverWhen: list active keys: %w", err)
+	}
+	var activeZSK *DnssecKeyWithTimestamps
+	for i := range activeKeys {
+		if activeKeys[i].Flags == 256 {
+			activeZSK = &activeKeys[i]
+			break
+		}
+	}
+	if activeZSK == nil {
+		out.Note = "no active ZSK"
+		return out, nil
+	}
+	out.FromKeyID = activeZSK.KeyTag
+
+	// Standby readiness: a ZSK roll cannot fire without one to promote.
+	standbyKeys, err := GetDnssecKeysByState(kdb, zone, DnskeyStateStandby)
+	if err != nil {
+		return nil, fmt.Errorf("ComputeZskRolloverWhen: list standby keys: %w", err)
+	}
+	var standbyZSK *DnssecKeyWithTimestamps
+	for i := range standbyKeys {
+		if standbyKeys[i].Flags == 256 {
+			// GetDnssecKeysByState is ordered published_at ASC, so the first
+			// is the oldest — the FIFO next-to-promote.
+			standbyZSK = &standbyKeys[i]
+			break
+		}
+	}
+	if standbyZSK != nil {
+		out.ToKeyID = standbyZSK.KeyTag
+	}
+
+	// Next scheduled = active_at + ZSK.Lifetime.
+	if pol.ZSK.Lifetime > 0 && activeZSK.ActiveAt != nil {
+		out.NextScheduled = activeZSK.ActiveAt.Add(time.Duration(pol.ZSK.Lifetime) * time.Second).UTC().Format(time.RFC3339)
+	} else if pol.ZSK.Lifetime == 0 {
+		out.Note = "ZSK.Lifetime is 0 (no scheduled ZSK rollover); roll manually with \"asap --zsk\""
+	}
+
+	// Earliest possible. No parent gates — bounded only by standby readiness
+	// and any pending manual-asap earliest.
+	if standbyZSK == nil {
+		out.Status = "waiting-for-standby"
+		out.Note = "no standby ZSK available; a roll waits until one reaches standby"
+		return out, nil
+	}
+	out.Status = "ready"
+	earliest := now
+	if m, err := LoadZskManualRollover(kdb, zone); err == nil && m.Earliest != "" {
+		if t, perr := time.Parse(time.RFC3339, m.Earliest); perr == nil && t.After(earliest) {
+			earliest = t
+		}
+	}
+	out.EarliestPossible = earliest.UTC().Format(time.RFC3339)
+	return out, nil
+}
+
 // zskRemovalMargin is the hold time before a retired ZSK may be removed:
 // propagationDelay + max observed signing TTL (sum, not max).
 func zskRemovalMargin(propagationDelay time.Duration, maxObservedTTL uint32) time.Duration {

--- a/v2/zsk_rollover.go
+++ b/v2/zsk_rollover.go
@@ -198,6 +198,58 @@ func LoadZskManualRollover(kdb *KeyDB, zone string) (ZskManualRollover, error) {
 	return out, nil
 }
 
+// ZskAlgRollState describes an in-flight relaxed-mode ZSK algorithm rollover.
+// FromAlg is an old algorithm still present in the pipeline; ToAlg is the
+// target (effective-policy) ZSK algorithm. Done/Total give a coarse progress
+// count for the operator (promotions of target-alg keys / total live ZSK
+// pipeline members of any algorithm).
+type ZskAlgRollState struct {
+	InFlight bool
+	FromAlg  uint8
+	ToAlg    uint8
+	Done     int
+	Total    int
+}
+
+// zskAlgRollInFlight reports whether a ZSK algorithm rollover toward targetZSKAlg
+// is in flight for a zone, using the FULLER drain-window predicate (the spec's
+// re-entrancy / status notion of "in progress", §8.3): a ZSK of an algorithm
+// other than targetZSKAlg present in any of standby / active / retired. This is
+// stricter than "active ZSK alg ≠ policy alg" (D4) — it stays true through the
+// drain window, after the new-alg key has been promoted to active while an
+// old-alg ZSK is still retired/draining. Both the change-policy re-entrancy
+// guard and the status display derive "in flight" from this one function.
+func zskAlgRollInFlight(kdb *KeyDB, zone string, targetZSKAlg uint8) (ZskAlgRollState, error) {
+	zone = dns.Fqdn(zone)
+	var out ZskAlgRollState
+	var fromAlg uint8
+	for _, state := range []string{DnskeyStateStandby, DnskeyStateActive, DnskeyStateRetired} {
+		keys, err := GetDnssecKeysByState(kdb, zone, state)
+		if err != nil {
+			return out, fmt.Errorf("zskAlgRollInFlight: list %s keys for zone %s: %w", state, zone, err)
+		}
+		for _, k := range keys {
+			if k.Flags != 256 {
+				continue
+			}
+			out.Total++
+			if k.Algorithm == targetZSKAlg {
+				out.Done++
+			} else {
+				out.InFlight = true
+				if fromAlg == 0 {
+					fromAlg = k.Algorithm
+				}
+			}
+		}
+	}
+	if out.InFlight {
+		out.FromAlg = fromAlg
+		out.ToAlg = targetZSKAlg
+	}
+	return out, nil
+}
+
 // zskRemovalMargin is the hold time before a retired ZSK may be removed:
 // propagationDelay + max observed signing TTL (sum, not max).
 func zskRemovalMargin(propagationDelay time.Duration, maxObservedTTL uint32) time.Duration {

--- a/v2/zsk_rollover.go
+++ b/v2/zsk_rollover.go
@@ -334,8 +334,17 @@ func ComputeZskRolloverWhen(kdb *KeyDB, zone string, pol *DnssecPolicy, now time
 	}
 	out.Status = "ready"
 	earliest := now
-	if m, err := LoadZskManualRollover(kdb, zone); err == nil && m.Earliest != "" {
-		if t, perr := time.Parse(time.RFC3339, m.Earliest); perr == nil && t.After(earliest) {
+	// A pending manual asap with a future earliest pushes the soonest roll out
+	// to that time. A DB / parse failure here falls back to `earliest = now`
+	// (safe: the worker re-evaluates the manual request before it actually
+	// rolls — this is an observational read, so we log and continue rather than
+	// fail the whole "when" response).
+	if m, err := LoadZskManualRollover(kdb, zone); err != nil {
+		lgSigner.Warn("ComputeZskRolloverWhen: LoadZskManualRollover failed; ignoring manual earliest", "zone", zone, "err", err)
+	} else if m.Earliest != "" {
+		if t, perr := time.Parse(time.RFC3339, m.Earliest); perr != nil {
+			lgSigner.Warn("ComputeZskRolloverWhen: invalid manual_rollover_earliest; ignoring", "zone", zone, "value", m.Earliest, "err", perr)
+		} else if t.After(earliest) {
 			earliest = t
 		}
 	}


### PR DESCRIPTION
## Summary

Implements **step 2** of the DNSSEC algorithm-rollover plan
(`tdns/docs/2026-06-17-algorithm-rollover-evaluation.md` §8.3): a
**relaxed-mode ZSK algorithm rollover** that rides the existing FIFO key
pipeline. `change-policy` binds the new algorithm to future-generated keys,
the old-alg keys drain in FIFO order, and `asap --zsk` is the throttle — no
new key state, no maintained double-signature, no out-of-order promotion.

Builds on steps 0 + 1 (already merged: ZSK manual trigger / `asap` / `cancel`,
the `dnssec.completeness` knob). Testbed-validated on `cpt.p.axfr.net`
(fastroll ED25519 → mayo1 → snova24_5_4).

## Core (§8.3)

- **FIFO fix (pre-existing latent bug):** `GetDnssecKeysByState` now
  `ORDER BY published_at ASC, keyid ASC`. ZSK standby promotion was
  effectively arbitrary (unordered query); now it is FIFO by propagation age.
  Required for a correct gradual roll. All callers consume the result as a set.
- **Mode-aware `reconcileActiveKeyAlgorithms`:** KSK mismatch (either mode) →
  REFUSE; ZSK mismatch + strict → REFUSE; ZSK mismatch + relaxed → no-op (the
  FIFO carries it). The algorithm-based standby/published deletion is skipped
  for same-role ZSK keys in relaxed mode. Refusals are errors so a background
  re-sign can never run the unsafe synchronous swap (entry front door +
  reconcile backstop).
- **Role-only counting + cap (relaxed):** the ZSK standby maintainer counts by
  role only (`countKeysForMaintain`), and `capStandbyZsksByCount` deletes the
  youngest surplus standby ZSK by `published_at` — sharing one role-total count
  so generate and cap never oscillate. Strict mode keeps today's per-alg shape.
- **`change-policy` entry layer + guards:** new `change-policy` zone command +
  `auto-rollover policy-change -z -p` CLI. Reuses set-policy's override-write +
  rebind + SignZone path (the relaxed reconcile no-ops the swap). Entry guards,
  validated **before** any override write: CSK, both-role, KSK-only,
  strict-mode ZSK, and **re-entrancy** via the fuller drain-window predicate
  `zskAlgRollInFlight` (measured against the zone's currently-bound ZSK alg).
- **Status:** `RolloverStatus.AlgTransition` + a zone-global header line
  (`Algorithm rollover: ZSK X -> Y (in progress), N of M published ZSKs on new
  algorithm`), shared with the re-entrancy predicate.

### Refusals (out of scope, but safely gated — not left to run unsafely)

KSK alg roll, CSK alg change, strict-mode ZSK alg roll, and both-role targets
are all refused with a clear "not implemented" error and zero key churn.

## Status-display polish (from testbed review)

- Policy + alg-rollover hoisted to a **zone-global header** above both KSK and
  ZSK sections (visible under `--ksk`/`--zsk`, not just the KSK block).
- Verbose `policy:` detail moved up, laid out compactly in columns
  (KSK | ZSK | rollover | clamping), both per-role algorithms shown, redundant
  `name`/`policy:` label dropped, label/value split so values align.

## ZSK `auto-rollover when` (was KSK-only)

`when` reported the KSK schedule unconditionally — `--zsk` was ignored and even
headed "KSK rollover schedule". Added `ComputeZskRolloverWhen` (next = active_at
+ ZSK.Lifetime; earliest = now when a standby is ready, or manual-asap; else
`waiting-for-standby`). A ZSK roll has no parent-DS gates, so the gates section
is omitted. `GET /rollover/when?keytype=ZSK` dispatches; the renderer is
role-aware.

## Config-reload fix (testbed-found, separate bug)

Config reload re-parsed `DnsEngine` options into `conf.DnsEngine.Options` but
never refreshed the long-lived `KeyDB` (built once at startup, reused across
reloads). The query responder reads `kdb.Options`, so a reloaded auth option
(e.g. `minimal-responses`) updated only the presentation (`config status`
showed it) while the running server kept the stale startup map — taking effect
only after a full restart. The reload branch now reassigns
`conf.Internal.KeyDB.Options` from the freshly-parsed config.

## Tests

`zsk_alg_rollover_test.go` + a split of `sign_reconcile_test.go`:
T1, T2, T2b, T2c, T2d (pre-promotion + drain-window), T-timing, T3, T3b, T4,
T4b, T4c, T5, T6, T7, T8, T9, plus `TestComputeZskRolloverWhen` and a
re-entrancy regression. `go test ./... -race` green except the two pre-existing,
unrelated `TestGlobalStuffValidate*` failures (BaseUri/URL on clean main). Full
`make` builds all binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ZSK algorithm rollover support, including role-aware `/rollover/when` responses and status “in-flight” algorithm transition details.
  * Introduced `auto-rollover policy-change` to switch DNSSEC policies for gradual ZSK rollover.
* **Improvements**
  * Updated CLI scheduling/output with ZSK/KSK filters and clearer “asap” hints.
  * Enhanced relaxed-mode ZSK maintenance and standby capping behavior.
* **Bug Fixes**
  * Made rollover calculations more deterministic and improved reconciliation behavior for active algorithm mismatches.
  * Improved config reload so refreshed KeyDB options take effect; updated API error handling to return a successful response with an explanatory note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->