### PR TITLE
fix: GlobalStuff.Validate rejects a BaseUri without scheme/host

### DIFF
--- a/v2/global.go
+++ b/v2/global.go
@@ -62,7 +62,11 @@ func (gs *GlobalStuff) Validate() error {
 		}
 	}
 	if gs.BaseUri != "" {
-		if _, err := url.Parse(gs.BaseUri); err != nil {
+		// url.Parse alone is too lax: "not a uri" parses without error as a
+		// relative reference. A usable base URI for an API endpoint needs both
+		// a scheme and a host, so require them explicitly.
+		u, err := url.Parse(gs.BaseUri)
+		if err != nil || u.Scheme == "" || u.Host == "" {
 			return fmt.Errorf("invalid base URI: %s", gs.BaseUri)
 		}
 	}


### PR DESCRIPTION
## Summary

`GlobalStuff.Validate()` checked `BaseUri` only via `url.Parse(...) != nil`,
but `url.Parse` does not error on a malformed value like `"not a uri"` — it
parses as a relative reference — so the check never rejected anything. A
usable base URI for an API endpoint needs both a scheme and a host; require
them explicitly.

This was the intended contract all along: the test's own expectation already
spelled it out (`parseErr == nil && parsed.Scheme != "" && parsed.Host != ""`).
So this is a code bug, not a test bug.

## Result

Fixes the two long-standing v2 test failures that have been "ignore these two
only" throughout the recent DNSSEC work:
- `TestGlobalStuffValidate/InvalidBaseUri`
- `TestGlobalStuffValidateUsesURLParse/not_a_uri`

The full `tdns/v2` suite is now green under `-race`. All previously-valid
BaseUri cases (`http://example.com`, `https://example.com:8080/path`,
`http://[2001:db8::1]:8080`, empty) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base URI validation to require fully-qualified URLs with both scheme and host components. Previously, incomplete or relative URI formats could be accepted; they are now properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->