### PR TITLE
agent: DSYNC proxy for a DSYNC-unaware primary (NOTIFY-only)

### DIFF
--- a/cmd/agent/agent-zones.yaml
+++ b/cmd/agent/agent-zones.yaml
@@ -11,6 +11,22 @@ templates:
      dnssecpolicy:    none
      multisigner:     mstest
 
+   # delegation-sync-proxy: run tdns-agent as a SECONDARY for a zone whose
+   # PRIMARY is DSYNC-unaware (BIND9, Knot, NSD). The agent inspects each
+   # incoming transfer for changes to the zone's CDS / CSYNC / NS+glue / DNSKEY
+   # and forwards NOTIFY(CDS) / NOTIFY(CSYNC) to the parent's advertised DSYNC
+   # NOTIFY receiver on the primary's behalf. The primary stays unchanged.
+   #
+   # Requirements: the PARENT advertises a DSYNC RRset with a NOTIFY scheme for
+   # CDS/CSYNC (NOTIFY-only for now; an UPDATE-only parent is a no-op). The
+   # PRIMARY publishes CDS/CDNSKEY and/or CSYNC when it wants the parent updated
+   # (its own tooling). Valid ONLY on an agent secondary zone; no SIG(0) key is
+   # needed (a NOTIFY carries no payload the agent must sign).
+   - name:            dsync-proxy
+     store:           map
+     type:            secondary
+     options:         [ delegation-sync-proxy ]
+
 zones:
    - name:            test.net
      zonefile:        /etc/tdns/zones/test.net
@@ -21,6 +37,14 @@ zones:
      zonefile:        /etc/tdns/zones/johani.org
      options:	      [ online-signing ]
      template:        secondary
+
+   # Example: proxy delegation-sync for a zone served by a DSYNC-unaware
+   # primary. The agent transfers child.example. from that primary (here a
+   # BIND/Knot at 192.0.2.10:53) and forwards NOTIFY(CDS/CSYNC) to the parent
+   # whenever the primary changes the zone's CDS/CSYNC/NS/glue/DNSKEY.
+   - name:            child.example.
+     primary:         192.0.2.10:53
+     template:        dsync-proxy
 
    # Commented zones kept for reference
    # child.test.net:

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -620,10 +620,24 @@ each transfer):
      proxy for this zone; keep serving the zone normally.
    - **No KEY present**: GENERATE a SIG(0) keypair (reuse the keystore
      `Sig0KeyMgmt` generate path), store it under the child zone name, and
-     INSTRUCT the operator with the exact KEY record to add at the primary.
-     WARN status on `zone list`: "DSYNC UPDATE proxy waiting: publish this
-     KEY at the primary." HOLD OFF on UPDATEs until the KEY appears in a
-     transfer (sending before then just earns a REFUSED).
+     INSTRUCT the operator to add TWO records at the primary apex (U10):
+     the agent's **KEY RR**, AND an **HSYNCPARAM `pubkey`** flag. WARN
+     status on `zone list`: "DSYNC UPDATE proxy waiting: publish the KEY +
+     HSYNCPARAM pubkey at the primary." HOLD OFF on UPDATEs until the KEY
+     appears in a transfer (sending before then just earns a REFUSED).
+
+DECISION U10 — the no-KEY operator instruction is TWO records, not one, and
+is emitted ONLY when the parent advertises DSYNC UPDATE (step 1 gate):
+  1. the **KEY RR** — the agent's SIG(0) public key at the child apex (the
+     record the parent's path-3 validation resolves);
+  2. an **HSYNCPARAM record with the `pubkey` flag** — the standardized
+     instruction to ALL zone providers to (re-)publish the KEY found at the
+     apex. `HSYNCPARAM_PUBKEY` is a real flag (key code 4, `core/
+     rr_hsyncparam.go:45`; `HasPubkey()` at `:387`). Without it the KEY
+     sits only in the one primary's copy; with it every provider in the
+     zone's HSYNC set republishes it, so the bootstrap works in the
+     multi-provider world too — not just a single primary. (Sibling flag
+     `HSYNCPARAM_PUBCDS` does the analogous job for CDS.)
 
 DECISION U8 — error severity: NONE of the above hard-fails. The agent
 starts; all zones, including this one, are served normally as a secondary.
@@ -634,11 +648,14 @@ per-zone status on `tdns-cli zone list` (reuse the existing
 quarantine model: the UPDATE-proxy FUNCTION is degraded, not the zone.
 
 DECISION U9 — operator instruction surfacing (BOTH): (a) on generation, log
-the ready-to-paste KEY record at Warn AND record it in the per-zone status
-so it persists (and re-emit while still missing); (b) a CLI command (e.g.
-`... keystore dnssec proxy-key -z <zone>`) that prints, on demand, the
-exact KEY record to publish plus the current state (update-unsupported /
-ready / foreign / waiting).
+the ready-to-paste records (KEY RR + HSYNCPARAM pubkey, U10) at Warn AND
+record them in the per-zone status so they persist (and re-emit while still
+missing); (b) a CLI command (e.g. `... keystore dnssec proxy-key -z
+<zone>`) that prints, on demand, the exact KEY RR + HSYNCPARAM pubkey to
+publish plus the current state (update-unsupported / ready / foreign /
+waiting). The CLI emits the records ONLY in the waiting state (parent
+supports UPDATE, no KEY yet); in the update-unsupported state it says so
+and emits nothing to publish.
 
 Reuse map: `DelegationSyncSetup` / `Sig0KeyPreparation`
 (`delegation_sync.go:192,265`) are the child-side precedent — they

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -345,17 +345,25 @@ primary once it builds).
   DSYNC-discovery half of `ProxyNotifyParent` needs the network and is
   left for testbed validation. Build + full `go test -race` green.
 
-- **Step P-4 — loop/debounce (D8) + tests + operator doc.** Confirm Q5
-  (IXFR reads the post-flip served zone, so AXFR/IXFR behave identically)
-  and settle Q6 (a "last-proxied content/serial" guard so a parent that is
-  slow to absorb does not get re-NOTIFYd every refresh — though the
-  content-diff trigger already suppresses the common case). Full test
-  matrix: CDS-only, CSYNC-only, both, DNSKEY-only→NOTIFY(CDS),
-  NS/glue-only→NOTIFY(CSYNC), delete-DS CDS (must NOTIFY like any CDS
-  change), no-change no-op, no-DSYNC-at-parent no-op, AXFR vs IXFR,
-  unsigned zone (no CDS/CSYNC/DNSKEY ⇒ nothing to send, but NOT refused —
-  D5). Operator doc: configuring tdns-agent as a DSYNC proxy secondary for
-  a BIND/Knot primary.
+- **Step P-4 — loop/debounce (D8) + tests + operator doc.** STATUS: DONE.
+  Q6 RESOLVED with NO extra state: the trigger is content-edge-triggered
+  (it diffs the served zone against the incoming one), so a change fires
+  exactly ONCE — on the transfer where the content appears — and a later
+  transfer carrying the SAME already-forwarded content does NOT re-fire,
+  even with a bumped serial. So a slow parent gets no NOTIFY storm and no
+  "last-proxied serial" marker is needed; the self-debounce falls out of
+  P-2's design. Q5 (AXFR vs IXFR) is handled by construction: PreRefresh
+  reads the post-flip served zone, identical for both. Test
+  (`delsync_proxy_p4_test.go`): three sequential refreshes (serial-only
+  bump → CDS change → same-CDS re-transfer) enqueue exactly ONE
+  PROXY-NOTIFY. Operator guide written
+  (`2026-06-22-agent-dsync-proxy-operator-guide.md`). The remaining
+  matrix rows (delete-DS CDS, unsigned-zone, no-DSYNC-target) are covered
+  by earlier unit tests + by construction: delete-DS is just another CDS
+  change (D1, the proxy never reads CDS contents); an unsigned zone has no
+  CDS/CSYNC/DNSKEY so the diff finds nothing (and the option is not
+  refused, D5); a no-NOTIFY-target parent is the logged no-op in
+  `ProxyNotifyParent` (P-3). Build + full `go test -race` green.
 
 - **Step P-5 (LATER, not this work) — UPDATE-proxy.** Add the DNS-UPDATE-
   to-parent scheme: reuse `AnalyseZoneDelegation`'s delta +

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -307,20 +307,26 @@ primary once it builds).
   ConfigError. Build (all binaries incl. tdns-agent) + full
   `go test -race` green.
 
-- **Step P-2 — wide change-detection hook (the trigger).** Mirror the
-  tdns-mp template (`tdns-mp/v2/config.go:60-71` registers the hook;
-  `MPPreRefresh` runs the diffs): register an `OnZonePreRefresh` callback
-  for proxy zones in the NON-MP path (PreRefresh because it receives BOTH
-  old `zd` and incoming `new_zd`, `zone_utils.go:248`). REUSE the existing
-  detection: `DelegationDataChangedNG` (`delegation_utils.go:239`) for
-  NS+glue+DS and `DnskeysChangedNG` (`delegation_utils.go:462`) for DNSKEY;
-  ADD a small CDS/CSYNC RRset diff (`RRsetDiffer` over
-  `dns.TypeCDS`/`dns.TypeCSYNC`). Record which dimensions changed in
-  `ZoneRefreshAnalysis` and, when any changed, enqueue a proxy-sync request
-  carrying the changed-dimension set. Verify (unit tests): a transfer that
-  changes CDS / CSYNC / NS / glue / DNSKEY each sets the right flag and
-  enqueues; an unchanged transfer (same content, new serial only) enqueues
-  nothing (D8 edge-trigger).
+- **Step P-2 — wide change-detection hook (the trigger).** STATUS: DONE.
+  Mirrored the tdns-mp template: `parseconfig.go` registers an
+  `OnZonePreRefresh` + `OnZonePostRefresh` pair for `OptDelSyncProxy`
+  zones. `delsync_proxy.go` adds `ProxyDelegationAnalysis` (the carrier;
+  also stored on `ZoneData.ProxyRefreshAnalysis`, `structs.go`),
+  `ProxyDelegationPreRefresh` (diffs old-vs-new: CDS/CSYNC via a small
+  apex `core.RRsetDiffer`, NS+glue+DS via the existing
+  `DelegationDataChangedNG`, DNSKEY via the existing `DnskeysChangedNG`),
+  and `ProxyDelegationPostRefresh` (on any change, enqueues a
+  `PROXY-NOTIFY` `DelegationSyncRequest` carrying the changed dimensions +
+  the delegation deltas, and clears the analysis). The D4 act-mapping is
+  encoded as `wantCDSNotify` (CDS|DNSKEY) / `wantCSYNCNotify`
+  (CSYNC|NS-glue). The `PROXY-NOTIFY` command currently lands on the
+  DelegationSyncher's safe `default` (warn+ignore) until P-3 adds the
+  handler — so P-2 is working code on its own. Tests
+  (`delsync_proxy_p2_test.go`): no-change → nothing; each of CDS / CSYNC /
+  NS-glue / DNSKEY flips exactly its flag and the right
+  want{CDS,CSYNC}Notify; PostRefresh enqueues exactly one PROXY-NOTIFY on
+  change, nothing on empty/absent analysis, and clears the analysis. Build
+  + full `go test -race` green.
 
 - **Step P-3 — proxy NOTIFY action (the act).** A delegation-sync command
   (new `PROXY-NOTIFY`, or a proxy flag on the existing path) that, gated on

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -365,12 +365,14 @@ primary once it builds).
   refused, D5); a no-NOTIFY-target parent is the logged no-op in
   `ProxyNotifyParent` (P-3). Build + full `go test -race` green.
 
-- **Step P-5 (LATER, not this work) — UPDATE-proxy.** Add the DNS-UPDATE-
-  to-parent scheme: reuse `AnalyseZoneDelegation`'s delta +
-  `SyncZoneDelegationViaUpdate`. Brings the SIG(0)-trust question (parent
-  must authorize the agent's key as updater for a child it does not own)
-  and the advantage of working for UNSIGNED zones (D5). Designed later;
-  D5/D6 pre-position the change-detection so this step does not redo it.
+- **Step P-5 — UPDATE-proxy (DESIGNED 2026-06-22, ready to build).** Add
+  the DNS-UPDATE-to-parent scheme alongside the NOTIFY proxy. Unlike NOTIFY,
+  UPDATE carries the actual delegation records as payload, so it works for
+  UNSIGNED zones too (the headline advantage) and lands the change in one
+  round-trip without relying on the parent's scanner. Full design below
+  (§10). Estimate: ~150–280 source + ~150–250 test LOC, ~8–14 h; the SIG(0)
+  trust model and the replace-form question are now resolved, so the HIGH
+  risk from the NOTIFY-cut estimate is reduced to MED.
 
 
 ## 8. Why this is small (NOTIFY-only first cut)
@@ -448,3 +450,120 @@ both now verified — the heavy machinery operates on transferred-in data
 The main estimate risk is the debounce/loop-safety detail (Q6), which
 could push P-4 up if the existing delegation-sync path has no reusable
 "already-synced" marker and one must be added.
+
+
+## 10. UPDATE-proxy design (P-5)
+
+All open questions resolved with the operator on 2026-06-22.
+
+### 10.1 Trust model (resolved)
+
+The parent authorizes a DNS UPDATE by the SIG(0) key that signed it
+(`ValidateUpdate`, `sig0_validate.go:21`). Its path-3 (`FindSig0KeyViaDNS`,
+`sig0_validate.go:161`) trusts a key whose public KEY is **published in the
+child zone** and resolvable via DNS — exactly how a DSYNC-native child is
+trusted, with NO parent-side configuration.
+
+DECISION U1 — the agent holds a SIG(0) keypair and signs proxied UPDATEs
+with `SignerName = <child zone>`. The agent's public KEY is published at
+the child apex (the parent then resolves+trusts it via path-3). The agent
+effectively signs *as the child*, with a key the child zone vouches for.
+
+DECISION U2 (bootstrap) — the agent generates the keypair on proxy setup
+and EXPORTS the public KEY; the OPERATOR publishes that KEY record at the
+DSYNC-unaware primary, once, exactly as they already add DS/CDS there. No
+new bootstrap protocol; the agent uses the private half once it sees its
+KEY in the transferred zone. (P-5 includes the keygen + export tooling,
+DECISION U6.)
+
+### 10.2 Form: replace, not delta (resolved)
+
+DECISION U3 — proxied UPDATEs are REPLACE-form (delete the RRset, re-add
+the current authoritative members) rather than delta (add/remove diff).
+Replace is idempotent and self-correcting: it does not depend on the
+parent's current state matching our assumption, so it fixes drift instead
+of risking duplicate-adds or missed-removes. The builder already exists:
+`CreateChildReplaceUpdate` (`childsync_utils.go:173`) does whole-RRset
+replace for NS + glue + DS.
+
+NOTE — `SyncZoneDelegationViaUpdate` currently refuses replace mode with a
+stale "replace mode is currently broken" guard. That bug was in upstream
+miekg/dns, NOT tdns; the tdns fork fixes it, so the guard is obsolete.
+DECISION U4 — remove that refusal and re-enable shared replace mode as
+part of P-5 (verify the existing child UPDATE path still works before/after
+— it benefits too).
+
+### 10.3 Scope: NS+glue AND DS (resolved)
+
+DECISION U5 — the UPDATE-proxy reconciles the full delegation: NS, A/AAAA
+glue, and DS. DS is derived from the child's apex DNSKEYs (signed zones;
+`AnalyseZoneDelegation` already does this, `delegation_utils.go:126`).
+NS+glue applies to all zones including UNSIGNED — which is the case NOTIFY
+cannot serve and the main reason to build UPDATE-proxy.
+
+### 10.4 Trigger: two phases (the operator's model)
+
+The expensive parent comparison is a STARTUP reconciliation, not a
+per-transfer operation:
+
+- STARTUP (once, on first load of a proxy zone): run the full parent-vs-
+  child compare `AnalyseZoneDelegation` (one network round-trip to the
+  parent). If out of sync, send a replace UPDATE. This catches drift that
+  accumulated while the agent was down, and means a restart does NOT
+  re-send unless there is a genuine difference.
+- STEADY-STATE (every transfer after): the LOCAL old-vs-new compare
+  `DelegationDataChangedNG` (the PreRefresh diff already built for the
+  NOTIFY proxy, P-2 — no parent round-trip). If the child's own delegation
+  data changed, send a replace UPDATE.
+
+Both phases share ONE payload builder: the replace of the current
+authoritative NS/glue/DS read from the freshly-transferred zone. The two
+comparisons only decide WHETHER to send; the payload never depends on the
+parent's state (that is the point of replace-form). So the parent
+round-trip happens once at startup, never in steady state.
+
+### 10.5 Scheme selection
+
+`BestSyncScheme` (`childsync_utils.go:386`) already picks UPDATE vs NOTIFY
+from the parent's advertised DSYNC RRset + local preference. UPDATE
+advertised → this path; NOTIFY advertised → the existing NOTIFY proxy
+(§5). A parent advertising both is the operator's preference choice, as for
+the native child path.
+
+### 10.6 Build sub-steps
+
+- U-a: agent SIG(0) keygen + storage (under the child zone name) + public-
+  KEY export tooling (CLI/log) for the operator to publish (U1/U2/U6).
+- U-b: remove the stale replace-mode refusal; confirm shared replace works
+  on the fork (U4).
+- U-c: the startup reconcile pass — run `AnalyseZoneDelegation` once on
+  first load for proxy zones, send a replace UPDATE if out of sync (U4
+  trigger phase 1).
+- U-d: the steady-state UPDATE action — on a PROXY-UPDATE request (the
+  UPDATE sibling of PROXY-NOTIFY), build the replace via
+  `CreateChildReplaceUpdate`, sign with the agent's SIG(0) key
+  (`SignerName = child`), send via `SendUpdate`. ctx-aware sends (the
+  review lesson).
+- U-e: scheme dispatch — extend the proxy PostRefresh/handler so a parent
+  advertising UPDATE routes to PROXY-UPDATE, NOTIFY routes to the existing
+  PROXY-NOTIFY.
+- U-f: tests (signed + unsigned zones; startup-reconcile fires once;
+  steady-state local-diff fires on change; replace payload correctness;
+  no-resend-on-restart) + operator doc (the manual KEY-publication
+  bootstrap step).
+
+DECISION U6 — the keygen + export tooling is part of P-5, not a separate
+prerequisite.
+
+### 10.7 Open items for U-build time
+
+- The agent's SIG(0) key is per-child (stored under the child zone name).
+  Confirm the keystore cleanly holds a key for a zone the agent only
+  secondaries (not authors) — it should, since the key is keyed by zone
+  name, but verify against `GetSig0Keys`/`Sig0StateActive`.
+- Until the operator publishes the agent's KEY at the primary, the parent
+  cannot validate the UPDATE (path-3 fails). The proxy should detect "my
+  KEY is not yet in the transferred zone" and hold off / warn, rather than
+  send UPDATEs the parent will REFUSE. A clean precondition check.
+
+

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -1,0 +1,430 @@
+# tdns-agent as a DSYNC proxy for a DSYNC-unaware primary
+
+Status: PLANNING (2026-06-22). Scope decisions resolved with the operator
+(§4): NOTIFY-only first cut; a new `delegation-sync-proxy` zone option; a
+WIDE change-detection trigger (CDS / CSYNC / NS+glue / DNSKEY) with an
+optimistic act-mapping (CDS|DNSKEY change → NOTIFY(CDS), CSYNC|NS-glue
+change → NOTIFY(CSYNC)); no special delete-DS handling; do not gate on
+unsigned. UPDATE-to-parent is deferred to a later step. Ready to build. Estimate
+(§9): ~150–280 source + ~330–520 test LOC, ~11–18 h for the NOTIFY-only
+cut (P-1..P-4); no HIGH-risk step (a wrong NOTIFY only makes the parent
+re-scan). The change-detection pattern is a proven tdns-mp template
+(`MPPreRefresh`), and two of the three diff dimensions reuse existing v2
+functions — so this is mostly trigger+gate glue, not new mechanism.
+
+## 1. The problem
+
+A zone's primary is often a stock nameserver (BIND9, Knot, NSD) that knows
+nothing about DSYNC — it cannot discover the parent's DSYNC RRset, and it
+will never send a NOTIFY(CDS/CSYNC) or a DNS UPDATE to the parent to keep
+the delegation in sync. But that primary CAN be configured (or scripted)
+to PUBLISH a CDS/CDNSKEY RRset (RFC 7344) and/or a CSYNC RRset (RFC 7477)
+in the zone, which is the standard, vendor-neutral way for a child to
+SIGNAL "please sync my DS / my delegation."
+
+The idea: run tdns-agent as a SECONDARY for that zone. The agent already
+receives the full zone by AXFR/IXFR from the clueless primary. If the
+transferred zone contains a CDS and/or CSYNC RRset, the agent can act as a
+DSYNC PROXY: discover the parent's DSYNC receiver and forward the
+appropriate NOTIFY(CDS/CSYNC) and/or DNS UPDATE to it on the primary's
+behalf. The primary stays DSYNC-clueless; the agent does the DSYNC legwork.
+
+This is the missing third leg. Today:
+
+- PARENT side: complete. tdns-auth as a parent publishes a DSYNC RRset and
+  receives both NOTIFY(CDS/CSYNC) and DNS UPDATE from children
+  (`notifyresponder.go:195` dispatches CDS/CSYNC to the scanner;
+  `scanner.go` runs `CheckCDS` / `ProcessCSYNCNotify` and applies changes).
+- CHILD-PRIMARY side (tdns-auth as the primary): complete. On a local
+  delegation/DNSKEY change it analyses, then sends NOTIFY(CDS/CSYNC) or
+  UPDATE to the parent (`SyncZoneDelegationViaNotify` /
+  `SyncZoneDelegationViaUpdate`, driven from `zone_updater.go` on local
+  UPDATEs and from key bootstrap).
+- CHILD-SECONDARY side (tdns-agent secondary for a clueless primary):
+  MISSING. Nothing inspects an incoming transfer for CDS/CSYNC, and nothing
+  triggers a parent-sync off a transfer. This plan closes that gap.
+
+
+## 2. Key finding: the analyse + send machinery already works on xfr data
+
+The most important discovery from the code survey is that the EXPENSIVE
+parts are already built and already operate on transferred-in zone data —
+NOT on a local keystore. So this is mostly a TRIGGER + GATE problem, not a
+"build CDS/CSYNC forwarding from scratch" problem.
+
+- `AnalyseZoneDelegation` (`delegation_utils.go:28`) computes the full
+  parent-vs-child delta:
+  - NS + A/AAAA glue: compares the child's apex/glue RRsets (from the
+    SERVED zone data — i.e. what we transferred in) against what the parent
+    publishes (`AuthQuery` to the parent servers). `delegation_utils.go:
+    52-118`.
+  - DS: derives the child DS from the apex DNSKEY SEP keys PRESENT IN THE
+    ZONE (`apex.RRtypes...TypeDNSKEY ... dnskey.ToDS(SHA256)`,
+    `delegation_utils.go:126-146`) and diffs against the parent's DS. It
+    does NOT require a local keystore — a signed secondary zone carries its
+    DNSKEYs, so this already yields the right DS for a clueless primary's
+    zone.
+  - Result is a `DelegationSyncStatus` with NsAdds/NsRemoves,
+    A/AAAA adds/removes, DSAdds/DSRemoves.
+- `SyncZoneDelegationViaNotify` (`delegation_sync.go:486`) takes that
+  status and:
+  - sends NOTIFY(CSYNC) iff any NS/glue delta, and NOTIFY(CDS) iff any DS
+    delta (`delegation_sync.go:531-550`);
+  - (for the notify path it currently also calls `PublishCsyncRR()` to mint
+    a fresh CSYNC at the apex — see §5, this needs care for the proxy
+    case).
+- `SyncZoneDelegationViaUpdate` (sibling) sends the DNS UPDATE form.
+- The `EXPLICIT-SYNC-DELEGATION` command (`delegation_sync.go:99`) already
+  chains "analyse → if not in sync, sync via the parent's preferred
+  scheme." That is almost exactly the proxy action; it just is never
+  triggered for a secondary on transfer.
+
+So for the DS / DNSKEY dimension and the NS/glue dimension, the agent does
+NOT need to parse the incoming CDS/CSYNC contents to know WHAT to send —
+`AnalyseZoneDelegation` already derives the correct delta from the zone
+data + the parent. The incoming CDS/CSYNC is the OPT-IN SIGNAL ("the
+primary wants parent-sync"), not the payload the agent must transcribe.
+
+This reframes the CDS/CSYNC RRs: they are the primary's machine-readable
+CONSENT to proxying, gating an action the existing analyse-and-sync engine
+already knows how to perform.
+
+
+## 3. What is actually missing
+
+1. **A post-transfer trigger for the NON-MP agent-proxy case.** The
+   `OnZonePreRefresh`/`OnZonePostRefresh` callback hooks
+   (`structs.go:158-168`, fired in `FetchFromUpstream`,
+   `zone_utils.go:248-285`) are a PROVEN pattern — tdns-mp already uses
+   them exactly this way: `tdns-mp/v2/config.go:60-71` registers
+   `MPPreRefresh`/`PostRefresh`, and `MPPreRefresh`
+   (`tdns-mp/v2/hsync_utils.go:1257`) runs delegation + HSYNC + DNSKEY
+   change-detection on old-vs-new and records it in a `ZoneRefreshAnalysis`
+   struct, which `PostRefresh` then acts on. So "PreRefresh diff → analysis
+   → PostRefresh act" is not speculative; it is the established template.
+   What is MISSING is the analogous registration for the plain
+   `agent + Secondary` NON-MP zone: the MP wiring is gated on
+   `OptMultiProvider` and lives in tdns-mp, so the proxy needs its own
+   (smaller) registration in the non-MP path. The reusable PARTS are
+   already in `tdns/v2/`:
+   - `DelegationDataChangedNG` (`delegation_utils.go:239`) — old-vs-new
+     NS / A-glue / AAAA-glue / DS delta, returns a `DelegationSyncStatus`.
+   - `DnskeysChangedNG` (`delegation_utils.go:462`) — old-vs-new DNSKEY
+     change. (Both are `*ZoneData` methods, usable outside MP.)
+   - The `ZoneRefreshAnalysis` struct (`structs.go:78-85`) — the carrier.
+   Only the CDS/CSYNC RRset-change detection is genuinely new (a small
+   `RRsetDiffer` over `dns.TypeCDS`/`dns.TypeCSYNC`).
+
+2. **The change-detection trigger (WIDE — operator decision).** After a
+   transfer, compare the new zone against the previously-served one and
+   detect a change to ANY of: the CDS RRset, the CSYNC RRset, the NS RRset
+   or its glue (A/AAAA), or the DNSKEY RRset. This is DELIBERATELY wider
+   than "CDS/CSYNC present" (§4 D6): NS/glue and DNSKEY deltas feed the
+   future UPDATE path's payload, and — per the act-mapping below — also
+   drive NOTIFYs today. The read/diff primitives exist
+   (`owner.RRtypes.Get(dns.TypeCDS/CSYNC/NS/DNSKEY)`, `core.RRsetDiffer`,
+   and the old-vs-new zone pair the PreRefresh hook already receives).
+
+3. **The config gate for the secondary-proxy role.** Today the child-side
+   delegation-sync gate (`SetupZoneSync`, `zone_utils.go:858-860`) is:
+   `OptDelSyncChild AND ((auth AND !MP) OR (agent AND MP))`. A tdns-agent
+   that is a plain secondary for a clueless primary is `agent AND !MP` —
+   which the current gate EXCLUDES. The proxy role is gated by a NEW,
+   distinct option (§4 D2), not by loosening `delegation-sync-child`.
+
+4. **Proxy semantics for the send path (do not mint a fresh CSYNC).** The
+   notify path currently calls `PublishCsyncRR()` to publish a freshly
+   minted CSYNC at OUR apex and sign it. As a PROXY for someone else's
+   zone, we must NOT author/sign a new CSYNC into a zone we are only a
+   secondary of — we forward the SIGNAL, we do not become the source of
+   truth. The proxy send must skip the publish-and-sign step and just emit
+   the NOTIFY (§5).
+
+
+## 4. Resolved decisions (operator-confirmed 2026-06-22)
+
+- **D1 — Reuse the existing send path; the proxy NEVER reads CDS/CSYNC
+  contents.** A NOTIFY is a bare "come scan me" signal with no payload, so
+  for the NOTIFY-only first cut the proxy never needs to interpret a CDS
+  or CSYNC — it only detects that one CHANGED and emits the corresponding
+  NOTIFY; the parent re-scans and reads whatever is there. This makes the
+  RFC 8078 "delete DS" (`CDS 0 0 0 00`) case automatic: a changed CDS
+  fires NOTIFY(CDS) regardless of whether it is a delete-DS sentinel or a
+  normal CDS — the parent reads and acts (operator-confirmed: "doesn't
+  matter if it is a CDS 0 0 0 00 or not").
+
+- **D2 — NEW zone option `delegation-sync-proxy` (CHILD-side, agent
+  secondary).** Distinct from `delegation-sync-child` ("I am the child,
+  sync my own delegation up") because proxying for a clueless primary is a
+  different role/consent statement. Explicit option beats inferring the
+  role from `ZoneType==Secondary`. (Operator-confirmed.)
+
+- **D3 — FIRST STEP IS NOTIFY-ONLY.** No DNS UPDATE to the parent in step
+  one. The UPDATE-to-parent path is later work (§4 D5 notes why it is
+  attractive). (Operator-confirmed Q1.)
+
+- **D4 — Act mapping (operator-chosen, "be optimistic"):**
+  - NOTIFY(CDS) is sent when the **CDS RRset changed OR the DNSKEY RRset
+    changed**.
+  - NOTIFY(CSYNC) is sent when the **CSYNC RRset changed OR the NS RRset
+    and/or glue (A/AAAA) changed**.
+  Rationale: a NOTIFY is cheap and harmless — it just tells the parent to
+  re-scan; the parent decides for itself and ignores it if there is
+  nothing to do or it offers no DSYNC service. So we forward the INTENT
+  even when the primary changed keys/NS without (yet) republishing the
+  CDS/CSYNC. Consequence: under D4 every dimension of the wide trigger
+  drives a NOTIFY today, so the "detect-but-don't-act-yet" set is empty in
+  step one — the NS/glue and DNSKEY deltas are still COMPUTED (they feed
+  the future UPDATE payload) but they also fire their NOTIFY now.
+
+- **D5 — Do NOT gate on "zone unsigned" in the trigger/gate.** CDS and
+  CSYNC presuppose a signed zone, so in practice the NOTIFY-only cut only
+  has something to forward for signed zones — but the GATE must not refuse
+  unsigned zones, because the future DNS UPDATE path works for UNSIGNED
+  zones too (its advantage over NOTIFY). Gating on "unsigned" now would
+  wrongly foreclose that. (Operator-confirmed Q4.) So: no unsigned refusal;
+  it simply happens that an unsigned zone has no CDS/CSYNC/DNSKEY to act on
+  in the NOTIFY cut.
+
+- **D6 — The trigger is WIDER than the act.** Detect changes to CDS /
+  CSYNC / NS+glue / DNSKEY even though (per D4) all of them currently
+  drive a NOTIFY. The point is that the change-DETECTION machinery (the
+  old-vs-new delegation/DNSKEY diff) is built once, correctly, now — so the
+  later UPDATE path has its payload deltas ready and does not need a second
+  detection pass. (Operator-confirmed: "make the trigger wider … better
+  positioned later for DNS UPDATEs.")
+
+- **D7 — Gate on the conditions below before any send, every time:**
+  (a) the `delegation-sync-proxy` option is set on the zone; AND
+  (b) a relevant change was detected in this transfer (D4 dimensions); AND
+  (c) the parent actually advertises a DSYNC RRset with a scheme/type we
+      can use (`DsyncDiscovery` / `BestSyncScheme`, `childsync_utils.go:
+      386`). No NOTIFY scheme advertised at the parent ⇒ do nothing (not an
+      error; the parent may not offer the service).
+  This mirrors the operator's stated IFF.
+
+- **D8 — Idempotency / no loop: act on a detected change, but suppress a
+  re-NOTIFY when nothing new is owed.** The trigger fires on a zone-content
+  change (old-vs-new diff), which is already edge-triggered, so a plain
+  SOA-refresh with no zone change sends nothing. Additionally, to avoid
+  re-NOTIFYing across refreshes while the parent is slow to absorb,
+  remember the last serial we proxied for and/or only NOTIFY when the
+  relevant RRset's content (not just the SOA serial) actually changed since
+  the last proxy. (See §6 Q6 — confirm the exact debounce; the wide trigger
+  already removes the common "every refresh re-sends" case because it keys
+  on RRset content, not serial.)
+
+- **D9 — Scheme: NOTIFY only, for now.** Use the DSYNC NOTIFY target the
+  parent advertises (filtered via `DsyncDiscovery` / the CSYNC-and-CDS-
+  capable scheme picker). UPDATE is explicitly NOT used in step one (D3).
+  When UPDATE-proxy lands later, `BestSyncScheme` (`childsync_utils.go:
+  386`) picks UPDATE vs NOTIFY per the parent's advertisement + local
+  preference, as the primary-child path already does.
+
+
+## 5. The proxy send: what differs from the primary-child send
+
+The primary-child notify path (`SyncZoneDelegationViaNotify`) does, in
+order: publish a fresh CSYNC at our apex → sign it → send NOTIFY. For the
+proxy we change the first two steps:
+
+- **Do NOT `PublishCsyncRR()` and do NOT sign.** We are a secondary; the
+  CSYNC/CDS already exists in the zone (the primary put it there) and is
+  already signed by the primary's keys (if the zone is signed). We forward
+  the SIGNAL. Authoring a second CSYNC into a zone we don't own is wrong
+  and, for a signed secondary without the primary's ZSK, impossible to
+  sign correctly anyway.
+- **The NOTIFY is a bare signal.** A NOTIFY(CDS) / NOTIFY(CSYNC) carries no
+  payload — it just tells the parent "come scan my child." The parent then
+  queries the child (via its configured scanner) and reads the CDS/CSYNC
+  ITSELF. So for the NOTIFY scheme the proxy literally only needs to emit
+  the NOTIFY to the parent's advertised target; the parent's existing
+  `CheckCDS`/`ProcessCSYNCNotify` does the rest by querying the zone (which
+  it can reach — the agent serves it, or the primary does). This makes the
+  NOTIFY proxy path very small.
+- **No `AnalyseZoneDelegation` needed for the NOTIFY decision (D1).**
+  Because a NOTIFY is contentless and the parent re-scans, the proxy does
+  NOT need the parent-vs-child delta to decide whether to NOTIFY — the
+  local old-vs-new change-detection (D6) is sufficient: "this RRset changed
+  ⇒ NOTIFY." (We still keep the delta computation around per D6 to
+  pre-position the UPDATE path, but it does not gate the NOTIFY.) This
+  removes a parent round-trip (`AuthQuery` to the parent servers) from the
+  hot path; the only parent contact in step one is DSYNC discovery + the
+  NOTIFY send itself.
+
+The future UPDATE-proxy step (NOT step one) carries payload and reuses
+`AnalyseZoneDelegation`'s delta + `SyncZoneDelegationViaUpdate`'s signed-
+UPDATE builder, and brings a SIG(0)-trust question (the parent must accept
+the agent's key as the authorized updater for a child the agent does not
+own). That is deferred; see §6 Q-UPDATE.
+
+
+## 6. Sharp edges (most resolved 2026-06-22; two confirmations left)
+
+RESOLVED by operator (recorded in §4): delete-DS needs no special handling
+(D1 — a changed CDS NOTIFYs regardless of sentinel); NOTIFY-only first
+(D3); the act mapping is the optimistic CDS|DNSKEY→NOTIFY(CDS) /
+CSYNC|NS-glue→NOTIFY(CSYNC) (D4); do not gate on unsigned (D5); the trigger
+is wide (D6); a new `delegation-sync-proxy` option (D2). CDS and CSYNC are
+evaluated independently and can both fire (falls out of D4).
+
+Remaining to confirm during build:
+
+- **Q5 — IXFR (delta) transfers.** On an IXFR we get a delta; the
+  post-refresh hook sees the new full zone regardless (the hard flip
+  rebuilds `zd.Data`), so reading the apex CDS/CSYNC post-flip works for
+  both AXFR and IXFR. Confirm — but it should be fine since we read the
+  post-flip served zone, not the wire delta.
+
+- **Q6 — Rate / loop safety.** A parent that is slow to absorb the change
+  will leave the zone "not in sync" across refreshes, so every SOA refresh
+  would re-send. Reuse whatever debounce the primary-child path uses (or
+  add a "last proxied serial / last sync attempt" marker) so we don't
+  NOTIFY the parent on every refresh tick. Check what the existing path
+  does to avoid re-sending; the rollover path has `last_success_at` style
+  state — the delegation-sync path may need an analog.
+
+
+## 7. Build order
+
+Scope is settled (§4). Per the project rules: gofmt after edits; build
+with `cd tdns/cmdv2 && GOROOT=/opt/local/lib/go make`; show diff + update
+this doc's step status before committing each step; verify by build +
+`go test -race` (no testbed in the loop — but the agent-as-DSYNC-proxy is
+exactly the kind of thing that wants a testbed run against a BIND/Knot
+primary once it builds).
+
+- **Step P-1 — config: the `delegation-sync-proxy` option + gate.**
+  STATUS: DONE. Added `OptDelSyncProxy` / `"delegation-sync-proxy"` to
+  `enums.go` (within the tdns ZoneOption range; the compile-time sentinel
+  gate still passes) and to the simple-enable case in `parseoptions.go`.
+  Added a proxy gate block in `SetupZoneSync` (`zone_utils.go`) that
+  validates the option is used only on a `tdns-agent + Secondary` zone
+  (loud ConfigError otherwise) and logs it; no send behavior yet — the
+  change-detection hook (P-2) and NOTIFY action (P-3) are wired
+  separately. Tests (`delsync_proxy_test.go`): option string<->enum
+  mapping both directions; `parseZoneOptions` enables it without a
+  ConfigError. Build (all binaries incl. tdns-agent) + full
+  `go test -race` green.
+
+- **Step P-2 — wide change-detection hook (the trigger).** Mirror the
+  tdns-mp template (`tdns-mp/v2/config.go:60-71` registers the hook;
+  `MPPreRefresh` runs the diffs): register an `OnZonePreRefresh` callback
+  for proxy zones in the NON-MP path (PreRefresh because it receives BOTH
+  old `zd` and incoming `new_zd`, `zone_utils.go:248`). REUSE the existing
+  detection: `DelegationDataChangedNG` (`delegation_utils.go:239`) for
+  NS+glue+DS and `DnskeysChangedNG` (`delegation_utils.go:462`) for DNSKEY;
+  ADD a small CDS/CSYNC RRset diff (`RRsetDiffer` over
+  `dns.TypeCDS`/`dns.TypeCSYNC`). Record which dimensions changed in
+  `ZoneRefreshAnalysis` and, when any changed, enqueue a proxy-sync request
+  carrying the changed-dimension set. Verify (unit tests): a transfer that
+  changes CDS / CSYNC / NS / glue / DNSKEY each sets the right flag and
+  enqueues; an unchanged transfer (same content, new serial only) enqueues
+  nothing (D8 edge-trigger).
+
+- **Step P-3 — proxy NOTIFY action (the act).** A delegation-sync command
+  (new `PROXY-NOTIFY`, or a proxy flag on the existing path) that, gated on
+  D7 (proxy option set; a change was detected; parent advertises a NOTIFY
+  DSYNC target), sends — per the D4 act mapping — NOTIFY(CDS) when CDS or
+  DNSKEY changed, and NOTIFY(CSYNC) when CSYNC or NS/glue changed. It does
+  NOT call `PublishCsyncRR()` / sign and does NOT need `AnalyseZoneDelegation`
+  (§5, D1): a NOTIFY is a contentless "come re-scan" and the parent reads
+  the zone itself. Verify: each act-mapping case emits the right NOTIFY(s);
+  no DSYNC-NOTIFY target ⇒ no send, no error; both CDS+CSYNC changing fires
+  both, independently.
+
+- **Step P-4 — loop/debounce (D8) + tests + operator doc.** Confirm Q5
+  (IXFR reads the post-flip served zone, so AXFR/IXFR behave identically)
+  and settle Q6 (a "last-proxied content/serial" guard so a parent that is
+  slow to absorb does not get re-NOTIFYd every refresh — though the
+  content-diff trigger already suppresses the common case). Full test
+  matrix: CDS-only, CSYNC-only, both, DNSKEY-only→NOTIFY(CDS),
+  NS/glue-only→NOTIFY(CSYNC), delete-DS CDS (must NOTIFY like any CDS
+  change), no-change no-op, no-DSYNC-at-parent no-op, AXFR vs IXFR,
+  unsigned zone (no CDS/CSYNC/DNSKEY ⇒ nothing to send, but NOT refused —
+  D5). Operator doc: configuring tdns-agent as a DSYNC proxy secondary for
+  a BIND/Knot primary.
+
+- **Step P-5 (LATER, not this work) — UPDATE-proxy.** Add the DNS-UPDATE-
+  to-parent scheme: reuse `AnalyseZoneDelegation`'s delta +
+  `SyncZoneDelegationViaUpdate`. Brings the SIG(0)-trust question (parent
+  must authorize the agent's key as updater for a child it does not own)
+  and the advantage of working for UNSIGNED zones (D5). Designed later;
+  D5/D6 pre-position the change-detection so this step does not redo it.
+
+
+## 8. Why this is small (NOTIFY-only first cut)
+
+The parent side is done (receive + scan + apply). DSYNC discovery is done.
+NOTIFY emission is done. And critically (§5, D1) the NOTIFY decision needs
+NEITHER the publish-and-sign step NOR the parent-vs-child `AnalyseZone
+Delegation` round-trip — a changed RRset simply NOTIFYs and the parent
+re-scans. So the genuinely new code is:
+
+1. one config option + a one-line gate change (P-1);
+2. a PreRefresh callback that diffs four RRsets old-vs-new and enqueues on
+   change (P-2) — the only real new logic, and it is reused wholesale by
+   the future UPDATE path;
+3. a proxy NOTIFY action that maps changed-dimension → NOTIFY type and
+   emits to the parent's advertised target, skipping publish-and-sign (P-3).
+
+Everything heavy (DSYNC discovery, NOTIFY wire send, parent-side
+scan-and-apply, the RRset-differ) is reused. The part with the real open
+question — SIG(0) trust for UPDATE-proxy — is explicitly deferred to P-5,
+which is why NOTIFY-only is the first cut.
+
+
+## 9. Effort / risk / LOC estimate
+
+Per-step, for me to implement (build + `go test -race` green; testbed
+validation is operator-gated and not in these figures). LOC are net new
+source / new test, excluding reuse.
+
+| Step | What | Risk | Src LOC | Test LOC | Time |
+|------|------|------|---------|----------|------|
+| P-1 | `delegation-sync-proxy` option + gate | LOW | 20–40 | 30–50 | 1–2 h |
+| P-2 | Wide PreRefresh diff hook + enqueue | MED | 60–110 | 100–160 | 4–6 h |
+| P-3 | Proxy NOTIFY action (act-mapping) | MED | 50–90 | 80–130 | 3–5 h |
+| P-4 | Debounce + test matrix + operator doc | LOW–MED | 20–40 | 120–180 | 3–5 h |
+| **Total (P-1..P-4, NOTIFY-only)** | | | **~150–280** | **~330–520** | **~11–18 h** |
+| P-5 | UPDATE-proxy (LATER, separate) | HIGH | 80–160 | 120–200 | 6–10 h |
+
+Calibration: tdns-mp's `MPPreRefresh` (the proven template) is ~120 lines
+covering three detection dimensions plus role dispatch; the proxy hook is
+narrower (no role dispatch, two dimensions reused + one new), so P-2's new
+code is mostly the CDS/CSYNC diff + the enqueue glue, not the detection
+itself.
+
+Risk notes:
+
+- **P-2 is the load-bearing step (MED).** The risk is not the diff logic
+  (reuses `DelegationDataChangedNG`/`DnskeysChangedNG`, adds a small
+  CDS/CSYNC `RRsetDiffer`) but the LIFECYCLE: registering the hook only
+  for the right zones (agent + Secondary + proxy option), making sure it
+  fires on the secondary transfer path (`FetchFromUpstream`, confirmed),
+  and the old-vs-new pointer discipline the MP code already documents
+  (PreRefresh sees both; do not act before the hard flip). The MP template
+  de-risks this substantially — it is a known-good pattern to mirror, not
+  a green-field design.
+- **P-3 is MED for a subtle reason:** "skip publish-and-sign" means the
+  proxy must NOT reuse `SyncZoneDelegationViaNotify` verbatim (that path
+  mints + signs a CSYNC). It needs a thin proxy variant that emits the
+  NOTIFY directly to the parent's DSYNC target. Getting the "we are a
+  forwarder, not the source of truth" boundary right is the care item; the
+  wire send itself is reused.
+- **P-1, P-4 are LOW.** Config plumbing and tests/docs.
+- **No HIGH-risk step in the NOTIFY-only cut.** Unlike the KSK alg-roll
+  plan (whose K-2 sat one branch from a bogus-zone path), nothing here can
+  break a served zone: the worst failure mode of a wrong NOTIFY is a
+  parent that re-scans and finds nothing to do. That bounds the blast
+  radius and is why this is comfortable to build incrementally.
+- **P-5 (UPDATE-proxy) is HIGH and deliberately out of this work** — the
+  SIG(0)-trust model (parent authorizing the agent as updater for a child
+  it does not own) is an unresolved design question, not just code.
+
+Confidence: HIGH for P-1..P-4. The two facts the estimate rests on are
+both now verified — the heavy machinery operates on transferred-in data
+(§2), and the PreRefresh→analysis→act pattern is proven in tdns-mp (§3).
+The main estimate risk is the debounce/loop-safety detail (Q6), which
+could push P-4 up if the existing delegation-sync path has no reusable
+"already-synced" marker and one must be added.

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -482,16 +482,29 @@ DECISION U3 — proxied UPDATEs are REPLACE-form (delete the RRset, re-add
 the current authoritative members) rather than delta (add/remove diff).
 Replace is idempotent and self-correcting: it does not depend on the
 parent's current state matching our assumption, so it fixes drift instead
-of risking duplicate-adds or missed-removes. The builder already exists:
-`CreateChildReplaceUpdate` (`childsync_utils.go:173`) does whole-RRset
-replace for NS + glue + DS.
+of risking duplicate-adds or missed-removes.
+
+PRECEDENT — the KSK rollover engine ALREADY pushes the child's DS RRset to
+the parent in replace form, in production: `BuildChildWholeDSUpdate`
+(`ksk_rollover_ds_push.go:38`) does `RemoveRRset` (DEL ANY DS) + `Insert`
+(new DS), and it does NOT go through the disabled
+`SyncZoneDelegationViaUpdate` mode-switch. So replace-form is the normal,
+exercised parent-UPDATE shape on the fork — strong corroboration of U3/U4.
+Two conventions to copy from it that `CreateChildReplaceUpdate` should
+match: `Ttl: 0` on the ClassANY delete (not 3600), and `m.SetEdns0(1232,
+true)` (EDNS0 + DO — matters for PQ-sized records). Open U-build choice:
+reuse `CreateChildReplaceUpdate` (`childsync_utils.go:173`, NS+glue+DS) for
+the whole payload after aligning those conventions, OR reuse the proven
+`BuildChildWholeDSUpdate` for the DS dimension and `CreateChildReplaceUpdate`
+only for NS+glue. Lean toward one builder for all three, aligned to the
+KSK conventions.
 
 NOTE — `SyncZoneDelegationViaUpdate` currently refuses replace mode with a
 stale "replace mode is currently broken" guard. That bug was in upstream
-miekg/dns, NOT tdns; the tdns fork fixes it, so the guard is obsolete.
-DECISION U4 — remove that refusal and re-enable shared replace mode as
-part of P-5 (verify the existing child UPDATE path still works before/after
-— it benefits too).
+miekg/dns, NOT tdns; the tdns fork fixes it (and the KSK path above already
+relies on the fix), so the guard is obsolete. DECISION U4 — remove that
+refusal and re-enable shared replace mode as part of P-5 (verify the
+existing child UPDATE path still works before/after — it benefits too).
 
 ### 10.3 Scope: NS+glue AND DS (resolved)
 

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -516,6 +516,11 @@ cannot serve and the main reason to build UPDATE-proxy.
 
 ### 10.4 Trigger: two phases (the operator's model)
 
+Both phases are gated by §10.8: they only run once the precondition state
+machine reports READY (parent advertises UPDATE AND the agent's KEY is
+published at the apex). In the foreign-KEY or waiting-for-KEY states no
+UPDATE is sent.
+
 The expensive parent comparison is a STARTUP reconciliation, not a
 per-transfer operation:
 
@@ -545,8 +550,11 @@ the native child path.
 
 ### 10.6 Build sub-steps
 
-- U-a: agent SIG(0) keygen + storage (under the child zone name) + public-
-  KEY export tooling (CLI/log) for the operator to publish (U1/U2/U6).
+- U-a: the precondition + KEY-bootstrap state machine (§10.8) — the
+  UPDATE-support gate, the apex-KEY check, agent SIG(0) keygen/storage, the
+  operator-instruction surfacing (log + zone-list status + CLI), and the
+  ready/foreign/waiting state handling. This is the gate that everything
+  else depends on; build it first.
 - U-b: remove the stale replace-mode refusal; confirm shared replace works
   on the fork (U4).
 - U-c: the startup reconcile pass — run `AnalyseZoneDelegation` once on
@@ -578,5 +586,73 @@ prerequisite.
   cannot validate the UPDATE (path-3 fails). The proxy should detect "my
   KEY is not yet in the transferred zone" and hold off / warn, rather than
   send UPDATEs the parent will REFUSE. A clean precondition check.
+
+
+### 10.8 The precondition + KEY-bootstrap state machine (resolved)
+
+The UPDATE-proxy cannot just "sign and send." The parent only trusts an
+UPDATE signed by a SIG(0) key published as a KEY RR at the child apex
+(§10.1, path-3). Since the agent is a SECONDARY, it cannot publish that
+KEY itself — the operator must add it at the DSYNC-unaware primary. So the
+agent needs a small state machine to (a) decide whether UPDATE-proxy is
+even relevant, (b) ensure it holds a usable key, and (c) tell the operator
+exactly what to publish — without ever hard-failing the zone.
+
+DECISION U7 — the resolved flow, evaluated on a proxy zone (on setup and on
+each transfer):
+
+1. GATE: does the parent advertise DSYNC **UPDATE**? (DSYNC discovery /
+   `BestSyncScheme`.) If NOT, UPDATE-proxy is not applicable to this zone —
+   do NOT generate a key, do NOT nag the operator about a KEY record. The
+   NOTIFY proxy (P-3) may still apply if the parent advertises NOTIFY. This
+   gate comes FIRST, before any KEY handling.
+
+2. If UPDATE is advertised, inspect the apex KEY RRset:
+   - **KEY present, and we hold the matching private key** (the keystore
+     has it — `GetSig0Keys(child, Sig0StateActive)` non-empty and
+     `VerifyPublishedKeyRRs` confirms the published KEY is ours): READY.
+     Sign and send proxied UPDATEs.
+   - **KEY present, but it is FOREIGN** (we do not hold the private key for
+     the published KEY): we cannot proxy via UPDATE, and we MUST NOT mint a
+     competing KEY. WARN (not error) — surface a per-zone status visible on
+     `tdns-cli zone list`: "DSYNC UPDATE proxy not operable: a foreign KEY
+     occupies the apex; NOTIFY proxy may still apply." Disable the UPDATE
+     proxy for this zone; keep serving the zone normally.
+   - **No KEY present**: GENERATE a SIG(0) keypair (reuse the keystore
+     `Sig0KeyMgmt` generate path), store it under the child zone name, and
+     INSTRUCT the operator with the exact KEY record to add at the primary.
+     WARN status on `zone list`: "DSYNC UPDATE proxy waiting: publish this
+     KEY at the primary." HOLD OFF on UPDATEs until the KEY appears in a
+     transfer (sending before then just earns a REFUSED).
+
+DECISION U8 — error severity: NONE of the above hard-fails. The agent
+starts; all zones, including this one, are served normally as a secondary.
+The foreign-KEY and waiting-for-KEY conditions are WARNINGS surfaced as a
+per-zone status on `tdns-cli zone list` (reuse the existing
+`zd.SetError`/zone-status surface that `VerboseListZone` already renders,
+`cli/zone_cmds.go:408`). This matches the project's resilient-config
+quarantine model: the UPDATE-proxy FUNCTION is degraded, not the zone.
+
+DECISION U9 — operator instruction surfacing (BOTH): (a) on generation, log
+the ready-to-paste KEY record at Warn AND record it in the per-zone status
+so it persists (and re-emit while still missing); (b) a CLI command (e.g.
+`... keystore dnssec proxy-key -z <zone>`) that prints, on demand, the
+exact KEY record to publish plus the current state (update-unsupported /
+ready / foreign / waiting).
+
+Reuse map: `DelegationSyncSetup` / `Sig0KeyPreparation`
+(`delegation_sync.go:192,265`) are the child-side precedent — they
+generate a keypair AND publish the KEY into the zone. The proxy reuses the
+KEYGEN + keystore half (`Sig0KeyMgmt` generate, `GetSig0Keys`,
+`VerifyPublishedKeyRRs`) but REPLACES the "publish into the zone" half with
+the operator-instruction surfacing, because a secondary cannot author the
+zone. So U-a is a new `ProxySig0KeyPreparation`-style function modelled on
+`Sig0KeyPreparation` minus the publish step, plus the §10.8 state machine.
+
+Open U-build detail: where the per-zone "UPDATE-proxy state" is rendered —
+the simplest is the existing zone-error/status field (one warning line);
+if a distinct non-error "warning" severity is wanted on `zone list`,
+that may need a small status-field addition. Decide at build time; the
+error-field reuse works for a first cut.
 
 

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -1,16 +1,24 @@
 # tdns-agent as a DSYNC proxy for a DSYNC-unaware primary
 
-Status: PLANNING (2026-06-22). Scope decisions resolved with the operator
-(§4): NOTIFY-only first cut; a new `delegation-sync-proxy` zone option; a
+Status: IMPLEMENTED (2026-06-22), on branch feat/agent-dsync-proxy,
+pending testbed validation of the network paths. Both schemes are built:
+the NOTIFY proxy (P-1..P-4) and the UPDATE proxy (P-5: U-a precondition +
+KEY-bootstrap state machine, U-b replace-mode re-enable, U-c startup
+reconcile, U-d the configurable replace/delta UPDATE action, U-e UPDATE/
+NOTIFY scheme dispatch, U-a2 the `zone proxy-key` CLI, U-f docs). The agent
+forwards via whichever scheme the parent advertises (UPDATE preferred when
+available; it also serves unsigned zones). All build + `go test -race`
+green; the network-dependent paths (DSYNC discovery, NOTIFY/UPDATE on the
+wire) are operator/testbed-validated. Per-step as-built detail in §7.
+
+Original scope decisions (§4): a new `delegation-sync-proxy` zone option; a
 WIDE change-detection trigger (CDS / CSYNC / NS+glue / DNSKEY) with an
-optimistic act-mapping (CDS|DNSKEY change → NOTIFY(CDS), CSYNC|NS-glue
-change → NOTIFY(CSYNC)); no special delete-DS handling; do not gate on
-unsigned. UPDATE-to-parent is deferred to a later step. Ready to build. Estimate
-(§9): ~150–280 source + ~330–520 test LOC, ~11–18 h for the NOTIFY-only
-cut (P-1..P-4); no HIGH-risk step (a wrong NOTIFY only makes the parent
-re-scan). The change-detection pattern is a proven tdns-mp template
+optimistic act-mapping; no special delete-DS handling; do not gate on
+unsigned. The change-detection pattern follows the proven tdns-mp template
 (`MPPreRefresh`), and two of the three diff dimensions reuse existing v2
-functions — so this is mostly trigger+gate glue, not new mechanism.
+functions. UPDATE decisions (§10): replace-form default but operator-
+overridable via `parent-update`; the agent signs as the child with a key
+the operator publishes at the primary (KEY + HSYNCPARAM pubkey).
 
 ## 1. The problem
 
@@ -626,10 +634,21 @@ the native child path.
   Scheme discovery + send run in the syncher (off the refresh path). Tests
   updated for the command rename; the dispatch itself is network/testbed-
   validated. Build + full `go test -race` green.
-- U-f: tests (signed + unsigned zones; startup-reconcile fires once;
-  steady-state local-diff fires on change; replace payload correctness;
-  no-resend-on-restart) + operator doc (the manual KEY-publication
-  bootstrap step).
+- U-f: operator doc + test-matrix. STATUS: DONE. `guide/agent-dsync-proxy.md`
+  rewritten to cover both schemes: an "UPDATE proxy" section (the SIG(0)
+  trust model, the step-by-step KEY + HSYNCPARAM-pubkey bootstrap via
+  `zone proxy-key`, the four states, the startup reconcile), corrected
+  requirements/limitations, and dual-scheme verification.
+  `guide/special-features.md` §1.6 and `guide/README.md` updated (no longer
+  "NOTIFY-only"; the Future-Work UPDATE-proxy entry removed). Unit tests
+  cover the decision logic (25 proxy tests): precondition states,
+  ours-vs-foreign, keygen idempotency, instruction text, the
+  authoritative-RR reader (signed + unsigned), parent-update mode
+  default/override, the not-ready startup early-return, the replace-UPDATE
+  builder structure, and `proxy-key` formatting. The remaining matrix rows
+  (signed/unsigned UPDATE on the wire, startup-reconcile-fires-once,
+  no-resend-on-restart) are network/testbed — operator-gated, not
+  agent-side unit-testable. Full `go test -race` green.
 
 DECISION U6 — the keygen + export tooling is part of P-5, not a separate
 prerequisite.

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -750,3 +750,126 @@ that may need a small status-field addition. Decide at build time; the
 error-field reuse works for a first cut.
 
 
+
+
+## 11. The HSYNCPARAM pubkey CONSUMER (tdns-auth secondary)
+
+This is the COUNTERPART to §10's producer. The proxy (and any provider)
+publishes `HSYNCPARAM pubkey` at the customer apex (§9 U10); SOMEONE must
+act on it. This section is that consumer, on the tdns-auth side — and it is
+a tdns-auth feature, NOT an agent/proxy one.
+
+### 11.1 The mechanism (RFC 9615 at-NS signaling, for the SIG(0) KEY)
+
+RFC 9615 (DNSSEC bootstrapping) defines authenticated signaling names of
+the form `_dsboot.<child>._signal.<ns>` under each of the child's
+nameservers, so a parent can DNSSEC-validate the child's bootstrap data
+out-of-band (the scanner already CONSUMES this for CDS:
+`queryCDSAtSignalingNames`, `scanner.go:1283`). The same shape applies to
+the child's SIG(0) KEY, at `_sig0key.<child>._signal.<ns>` — and there is
+already a CONSUMER for THAT: `LookupChildKeyAtSignal` /`VerifyChildKey`
+(`truststore_verify.go:33,57`). What is missing is a PRODUCER on a
+plain tdns-auth secondary. The `pubkey` flag is the instruction to produce
+it.
+
+Worked example (the operator's framing):
+- tdns-auth server `ns.foobar.com` is a SECONDARY for customer zone
+  `example.com.`.
+- `example.com.` apex carries `example.com. KEY …` and
+  `example.com. HSYNCPARAM pubkey`.
+- On the transfer, `ns.foobar.com` republishes the customer's apex KEY
+  under the signaling name
+  `_sig0key.example.com._signal.ns.foobar.com.  KEY …`.
+
+The republished record's owner is built from the NS HOSTNAME
+(`<ns> = ns.foobar.com`), so the signal record lives UNDER THE NS'S ZONE,
+not under the customer zone. That is the whole point: the parent/validator
+finds the child's KEY via the child's nameservers, authenticated by those
+nameservers' own DNSSEC.
+
+### 11.2 The hard precondition (and what's out of scope)
+
+`ns.foobar.com` can publish `_sig0key.example.com._signal.ns.foobar.com.`
+ONLY if it is PRIMARY (locally authoritative AND writable) for a zone that
+is a parent of `_signal.ns.foobar.com.` — i.e. it locally owns and can
+write `ns.foobar.com.` (as its own zone) or `foobar.com.`. If no such
+local primary zone exists, this NS's signal record is a NON-STARTER —
+skip it (warn).
+
+OUT OF SCOPE (for now): the case where `ns.foobar.com` is NOT primary for
+that zone but some intra-company mechanism could convey the publish request
+to wherever the real primary is. We handle only the locally-primary case.
+
+### 11.3 The algorithm (per incoming transfer of a customer zone)
+
+1. Read the apex HSYNCPARAM of the transferred zone; if it has no `pubkey`
+   flag (`HSYNCPARAM.HasPubkey()`, `core/rr_hsyncparam.go:387` — already in
+   tdns, currently unused), do nothing.
+2. Collect the apex KEY RRset of the transferred customer zone (ALL KEYs).
+3. For each NS hostname `<ns>` in the customer zone's apex NS RRset:
+   a. Build the signal owner `_sig0key.<customerzone>._signal.<ns>.`.
+   b. `FindZone(signalOwner)` (`zone_utils.go:602` — longest-suffix match
+      over locally-served zones). If it returns a zone we are PRIMARY for,
+      that is the target; else skip this NS (non-starter, §11.2).
+   c. Publish each apex KEY (re-owned to the signal name) into the target
+      zone via the internal publish path (the `UpdateQ <- UpdateRequest{
+      Cmd:"ZONE-UPDATE", InternalUpdate:true}` idiom that `PublishKeyRRs`
+      uses, `ops_key.go:17`). If the target zone is signed (inline-signing),
+      the normal publish path re-signs the new `_signal` KEY RRset.
+4. Idempotency: republish only on CHANGE (the apex KEY or the NS set
+   differs from what we last published), so a plain re-transfer of unchanged
+   data is a no-op — same content-edge discipline as the proxy's §10.4/D8.
+
+### 11.4 Reuse vs. new (and the tdns-mp question)
+
+- REUSE (parsing): `HSYNCPARAM.HasPubkey()` lives in `tdns/v2/core` — the
+  flag check is ~3 lines, no analysis engine needed.
+- DO NOT reuse the tdns-mp HSYNC analysis (`HsyncChanged`,
+  `tdns-mp/v2/hsync_utils.go`): it returns an MP-specific `*HsyncStatus`
+  and is entangled with provider-groups/signers. A plain tdns-auth
+  secondary must NOT depend on tdns-mp. For `pubkey` we need none of that —
+  just the flag, the apex KEY/NS RRsets, `FindZone`, and the publish idiom.
+- NEW: the per-NS signal-name publish (build owner, find local primary
+  zone, publish/re-sign), and the change-detection gate.
+
+### 11.5 Always-on (operator decision)
+
+The check runs on EVERY tdns-auth secondary, with NO option gating it
+(operator-confirmed). The flag should "just work" as the producer intends.
+It is safe to be always-on: it only acts when (a) the transferred zone
+actually carries `HSYNCPARAM pubkey` AND (b) this server is locally primary
+for a parent of the signal name — both narrow conditions. A secondary that
+is primary for nothing relevant does nothing.
+
+### 11.6 Wiring (the hook)
+
+The natural home is the post-transfer path — the same `OnZonePreRefresh`/
+`OnZonePostRefresh` machinery the proxy uses (§3), but registered for ALL
+secondary zones on tdns-auth (the always-on decision), not just
+proxy-option zones. PreRefresh detects the `pubkey` + apex-KEY/NS change;
+PostRefresh publishes into the target zone(s). (Or run it from the existing
+refresh callback path if a lighter touch fits — decide at build time.) The
+publish targets a DIFFERENT zone than the one being refreshed (the NS's
+zone), so this is a cross-zone internal publish via `UpdateQ`, not a
+mutation of the transferred zone.
+
+### 11.7 Open items for build time
+
+- Confirm the change-detection gate's state: where to remember "what we
+  last published at the signal names" so re-publish is change-only (a small
+  per-zone marker, or diff the live `_signal` RRset in the target zone vs.
+  the apex KEY — the latter needs no new state).
+- A signed TARGET zone (the NS's zone, inline-signing) must re-sign the new
+  `_signal` KEY RRset; confirm the internal publish path does this for a
+  non-apex owner.
+- Out-of-bailiwick NS whose zone we do not serve: skip + (rate-limited)
+  warn, so the operator sees that some NS signal records could not be
+  produced locally.
+
+### 11.8 Estimate
+
+Small-to-medium: ~120–200 source + ~120–200 test LOC. No HIGH-risk step
+(it only ADDS a signaling RRset to a zone we already author; worst case is
+a spurious `_signal` KEY, which a validator simply ignores if it doesn't
+match). The producer (this) plus the existing consumer
+(`LookupChildKeyAtSignal`) closes the RFC-9615-style loop for SIG(0) KEYs.

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -478,11 +478,17 @@ DECISION U6.)
 
 ### 10.2 Form: replace, not delta (resolved)
 
-DECISION U3 — proxied UPDATEs are REPLACE-form (delete the RRset, re-add
-the current authoritative members) rather than delta (add/remove diff).
-Replace is idempotent and self-correcting: it does not depend on the
-parent's current state matching our assumption, so it fixes drift instead
-of risking duplicate-adds or missed-removes.
+DECISION U3 — proxied UPDATEs are REPLACE-form by DEFAULT (delete the
+RRset, re-add the current authoritative members) rather than delta
+(add/remove diff). Replace is idempotent and self-correcting: it does not
+depend on the parent's current state matching our assumption, so it fixes
+drift instead of risking duplicate-adds or missed-removes. The form is
+OPERATOR-OVERRIDABLE via the existing `parent-update` auth option
+(`delta|replace`), mirroring the tdns-auth child path — the proxy reads the
+same option but DEFAULTS to replace (auth defaults to delta). NOTE — this
+required un-gating `replace` at the config parser too: `parseAuthOptions`
+previously rejected `parent-update: replace` (the other half of the stale
+miekg/dns workaround); it now accepts both values.
 
 PRECEDENT — the KSK rollover engine ALREADY pushes the child's DS RRset to
 the parent in replace form, in production: `BuildChildWholeDSUpdate`
@@ -581,11 +587,19 @@ the native child path.
 - U-c: the startup reconcile pass — run `AnalyseZoneDelegation` once on
   first load for proxy zones, send a replace UPDATE if out of sync (U4
   trigger phase 1).
-- U-d: the steady-state UPDATE action — on a PROXY-UPDATE request (the
-  UPDATE sibling of PROXY-NOTIFY), build the replace via
-  `CreateChildReplaceUpdate`, sign with the agent's SIG(0) key
-  (`SignerName = child`), send via `SendUpdate`. ctx-aware sends (the
-  review lesson).
+- U-d: the UPDATE action. STATUS: DONE. `ProxyUpdateParent`
+  (`delsync_proxy_update.go`): re-checks the §10.8 precondition (sends only
+  in READY), resolves the parent UPDATE target, builds the UPDATE in the
+  configured form (`proxyUpdateMode` — REPLACE default, DELTA if
+  `parent-update: delta`), signs with the agent's SIG(0) key as the child
+  (`SignerName = child zone`), and sends via `SendUpdate`. Replace reads the
+  current authoritative NS+glue+DS from the served zone
+  (`proxyCurrentDelegationRRs`; DS from apex DNSKEY SEP keys, empty for an
+  unsigned zone); delta uses `AnalyseZoneDelegation`. The config parser now
+  accepts `parent-update: replace` (U3). Tests: mode default/override,
+  authoritative-RR reader (signed + unsigned). The send itself is
+  network/testbed-validated. NOT yet wired to a trigger — U-c (startup) and
+  U-e (scheme dispatch) call it. Build + full `go test -race` green.
 - U-e: scheme dispatch — extend the proxy PostRefresh/handler so a parent
   advertising UPDATE routes to PROXY-UPDATE, NOTIFY routes to the existing
   PROXY-NOTIFY.

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -566,8 +566,18 @@ the native child path.
   DSYNC-discovery gate itself is network — testbed-validated. The on-demand
   CLI (`proxy-key`) is U-a2 (needs a daemon API endpoint). Build + full
   `go test -race` green.
-- U-b: remove the stale replace-mode refusal; confirm shared replace works
-  on the fork (U4).
+- U-b: remove the stale replace-mode refusal (U4). STATUS: DONE. The
+  refusal in `SyncZoneDelegationViaUpdate` is replaced with the real
+  replace implementation: `CreateChildReplaceUpdate` over the
+  `DelegationSyncStatus.New{NS,A,AAAA,DS}` full-set fields (already
+  populated by the delegation analysis). The default delta path is
+  untouched, so the existing child UPDATE path is unchanged. Tests
+  (`childsync_replace_test.go`): the replace UPDATE is well-formed
+  (ClassANY deletes of NS/DS + ClassINET adds of the new members), and the
+  unsigned case (no DS) replaces NS+glue only. Build + full `go test -race`
+  green. (The actual replace UPDATE landing at a real parent is
+  testbed-validated — it is the fork's miekg/dns fix that makes it work on
+  the wire.)
 - U-c: the startup reconcile pass — run `AnalyseZoneDelegation` once on
   first load for proxy zones, send a replace UPDATE if out of sync (U4
   trigger phase 1).

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -584,9 +584,16 @@ the native child path.
   green. (The actual replace UPDATE landing at a real parent is
   testbed-validated — it is the fork's miekg/dns fix that makes it work on
   the wire.)
-- U-c: the startup reconcile pass — run `AnalyseZoneDelegation` once on
-  first load for proxy zones, send a replace UPDATE if out of sync (U4
-  trigger phase 1).
+- U-c: the startup reconcile pass. STATUS: DONE. `ProxyStartupReconcile`
+  (`delsync_proxy_update.go`), called once on first load from the
+  `PROXY-UPDATE-SETUP` handler: runs the §10.8 precondition and, if READY,
+  does a one-time parent compare (`AnalyseZoneDelegation`) and a proxied
+  UPDATE ONLY when out of sync — so downtime drift is fixed without
+  re-sending on every restart (the sync check gates the send even though
+  replace-form would be harmless to re-send). Steady-state changes after
+  this go through the U-e PreRefresh diff (no parent round-trip). Test: the
+  not-ready early return (network-free). The READY reconcile path is
+  network/testbed-validated. Build + full `go test -race` green.
 - U-d: the UPDATE action. STATUS: DONE. `ProxyUpdateParent`
   (`delsync_proxy_update.go`): re-checks the §10.8 precondition (sends only
   in READY), resolves the parent UPDATE target, builds the UPDATE in the

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -600,9 +600,17 @@ the native child path.
   authoritative-RR reader (signed + unsigned). The send itself is
   network/testbed-validated. NOT yet wired to a trigger — U-c (startup) and
   U-e (scheme dispatch) call it. Build + full `go test -race` green.
-- U-e: scheme dispatch — extend the proxy PostRefresh/handler so a parent
-  advertising UPDATE routes to PROXY-UPDATE, NOTIFY routes to the existing
-  PROXY-NOTIFY.
+- U-e: scheme dispatch. STATUS: DONE. The PostRefresh hook now enqueues a
+  single generic `PROXY-SYNC` request (was `PROXY-NOTIFY`); the
+  DelegationSyncher handler calls `ProxyDelegationSync`
+  (`delsync_proxy_update.go`), which picks the scheme via `BestSyncScheme`
+  and routes to `ProxyUpdateParent` (UPDATE) or `ProxyNotifyParent`
+  (NOTIFY). UPDATE is preferred when advertised (one round-trip, works
+  unsigned); if the UPDATE precondition is not yet READY (KEY not published)
+  it falls back to NOTIFY so the change is not dropped during bootstrap.
+  Scheme discovery + send run in the syncher (off the refresh path). Tests
+  updated for the command rename; the dispatch itself is network/testbed-
+  validated. Build + full `go test -race` green.
 - U-f: tests (signed + unsigned zones; startup-reconcile fires once;
   steady-state local-diff fires on change; replace payload correctness;
   no-resend-on-restart) + operator doc (the manual KEY-publication

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -328,16 +328,22 @@ primary once it builds).
   change, nothing on empty/absent analysis, and clears the analysis. Build
   + full `go test -race` green.
 
-- **Step P-3 — proxy NOTIFY action (the act).** A delegation-sync command
-  (new `PROXY-NOTIFY`, or a proxy flag on the existing path) that, gated on
-  D7 (proxy option set; a change was detected; parent advertises a NOTIFY
-  DSYNC target), sends — per the D4 act mapping — NOTIFY(CDS) when CDS or
-  DNSKEY changed, and NOTIFY(CSYNC) when CSYNC or NS/glue changed. It does
-  NOT call `PublishCsyncRR()` / sign and does NOT need `AnalyseZoneDelegation`
-  (§5, D1): a NOTIFY is a contentless "come re-scan" and the parent reads
-  the zone itself. Verify: each act-mapping case emits the right NOTIFY(s);
-  no DSYNC-NOTIFY target ⇒ no send, no error; both CDS+CSYNC changing fires
-  both, independently.
+- **Step P-3 — proxy NOTIFY action (the act).** STATUS: DONE. New
+  `PROXY-NOTIFY` command in the `DelegationSyncher` switch
+  (`delegation_sync.go`) calls `ProxyNotifyParent` (`delsync_proxy.go`):
+  resolve parent if needed, `BestSyncScheme` for DSYNC discovery, require a
+  NOTIFY target (NOTIFY-only, D3/D9 — UPDATE-only parent ⇒ logged no-op,
+  not an error), then emit per the D4 act-mapping. The emission is factored
+  into `emitProxyNotifies` (CSYNC-then-CDS) so the mapping → NOTIFY is
+  unit-testable without the network. NO `PublishCsyncRR()` / sign and NO
+  `AnalyseZoneDelegation` (§5, D1). The changed-dimension set is carried
+  from PostRefresh to the handler via a new
+  `DelegationSyncRequest.ProxyAnalysis` field. Tests
+  (`delsync_proxy_p3_test.go`): all seven act-mapping combinations emit the
+  exact NOTIFY set (CDS-only, CSYNC-only, DNSKEY→CDS, NS/glue→CSYNC, both,
+  all-four, none); target + zone pass through unchanged. The
+  DSYNC-discovery half of `ProxyNotifyParent` needs the network and is
+  left for testbed validation. Build + full `go test -race` green.
 
 - **Step P-4 — loop/debounce (D8) + tests + operator doc.** Confirm Q5
   (IXFR reads the post-flip served zone, so AXFR/IXFR behave identically)

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -569,9 +569,17 @@ the native child path.
   Wired off the refresh path via a `PROXY-UPDATE-SETUP` DelegationSyncher
   command enqueued from `SetupZoneSync`. Tests: keygen idempotency,
   ours-vs-foreign, apex-KEY read, instruction text, pubkey RR. The
-  DSYNC-discovery gate itself is network — testbed-validated. The on-demand
-  CLI (`proxy-key`) is U-a2 (needs a daemon API endpoint). Build + full
+  DSYNC-discovery gate itself is network — testbed-validated. Build + full
   `go test -race` green.
+- U-a2: the on-demand CLI + API. STATUS: DONE. `tdns-cli ... zone proxy-key
+  -z <zone>` sends a `proxy-key` ZonePost command to the daemon; the
+  `APIzone` handler runs `ProxyKeyStatus` (`delsync_proxy_update.go`) on the
+  live zone and returns a human-readable report: the state
+  (update-unsupported / ready / foreign-key / waiting) and, in the waiting
+  state, the exact KEY RR + HSYNCPARAM pubkey to publish at the primary.
+  Online (it reads the served zone's apex + does DSYNC discovery, not
+  doable offline). Tests: non-proxy-zone error + update-unsupported message.
+  Build (incl. tdns-cli) + full `go test -race` green.
 - U-b: remove the stale replace-mode refusal (U4). STATUS: DONE. The
   refusal in `SyncZoneDelegationViaUpdate` is replaced with the real
   replace implementation: `CreateChildReplaceUpdate` over the

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -550,11 +550,22 @@ the native child path.
 
 ### 10.6 Build sub-steps
 
-- U-a: the precondition + KEY-bootstrap state machine (§10.8) — the
-  UPDATE-support gate, the apex-KEY check, agent SIG(0) keygen/storage, the
-  operator-instruction surfacing (log + zone-list status + CLI), and the
-  ready/foreign/waiting state handling. This is the gate that everything
-  else depends on; build it first.
+- U-a: the precondition + KEY-bootstrap state machine (§10.8). STATUS:
+  DONE (state machine + wiring). `delsync_proxy_update.go`:
+  `ProxyUpdatePreconditionCheck` runs the §10.8 flow — UPDATE-support gate
+  (`LookupDSYNCTarget` with `SchemeUpdate`), apex-KEY check, ours-vs-foreign
+  match (`proxyHoldsPrivateKeyFor`), keygen on absence (`proxyEnsureSig0Key`
+  via `Sig0KeyMgmt`, no publish — a secondary can't author the zone), and
+  the KEY-RR + HSYNCPARAM-pubkey operator instruction
+  (`proxyBootstrapInstruction`). New `DelegationSyncWarning` ErrorType
+  surfaces the foreign/waiting states on `zone list` (resilient-config
+  quarantine; never hard-fails). New exported `core.NewHsyncparamPubkeyFlag`.
+  Wired off the refresh path via a `PROXY-UPDATE-SETUP` DelegationSyncher
+  command enqueued from `SetupZoneSync`. Tests: keygen idempotency,
+  ours-vs-foreign, apex-KEY read, instruction text, pubkey RR. The
+  DSYNC-discovery gate itself is network — testbed-validated. The on-demand
+  CLI (`proxy-key`) is U-a2 (needs a daemon API endpoint). Build + full
+  `go test -race` green.
 - U-b: remove the stale replace-mode refusal; confirm shared replace works
   on the fork (U4).
 - U-c: the startup reconcile pass — run `AnalyseZoneDelegation` once on

--- a/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
+++ b/docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md
@@ -752,27 +752,43 @@ error-field reuse works for a first cut.
 
 
 
-## 11. The HSYNCPARAM pubkey CONSUMER (tdns-auth secondary)
+## 11. The HSYNCPARAM pubkey / pubcds CONSUMER (tdns-auth secondary)
 
 This is the COUNTERPART to §10's producer. The proxy (and any provider)
-publishes `HSYNCPARAM pubkey` at the customer apex (§9 U10); SOMEONE must
-act on it. This section is that consumer, on the tdns-auth side — and it is
-a tdns-auth feature, NOT an agent/proxy one.
+publishes `HSYNCPARAM pubkey` and/or `HSYNCPARAM pubcds` at the customer
+apex (§9 U10); SOMEONE must act on those flags. This section is that
+consumer, on the tdns-auth side — and it is a tdns-auth feature, NOT an
+agent/proxy one. Both flags are handled by the SAME machinery, differing
+only in which apex RRset is republished and under which signal-name prefix.
 
-### 11.1 The mechanism (RFC 9615 at-NS signaling, for the SIG(0) KEY)
+Note on producers: the §10 proxy emits ONLY `pubkey`
+(`proxyBootstrapInstruction`, `delsync_proxy_update.go:194`) — it needs its
+SIG(0) KEY republished so it can sign UPDATEs; it never authors CDS, so it
+has no reason to set `pubcds`. But `pubcds` is a real, independently-set
+flag (an operator by hand, or multi-provider/HSYNC tooling that wants
+providers to republish the child's CDS at the signal names). The consumer
+must act on whichever flag it finds, regardless of who set it; it does NOT
+assume the proxy is the source.
 
-RFC 9615 (DNSSEC bootstrapping) defines authenticated signaling names of
-the form `_dsboot.<child>._signal.<ns>` under each of the child's
-nameservers, so a parent can DNSSEC-validate the child's bootstrap data
-out-of-band (the scanner already CONSUMES this for CDS:
-`queryCDSAtSignalingNames`, `scanner.go:1283`). The same shape applies to
-the child's SIG(0) KEY, at `_sig0key.<child>._signal.<ns>` — and there is
-already a CONSUMER for THAT: `LookupChildKeyAtSignal` /`VerifyChildKey`
-(`truststore_verify.go:33,57`). What is missing is a PRODUCER on a
-plain tdns-auth secondary. The `pubkey` flag is the instruction to produce
-it.
+### 11.1 The mechanism (RFC 9615 at-NS signaling)
 
-Worked example (the operator's framing):
+RFC 9615 (DNSSEC bootstrapping) defines authenticated signaling names
+under each of the child's nameservers, so a parent can DNSSEC-validate the
+child's bootstrap data out-of-band. There are two such names, and tdns
+already has a CONSUMER for each:
+
+| Flag     | Apex RRset republished | Signal name                       | Existing consumer in tdns                                  |
+|----------|------------------------|-----------------------------------|------------------------------------------------------------|
+| `pubcds` | CDS (and CDNSKEY)      | `_dsboot.<child>._signal.<ns>`    | `queryCDSAtSignalingNames` (`scanner.go:1288`)             |
+| `pubkey` | KEY (SIG(0))           | `_sig0key.<child>._signal.<ns>`   | `LookupChildKeyAtSignal`/`VerifyChildKey` (`truststore_verify.go:33,57`) |
+
+What is missing on a plain tdns-auth secondary is the PRODUCER. The flag is
+the instruction to produce the signal record; the consumer is whoever
+validates the bootstrap (a DSYNC parent for `pubcds`, a SIG(0)-validating
+UPDATE receiver for `pubkey`).
+
+Worked example (the operator's framing, `pubkey` shown; `pubcds` is
+identical with CDS in place of KEY and `_dsboot` in place of `_sig0key`):
 - tdns-auth server `ns.foobar.com` is a SECONDARY for customer zone
   `example.com.`.
 - `example.com.` apex carries `example.com. KEY …` and
@@ -781,20 +797,24 @@ Worked example (the operator's framing):
   under the signaling name
   `_sig0key.example.com._signal.ns.foobar.com.  KEY …`.
 
+For `pubcds`, the apex carries `example.com. CDS …` (and optionally
+`CDNSKEY`) plus `example.com. HSYNCPARAM pubcds`, and the republished
+record is `_dsboot.example.com._signal.ns.foobar.com.  CDS …`.
+
 The republished record's owner is built from the NS HOSTNAME
 (`<ns> = ns.foobar.com`), so the signal record lives UNDER THE NS'S ZONE,
 not under the customer zone. That is the whole point: the parent/validator
-finds the child's KEY via the child's nameservers, authenticated by those
-nameservers' own DNSSEC.
+finds the child's bootstrap data via the child's nameservers, authenticated
+by those nameservers' own DNSSEC.
 
 ### 11.2 The hard precondition (and what's out of scope)
 
-`ns.foobar.com` can publish `_sig0key.example.com._signal.ns.foobar.com.`
-ONLY if it is PRIMARY (locally authoritative AND writable) for a zone that
-is a parent of `_signal.ns.foobar.com.` — i.e. it locally owns and can
-write `ns.foobar.com.` (as its own zone) or `foobar.com.`. If no such
-local primary zone exists, this NS's signal record is a NON-STARTER —
-skip it (warn).
+`ns.foobar.com` can publish a `_signal.ns.foobar.com.` record ONLY if it is
+PRIMARY (locally authoritative AND writable) for a zone that is a parent of
+`_signal.ns.foobar.com.` — i.e. it locally owns and can write
+`ns.foobar.com.` (as its own zone) or `foobar.com.`. If no such local
+primary zone exists, this NS's signal record is a NON-STARTER — skip it
+(warn). This precondition is identical for both flags.
 
 OUT OF SCOPE (for now): the case where `ns.foobar.com` is NOT primary for
 that zone but some intra-company mechanism could convey the publish request
@@ -802,74 +822,96 @@ to wherever the real primary is. We handle only the locally-primary case.
 
 ### 11.3 The algorithm (per incoming transfer of a customer zone)
 
-1. Read the apex HSYNCPARAM of the transferred zone; if it has no `pubkey`
-   flag (`HSYNCPARAM.HasPubkey()`, `core/rr_hsyncparam.go:387` — already in
-   tdns, currently unused), do nothing.
-2. Collect the apex KEY RRset of the transferred customer zone (ALL KEYs).
+Run once per active flag. The two flags share every step except the
+source RRset and the signal-name prefix (drive both from the table in
+§11.1):
+
+1. Read the apex HSYNCPARAM of the transferred zone. Determine which flags
+   are set: `HSYNCPARAM.HasPubkey()` (`core/rr_hsyncparam.go:387`) and
+   `HSYNCPARAM.HasPubcds()` (`core/rr_hsyncparam.go:397`) — both already in
+   tdns, currently unused. If neither, do nothing.
+2. For each set flag, collect the corresponding apex RRset of the
+   transferred customer zone: ALL KEYs for `pubkey`; CDS (and CDNSKEY if
+   present) for `pubcds`. If the flag is set but the apex RRset is empty,
+   skip that flag (nothing to republish) and warn.
 3. For each NS hostname `<ns>` in the customer zone's apex NS RRset:
-   a. Build the signal owner `_sig0key.<customerzone>._signal.<ns>.`.
+   a. Build the signal owner from the flag's prefix:
+      `_sig0key.<customerzone>._signal.<ns>.` (pubkey) or
+      `_dsboot.<customerzone>._signal.<ns>.` (pubcds).
    b. `FindZone(signalOwner)` (`zone_utils.go:602` — longest-suffix match
       over locally-served zones). If it returns a zone we are PRIMARY for,
       that is the target; else skip this NS (non-starter, §11.2).
-   c. Publish each apex KEY (re-owned to the signal name) into the target
-      zone via the internal publish path (the `UpdateQ <- UpdateRequest{
-      Cmd:"ZONE-UPDATE", InternalUpdate:true}` idiom that `PublishKeyRRs`
-      uses, `ops_key.go:17`). If the target zone is signed (inline-signing),
-      the normal publish path re-signs the new `_signal` KEY RRset.
-4. Idempotency: republish only on CHANGE (the apex KEY or the NS set
-   differs from what we last published), so a plain re-transfer of unchanged
-   data is a no-op — same content-edge discipline as the proxy's §10.4/D8.
+   c. Publish each apex record (re-owned to the signal name) into the
+      target zone via the internal publish path (the `UpdateQ <-
+      UpdateRequest{Cmd:"ZONE-UPDATE", InternalUpdate:true}` idiom that
+      `PublishKeyRRs` uses, `ops_key.go:17`). If the target zone is signed
+      (inline-signing), the normal publish path re-signs the new `_signal`
+      RRset.
+4. Idempotency: republish only on CHANGE (the apex source RRset or the NS
+   set differs from what we last published), so a plain re-transfer of
+   unchanged data is a no-op — same content-edge discipline as the proxy's
+   §10.4/D8. The two flags are gated independently (a CDS change does not
+   force a KEY republish, and vice versa).
 
 ### 11.4 Reuse vs. new (and the tdns-mp question)
 
-- REUSE (parsing): `HSYNCPARAM.HasPubkey()` lives in `tdns/v2/core` — the
-  flag check is ~3 lines, no analysis engine needed.
+- REUSE (parsing): `HSYNCPARAM.HasPubkey()` and `HasPubcds()` live in
+  `tdns/v2/core` — the flag checks are ~3 lines each, no analysis engine
+  needed.
 - DO NOT reuse the tdns-mp HSYNC analysis (`HsyncChanged`,
   `tdns-mp/v2/hsync_utils.go`): it returns an MP-specific `*HsyncStatus`
   and is entangled with provider-groups/signers. A plain tdns-auth
-  secondary must NOT depend on tdns-mp. For `pubkey` we need none of that —
-  just the flag, the apex KEY/NS RRsets, `FindZone`, and the publish idiom.
+  secondary must NOT depend on tdns-mp. For these flags we need none of
+  that — just the flags, the apex KEY/CDS/NS RRsets, `FindZone`, and the
+  publish idiom.
 - NEW: the per-NS signal-name publish (build owner, find local primary
-  zone, publish/re-sign), and the change-detection gate.
+  zone, publish/re-sign), parameterized over the (flag, source RRset,
+  prefix) pair, and the per-flag change-detection gate.
 
 ### 11.5 Always-on (operator decision)
 
 The check runs on EVERY tdns-auth secondary, with NO option gating it
-(operator-confirmed). The flag should "just work" as the producer intends.
+(operator-confirmed). The flags should "just work" as the producer intends.
 It is safe to be always-on: it only acts when (a) the transferred zone
-actually carries `HSYNCPARAM pubkey` AND (b) this server is locally primary
-for a parent of the signal name — both narrow conditions. A secondary that
-is primary for nothing relevant does nothing.
+actually carries `HSYNCPARAM pubkey`/`pubcds` AND (b) this server is locally
+primary for a parent of the signal name — both narrow conditions. A
+secondary that is primary for nothing relevant does nothing.
 
 ### 11.6 Wiring (the hook)
 
 The natural home is the post-transfer path — the same `OnZonePreRefresh`/
 `OnZonePostRefresh` machinery the proxy uses (§3), but registered for ALL
 secondary zones on tdns-auth (the always-on decision), not just
-proxy-option zones. PreRefresh detects the `pubkey` + apex-KEY/NS change;
-PostRefresh publishes into the target zone(s). (Or run it from the existing
-refresh callback path if a lighter touch fits — decide at build time.) The
-publish targets a DIFFERENT zone than the one being refreshed (the NS's
-zone), so this is a cross-zone internal publish via `UpdateQ`, not a
-mutation of the transferred zone.
+proxy-option zones. PreRefresh detects the active flag(s) + apex-source/NS
+change; PostRefresh publishes into the target zone(s). (Or run it from the
+existing refresh callback path if a lighter touch fits — decide at build
+time.) The publish targets a DIFFERENT zone than the one being refreshed
+(the NS's zone), so this is a cross-zone internal publish via `UpdateQ`, not
+a mutation of the transferred zone.
 
 ### 11.7 Open items for build time
 
 - Confirm the change-detection gate's state: where to remember "what we
   last published at the signal names" so re-publish is change-only (a small
-  per-zone marker, or diff the live `_signal` RRset in the target zone vs.
-  the apex KEY — the latter needs no new state).
+  per-zone-per-flag marker, or diff the live `_signal` RRset in the target
+  zone vs. the apex source RRset — the latter needs no new state).
 - A signed TARGET zone (the NS's zone, inline-signing) must re-sign the new
-  `_signal` KEY RRset; confirm the internal publish path does this for a
+  `_signal` RRset; confirm the internal publish path does this for a
   non-apex owner.
 - Out-of-bailiwick NS whose zone we do not serve: skip + (rate-limited)
   warn, so the operator sees that some NS signal records could not be
   produced locally.
+- `pubcds` specifics: republish CDNSKEY alongside CDS only if the customer
+  apex actually carries it (RFC 7344 allows either or both); never
+  synthesize one from the other.
 
 ### 11.8 Estimate
 
-Small-to-medium: ~120–200 source + ~120–200 test LOC. No HIGH-risk step
-(it only ADDS a signaling RRset to a zone we already author; worst case is
-a spurious `_signal` KEY, which a validator simply ignores if it doesn't
-match). The producer (this) plus the existing consumer
-(`LookupChildKeyAtSignal`) closes the RFC-9615-style loop for SIG(0) KEYs.
+Small-to-medium: ~150–230 source + ~150–230 test LOC for BOTH flags (the
+second flag is mostly a table row plus a second source-RRset path and its
+tests, not a second implementation). No HIGH-risk step (it only ADDS a
+signaling RRset to a zone we already author; worst case is a spurious
+`_signal` record, which a validator simply ignores if it doesn't match).
+The producer (this) plus the existing consumers (`queryCDSAtSignalingNames`
+for CDS, `LookupChildKeyAtSignal` for the SIG(0) KEY) closes the
+RFC-9615-style loop for both bootstrap kinds.

--- a/docs/2026-06-22-agent-dsync-proxy-operator-guide.md
+++ b/docs/2026-06-22-agent-dsync-proxy-operator-guide.md
@@ -1,0 +1,119 @@
+# Operator guide: tdns-agent as a DSYNC proxy
+
+This describes how to run tdns-agent as a SECONDARY that forwards
+delegation-sync signals (NOTIFY(CDS)/NOTIFY(CSYNC)) to the parent on
+behalf of a primary that is DSYNC-unaware (BIND9, Knot, NSD, etc.).
+
+See `2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md` for the
+design. This guide is the how-to.
+
+
+## When to use this
+
+Your zone's primary cannot speak DSYNC — it will never discover the
+parent's DSYNC RRset, and it will never tell the parent to update the DS
+or the delegation. But the primary CAN publish a CDS/CDNSKEY (RFC 7344)
+and/or a CSYNC (RFC 7477) in the zone — that is the standard, vendor-
+neutral way for a child to signal "please sync me."
+
+Run tdns-agent as a secondary for that zone. On each incoming AXFR/IXFR it
+watches for changes to the zone's CDS, CSYNC, NS+glue, or DNSKEY and, when
+something changes, forwards the matching NOTIFY to the parent's DSYNC
+NOTIFY receiver. The parent then re-scans the child and applies the change.
+The primary stays exactly as it is.
+
+
+## Requirements
+
+- The PARENT publishes a DSYNC RRset advertising a NOTIFY scheme for CDS
+  and/or CSYNC (e.g. tdns-auth as the parent does this with
+  `delegation-sync-parent`). If the parent advertises only UPDATE, the
+  proxy does nothing for now (UPDATE-proxy is later work).
+- The PRIMARY publishes CDS/CDNSKEY and/or CSYNC when it wants the parent
+  updated (this is the primary's own DNSSEC/delegation tooling — outside
+  tdns).
+- The AGENT is a secondary for the zone (transfers it from the primary)
+  and can reach the parent's advertised NOTIFY target.
+
+
+## Configuration
+
+On the tdns-agent, configure the zone as a normal secondary and add the
+`delegation-sync-proxy` option:
+
+```yaml
+zones:
+   child.example.:
+      type: secondary
+      primary: 192.0.2.10:53        # the DSYNC-unaware BIND/Knot primary
+      store: map
+      options:
+         - delegation-sync-proxy
+```
+
+Notes:
+
+- `delegation-sync-proxy` is valid ONLY on a tdns-agent secondary zone. On
+  any other app type, or on a primary zone, it is rejected with a config
+  error (so a misconfiguration is loud, not silent).
+- It is independent of `delegation-sync-child`. Use `delegation-sync-proxy`
+  when the agent forwards on behalf of a clueless primary; use
+  `delegation-sync-child` when the agent/auth IS the child syncing its own
+  delegation.
+- No SIG(0) key setup is needed for the proxy: a NOTIFY is a contentless
+  "come re-scan me" signal — the agent never signs or authors anything in
+  the zone.
+
+
+## What triggers a NOTIFY
+
+On each incoming transfer the agent diffs the new zone against the one it
+was serving. The mapping from "what changed" to "what is forwarded":
+
+| Change in the transfer            | NOTIFY sent to parent |
+|-----------------------------------|-----------------------|
+| CDS RRset changed                 | NOTIFY(CDS)           |
+| DNSKEY RRset changed              | NOTIFY(CDS)           |
+| CSYNC RRset changed               | NOTIFY(CSYNC)         |
+| NS RRset or glue (A/AAAA) changed | NOTIFY(CSYNC)         |
+
+The DNSKEY→NOTIFY(CDS) and NS/glue→NOTIFY(CSYNC) rows are intentional:
+even if the primary changed keys or nameservers without (yet) republishing
+the CDS/CSYNC, the agent nudges the parent to re-scan. A NOTIFY is cheap
+and the parent decides for itself — it ignores a NOTIFY it has nothing to
+do about.
+
+Both can fire from one transfer (e.g. a CDS change and an NS change → both
+NOTIFY(CDS) and NOTIFY(CSYNC)).
+
+
+## What does NOT trigger a NOTIFY
+
+- A bare SOA-serial bump with no change to CDS/CSYNC/NS/glue/DNSKEY. The
+  trigger compares RRset CONTENT, not the serial.
+- Re-transferring content the agent already forwarded. Because the agent
+  diffs against what it is currently serving, a change fires exactly ONCE
+  — on the transfer where it appears. A parent that is slow to absorb does
+  NOT get re-NOTIFYd on every refresh; there is no NOTIFY storm.
+
+
+## Limitations (first release)
+
+- NOTIFY only. If the parent advertises only the UPDATE scheme, the proxy
+  logs that it found no usable NOTIFY target and does nothing. (DNS-UPDATE
+  proxying — which would also cover UNSIGNED zones — is planned later.)
+- Signed zones only, in practice: CDS/CSYNC presuppose a signed zone, so an
+  unsigned zone has nothing for the NOTIFY path to forward. (The option is
+  NOT refused on an unsigned zone — that is deliberate, so the later
+  UPDATE path, which works unsigned, is not foreclosed.)
+- The agent must be able to reach the parent's advertised NOTIFY target.
+
+
+## Verifying
+
+- Change the CDS (or CSYNC) at the primary, let the agent transfer the
+  zone, and watch the agent log for
+  `delegation-sync-proxy: forwarded NOTIFY(...) to parent`.
+- On a tdns-auth parent, the incoming NOTIFY routes to the scanner
+  (`CheckCDS` / `ProcessCSYNCNotify`), which queries the child and applies
+  the DS / delegation change.

--- a/guide/README.md
+++ b/guide/README.md
@@ -19,12 +19,20 @@ companion [tdns-mp Guide](../../tdns-mp/guide/README.md).
   detailed documentation for each.
 
 - [TDNS Special Features and Extensions](special-features.md)
-  -- Delegation sync (both parent and child sides, including
+  -- Delegation sync (parent side, child side, and the
+  agent-as-proxy path for DSYNC-unaware primaries, including
   the DSYNC scheme dispatch, the NOTIFY scanner, and the
   pluggable delegation backends), DNS transport signaling,
   experimental record types, and post-quantum algorithm
   support (ML-DSA / SLH-DSA / Falcon / MAYO / SNOVA for both
   SIG(0) and DNSSEC).
+
+- [Agent as a DSYNC proxy](agent-dsync-proxy.md)
+  -- Operator how-to for running tdns-agent as a secondary
+  that forwards NOTIFY(CDS/CSYNC) to the parent on behalf of
+  a DSYNC-unaware primary (BIND/Knot/NSD): when to use it,
+  configuration, the change-to-NOTIFY mapping, limitations,
+  and verification.
 
 - [Automatic DNSSEC Key Rollovers](key-rollover.md)
   -- Operator manual for the automated KSK rollover engine,
@@ -43,5 +51,6 @@ companion [tdns-mp Guide](../../tdns-mp/guide/README.md).
   reading when changing engine timing behaviour.
 
 - Future Work (coming soon)
-  -- IXFR support, TSIG authentication, scanner integration
-  for parent-side delegation sync.
+  -- IXFR support, TSIG authentication, and UPDATE-scheme
+  delegation-sync proxying (the NOTIFY-scheme proxy ships
+  now; see the agent-as-proxy guide above).

--- a/guide/README.md
+++ b/guide/README.md
@@ -29,10 +29,11 @@ companion [tdns-mp Guide](../../tdns-mp/guide/README.md).
 
 - [Agent as a DSYNC proxy](agent-dsync-proxy.md)
   -- Operator how-to for running tdns-agent as a secondary
-  that forwards NOTIFY(CDS/CSYNC) to the parent on behalf of
-  a DSYNC-unaware primary (BIND/Knot/NSD): when to use it,
-  configuration, the change-to-NOTIFY mapping, limitations,
-  and verification.
+  that forwards delegation-sync (NOTIFY and/or signed DNS
+  UPDATE) to the parent on behalf of a DSYNC-unaware primary
+  (BIND/Knot/NSD): when to use it, configuration, the
+  change mapping, the UPDATE KEY-bootstrap (`zone proxy-key`),
+  limitations, and verification.
 
 - [Automatic DNSSEC Rollovers](key-rollover.md)
   -- Operator manual for all three rollover kinds:
@@ -53,6 +54,4 @@ companion [tdns-mp Guide](../../tdns-mp/guide/README.md).
   reading when changing engine timing behaviour.
 
 - Future Work (coming soon)
-  -- IXFR support, TSIG authentication, and UPDATE-scheme
-  delegation-sync proxying (the NOTIFY-scheme proxy ships
-  now; see the agent-as-proxy guide above).
+  -- IXFR support and TSIG authentication.

--- a/guide/README.md
+++ b/guide/README.md
@@ -34,14 +34,16 @@ companion [tdns-mp Guide](../../tdns-mp/guide/README.md).
   configuration, the change-to-NOTIFY mapping, limitations,
   and verification.
 
-- [Automatic DNSSEC Key Rollovers](key-rollover.md)
-  -- Operator manual for the automated KSK rollover engine,
-  covering policy YAML, the `auto-rollover` CLI subcommand
-  tree, the status output, PQ-safe parent UPDATEs,
-  DSYNC-aware dispatch and verification, the three-knob
-  mental model (TTLs, KSK lifetime, RRSIG validity), worked
-  examples at testbed, weekly, and monthly cadences, and
-  the failure-category model.
+- [Automatic DNSSEC Rollovers](key-rollover.md)
+  -- Operator manual for all three rollover kinds:
+  parent-coordinated **KSK** rollover (the bulk -- policy
+  YAML, the `auto-rollover` CLI tree, status output, PQ-safe
+  parent UPDATEs, DSYNC-aware dispatch and verification, the
+  three-knob mental model, worked examples, and the
+  failure-category model), local **ZSK** rollover, and
+  **algorithm** rollover (the relaxed-mode ZSK alg roll via
+  `policy-change` + `asap --zsk`, with the `completeness`
+  knob and the KSK/CSK/both-role/strict refusals).
 
 - [Rollover Timing Equations](rollover-timing-equations.md)
   -- Canonical reference for the cache-flush invariants,

--- a/guide/agent-dsync-proxy.md
+++ b/guide/agent-dsync-proxy.md
@@ -1,8 +1,10 @@
 # Operator guide: tdns-agent as a DSYNC proxy
 
 This describes how to run tdns-agent as a SECONDARY that forwards
-delegation-sync signals (NOTIFY(CDS)/NOTIFY(CSYNC)) to the parent on
-behalf of a primary that is DSYNC-unaware (BIND9, Knot, NSD, etc.).
+delegation-sync to the parent on behalf of a primary that is DSYNC-unaware
+(BIND9, Knot, NSD, etc.). The agent forwards via whichever scheme the
+parent advertises: a generalized NOTIFY (the parent re-scans the child), or
+a signed DNS UPDATE (the agent sends the delegation records directly).
 
 This proxy is one of the three delegation-sync roles; for how it fits with
 the parent and self-syncing-child roles see
@@ -27,15 +29,16 @@ The primary stays exactly as it is.
 
 ## Requirements
 
-- The PARENT publishes a DSYNC RRset advertising a NOTIFY scheme for CDS
-  and/or CSYNC (e.g. tdns-auth as the parent does this with
-  `delegation-sync-parent`). If the parent advertises only UPDATE, the
-  proxy does nothing for now (UPDATE-proxy is later work).
-- The PRIMARY publishes CDS/CDNSKEY and/or CSYNC when it wants the parent
-  updated (this is the primary's own DNSSEC/delegation tooling — outside
-  tdns).
+- The PARENT publishes a DSYNC RRset (e.g. tdns-auth with
+  `delegation-sync-parent`). The proxy uses whichever scheme it advertises:
+  NOTIFY (for CDS/CSYNC) and/or UPDATE. When both are advertised, UPDATE is
+  preferred (it lands the change in one round-trip and works for unsigned
+  zones).
+- For the NOTIFY scheme: the PRIMARY publishes CDS/CDNSKEY and/or CSYNC when
+  it wants the parent updated (its own tooling). For the UPDATE scheme: the
+  agent needs a SIG(0) key the parent trusts (see "UPDATE proxy" below).
 - The AGENT is a secondary for the zone (transfers it from the primary)
-  and can reach the parent's advertised NOTIFY target.
+  and can reach the parent's advertised target.
 
 
 ## Configuration
@@ -62,9 +65,13 @@ Notes:
   when the agent forwards on behalf of a clueless primary; use
   `delegation-sync-child` when the agent/auth IS the child syncing its own
   delegation.
-- No SIG(0) key setup is needed for the proxy: a NOTIFY is a contentless
-  "come re-scan me" signal — the agent never signs or authors anything in
-  the zone.
+- For the NOTIFY scheme no SIG(0) key is needed (a NOTIFY is a contentless
+  "come re-scan me" signal). The UPDATE scheme DOES need a SIG(0) key — the
+  agent generates it and you publish its public KEY at the primary (see
+  "UPDATE proxy" below). The agent never authors anything else in the zone.
+- The UPDATE form is REPLACE by default (delete the RRset, re-add the
+  current members — idempotent and self-correcting). To use delta instead,
+  set the `parent-update: delta` auth option under `dnsengine.options`.
 
 
 ## What triggers a NOTIFY
@@ -99,23 +106,69 @@ NOTIFY(CDS) and NOTIFY(CSYNC)).
   NOT get re-NOTIFYd on every refresh; there is no NOTIFY storm.
 
 
-## Limitations (first release)
+## UPDATE proxy (parent advertises DSYNC UPDATE)
 
-- NOTIFY only. If the parent advertises only the UPDATE scheme, the proxy
-  logs that it found no usable NOTIFY target and does nothing. (DNS-UPDATE
-  proxying — which would also cover UNSIGNED zones — is planned later.)
-- Signed zones only, in practice: CDS/CSYNC presuppose a signed zone, so an
-  unsigned zone has nothing for the NOTIFY path to forward. (The option is
-  NOT refused on an unsigned zone — that is deliberate, so the later
-  UPDATE path, which works unsigned, is not foreclosed.)
-- The agent must be able to reach the parent's advertised NOTIFY target.
+When the parent advertises the UPDATE scheme, the agent can send the
+delegation records (NS + glue + DS) to the parent directly in a signed DNS
+UPDATE, rather than asking it to re-scan. This is preferred over NOTIFY
+when available, and — unlike NOTIFY — it works for an UNSIGNED zone too
+(there is no CDS/CSYNC to scan, but the NS/glue can still be synced).
+
+The parent must trust the UPDATE. It does so by the SIG(0) key that signs
+it: the agent signs AS the child, with a key whose public KEY is published
+at the child apex (exactly how a DSYNC-native child is trusted). Since the
+agent is only a secondary, it cannot publish that KEY itself — you publish
+it once at the primary.
+
+**Bootstrap, step by step:**
+
+1. Enable `delegation-sync-proxy` on the zone (above) and start/reload the
+   agent. If the parent advertises UPDATE and no KEY is published yet, the
+   agent generates a SIG(0) keypair and records a warning on the zone.
+2. Ask the agent what to publish:
+
+   ```
+   tdns-cli ... zone proxy-key -z child.example.
+   ```
+
+   In the waiting state this prints two records to add at the primary apex:
+   the agent's **KEY** RR, and an **HSYNCPARAM** record with the `pubkey`
+   flag. (The `pubkey` flag tells every provider of the zone to republish
+   the apex KEY — so the bootstrap works even with multiple providers.)
+3. Add those two records to the zone at the primary. They transfer in to the
+   agent on the next refresh.
+4. Once the agent sees its KEY at the apex, `proxy-key` reports READY and the
+   agent starts proxying UPDATEs.
+
+`proxy-key` reports one of four states: `update-unsupported` (parent
+advertises no UPDATE — use NOTIFY), `waiting` (publish the printed records),
+`ready` (operating), or `foreign-key` (a KEY the agent does not own occupies
+the apex — remove it, or UPDATE-proxy cannot work; NOTIFY may still apply).
+
+On startup the agent also does a one-time parent-vs-child reconcile: if the
+delegation drifted while the agent was down, it sends one UPDATE to fix it
+— but it does NOT re-send on every restart when nothing changed.
+
+
+## Limitations
+
+- The agent must be able to reach the parent's advertised target.
+- UPDATE-proxy for a zone served by multiple providers relies on the
+  HSYNCPARAM `pubkey` flag to get the agent's KEY published across all
+  providers; the primary must support adding that record.
+- A `foreign-key` state (a KEY at the apex the agent does not own) disables
+  the UPDATE proxy for that zone until resolved; NOTIFY may still apply.
 
 
 ## Verifying
 
-- Change the CDS (or CSYNC) at the primary, let the agent transfer the
-  zone, and watch the agent log for
-  `delegation-sync-proxy: forwarded NOTIFY(...) to parent`.
-- On a tdns-auth parent, the incoming NOTIFY routes to the scanner
-  (`CheckCDS` / `ProcessCSYNCNotify`), which queries the child and applies
-  the DS / delegation change.
+- Change the CDS (or CSYNC, or NS/glue) at the primary, let the agent
+  transfer the zone, and watch the agent log for either
+  `delegation-sync-proxy: forwarded NOTIFY(...) to parent` (NOTIFY scheme)
+  or `proxied ... UPDATE to parent ... (rcode NOERROR)` (UPDATE scheme).
+- For the NOTIFY scheme on a tdns-auth parent, the incoming NOTIFY routes to
+  the scanner (`CheckCDS` / `ProcessCSYNCNotify`), which queries the child
+  and applies the change. For the UPDATE scheme the parent applies the
+  records directly after validating the SIG(0) signature.
+- `tdns-cli ... zone proxy-key -z <zone>` reports the current UPDATE-proxy
+  state at any time.

--- a/guide/agent-dsync-proxy.md
+++ b/guide/agent-dsync-proxy.md
@@ -4,8 +4,10 @@ This describes how to run tdns-agent as a SECONDARY that forwards
 delegation-sync signals (NOTIFY(CDS)/NOTIFY(CSYNC)) to the parent on
 behalf of a primary that is DSYNC-unaware (BIND9, Knot, NSD, etc.).
 
-See `2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md` for the
-design. This guide is the how-to.
+This proxy is one of the three delegation-sync roles; for how it fits with
+the parent and self-syncing-child roles see
+[Special Features §1.6](special-features.md). For the design rationale see
+`../docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md`.
 
 
 ## When to use this

--- a/guide/key-rollover.md
+++ b/guide/key-rollover.md
@@ -1,4 +1,10 @@
-# TDNS Operator Guide: Automatic DNSSEC Key Rollovers
+# TDNS Operator Guide: Automatic DNSSEC Rollovers
+
+TDNS automates three kinds of DNSSEC rollover. This guide
+covers all three; most of it (sections 1-12) is the KSK
+engine, which is the most involved because it coordinates
+with the parent. Sections 14 (ZSK) and 15 (algorithm
+rollover) build on that foundation and are shorter.
 
 TDNS includes a fully automated KSK rollover engine. Once
 a zone is configured with a DNSSEC policy that has
@@ -33,6 +39,35 @@ companion document
 For multi-provider deployments where leader election picks
 which provider drives the rollover, see the
 [tdns-mp guide](../../tdns-mp/guide/).
+
+
+## 0. Three kinds of rollover
+
+It helps to keep the three rollover types distinct, because
+they differ in whether the parent is involved:
+
+- **KSK rollover** (same algorithm) -- replace the
+  key-signing key. The DS at the parent must change, so this
+  is **parent-coordinated**: the engine publishes the new
+  key, pushes/confirms the DS at the parent, then retires
+  the old key. This is the bulk of the guide (sections
+  1-13).
+- **ZSK rollover** (same algorithm) -- replace the
+  zone-signing key. The ZSK has **no parent dependency** (no
+  DS), so this is purely local: pre-publish, activate,
+  retire, remove, on a lifetime cadence. Section 14.
+- **Algorithm rollover** -- change the signing *algorithm*
+  (e.g. ED25519 -> a PQ algorithm), not just the key. This
+  rides the same pipelines but the generator starts minting
+  the new algorithm and the old one drains out. Section 15.
+  Today the **relaxed-mode ZSK** algorithm rollover is
+  implemented; KSK-algorithm and strict-mode rollovers are
+  refused with a clear error (later work).
+
+All three share the same policy YAML (section 1), the same
+`auto-rollover` CLI tree (section 2), and the same `status`
+output (section 3). The role filter flags `--ksk` / `--zsk`
+select which role a command acts on.
 
 
 ## 1. Configuring the engine
@@ -165,14 +200,21 @@ inherits two persistent filter flags, `--ksk` and `--zsk`,
 which limit the operation to keys of that role.
 
 ```
-auto-rollover when     --zone Z [--offline]
-auto-rollover asap     --zone Z
-auto-rollover cancel   --zone Z
-auto-rollover status   --zone Z [--offline] [-v]
-auto-rollover reset    --zone Z --keyid N [--offline [--force]]
-auto-rollover unstick  --zone Z [--offline [--force]]
+auto-rollover when          --zone Z [--ksk|--zsk] [--offline]
+auto-rollover asap          --zone Z [--ksk|--zsk]
+auto-rollover cancel        --zone Z [--ksk|--zsk]
+auto-rollover policy-change  --zone Z --policy P
+auto-rollover status        --zone Z [--ksk|--zsk] [--offline] [-v]
+auto-rollover reset         --zone Z --keyid N [--offline [--force]]
+auto-rollover unstick       --zone Z [--offline [--force]]
 auto-rollover validate ...
 ```
+
+`when`, `asap`, and `cancel` default to the KSK role; pass
+`--zsk` to operate on the zone-signing key instead (a ZSK
+roll has no parent coordination -- see section 14).
+`policy-change` is the algorithm-rollover trigger (section
+15).
 
 | Subcommand | Purpose |
 |------------|---------|
@@ -183,6 +225,7 @@ auto-rollover validate ...
 | `reset`    | Clears `last_rollover_error` for one specific key after the operator has intervened. Takes `--keyid` because errors are scoped per key. `--offline` writes directly to the keystore with a daemon-alive guard you can override with `--force`. |
 | `unstick`  | The engine throttles itself after persistent failures by setting `next_push_at` into the future. `unstick` clears that field so the next tick will probe the parent immediately, without waiting `softfail-delay`. |
 | `validate` | Parses and cross-checks a DNSSEC policy file; surfaces invalid durations, missing required fields, and cross-field constraint violations. |
+| `policy-change` | Binds the zone to a new DNSSEC policy to start an algorithm rollover (section 15). It only changes the algorithm of *future*-generated keys; the existing keys drain out in order. It does NOT perform the roll -- `asap --zsk` is the throttle. |
 
 The `when` command shows two times:
 
@@ -856,7 +899,140 @@ attempts have happened. The `last_softfail_*` fields tell
 you when and why.
 
 
-## 13. Further reading
+## 14. ZSK rollover
+
+A ZSK rollover replaces the zone-signing key. Unlike the
+KSK, the ZSK has no DS at the parent, so there is **no
+parent coordination** -- the whole rollover is local to the
+zone and bounded only by the zone's own TTLs. This makes it
+much simpler than the KSK case, and most of sections 4-12
+(parent DS push, confirm, softfail, DSYNC dispatch) do not
+apply.
+
+The lifecycle is the familiar pre-publish roll: a standby
+ZSK is generated and published ahead of time; when the
+active ZSK reaches `zsk.lifetime` (or you trigger it),
+standby becomes active, the old active becomes retired, and
+after a drain window (propagation delay + the longest TTL it
+signed) the retired key is removed and its signatures are
+stripped. The engine keeps `standby-zsk-count` standbys
+ready so a roll never waits on key generation.
+
+**Configuration.** The ZSK lifetime and signature validity
+live in the same policy block as the KSK:
+
+```yaml
+   mypolicy:
+      algorithm:   ED25519
+      zsk:
+         lifetime:    2w      # roll cadence (forever = never)
+         sigvalidity: 2h
+```
+
+`zsk.lifetime: forever` disables the scheduled roll; you can
+still roll manually with `asap --zsk`.
+
+**Operating it.** The same `auto-rollover` commands drive
+the ZSK, with `--zsk`:
+
+```
+auto-rollover when   --zone Z --zsk     # next/earliest ZSK roll
+auto-rollover asap   --zone Z --zsk     # roll at the earliest moment
+auto-rollover cancel --zone Z --zsk     # cancel a pending asap
+auto-rollover status --zone Z           # shows KSK and ZSK both
+```
+
+`asap --zsk` schedules a roll for the next worker tick; if
+no standby ZSK is ready yet, the request persists until one
+is and then fires (it is not lost). Because a ZSK roll has
+no DS dance, `when --zsk` shows only the local schedule
+(active_at + lifetime) and a "ready / waiting-for-standby"
+status -- there are no parent-DS gates. The `status` output
+lists ZSKs alongside KSKs, each with its own `active_seq`
+counter (the n-th active ZSK in the zone's history), which
+ticks up by one on every roll -- a quick confirmation that a
+roll progressed.
+
+
+## 15. Algorithm rollover
+
+An algorithm rollover changes the signing *algorithm*, not
+just the key -- for example ED25519 to a post-quantum
+algorithm. It reuses the rollover pipelines: you bind the
+zone to a policy with the new algorithm, and from then on
+newly-generated keys carry it while the old-algorithm keys
+drain out in the normal FIFO order. Nothing is swapped
+synchronously; the transition is gradual and safe at every
+instant.
+
+Today the **relaxed-mode ZSK** algorithm rollover is
+implemented. The following are deliberately **refused** with
+a clear error rather than run unsafely (they are later
+work): a KSK-algorithm rollover (it needs the parent-DS
+engine), a CSK-algorithm change, a both-roles-at-once
+change, and a ZSK-algorithm change under strict completeness
+mode.
+
+**The completeness knob.** A ZSK signs the whole zone, so a
+strict reading of RFC 4035 would require maintaining
+old-algorithm signatures over the entire zone throughout the
+drain -- expensive. TDNS exposes a global choice:
+
+```yaml
+dnssec:
+   completeness: relaxed     # strict (default) | relaxed
+```
+
+`relaxed` (the alg-split model) drops the maintained
+whole-zone double-signature: the new algorithm signs
+everything and the old-algorithm key simply drains, which
+every validator still accepts (a validator needs one working
+chain, not one per algorithm). A ZSK algorithm rollover
+requires `relaxed`; under the default `strict` it is
+refused.
+
+**The two-command workflow.** Binding the new algorithm and
+performing the roll are separate steps:
+
+```
+# 1. bind the new algorithm (changes only FUTURE keys)
+auto-rollover policy-change --zone Z --policy newalg-policy
+
+# 2. drive the drain (each asap promotes the next standby)
+auto-rollover asap --zone Z --zsk
+```
+
+`policy-change` does NOT roll anything -- it writes the
+zone's policy override so that future-generated ZSKs use the
+new algorithm, and the existing keys keep draining in order.
+The roll then advances on the normal ZSK cadence, or you
+accelerate it with `asap --zsk`: each `asap` promotes the
+next standby, and because the existing standbys are already
+propagated, successive `asap`s run back-to-back until the
+new-algorithm keys take over. A second `policy-change` while
+a roll is already in flight is refused; cancel first
+(`cancel --zsk`) if you need to change course.
+
+**Watching it.** `auto-rollover status` shows an
+algorithm-transition line in the header while a roll is in
+flight, e.g.
+
+```
+Algorithm rollover: ZSK ED25519 -> MAYO1  (in progress), 1 of 3 published ZSKs on new algorithm
+```
+
+The roll is complete when every live ZSK is on the new
+algorithm and the old-algorithm keys have drained out and
+been removed.
+
+For the design rationale and the safety model see
+`tdns/docs/2026-06-17-algorithm-rollover-evaluation.md` (the
+ZSK alg roll) and
+`tdns/docs/2026-06-21-ksk-algorithm-rollover-plan.md` (the
+planned KSK alg roll).
+
+
+## 16. Further reading
 
 - **Timing math:** the canonical engine reference is
   [Rollover Timing Equations](rollover-timing-equations.md)

--- a/guide/special-features.md
+++ b/guide/special-features.md
@@ -350,11 +350,15 @@ The three delegation-sync roles, side by side:
   DSYNC-unaware primary: forward the primary's CDS/CSYNC
   signals up on its behalf (this section).
 
-The proxy is NOTIFY-only for now; if the parent advertises
-only the UPDATE scheme, the proxy does nothing (UPDATE
-proxying, which would also cover unsigned zones, is planned
-work). For the full operator how-to -- configuration,
-requirements, limitations, and verification -- see
+The proxy forwards via whichever scheme the parent
+advertises: NOTIFY (the parent re-scans the child), or a
+signed DNS UPDATE (the agent sends the delegation records
+directly, which also covers unsigned zones). The UPDATE
+scheme needs a SIG(0) key the parent trusts -- the agent
+generates it and the operator publishes its KEY at the
+primary (a one-time `zone proxy-key` bootstrap). For the
+full operator how-to -- configuration, the UPDATE
+KEY-bootstrap, limitations, and verification -- see
 [Agent as a DSYNC proxy](agent-dsync-proxy.md).
 
 

--- a/guide/special-features.md
+++ b/guide/special-features.md
@@ -36,7 +36,10 @@ manual process. TDNS automates it on both sides: tdns-agent
 (or tdns-auth running as the child's primary) detects the
 change and pushes it to the parent; tdns-auth on the parent
 side receives the push, verifies it, and applies it to a
-configurable delegation backend.
+configurable delegation backend. tdns-agent can also act as
+a **proxy** for a child whose primary is DSYNC-unaware
+(BIND/Knot/NSD), forwarding the primary's CDS/CSYNC signals
+to the parent on its behalf (section 1.6).
 
 The mechanism is built on three components:
 
@@ -296,6 +299,63 @@ UPDATE, a generalized NOTIFY(CDS/CSYNC), or both -- driven
 by what the parent advertises and by per-policy preference.
 The same dispatch logic is reused by the auto-rollover
 engine; see section 5 for the full picture.
+
+
+### 1.6 Agent: proxying for a DSYNC-unaware primary
+
+The child side above assumes the child's primary speaks
+DSYNC. Many do not: a stock BIND9, Knot, or NSD primary
+will never discover the parent's DSYNC RRset and will never
+push a DS or delegation change to the parent. But such a
+primary *can* publish a CDS/CDNSKEY (RFC 7344) or CSYNC
+(RFC 7477) in the zone -- the standard, vendor-neutral way
+for a child to signal "please sync me."
+
+tdns-agent bridges that gap. Configure it as a **secondary**
+for the zone with the `delegation-sync-proxy` option. On
+every incoming AXFR/IXFR the agent diffs the new zone
+against the one it was serving and, when a
+delegation-relevant RRset changed, forwards the matching
+generalized NOTIFY to the parent's advertised NOTIFY
+receiver on the primary's behalf. The parent's scanner then
+queries the child and applies the change, exactly as for a
+DSYNC-native child. The primary is never modified.
+
+The change-to-NOTIFY mapping:
+
+| Change in the transfer            | NOTIFY forwarded |
+|-----------------------------------|------------------|
+| CDS RRset changed                 | NOTIFY(CDS)      |
+| DNSKEY RRset changed              | NOTIFY(CDS)      |
+| CSYNC RRset changed               | NOTIFY(CSYNC)    |
+| NS RRset or glue (A/AAAA) changed | NOTIFY(CSYNC)    |
+
+A NOTIFY is a contentless "come re-scan me" signal, so the
+proxy never reads or signs the CDS/CSYNC -- the parent reads
+them itself. That is why the proxy needs no SIG(0) key and
+why a `CDS 0 0 0 00` ("delete DS", RFC 8078) is handled like
+any other CDS change. The trigger is content-edge-triggered,
+so a change fires exactly once and a slow parent is never
+re-NOTIFYd on subsequent refreshes.
+
+The three delegation-sync roles, side by side:
+
+- `delegation-sync-parent` -- I am the parent: publish a
+  DSYNC RRset and receive UPDATE / NOTIFY from children
+  (sections 1.1-1.4).
+- `delegation-sync-child` -- I am the child and author my
+  own zone: detect my delegation changes and push them up
+  (section 1.5).
+- `delegation-sync-proxy` -- I am a secondary for a
+  DSYNC-unaware primary: forward the primary's CDS/CSYNC
+  signals up on its behalf (this section).
+
+The proxy is NOTIFY-only for now; if the parent advertises
+only the UPDATE scheme, the proxy does nothing (UPDATE
+proxying, which would also cover unsigned zones, is planned
+work). For the full operator how-to -- configuration,
+requirements, limitations, and verification -- see
+[Agent as a DSYNC proxy](agent-dsync-proxy.md).
 
 
 ## 2. DNS Transport Signaling

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -103,6 +103,13 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 				resp.ErrorMsg = err.Error()
 			}
 
+		case "proxy-key":
+			resp.Msg, err = zd.ProxyKeyStatus(context.Background(), kdb, Globals.ImrEngine)
+			if err != nil {
+				resp.Error = true
+				resp.ErrorMsg = err.Error()
+			}
+
 		case "generate-nsec":
 			err := zd.GenerateNsecChain(kdb)
 			if err != nil {

--- a/v2/childsync_replace_test.go
+++ b/v2/childsync_replace_test.go
@@ -1,0 +1,108 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// U-b: replace-mode parent UPDATE. CreateChildReplaceUpdate builds a DNS UPDATE
+// that DELETEs the child's delegation RRsets (ClassANY) and ADDs the current
+// authoritative members. This is the path re-enabled in SyncZoneDelegationViaUpdate
+// (the old "replace mode broken" refusal was an upstream-miekg/dns workaround,
+// fixed in the tdns fork).
+
+func mustRR(t *testing.T, s string) dns.RR {
+	t.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return rr
+}
+
+func TestCreateChildReplaceUpdateStructure(t *testing.T) {
+	parent := "example."
+	child := "child.example."
+	newNS := []dns.RR{
+		mustRR(t, "child.example. 3600 IN NS ns1.child.example."),
+		mustRR(t, "child.example. 3600 IN NS ns2.child.example."),
+	}
+	newA := []dns.RR{mustRR(t, "ns1.child.example. 3600 IN A 192.0.2.1")}
+	newAAAA := []dns.RR{mustRR(t, "ns1.child.example. 3600 IN AAAA 2001:db8::1")}
+	newDS := []dns.RR{mustRR(t, "child.example. 3600 IN DS 12345 15 2 "+
+		"0000000000000000000000000000000000000000000000000000000000000000")}
+
+	m, err := CreateChildReplaceUpdate(parent, child, newNS, newA, newAAAA, newDS)
+	if err != nil {
+		t.Fatalf("CreateChildReplaceUpdate: %v", err)
+	}
+	if m == nil {
+		t.Fatal("nil update message")
+	}
+	if m.Opcode != dns.OpcodeUpdate {
+		t.Fatalf("opcode = %d, want UPDATE", m.Opcode)
+	}
+	// The UPDATE zone (Question) must be the parent.
+	if len(m.Question) != 1 || m.Question[0].Name != dns.Fqdn(parent) {
+		t.Fatalf("update zone = %v, want parent %q", m.Question, parent)
+	}
+
+	// Tally the update (Ns) section: ClassANY deletes vs ClassINET adds, per type.
+	var anyNS, anyDS, addNS, addA, addAAAA, addDS int
+	for _, rr := range m.Ns {
+		h := rr.Header()
+		switch {
+		case h.Class == dns.ClassANY && h.Rrtype == dns.TypeNS:
+			anyNS++
+		case h.Class == dns.ClassANY && h.Rrtype == dns.TypeDS:
+			anyDS++
+		case h.Class == dns.ClassINET && h.Rrtype == dns.TypeNS:
+			addNS++
+		case h.Class == dns.ClassINET && h.Rrtype == dns.TypeA:
+			addA++
+		case h.Class == dns.ClassINET && h.Rrtype == dns.TypeAAAA:
+			addAAAA++
+		case h.Class == dns.ClassINET && h.Rrtype == dns.TypeDS:
+			addDS++
+		}
+	}
+
+	// A whole-RRset replace: at least one ClassANY delete for NS and DS, and the
+	// new members added.
+	if anyNS == 0 {
+		t.Error("missing ClassANY delete of the NS RRset")
+	}
+	if anyDS == 0 {
+		t.Error("missing ClassANY delete of the DS RRset")
+	}
+	if addNS != 2 {
+		t.Errorf("added NS = %d, want 2", addNS)
+	}
+	if addA != 1 {
+		t.Errorf("added A glue = %d, want 1", addA)
+	}
+	if addAAAA != 1 {
+		t.Errorf("added AAAA glue = %d, want 1", addAAAA)
+	}
+	if addDS != 1 {
+		t.Errorf("added DS = %d, want 1", addDS)
+	}
+}
+
+// Replace with no DS (unsigned zone) still replaces NS+glue and does not add a
+// DS — the unsigned-zone case the UPDATE path serves that NOTIFY cannot.
+func TestCreateChildReplaceUpdateUnsigned(t *testing.T) {
+	m, err := CreateChildReplaceUpdate("example.", "child.example.",
+		[]dns.RR{mustRR(t, "child.example. 3600 IN NS ns1.child.example.")},
+		[]dns.RR{mustRR(t, "ns1.child.example. 3600 IN A 192.0.2.1")},
+		nil, nil)
+	if err != nil {
+		t.Fatalf("CreateChildReplaceUpdate (unsigned): %v", err)
+	}
+	for _, rr := range m.Ns {
+		if rr.Header().Rrtype == dns.TypeDS {
+			t.Fatalf("unsigned replace must not touch DS, got %v", rr)
+		}
+	}
+}

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -108,6 +108,21 @@ throughout.`,
 	setPolicy.MarkFlagRequired("zone")
 	setPolicy.MarkFlagRequired("policy")
 
+	proxyKey := &cobra.Command{
+		Use:   "proxy-key",
+		Short: "Show the delegation-sync-proxy UPDATE state and the KEY to publish at the primary",
+		Long: `For a zone with the delegation-sync-proxy option (a tdns-agent acting as a
+secondary for a DSYNC-unaware primary), report whether the agent can proxy
+DNS UPDATEs to the parent, and — when waiting — print the exact records to
+add at the primary apex (the agent's KEY RR and an HSYNCPARAM pubkey flag).
+States: update-unsupported / ready / foreign-key / waiting-for-key.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			RunZoneProxyKey(role)
+		},
+	}
+	proxyKey.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to report proxy-key state for")
+	proxyKey.MarkFlagRequired("zone")
+
 	nsec := &cobra.Command{
 		Use:   "nsec",
 		Short: "Prefix command, not usable by itself",
@@ -128,7 +143,7 @@ throughout.`,
 	}
 	nsec.AddCommand(nsecGenerate, nsecShow)
 
-	c.AddCommand(list, nsec, sign, resign, reload, bump, write, freeze, thaw, setPolicy)
+	c.AddCommand(list, nsec, sign, resign, reload, bump, write, freeze, thaw, setPolicy, proxyKey)
 	// Role-independent extras attached to every zone tree. Each is built
 	// fresh so the command pointer is unique per NewZoneCmd invocation.
 	c.AddCommand(newZoneReadFakeCmd(), newZoneUpdateCmd(role), newZoneDsyncCmd(role))
@@ -262,6 +277,33 @@ func RunZoneSetPolicy(parent, policy string) {
 		os.Exit(1)
 	}
 
+	if cr.Msg != "" {
+		fmt.Printf("%s\n", cr.Msg)
+	}
+}
+
+func RunZoneProxyKey(parent string) {
+	if tdns.Globals.Zonename == "" {
+		fmt.Println("Error: zone name not specified")
+		os.Exit(1)
+	}
+	api, err := GetApiClient(parent, true)
+	if err != nil {
+		log.Fatalf("Error getting API client for %s: %v", parent, err)
+	}
+
+	cr, err := SendZoneCommand(api, tdns.ZonePost{
+		Command: "proxy-key",
+		Zone:    dns.Fqdn(tdns.Globals.Zonename),
+	})
+	if err != nil {
+		fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+		os.Exit(1)
+	}
+	if cr.Error {
+		fmt.Printf("Error: %s\n", cr.ErrorMsg)
+		os.Exit(1)
+	}
 	if cr.Msg != "" {
 		fmt.Printf("%s\n", cr.Msg)
 	}

--- a/v2/core/rr_hsyncparam.go
+++ b/v2/core/rr_hsyncparam.go
@@ -755,6 +755,14 @@ func (s *HSYNCPARAMFlag) copy() HSYNCPARAMKeyValue {
 	return &HSYNCPARAMFlag{code: s.code}
 }
 
+// NewHsyncparamPubkeyFlag returns an HSYNCPARAM pubkey flag value. Exported so
+// callers outside this package (e.g. the delegation-sync-proxy bootstrap
+// instruction) can construct a pubkey flag without reaching the unexported
+// field.
+func NewHsyncparamPubkeyFlag() HSYNCPARAMKeyValue {
+	return &HSYNCPARAMFlag{code: HSYNCPARAM_PUBKEY}
+}
+
 // --- HSYNCPARAMLocal: catch-all for unknown keys ---
 
 type HSYNCPARAMLocal struct {

--- a/v2/delegation_sync.go
+++ b/v2/delegation_sync.go
@@ -160,16 +160,15 @@ func (kdb *KeyDB) DelegationSyncher(ctx context.Context, delsyncq chan Delegatio
 					}
 				}
 
-			case "PROXY-NOTIFY":
-				// delegation-sync-proxy: an agent secondary forwards
-				// NOTIFY(CDS/CSYNC) to the parent on behalf of a DSYNC-unaware
-				// primary, for the dimensions detected in the incoming transfer.
-				// NOTIFY-only; no publish/sign.
-				msg, perr := zd.ProxyNotifyParent(ctx, notifyq, imr(), ds.ProxyAnalysis)
+			case "PROXY-SYNC":
+				// delegation-sync-proxy: an agent secondary forwards a detected
+				// change to the parent on behalf of a DSYNC-unaware primary,
+				// picking UPDATE or NOTIFY by what the parent advertises.
+				msg, perr := zd.ProxyDelegationSync(ctx, kdb, notifyq, imr(), ds.ProxyAnalysis)
 				if perr != nil {
-					lgDns.Error("DelegationSyncher: proxy NOTIFY failed", "zone", ds.ZoneName, "err", perr)
+					lgDns.Error("DelegationSyncher: proxy sync failed", "zone", ds.ZoneName, "err", perr)
 				} else {
-					lgDns.Info("DelegationSyncher: proxy NOTIFY done", "zone", ds.ZoneName, "msg", msg)
+					lgDns.Info("DelegationSyncher: proxy sync done", "zone", ds.ZoneName, "msg", msg)
 				}
 
 			case "PROXY-UPDATE-SETUP":

--- a/v2/delegation_sync.go
+++ b/v2/delegation_sync.go
@@ -172,16 +172,17 @@ func (kdb *KeyDB) DelegationSyncher(ctx context.Context, delsyncq chan Delegatio
 				}
 
 			case "PROXY-UPDATE-SETUP":
-				// delegation-sync-proxy UPDATE path: run the precondition +
-				// KEY-bootstrap state machine (§10.8) off the refresh path (it
-				// does DSYNC discovery and may generate a SIG(0) key). Sets the
-				// per-zone warning for the not-yet-operable states; a no-op for
-				// the NOTIFY proxy.
-				state, perr := zd.ProxyUpdatePreconditionCheck(ctx, kdb, imr())
+				// delegation-sync-proxy UPDATE path, first load: run the
+				// precondition + KEY-bootstrap state machine (§10.8) and, if
+				// READY, a one-time parent-vs-child reconcile (catches drift from
+				// while the agent was down, without re-sending every restart).
+				// Off the refresh path (DSYNC discovery + parent compare are
+				// network). A no-op for the NOTIFY proxy.
+				msg, perr := zd.ProxyStartupReconcile(ctx, kdb, imr())
 				if perr != nil {
-					lgDns.Error("DelegationSyncher: proxy UPDATE precondition error", "zone", ds.ZoneName, "state", state, "err", perr)
+					lgDns.Error("DelegationSyncher: proxy startup reconcile error", "zone", ds.ZoneName, "err", perr)
 				} else {
-					lgDns.Info("DelegationSyncher: proxy UPDATE precondition", "zone", ds.ZoneName, "state", state)
+					lgDns.Info("DelegationSyncher: proxy startup reconcile", "zone", ds.ZoneName, "msg", msg)
 				}
 
 			default:

--- a/v2/delegation_sync.go
+++ b/v2/delegation_sync.go
@@ -160,6 +160,18 @@ func (kdb *KeyDB) DelegationSyncher(ctx context.Context, delsyncq chan Delegatio
 					}
 				}
 
+			case "PROXY-NOTIFY":
+				// delegation-sync-proxy: an agent secondary forwards
+				// NOTIFY(CDS/CSYNC) to the parent on behalf of a DSYNC-unaware
+				// primary, for the dimensions detected in the incoming transfer.
+				// NOTIFY-only; no publish/sign.
+				msg, perr := zd.ProxyNotifyParent(ctx, notifyq, imr(), ds.ProxyAnalysis)
+				if perr != nil {
+					lgDns.Error("DelegationSyncher: proxy NOTIFY failed", "zone", ds.ZoneName, "err", perr)
+				} else {
+					lgDns.Info("DelegationSyncher: proxy NOTIFY done", "zone", ds.ZoneName, "msg", msg)
+				}
+
 			default:
 				lgDns.Warn("DelegationSyncher: unknown command, ignoring", "zone", ds.ZoneName, "command", ds.Command)
 			}

--- a/v2/delegation_sync.go
+++ b/v2/delegation_sync.go
@@ -172,6 +172,19 @@ func (kdb *KeyDB) DelegationSyncher(ctx context.Context, delsyncq chan Delegatio
 					lgDns.Info("DelegationSyncher: proxy NOTIFY done", "zone", ds.ZoneName, "msg", msg)
 				}
 
+			case "PROXY-UPDATE-SETUP":
+				// delegation-sync-proxy UPDATE path: run the precondition +
+				// KEY-bootstrap state machine (§10.8) off the refresh path (it
+				// does DSYNC discovery and may generate a SIG(0) key). Sets the
+				// per-zone warning for the not-yet-operable states; a no-op for
+				// the NOTIFY proxy.
+				state, perr := zd.ProxyUpdatePreconditionCheck(ctx, kdb, imr())
+				if perr != nil {
+					lgDns.Error("DelegationSyncher: proxy UPDATE precondition error", "zone", ds.ZoneName, "state", state, "err", perr)
+				} else {
+					lgDns.Info("DelegationSyncher: proxy UPDATE precondition", "zone", ds.ZoneName, "state", state)
+				}
+
 			default:
 				lgDns.Warn("DelegationSyncher: unknown command, ignoring", "zone", ds.ZoneName, "command", ds.Command)
 			}

--- a/v2/delegation_sync.go
+++ b/v2/delegation_sync.go
@@ -432,11 +432,19 @@ func (zd *ZoneData) SyncZoneDelegationViaUpdate(kdb *KeyDB, syncstate Delegation
 	var err error
 
 	if updateMode == UpdateModeReplace {
-		// Replace mode has an unresolved bug — refuse to proceed and make it visible.
-		err := fmt.Errorf("parent-update replace mode is currently broken and cannot be used")
-		zd.SetError(ConfigError, "parent-update replace mode is currently broken and cannot be used")
-		lgDns.Error("SyncZoneDelegationViaUpdate: replace mode disabled", "zone", zd.ZoneName)
-		return "", 0, UpdateResult{}, err
+		// Replace mode: DEL the whole RRset, then ADD the current authoritative
+		// members (NewNS / NewA / NewAAAA / NewDS, populated by the delegation
+		// analysis). Idempotent and self-correcting — it does not depend on the
+		// parent's current state. The historical "replace mode is broken" guard
+		// here was a workaround for an upstream miekg/dns bug fixed in the tdns
+		// fork (the KSK rollover engine's BuildChildWholeDSUpdate already relies
+		// on the fix in production).
+		lgDns.Info("SyncZoneDelegationViaUpdate: using replace mode", "zone", zd.ZoneName)
+		m, err = CreateChildReplaceUpdate(zd.Parent, zd.ZoneName,
+			syncstate.NewNS, syncstate.NewA, syncstate.NewAAAA, syncstate.NewDS)
+		if err != nil {
+			return "", 0, UpdateResult{}, err
+		}
 	} else {
 		// Delta mode: use adds and removes (existing behavior)
 		lgDns.Info("SyncZoneDelegationViaUpdate: using delta mode", "zone", zd.ZoneName)

--- a/v2/delsync_proxy.go
+++ b/v2/delsync_proxy.go
@@ -15,6 +15,9 @@
 package tdns
 
 import (
+	"context"
+	"fmt"
+
 	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
 )
@@ -129,9 +132,65 @@ func (zd *ZoneData) ProxyDelegationPostRefresh(delsyncq chan DelegationSyncReque
 		"want_cds_notify", analysis.wantCDSNotify(), "want_csync_notify", analysis.wantCSYNCNotify())
 
 	delsyncq <- DelegationSyncRequest{
-		Command:    "PROXY-NOTIFY",
-		ZoneName:   zd.ZoneName,
-		ZoneData:   zd,
-		SyncStatus: analysis.DelegationStatus,
+		Command:       "PROXY-NOTIFY",
+		ZoneName:      zd.ZoneName,
+		ZoneData:      zd,
+		SyncStatus:    analysis.DelegationStatus,
+		ProxyAnalysis: analysis,
 	}
+}
+
+// ProxyNotifyParent forwards NOTIFY(CDS) and/or NOTIFY(CSYNC) to the parent's
+// DSYNC NOTIFY receiver on behalf of a DSYNC-unaware primary, for the
+// dimensions recorded in analysis (D4 act-mapping). It does NOT publish or sign
+// anything: a NOTIFY is a contentless "come re-scan me" signal — the CDS/CSYNC
+// the primary published are already in the served zone, and the parent reads
+// them itself. NOTIFY is the only scheme used here (D3/D9); if the parent does
+// not advertise a NOTIFY DSYNC target, this is a no-op (not an error — the
+// parent may not offer the service, or may want UPDATE, which is later work).
+func (zd *ZoneData) ProxyNotifyParent(ctx context.Context, notifyq chan NotifyRequest, imr *Imr, analysis *ProxyDelegationAnalysis) (string, error) {
+	if analysis == nil || !analysis.anyChange() {
+		return "no change to proxy", nil
+	}
+	if zd.Parent == "" || zd.Parent == "." {
+		p, err := imr.ParentZone(zd.ZoneName)
+		if err != nil {
+			return "", fmt.Errorf("ProxyNotifyParent: ParentZone(%s): %w", zd.ZoneName, err)
+		}
+		zd.Parent = p
+	}
+
+	scheme, dsynctarget, err := zd.BestSyncScheme(ctx, imr)
+	if err != nil {
+		return "", fmt.Errorf("ProxyNotifyParent: BestSyncScheme(%s): %w", zd.ZoneName, err)
+	}
+	// NOTIFY-only for now (D3/D9). If the parent advertises only UPDATE we
+	// cannot proxy yet; report and stop without error.
+	if scheme != "NOTIFY" || dsynctarget == nil || len(dsynctarget.Addresses) == 0 {
+		lgDns.Info("delegation-sync-proxy: parent does not advertise a usable NOTIFY DSYNC target; nothing forwarded",
+			"zone", zd.ZoneName, "parent", zd.Parent, "scheme", scheme)
+		return "parent advertises no NOTIFY DSYNC target; nothing forwarded", nil
+	}
+
+	sent := zd.emitProxyNotifies(notifyq, analysis, dsynctarget.Addresses)
+	lgDns.Info("delegation-sync-proxy: forwarded NOTIFY(s) to parent",
+		"zone", zd.ZoneName, "parent", zd.Parent, "sent", sent, "target", dsynctarget.Addresses)
+	return fmt.Sprintf("forwarded NOTIFY(%v) to parent %s", sent, zd.Parent), nil
+}
+
+// emitProxyNotifies sends the NOTIFY(s) the act-mapping (D4) calls for to the
+// given targets, and returns the list of RRtypes notified ("CSYNC"/"CDS").
+// Separated from DSYNC discovery so the act-mapping → emission is testable
+// without the network. CSYNC is sent before CDS for a stable, predictable order.
+func (zd *ZoneData) emitProxyNotifies(notifyq chan NotifyRequest, analysis *ProxyDelegationAnalysis, targets []string) []string {
+	var sent []string
+	if analysis.wantCSYNCNotify() {
+		notifyq <- NotifyRequest{ZoneName: zd.ZoneName, ZoneData: zd, RRtype: dns.TypeCSYNC, Targets: targets}
+		sent = append(sent, "CSYNC")
+	}
+	if analysis.wantCDSNotify() {
+		notifyq <- NotifyRequest{ZoneName: zd.ZoneName, ZoneData: zd, RRtype: dns.TypeCDS, Targets: targets}
+		sent = append(sent, "CDS")
+	}
+	return sent
 }

--- a/v2/delsync_proxy.go
+++ b/v2/delsync_proxy.go
@@ -131,12 +131,20 @@ func (zd *ZoneData) ProxyDelegationPostRefresh(delsyncq chan DelegationSyncReque
 		"ns_or_glue", analysis.NsOrGlueChanged, "dnskey", analysis.DnskeyChanged,
 		"want_cds_notify", analysis.wantCDSNotify(), "want_csync_notify", analysis.wantCSYNCNotify())
 
-	delsyncq <- DelegationSyncRequest{
+	// Non-blocking enqueue: this runs on the refresh path, which has no ctx to
+	// select on, so we must not block on a backed-up queue (e.g. during
+	// shutdown). Dropping is safe — the proxy is idempotent: the next transfer
+	// re-detects the still-unforwarded change and re-enqueues.
+	select {
+	case delsyncq <- DelegationSyncRequest{
 		Command:       "PROXY-NOTIFY",
 		ZoneName:      zd.ZoneName,
 		ZoneData:      zd,
 		SyncStatus:    analysis.DelegationStatus,
 		ProxyAnalysis: analysis,
+	}:
+	default:
+		zd.Logger.Printf("ProxyDelegationPostRefresh: DelegationSyncQ full for %s; dropping proxy NOTIFY (will re-detect on next transfer)", zd.ZoneName)
 	}
 }
 
@@ -172,7 +180,7 @@ func (zd *ZoneData) ProxyNotifyParent(ctx context.Context, notifyq chan NotifyRe
 		return "parent advertises no NOTIFY DSYNC target; nothing forwarded", nil
 	}
 
-	sent := zd.emitProxyNotifies(notifyq, analysis, dsynctarget.Addresses)
+	sent := zd.emitProxyNotifies(ctx, notifyq, analysis, dsynctarget.Addresses)
 	lgDns.Info("delegation-sync-proxy: forwarded NOTIFY(s) to parent",
 		"zone", zd.ZoneName, "parent", zd.Parent, "sent", sent, "target", dsynctarget.Addresses)
 	return fmt.Sprintf("forwarded NOTIFY(%v) to parent %s", sent, zd.Parent), nil
@@ -182,15 +190,25 @@ func (zd *ZoneData) ProxyNotifyParent(ctx context.Context, notifyq chan NotifyRe
 // given targets, and returns the list of RRtypes notified ("CSYNC"/"CDS").
 // Separated from DSYNC discovery so the act-mapping → emission is testable
 // without the network. CSYNC is sent before CDS for a stable, predictable order.
-func (zd *ZoneData) emitProxyNotifies(notifyq chan NotifyRequest, analysis *ProxyDelegationAnalysis, targets []string) []string {
+// The sends are ctx-aware so a backed-up notifyq cannot block shutdown; a
+// cancelled context stops further sends and returns what was sent so far.
+func (zd *ZoneData) emitProxyNotifies(ctx context.Context, notifyq chan NotifyRequest, analysis *ProxyDelegationAnalysis, targets []string) []string {
 	var sent []string
 	if analysis.wantCSYNCNotify() {
-		notifyq <- NotifyRequest{ZoneName: zd.ZoneName, ZoneData: zd, RRtype: dns.TypeCSYNC, Targets: targets}
-		sent = append(sent, "CSYNC")
+		select {
+		case notifyq <- NotifyRequest{ZoneName: zd.ZoneName, ZoneData: zd, RRtype: dns.TypeCSYNC, Targets: targets}:
+			sent = append(sent, "CSYNC")
+		case <-ctx.Done():
+			return sent
+		}
 	}
 	if analysis.wantCDSNotify() {
-		notifyq <- NotifyRequest{ZoneName: zd.ZoneName, ZoneData: zd, RRtype: dns.TypeCDS, Targets: targets}
-		sent = append(sent, "CDS")
+		select {
+		case notifyq <- NotifyRequest{ZoneName: zd.ZoneName, ZoneData: zd, RRtype: dns.TypeCDS, Targets: targets}:
+			sent = append(sent, "CDS")
+		case <-ctx.Done():
+			return sent
+		}
 	}
 	return sent
 }

--- a/v2/delsync_proxy.go
+++ b/v2/delsync_proxy.go
@@ -125,7 +125,7 @@ func (zd *ZoneData) ProxyDelegationPostRefresh(delsyncq chan DelegationSyncReque
 		return
 	}
 
-	lgDns.Info("delegation-sync-proxy: change detected in transfer; queueing proxy NOTIFY",
+	lgDns.Info("delegation-sync-proxy: change detected in transfer; queueing proxy sync",
 		"zone", zd.ZoneName,
 		"cds", analysis.CdsChanged, "csync", analysis.CsyncChanged,
 		"ns_or_glue", analysis.NsOrGlueChanged, "dnskey", analysis.DnskeyChanged,
@@ -134,17 +134,18 @@ func (zd *ZoneData) ProxyDelegationPostRefresh(delsyncq chan DelegationSyncReque
 	// Non-blocking enqueue: this runs on the refresh path, which has no ctx to
 	// select on, so we must not block on a backed-up queue (e.g. during
 	// shutdown). Dropping is safe — the proxy is idempotent: the next transfer
-	// re-detects the still-unforwarded change and re-enqueues.
+	// re-detects the still-unforwarded change and re-enqueues. The handler picks
+	// UPDATE vs NOTIFY off the refresh path (scheme discovery is network).
 	select {
 	case delsyncq <- DelegationSyncRequest{
-		Command:       "PROXY-NOTIFY",
+		Command:       "PROXY-SYNC",
 		ZoneName:      zd.ZoneName,
 		ZoneData:      zd,
 		SyncStatus:    analysis.DelegationStatus,
 		ProxyAnalysis: analysis,
 	}:
 	default:
-		zd.Logger.Printf("ProxyDelegationPostRefresh: DelegationSyncQ full for %s; dropping proxy NOTIFY (will re-detect on next transfer)", zd.ZoneName)
+		zd.Logger.Printf("ProxyDelegationPostRefresh: DelegationSyncQ full for %s; dropping proxy sync (will re-detect on next transfer)", zd.ZoneName)
 	}
 }
 

--- a/v2/delsync_proxy.go
+++ b/v2/delsync_proxy.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * delegation-sync-proxy: a tdns-agent acting as a SECONDARY for a zone whose
+ * primary is DSYNC-unaware (BIND/Knot). On each incoming transfer the agent
+ * diffs the apex CDS / CSYNC / NS+glue / DNSKEY RRsets old-vs-new and, when a
+ * relevant RRset changed, forwards a NOTIFY(CDS/CSYNC) to the parent's DSYNC
+ * receiver on the primary's behalf. The primary stays DSYNC-clueless.
+ *
+ * This file holds the change-detection trigger (P-2): a PreRefresh hook (which
+ * sees both old and new zone data) records what changed into
+ * zd.ProxyRefreshAnalysis, and a PostRefresh hook acts on it. The proxy NOTIFY
+ * action itself is the PROXY-NOTIFY DelegationSyncher command (P-3).
+ */
+package tdns
+
+import (
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+// ProxyDelegationAnalysis records, per incoming transfer, which
+// delegation-relevant apex RRsets changed. Computed by the PreRefresh hook
+// (old-vs-new), consumed by the PostRefresh hook. The wide set (NS/glue and
+// DNSKEY in addition to CDS/CSYNC) is detected now so the future UPDATE path
+// inherits the deltas; the NOTIFY act-mapping (D4) is:
+//
+//	NOTIFY(CDS)   when CdsChanged   OR DnskeyChanged
+//	NOTIFY(CSYNC) when CsyncChanged OR NsOrGlueChanged
+type ProxyDelegationAnalysis struct {
+	CdsChanged      bool
+	CsyncChanged    bool
+	NsOrGlueChanged bool
+	DnskeyChanged   bool
+	// DelegationStatus carries the NS/glue/DS deltas from DelegationDataChangedNG,
+	// kept for the future UPDATE-proxy path (it is not needed to decide a NOTIFY).
+	DelegationStatus DelegationSyncStatus
+}
+
+// anyChange reports whether any dimension that drives a NOTIFY changed.
+func (a *ProxyDelegationAnalysis) anyChange() bool {
+	return a.CdsChanged || a.CsyncChanged || a.NsOrGlueChanged || a.DnskeyChanged
+}
+
+// wantCDSNotify / wantCSYNCNotify apply the D4 act-mapping.
+func (a *ProxyDelegationAnalysis) wantCDSNotify() bool   { return a.CdsChanged || a.DnskeyChanged }
+func (a *ProxyDelegationAnalysis) wantCSYNCNotify() bool { return a.CsyncChanged || a.NsOrGlueChanged }
+
+// ProxyDelegationPreRefresh runs BEFORE the hard flip on a delegation-sync-proxy
+// zone. It diffs the incoming zone (new_zd) against the currently-served zone
+// (zd) for the four delegation-relevant dimensions and records the result in
+// zd.ProxyRefreshAnalysis for the PostRefresh hook. It must NOT act here (the
+// new data is not yet served).
+func (zd *ZoneData) ProxyDelegationPreRefresh(new_zd *ZoneData) {
+	analysis := &ProxyDelegationAnalysis{}
+
+	// CDS / CSYNC: direct apex RRset diff. These are the primary's explicit
+	// opt-in signal; a change in either is the core proxy trigger.
+	analysis.CdsChanged = zd.apexRRsetChanged(new_zd, dns.TypeCDS)
+	analysis.CsyncChanged = zd.apexRRsetChanged(new_zd, dns.TypeCSYNC)
+
+	// NS + glue + DS: reuse the existing delegation diff (also yields the
+	// deltas the future UPDATE path needs). NsOrGlueChanged is derived from the
+	// NS/A/AAAA adds/removes; DS deltas are kept in DelegationStatus but do not
+	// drive a NOTIFY on their own (a DS change at the child means a DNSKEY
+	// change, which DnskeysChangedNG catches below).
+	if changed, dss, err := zd.DelegationDataChangedNG(new_zd); err != nil {
+		zd.Logger.Printf("ProxyDelegationPreRefresh: DelegationDataChangedNG failed for %s: %v", zd.ZoneName, err)
+	} else if changed {
+		analysis.DelegationStatus = dss
+		analysis.NsOrGlueChanged = len(dss.NsAdds) > 0 || len(dss.NsRemoves) > 0 ||
+			len(dss.AAdds) > 0 || len(dss.ARemoves) > 0 ||
+			len(dss.AAAAAdds) > 0 || len(dss.AAAARemoves) > 0
+	}
+
+	// DNSKEY: reuse the existing DNSKEY diff. A DNSKEY change implies a possible
+	// DS change at the parent, so it drives a NOTIFY(CDS) (D4).
+	if changed, err := zd.DnskeysChangedNG(new_zd); err != nil {
+		zd.Logger.Printf("ProxyDelegationPreRefresh: DnskeysChangedNG failed for %s: %v", zd.ZoneName, err)
+	} else {
+		analysis.DnskeyChanged = changed
+	}
+
+	zd.mu.Lock()
+	zd.ProxyRefreshAnalysis = analysis
+	zd.mu.Unlock()
+}
+
+// apexRRsetChanged reports whether the apex RRset of type rrtype differs between
+// the served zone (zd) and the incoming zone (new_zd), using the canonical
+// RRset comparison. A missing owner / RRset on either side is treated as an
+// empty set, so an appearance or disappearance counts as a change.
+func (zd *ZoneData) apexRRsetChanged(new_zd *ZoneData, rrtype uint16) bool {
+	var oldRRs, newRRs []dns.RR
+	if oldapex, err := zd.GetOwner(zd.ZoneName); err == nil && oldapex != nil {
+		oldRRs = oldapex.RRtypes.GetOnlyRRSet(rrtype).RRs
+	}
+	if newapex, err := new_zd.GetOwner(zd.ZoneName); err == nil && newapex != nil {
+		newRRs = newapex.RRtypes.GetOnlyRRSet(rrtype).RRs
+	}
+	differ, _, _ := core.RRsetDiffer(zd.ZoneName, newRRs, oldRRs, rrtype, zd.Logger, Globals.Verbose, Globals.Debug)
+	return differ
+}
+
+// ProxyDelegationPostRefresh runs AFTER the hard flip on a
+// delegation-sync-proxy zone. It consumes the analysis recorded by the
+// PreRefresh hook and, when a NOTIFY-relevant dimension changed (D4), enqueues
+// a PROXY-NOTIFY request to the DelegationSyncher (the action lives there,
+// P-3). The analysis is cleared whether or not anything was enqueued, so a
+// later unrelated refresh starts fresh.
+func (zd *ZoneData) ProxyDelegationPostRefresh(delsyncq chan DelegationSyncRequest) {
+	zd.mu.Lock()
+	analysis := zd.ProxyRefreshAnalysis
+	zd.ProxyRefreshAnalysis = nil
+	zd.mu.Unlock()
+
+	if analysis == nil || !analysis.anyChange() {
+		return
+	}
+	if delsyncq == nil {
+		zd.Logger.Printf("ProxyDelegationPostRefresh: DelegationSyncQ unavailable for %s; cannot proxy", zd.ZoneName)
+		return
+	}
+
+	lgDns.Info("delegation-sync-proxy: change detected in transfer; queueing proxy NOTIFY",
+		"zone", zd.ZoneName,
+		"cds", analysis.CdsChanged, "csync", analysis.CsyncChanged,
+		"ns_or_glue", analysis.NsOrGlueChanged, "dnskey", analysis.DnskeyChanged,
+		"want_cds_notify", analysis.wantCDSNotify(), "want_csync_notify", analysis.wantCSYNCNotify())
+
+	delsyncq <- DelegationSyncRequest{
+		Command:    "PROXY-NOTIFY",
+		ZoneName:   zd.ZoneName,
+		ZoneData:   zd,
+		SyncStatus: analysis.DelegationStatus,
+	}
+}

--- a/v2/delsync_proxy_p2_test.go
+++ b/v2/delsync_proxy_p2_test.go
@@ -1,0 +1,167 @@
+package tdns
+
+import (
+	"testing"
+)
+
+// P-2: the change-detection trigger. ProxyDelegationPreRefresh diffs the
+// incoming zone against the served one across CDS / CSYNC / NS+glue / DNSKEY
+// and records the result; ProxyDelegationPostRefresh enqueues a PROXY-NOTIFY
+// only when a NOTIFY-relevant dimension changed.
+
+// A minimal signed delegation apex. Variants below flip exactly one dimension.
+const proxyBaseZone = `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 1 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns2.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns2.child.example.	3600 IN A 192.0.2.2
+child.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+child.example.	3600 IN CDS 12345 15 2 0000000000000000000000000000000000000000000000000000000000000000
+child.example.	3600 IN CSYNC 1 3 A NS AAAA
+`
+
+func proxyAnalysisFor(t *testing.T, oldZoneStr, newZoneStr string) *ProxyDelegationAnalysis {
+	t.Helper()
+	zd := testZone(t, "child.example.", oldZoneStr)
+	newzd := testZone(t, "child.example.", newZoneStr)
+	zd.ProxyDelegationPreRefresh(newzd)
+	if zd.ProxyRefreshAnalysis == nil {
+		t.Fatal("ProxyDelegationPreRefresh did not record an analysis")
+	}
+	return zd.ProxyRefreshAnalysis
+}
+
+// No change between old and new ⇒ nothing flagged, nothing to NOTIFY.
+func TestProxyPreRefreshNoChange(t *testing.T) {
+	a := proxyAnalysisFor(t, proxyBaseZone, proxyBaseZone)
+	if a.anyChange() {
+		t.Fatalf("identical zones must report no change: %+v", a)
+	}
+}
+
+// A changed CDS ⇒ CdsChanged, and (D4) wantCDSNotify.
+func TestProxyPreRefreshCDSChange(t *testing.T) {
+	newZone := `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 2 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns2.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns2.child.example.	3600 IN A 192.0.2.2
+child.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+child.example.	3600 IN CDS 54321 15 2 1111111111111111111111111111111111111111111111111111111111111111
+child.example.	3600 IN CSYNC 1 3 A NS AAAA
+`
+	a := proxyAnalysisFor(t, proxyBaseZone, newZone)
+	if !a.CdsChanged {
+		t.Fatal("CDS change not detected")
+	}
+	if !a.wantCDSNotify() {
+		t.Fatal("a CDS change must drive a NOTIFY(CDS)")
+	}
+	if a.CsyncChanged {
+		t.Fatal("CSYNC must not be flagged when only CDS changed")
+	}
+}
+
+// A changed CSYNC ⇒ CsyncChanged, and (D4) wantCSYNCNotify.
+func TestProxyPreRefreshCSYNCChange(t *testing.T) {
+	newZone := `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 2 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns2.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns2.child.example.	3600 IN A 192.0.2.2
+child.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+child.example.	3600 IN CDS 12345 15 2 0000000000000000000000000000000000000000000000000000000000000000
+child.example.	3600 IN CSYNC 2 3 A NS AAAA
+`
+	a := proxyAnalysisFor(t, proxyBaseZone, newZone)
+	if !a.CsyncChanged {
+		t.Fatal("CSYNC change not detected")
+	}
+	if !a.wantCSYNCNotify() {
+		t.Fatal("a CSYNC change must drive a NOTIFY(CSYNC)")
+	}
+}
+
+// An NS/glue change ⇒ NsOrGlueChanged, and (D4) wantCSYNCNotify even without a
+// CSYNC RRset change.
+func TestProxyPreRefreshNSChange(t *testing.T) {
+	newZone := `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 2 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns3.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns3.child.example.	3600 IN A 192.0.2.3
+child.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+child.example.	3600 IN CDS 12345 15 2 0000000000000000000000000000000000000000000000000000000000000000
+child.example.	3600 IN CSYNC 1 3 A NS AAAA
+`
+	a := proxyAnalysisFor(t, proxyBaseZone, newZone)
+	if !a.NsOrGlueChanged {
+		t.Fatal("NS/glue change not detected")
+	}
+	if !a.wantCSYNCNotify() {
+		t.Fatal("an NS/glue change must drive a NOTIFY(CSYNC)")
+	}
+}
+
+// A DNSKEY change ⇒ DnskeyChanged, and (D4) wantCDSNotify even without a CDS
+// RRset change.
+func TestProxyPreRefreshDNSKEYChange(t *testing.T) {
+	newZone := `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 2 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns2.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns2.child.example.	3600 IN A 192.0.2.2
+child.example.	3600 IN DNSKEY 257 3 15 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbB=
+child.example.	3600 IN CDS 12345 15 2 0000000000000000000000000000000000000000000000000000000000000000
+child.example.	3600 IN CSYNC 1 3 A NS AAAA
+`
+	a := proxyAnalysisFor(t, proxyBaseZone, newZone)
+	if !a.DnskeyChanged {
+		t.Fatal("DNSKEY change not detected")
+	}
+	if !a.wantCDSNotify() {
+		t.Fatal("a DNSKEY change must drive a NOTIFY(CDS)")
+	}
+}
+
+// PostRefresh enqueues a PROXY-NOTIFY when something changed, and enqueues
+// nothing when the analysis is absent or empty. It also clears the analysis.
+func TestProxyPostRefreshEnqueue(t *testing.T) {
+	zd := testZone(t, "child.example.", proxyBaseZone)
+	q := make(chan DelegationSyncRequest, 1)
+
+	// Change present ⇒ one PROXY-NOTIFY enqueued.
+	zd.ProxyRefreshAnalysis = &ProxyDelegationAnalysis{CdsChanged: true}
+	zd.ProxyDelegationPostRefresh(q)
+	select {
+	case req := <-q:
+		if req.Command != "PROXY-NOTIFY" {
+			t.Fatalf("enqueued command = %q, want PROXY-NOTIFY", req.Command)
+		}
+		if req.ZoneName != "child.example." {
+			t.Fatalf("enqueued zone = %q", req.ZoneName)
+		}
+	default:
+		t.Fatal("expected a PROXY-NOTIFY to be enqueued on change")
+	}
+	if zd.ProxyRefreshAnalysis != nil {
+		t.Fatal("analysis must be cleared after PostRefresh")
+	}
+
+	// No analysis ⇒ nothing enqueued.
+	zd.ProxyDelegationPostRefresh(q)
+	select {
+	case <-q:
+		t.Fatal("nothing should be enqueued when there is no analysis")
+	default:
+	}
+
+	// Empty analysis (no change) ⇒ nothing enqueued.
+	zd.ProxyRefreshAnalysis = &ProxyDelegationAnalysis{}
+	zd.ProxyDelegationPostRefresh(q)
+	select {
+	case <-q:
+		t.Fatal("nothing should be enqueued when no dimension changed")
+	default:
+	}
+}

--- a/v2/delsync_proxy_p2_test.go
+++ b/v2/delsync_proxy_p2_test.go
@@ -6,7 +6,7 @@ import (
 
 // P-2: the change-detection trigger. ProxyDelegationPreRefresh diffs the
 // incoming zone against the served one across CDS / CSYNC / NS+glue / DNSKEY
-// and records the result; ProxyDelegationPostRefresh enqueues a PROXY-NOTIFY
+// and records the result; ProxyDelegationPostRefresh enqueues a PROXY-SYNC
 // only when a NOTIFY-relevant dimension changed.
 
 // A minimal signed delegation apex. Variants below flip exactly one dimension.
@@ -124,25 +124,25 @@ child.example.	3600 IN CSYNC 1 3 A NS AAAA
 	}
 }
 
-// PostRefresh enqueues a PROXY-NOTIFY when something changed, and enqueues
+// PostRefresh enqueues a PROXY-SYNC when something changed, and enqueues
 // nothing when the analysis is absent or empty. It also clears the analysis.
 func TestProxyPostRefreshEnqueue(t *testing.T) {
 	zd := testZone(t, "child.example.", proxyBaseZone)
 	q := make(chan DelegationSyncRequest, 1)
 
-	// Change present ⇒ one PROXY-NOTIFY enqueued.
+	// Change present ⇒ one PROXY-SYNC enqueued.
 	zd.ProxyRefreshAnalysis = &ProxyDelegationAnalysis{CdsChanged: true}
 	zd.ProxyDelegationPostRefresh(q)
 	select {
 	case req := <-q:
-		if req.Command != "PROXY-NOTIFY" {
-			t.Fatalf("enqueued command = %q, want PROXY-NOTIFY", req.Command)
+		if req.Command != "PROXY-SYNC" {
+			t.Fatalf("enqueued command = %q, want PROXY-SYNC", req.Command)
 		}
 		if req.ZoneName != "child.example." {
 			t.Fatalf("enqueued zone = %q", req.ZoneName)
 		}
 	default:
-		t.Fatal("expected a PROXY-NOTIFY to be enqueued on change")
+		t.Fatal("expected a PROXY-SYNC to be enqueued on change")
 	}
 	if zd.ProxyRefreshAnalysis != nil {
 		t.Fatal("analysis must be cleared after PostRefresh")

--- a/v2/delsync_proxy_p3_test.go
+++ b/v2/delsync_proxy_p3_test.go
@@ -1,7 +1,9 @@
 package tdns
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -45,7 +47,7 @@ func TestEmitProxyNotifiesActMapping(t *testing.T) {
 			zd := &ZoneData{ZoneName: "child.example."}
 			q := make(chan NotifyRequest, 4)
 			a := tc.analysis
-			sent := zd.emitProxyNotifies(q, &a, targets)
+			sent := zd.emitProxyNotifies(context.Background(), q, &a, targets)
 
 			got := drainNotifyTypes(q)
 			if len(got) != len(tc.want) {
@@ -74,7 +76,7 @@ func TestEmitProxyNotifiesTargetPassthrough(t *testing.T) {
 	q := make(chan NotifyRequest, 2)
 	targets := []string{"192.0.2.53:53", "[2001:db8::53]:53"}
 
-	zd.emitProxyNotifies(q, &ProxyDelegationAnalysis{CsyncChanged: true}, targets)
+	zd.emitProxyNotifies(context.Background(), q, &ProxyDelegationAnalysis{CsyncChanged: true}, targets)
 	select {
 	case r := <-q:
 		if r.RRtype != dns.TypeCSYNC {
@@ -88,5 +90,28 @@ func TestEmitProxyNotifiesTargetPassthrough(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected a NOTIFY(CSYNC)")
+	}
+}
+
+// A cancelled context must stop the sends without blocking, even when the
+// notifyq is full (backpressure / shutdown). emitProxyNotifies returns what it
+// managed to send (here: nothing) rather than deadlocking.
+func TestEmitProxyNotifiesContextCancelled(t *testing.T) {
+	zd := &ZoneData{ZoneName: "child.example."}
+	full := make(chan NotifyRequest) // unbuffered, no reader → a blocking send would hang
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan []string, 1)
+	go func() {
+		done <- zd.emitProxyNotifies(ctx, full, &ProxyDelegationAnalysis{CsyncChanged: true, CdsChanged: true}, []string{"192.0.2.53:53"})
+	}()
+	select {
+	case sent := <-done:
+		if len(sent) != 0 {
+			t.Fatalf("cancelled ctx should send nothing, got %v", sent)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("emitProxyNotifies blocked on a full queue despite a cancelled context")
 	}
 }

--- a/v2/delsync_proxy_p3_test.go
+++ b/v2/delsync_proxy_p3_test.go
@@ -1,0 +1,92 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// P-3: the proxy NOTIFY action. emitProxyNotifies applies the D4 act-mapping —
+// NOTIFY(CSYNC) when CSYNC or NS/glue changed, NOTIFY(CDS) when CDS or DNSKEY
+// changed — and emits to the resolved target(s) without publish/sign. (The
+// DSYNC-discovery half of ProxyNotifyParent needs the network and is exercised
+// on the testbed.)
+
+func drainNotifyTypes(q chan NotifyRequest) []uint16 {
+	var got []uint16
+	for {
+		select {
+		case r := <-q:
+			got = append(got, r.RRtype)
+		default:
+			return got
+		}
+	}
+}
+
+func TestEmitProxyNotifiesActMapping(t *testing.T) {
+	targets := []string{"192.0.2.53:53"}
+	cases := []struct {
+		name     string
+		analysis ProxyDelegationAnalysis
+		want     []uint16 // order: CSYNC before CDS
+	}{
+		{"cds-only", ProxyDelegationAnalysis{CdsChanged: true}, []uint16{dns.TypeCDS}},
+		{"csync-only", ProxyDelegationAnalysis{CsyncChanged: true}, []uint16{dns.TypeCSYNC}},
+		{"dnskey-drives-cds", ProxyDelegationAnalysis{DnskeyChanged: true}, []uint16{dns.TypeCDS}},
+		{"nsglue-drives-csync", ProxyDelegationAnalysis{NsOrGlueChanged: true}, []uint16{dns.TypeCSYNC}},
+		{"both", ProxyDelegationAnalysis{CdsChanged: true, CsyncChanged: true}, []uint16{dns.TypeCSYNC, dns.TypeCDS}},
+		{"all-four", ProxyDelegationAnalysis{CdsChanged: true, CsyncChanged: true, NsOrGlueChanged: true, DnskeyChanged: true}, []uint16{dns.TypeCSYNC, dns.TypeCDS}},
+		{"none", ProxyDelegationAnalysis{}, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			zd := &ZoneData{ZoneName: "child.example."}
+			q := make(chan NotifyRequest, 4)
+			a := tc.analysis
+			sent := zd.emitProxyNotifies(q, &a, targets)
+
+			got := drainNotifyTypes(q)
+			if len(got) != len(tc.want) {
+				t.Fatalf("emitted %v NOTIFY types, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("NOTIFY[%d] = %d, want %d (full %v vs %v)", i, got[i], tc.want[i], got, tc.want)
+				}
+			}
+			// The returned label list must match the emitted count.
+			if len(sent) != len(tc.want) {
+				t.Fatalf("returned %v labels, want %d", sent, len(tc.want))
+			}
+			// Each emitted NOTIFY must carry the target through unchanged.
+			for _, r := range got {
+				_ = r // type checked above; targets verified below via a fresh send
+			}
+		})
+	}
+}
+
+// The emitted NOTIFY carries the resolved targets and the zone, unchanged.
+func TestEmitProxyNotifiesTargetPassthrough(t *testing.T) {
+	zd := &ZoneData{ZoneName: "child.example."}
+	q := make(chan NotifyRequest, 2)
+	targets := []string{"192.0.2.53:53", "[2001:db8::53]:53"}
+
+	zd.emitProxyNotifies(q, &ProxyDelegationAnalysis{CsyncChanged: true}, targets)
+	select {
+	case r := <-q:
+		if r.RRtype != dns.TypeCSYNC {
+			t.Fatalf("rrtype = %d, want CSYNC", r.RRtype)
+		}
+		if r.ZoneName != "child.example." || r.ZoneData != zd {
+			t.Fatalf("zone not passed through: name=%q zd=%p", r.ZoneName, r.ZoneData)
+		}
+		if len(r.Targets) != 2 || r.Targets[0] != targets[0] || r.Targets[1] != targets[1] {
+			t.Fatalf("targets not passed through: %v", r.Targets)
+		}
+	default:
+		t.Fatal("expected a NOTIFY(CSYNC)")
+	}
+}

--- a/v2/delsync_proxy_p4_test.go
+++ b/v2/delsync_proxy_p4_test.go
@@ -11,7 +11,7 @@ import (
 // the SOA serial advanced. This is the Q6 self-debounce: no extra state needed.
 
 // simulateRefresh runs one PreRefresh+PostRefresh cycle and reports whether a
-// PROXY-NOTIFY was enqueued. It mutates served (the running zone) to the new
+// PROXY-SYNC was enqueued. It mutates served (the running zone) to the new
 // content, mirroring the hard flip, so the next call diffs against it.
 func simulateRefresh(t *testing.T, served **ZoneData, newZoneStr string, q chan DelegationSyncRequest) bool {
 	t.Helper()
@@ -79,6 +79,6 @@ child.example.	3600 IN CSYNC 1 3 A NS AAAA
 
 	// Exactly one NOTIFY request total across the three refreshes.
 	if len(q) != 1 {
-		t.Fatalf("total enqueued PROXY-NOTIFY = %d, want exactly 1", len(q))
+		t.Fatalf("total enqueued PROXY-SYNC = %d, want exactly 1", len(q))
 	}
 }

--- a/v2/delsync_proxy_p4_test.go
+++ b/v2/delsync_proxy_p4_test.go
@@ -1,0 +1,84 @@
+package tdns
+
+import (
+	"testing"
+)
+
+// P-4: loop/debounce. The trigger is content-edge-triggered (it diffs the
+// served zone against the incoming one), so a CDS/CSYNC change fires exactly
+// once — on the transfer where the content changed — and a subsequent transfer
+// carrying the SAME (already-forwarded) content does NOT re-fire, even though
+// the SOA serial advanced. This is the Q6 self-debounce: no extra state needed.
+
+// simulateRefresh runs one PreRefresh+PostRefresh cycle and reports whether a
+// PROXY-NOTIFY was enqueued. It mutates served (the running zone) to the new
+// content, mirroring the hard flip, so the next call diffs against it.
+func simulateRefresh(t *testing.T, served **ZoneData, newZoneStr string, q chan DelegationSyncRequest) bool {
+	t.Helper()
+	incoming := testZone(t, "child.example.", newZoneStr)
+	(*served).ProxyDelegationPreRefresh(incoming)
+	// Hard flip: the served zone becomes the incoming one (carrying the
+	// analysis recorded on the old served zone forward to PostRefresh).
+	incoming.ProxyRefreshAnalysis = (*served).ProxyRefreshAnalysis
+	*served = incoming
+	before := len(q)
+	(*served).ProxyDelegationPostRefresh(q)
+	return len(q) > before
+}
+
+func TestProxySelfDebounceOnRepeatedTransfer(t *testing.T) {
+	q := make(chan DelegationSyncRequest, 8)
+
+	// Initial served zone (base).
+	served := testZone(t, "child.example.", proxyBaseZone)
+
+	// Transfer #1: same content as served, only the SOA serial differs.
+	// No RRset changed ⇒ no NOTIFY.
+	bumpedSameContent := `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 2 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns2.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns2.child.example.	3600 IN A 192.0.2.2
+child.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+child.example.	3600 IN CDS 12345 15 2 0000000000000000000000000000000000000000000000000000000000000000
+child.example.	3600 IN CSYNC 1 3 A NS AAAA
+`
+	if simulateRefresh(t, &served, bumpedSameContent, q) {
+		t.Fatal("serial-only bump must not enqueue a proxy NOTIFY")
+	}
+
+	// Transfer #2: the CDS changes ⇒ exactly one NOTIFY.
+	cdsChanged := `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 3 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns2.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns2.child.example.	3600 IN A 192.0.2.2
+child.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+child.example.	3600 IN CDS 54321 15 2 1111111111111111111111111111111111111111111111111111111111111111
+child.example.	3600 IN CSYNC 1 3 A NS AAAA
+`
+	if !simulateRefresh(t, &served, cdsChanged, q) {
+		t.Fatal("a CDS change must enqueue a proxy NOTIFY")
+	}
+
+	// Transfer #3: the SAME (already-forwarded) CDS, serial bumped again.
+	// The change is no longer "new" relative to the now-served zone ⇒ NO
+	// re-NOTIFY. This is the self-debounce.
+	cdsChangedAgainSameContent := `child.example.	3600 IN SOA ns1.child.example. hostmaster.child.example. 4 7200 1800 604800 3600
+child.example.	3600 IN NS ns1.child.example.
+child.example.	3600 IN NS ns2.child.example.
+ns1.child.example.	3600 IN A 192.0.2.1
+ns2.child.example.	3600 IN A 192.0.2.2
+child.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+child.example.	3600 IN CDS 54321 15 2 1111111111111111111111111111111111111111111111111111111111111111
+child.example.	3600 IN CSYNC 1 3 A NS AAAA
+`
+	if simulateRefresh(t, &served, cdsChangedAgainSameContent, q) {
+		t.Fatal("re-transferring the same already-forwarded CDS must NOT re-enqueue (self-debounce)")
+	}
+
+	// Exactly one NOTIFY request total across the three refreshes.
+	if len(q) != 1 {
+		t.Fatalf("total enqueued PROXY-NOTIFY = %d, want exactly 1", len(q))
+	}
+}

--- a/v2/delsync_proxy_test.go
+++ b/v2/delsync_proxy_test.go
@@ -1,6 +1,10 @@
 package tdns
 
-import "testing"
+import (
+	"log"
+	"os"
+	"testing"
+)
 
 // P-1: the delegation-sync-proxy zone option round-trips through the
 // string<->enum maps and is accepted by the option parser (it must NOT fall
@@ -42,5 +46,49 @@ func TestParseZoneOptionsAcceptsDelSyncProxy(t *testing.T) {
 		if e.Type == ConfigError {
 			t.Fatalf("unexpected ConfigError after parsing a valid option: %q", e.Msg)
 		}
+	}
+}
+
+// Regression (CodeRabbit PR #265): SetupZoneSync's wantsSync early-exit must NOT
+// skip a proxy-only zone, or the proxy validation gate is unreachable. A proxy
+// option on a non-agent / non-secondary zone must be REJECTED (the gate runs);
+// on an agent secondary it must be accepted (the gate passes).
+func TestSetupZoneSyncProxyGateReachable(t *testing.T) {
+	prevApp := Globals.App.Type
+	t.Cleanup(func() { Globals.App.Type = prevApp })
+
+	// Wrong app type (auth) with a proxy-only zone: the gate must fire and reject.
+	Globals.App.Type = AppTypeAuth
+	zdAuth := &ZoneData{
+		ZoneName: "child.example.",
+		ZoneType: Secondary,
+		Options:  map[ZoneOption]bool{OptDelSyncProxy: true},
+		Logger:   log.New(os.Stderr, "", 0),
+	}
+	if err := zdAuth.SetupZoneSync(nil); err == nil {
+		t.Fatal("proxy on a non-agent zone must be rejected (gate must be reachable, not skipped by wantsSync)")
+	}
+
+	// Wrong zone type (primary) on an agent: rejected.
+	Globals.App.Type = AppTypeAgent
+	zdPrimary := &ZoneData{
+		ZoneName: "child.example.",
+		ZoneType: Primary,
+		Options:  map[ZoneOption]bool{OptDelSyncProxy: true},
+		Logger:   log.New(os.Stderr, "", 0),
+	}
+	if err := zdPrimary.SetupZoneSync(nil); err == nil {
+		t.Fatal("proxy on a primary zone must be rejected")
+	}
+
+	// Correct: agent + secondary + proxy-only ⇒ accepted (gate passes, no error).
+	zdOK := &ZoneData{
+		ZoneName: "child.example.",
+		ZoneType: Secondary,
+		Options:  map[ZoneOption]bool{OptDelSyncProxy: true},
+		Logger:   log.New(os.Stderr, "", 0),
+	}
+	if err := zdOK.SetupZoneSync(nil); err != nil {
+		t.Fatalf("agent secondary proxy zone must be accepted, got: %v", err)
 	}
 }

--- a/v2/delsync_proxy_test.go
+++ b/v2/delsync_proxy_test.go
@@ -1,0 +1,46 @@
+package tdns
+
+import "testing"
+
+// P-1: the delegation-sync-proxy zone option round-trips through the
+// string<->enum maps and is accepted by the option parser (it must NOT fall
+// into parseZoneOptions' default "unknown option" case, which would reject it
+// with a config error).
+
+func TestDelSyncProxyOptionMapping(t *testing.T) {
+	const name = "delegation-sync-proxy"
+
+	opt, ok := StringToZoneOption[name]
+	if !ok {
+		t.Fatalf("StringToZoneOption has no entry for %q", name)
+	}
+	if opt != OptDelSyncProxy {
+		t.Fatalf("StringToZoneOption[%q] = %d, want OptDelSyncProxy (%d)", name, opt, OptDelSyncProxy)
+	}
+	if got := ZoneOptionToString[OptDelSyncProxy]; got != name {
+		t.Fatalf("ZoneOptionToString[OptDelSyncProxy] = %q, want %q", got, name)
+	}
+}
+
+// parseZoneOptions must enable the option (the simple-enable switch case),
+// not reject it as unknown. A zone with the option set should come back with
+// options[OptDelSyncProxy] == true and no ConfigError recorded for it.
+func TestParseZoneOptionsAcceptsDelSyncProxy(t *testing.T) {
+	zd := &ZoneData{ZoneName: "child.example."}
+	zconf := &ZoneConf{
+		Name:        "child.example.",
+		Type:        "secondary",
+		OptionsStrs: []string{"delegation-sync-proxy"},
+	}
+
+	options := parseZoneOptions(nil, "child.example.", zconf, zd)
+
+	if !options[OptDelSyncProxy] {
+		t.Fatalf("parseZoneOptions did not enable OptDelSyncProxy; got %v", options)
+	}
+	for _, e := range zd.ErrorList() {
+		if e.Type == ConfigError {
+			t.Fatalf("unexpected ConfigError after parsing a valid option: %q", e.Msg)
+		}
+	}
+}

--- a/v2/delsync_proxy_update.go
+++ b/v2/delsync_proxy_update.go
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * delegation-sync-proxy, UPDATE path (P-5): the precondition + KEY-bootstrap
+ * state machine (§10.8 of the plan). Before the agent can proxy DNS UPDATEs to
+ * the parent on a clueless primary's behalf it must (a) confirm the parent
+ * actually advertises a DSYNC UPDATE receiver, and (b) hold a SIG(0) key whose
+ * public KEY is published at the child apex so the parent trusts the UPDATE
+ * (path-3 validation). Since the agent is a SECONDARY it cannot publish that KEY
+ * itself — the operator must add it at the primary — so this code generates the
+ * key and instructs the operator, holding off on UPDATEs until the KEY appears.
+ *
+ * None of these conditions hard-fails: the agent starts, the zone is served, and
+ * a not-yet-operable UPDATE proxy is a per-zone WARNING (visible on `zone list`),
+ * matching the resilient-config quarantine model. The NOTIFY proxy (P-2/P-3) is
+ * unaffected and may still apply.
+ */
+package tdns
+
+import (
+	"context"
+	"fmt"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+// ProxyUpdateState is the result of the UPDATE-proxy precondition check (§10.8).
+type ProxyUpdateState string
+
+const (
+	// ProxyUpdateUnsupported: the parent does not advertise a DSYNC UPDATE
+	// receiver. UPDATE-proxy is not applicable; NOTIFY proxy may still apply.
+	// No key is generated and the operator is not asked to publish anything.
+	ProxyUpdateUnsupported ProxyUpdateState = "update-unsupported"
+	// ProxyUpdateReady: the parent advertises UPDATE and the agent holds the
+	// private key for a KEY published at the child apex. Proxied UPDATEs can be
+	// signed and sent.
+	ProxyUpdateReady ProxyUpdateState = "ready"
+	// ProxyUpdateForeignKey: a KEY is published at the apex but the agent does
+	// not hold its private key. The agent must not mint a competing key; the
+	// UPDATE proxy is not operable for this zone.
+	ProxyUpdateForeignKey ProxyUpdateState = "foreign-key"
+	// ProxyUpdateWaiting: the parent advertises UPDATE but no KEY is published
+	// yet. The agent has generated (or already holds) a keypair and is waiting
+	// for the operator to publish the KEY (+ HSYNCPARAM pubkey) at the primary.
+	ProxyUpdateWaiting ProxyUpdateState = "waiting-for-key"
+)
+
+// proxyApexKEYs returns the KEY RRs published at the zone apex (empty if none).
+func (zd *ZoneData) proxyApexKEYs() []dns.RR {
+	apex, err := zd.GetOwner(zd.ZoneName)
+	if err != nil || apex == nil {
+		return nil
+	}
+	rrset, ok := apex.RRtypes.Get(dns.TypeKEY)
+	if !ok {
+		return nil
+	}
+	return rrset.RRs
+}
+
+// proxyHoldsPrivateKeyFor reports whether the keystore has an active SIG(0)
+// private key matching one of the published apex KEYs (by keytag).
+func (zd *ZoneData) proxyHoldsPrivateKeyFor(kdb *KeyDB, apexKeys []dns.RR) bool {
+	sak, err := kdb.GetSig0Keys(zd.ZoneName, Sig0StateActive)
+	if err != nil || sak == nil || len(sak.Keys) == 0 {
+		return false
+	}
+	for _, pub := range apexKeys {
+		key, ok := pub.(*dns.KEY)
+		if !ok {
+			continue
+		}
+		for _, held := range sak.Keys {
+			if held.KeyRR.KeyTag() == key.KeyTag() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ProxyUpdatePreconditionCheck runs the §10.8 state machine for a
+// delegation-sync-proxy zone and returns the resulting state. It is
+// side-effecting in the WAITING state only: it generates a SIG(0) keypair if the
+// keystore has none, so the operator instruction (proxyBootstrapInstruction) can
+// be produced. It records a per-zone WARNING for the non-ready, UPDATE-relevant
+// states and clears it when ready; it never returns a hard error for an
+// operationally-degraded state (only for genuine internal failures).
+func (zd *ZoneData) ProxyUpdatePreconditionCheck(ctx context.Context, kdb *KeyDB, imr *Imr) (ProxyUpdateState, error) {
+	// Step 1 (gate): does the parent advertise a DSYNC UPDATE receiver?
+	// LookupDSYNCTarget with SchemeUpdate both detects support and would resolve
+	// the target; here we only need the yes/no. A lookup error or no target ⇒
+	// not supported (not a hard failure — the parent may simply not offer it).
+	if imr == nil {
+		return ProxyUpdateUnsupported, nil
+	}
+	target, err := imr.LookupDSYNCTarget(ctx, zd.ZoneName, dns.TypeANY, core.SchemeUpdate)
+	if err != nil || target == nil {
+		lgDns.Debug("proxy update precondition: parent advertises no DSYNC UPDATE target",
+			"zone", zd.ZoneName, "err", err)
+		zd.clearProxyUpdateWarning()
+		return ProxyUpdateUnsupported, nil
+	}
+
+	// Step 2: inspect the apex KEY RRset.
+	apexKeys := zd.proxyApexKEYs()
+	if len(apexKeys) > 0 {
+		if zd.proxyHoldsPrivateKeyFor(kdb, apexKeys) {
+			zd.clearProxyUpdateWarning()
+			lgDns.Info("proxy update precondition: ready (KEY at apex, private key held)", "zone", zd.ZoneName)
+			return ProxyUpdateReady, nil
+		}
+		// Foreign KEY: do not mint a competing key; degrade, don't fail.
+		msg := "DSYNC UPDATE proxy not operable: a foreign KEY occupies the apex (no matching private key); NOTIFY proxy may still apply"
+		zd.SetError(DelegationSyncWarning, "%s", msg)
+		lgDns.Warn("proxy update precondition: foreign KEY at apex", "zone", zd.ZoneName)
+		return ProxyUpdateForeignKey, nil
+	}
+
+	// No KEY at the apex: ensure we have a keypair, then instruct the operator.
+	if err := zd.proxyEnsureSig0Key(kdb); err != nil {
+		// Keygen failure is a genuine internal error; still don't take the zone
+		// down — degrade with a warning.
+		msg := fmt.Sprintf("DSYNC UPDATE proxy not operable: failed to prepare SIG(0) key: %v", err)
+		zd.SetError(DelegationSyncWarning, "%s", msg)
+		lgDns.Error("proxy update precondition: keygen failed", "zone", zd.ZoneName, "err", err)
+		return ProxyUpdateWaiting, err
+	}
+	instr, ierr := zd.proxyBootstrapInstruction(kdb)
+	if ierr != nil {
+		lgDns.Error("proxy update precondition: could not build operator instruction", "zone", zd.ZoneName, "err", ierr)
+	}
+	msg := "DSYNC UPDATE proxy waiting: publish the KEY + HSYNCPARAM pubkey at the primary (see log / `keystore dnssec proxy-key`)"
+	zd.SetError(DelegationSyncWarning, "%s", msg)
+	lgDns.Warn("proxy update precondition: waiting for KEY publication at primary",
+		"zone", zd.ZoneName, "instruction", instr)
+	return ProxyUpdateWaiting, nil
+}
+
+// proxyEnsureSig0Key makes sure the keystore holds an active SIG(0) key for this
+// zone, generating one if absent. Reuses the keystore Sig0KeyMgmt generate path
+// (the same one DelegationSyncSetup uses for the child case), but does NOT
+// publish the KEY into the zone — a secondary cannot author the zone.
+func (zd *ZoneData) proxyEnsureSig0Key(kdb *KeyDB) error {
+	sak, err := kdb.GetSig0Keys(zd.ZoneName, Sig0StateActive)
+	if err != nil {
+		return fmt.Errorf("GetSig0Keys: %w", err)
+	}
+	if sak != nil && len(sak.Keys) > 0 {
+		return nil
+	}
+	alg, err := parseKeygenAlgorithm("delegationsync.child.update.keygen.algorithm", dns.ED25519)
+	if err != nil {
+		return fmt.Errorf("keygen algorithm: %w", err)
+	}
+	kp := KeystorePost{
+		Command:    "sig0-mgmt",
+		SubCommand: "generate",
+		Zone:       zd.ZoneName,
+		Keyname:    zd.ZoneName,
+		Algorithm:  alg,
+		State:      Sig0StateActive,
+		Creator:    "delsync-proxy-setup",
+	}
+	if _, err := kdb.Sig0KeyMgmt(nil, kp); err != nil {
+		return fmt.Errorf("Sig0KeyMgmt generate: %w", err)
+	}
+	lgDns.Info("delegation-sync-proxy: generated SIG(0) keypair for UPDATE proxy", "zone", zd.ZoneName)
+	return nil
+}
+
+// proxyBootstrapInstruction returns the two records the operator must add at the
+// primary apex (§10.8 U10): the agent's KEY RR and an HSYNCPARAM with the pubkey
+// flag (the signal to all providers to republish the apex KEY). Returns the
+// records as zone-file text.
+func (zd *ZoneData) proxyBootstrapInstruction(kdb *KeyDB) (string, error) {
+	sak, err := kdb.GetSig0Keys(zd.ZoneName, Sig0StateActive)
+	if err != nil {
+		return "", fmt.Errorf("GetSig0Keys: %w", err)
+	}
+	if sak == nil || len(sak.Keys) == 0 {
+		return "", fmt.Errorf("no active SIG(0) key for zone %s", zd.ZoneName)
+	}
+	keyRR := sak.Keys[0].KeyRR
+	keyRR.Hdr.Name = zd.ZoneName
+	return keyRR.String() + "\n" + zd.proxyHsyncparamPubkeyRR(), nil
+}
+
+// proxyHsyncparamPubkeyRR returns the zone-file text for an HSYNCPARAM record
+// carrying the pubkey flag at the zone apex.
+func (zd *ZoneData) proxyHsyncparamPubkeyRR() string {
+	hp := &core.HSYNCPARAM{Value: []core.HSYNCPARAMKeyValue{core.NewHsyncparamPubkeyFlag()}}
+	return fmt.Sprintf("%s\t3600\tIN\tHSYNCPARAM\t%s", zd.ZoneName, hp.String())
+}
+
+// clearProxyUpdateWarning removes any delegation-sync-proxy UPDATE warning set
+// on the zone (when the state becomes ready or update-unsupported).
+func (zd *ZoneData) clearProxyUpdateWarning() {
+	zd.ClearError(DelegationSyncWarning)
+}

--- a/v2/delsync_proxy_update.go
+++ b/v2/delsync_proxy_update.go
@@ -237,6 +237,46 @@ func (zd *ZoneData) proxyCurrentDelegationRRs() (newNS, newA, newAAAA, newDS []d
 	return newNS, newA, newAAAA, newDS
 }
 
+// ProxyDelegationSync is the steady-state dispatcher: on a detected change it
+// picks the scheme the parent advertises and forwards accordingly — a DNS
+// UPDATE (carrying the delegation records) when the parent advertises UPDATE, or
+// a NOTIFY (a "come re-scan me" signal) when it advertises NOTIFY. Runs in the
+// DelegationSyncher (off the refresh path), so the network calls (scheme
+// discovery, the send) are fine here. UPDATE is preferred when both are
+// advertised because it lands the change in one round-trip and works for
+// unsigned zones; NOTIFY is the fallback (and the only option for an unsigned
+// zone whose parent offers only NOTIFY — there it is a no-op, nothing to scan).
+func (zd *ZoneData) ProxyDelegationSync(ctx context.Context, kdb *KeyDB, notifyq chan NotifyRequest, imr *Imr, analysis *ProxyDelegationAnalysis) (string, error) {
+	scheme, _, err := zd.BestSyncScheme(ctx, imr)
+	if err != nil {
+		return "", fmt.Errorf("ProxyDelegationSync: BestSyncScheme(%s): %w", zd.ZoneName, err)
+	}
+	switch scheme {
+	case "UPDATE":
+		msg, state, uerr := zd.ProxyUpdateParent(ctx, kdb, imr)
+		if uerr != nil {
+			return "", uerr
+		}
+		// If the UPDATE precondition is not ready (KEY not yet published, etc.)
+		// the parent may still accept a NOTIFY — fall back so the change is not
+		// silently dropped while the operator completes the KEY bootstrap.
+		if state != ProxyUpdateReady {
+			nmsg, nerr := zd.ProxyNotifyParent(ctx, notifyq, imr, analysis)
+			if nerr != nil {
+				return msg, nil // UPDATE not ready, NOTIFY failed — report the UPDATE state
+			}
+			return fmt.Sprintf("%s; fell back to NOTIFY: %s", msg, nmsg), nil
+		}
+		return msg, nil
+	case "NOTIFY":
+		return zd.ProxyNotifyParent(ctx, notifyq, imr, analysis)
+	default:
+		lgDns.Info("delegation-sync-proxy: parent advertises no usable sync scheme; nothing forwarded",
+			"zone", zd.ZoneName, "scheme", scheme)
+		return "parent advertises no usable sync scheme; nothing forwarded", nil
+	}
+}
+
 // proxyUpdateMode returns the parent-update form for the proxy: the operator's
 // `parent-update` auth option if set, otherwise REPLACE (the proxy default —
 // replace is idempotent and self-correcting, the right behavior for forwarding

--- a/v2/delsync_proxy_update.go
+++ b/v2/delsync_proxy_update.go
@@ -201,6 +201,37 @@ func (zd *ZoneData) clearProxyUpdateWarning() {
 	zd.ClearError(DelegationSyncWarning)
 }
 
+// ProxyKeyStatus is the operator-facing report for the `proxy-key` command: the
+// current UPDATE-proxy state and, in the waiting state, the records the operator
+// must publish at the primary (the KEY RR + HSYNCPARAM pubkey). It runs the
+// §10.8 precondition check (which generates a keypair if needed in the waiting
+// state) and formats a human-readable result.
+func (zd *ZoneData) ProxyKeyStatus(ctx context.Context, kdb *KeyDB, imr *Imr) (string, error) {
+	if !zd.Options[OptDelSyncProxy] {
+		return "", fmt.Errorf("zone %s does not have the delegation-sync-proxy option", zd.ZoneName)
+	}
+	state, err := zd.ProxyUpdatePreconditionCheck(ctx, kdb, imr)
+	if err != nil {
+		return "", err
+	}
+	switch state {
+	case ProxyUpdateUnsupported:
+		return fmt.Sprintf("zone %s: UPDATE proxy not applicable — the parent advertises no DSYNC UPDATE receiver (NOTIFY proxy may still apply); nothing to publish.", zd.ZoneName), nil
+	case ProxyUpdateReady:
+		return fmt.Sprintf("zone %s: UPDATE proxy READY — the agent's KEY is published at the apex and the agent holds its private key.", zd.ZoneName), nil
+	case ProxyUpdateForeignKey:
+		return fmt.Sprintf("zone %s: UPDATE proxy NOT operable — a foreign KEY occupies the apex (the agent does not hold its private key). Remove it, or the agent cannot proxy via UPDATE (NOTIFY may still apply).", zd.ZoneName), nil
+	case ProxyUpdateWaiting:
+		instr, ierr := zd.proxyBootstrapInstruction(kdb)
+		if ierr != nil {
+			return "", ierr
+		}
+		return fmt.Sprintf("zone %s: UPDATE proxy WAITING — publish the following at the primary apex, then the agent will proxy UPDATEs once it sees the KEY:\n\n%s\n", zd.ZoneName, instr), nil
+	default:
+		return fmt.Sprintf("zone %s: UPDATE proxy state %q", zd.ZoneName, state), nil
+	}
+}
+
 // proxyCurrentDelegationRRs reads the current authoritative delegation RRsets
 // from the SERVED zone (the freshly-transferred data): the apex NS, the in-
 // bailiwick glue (A/AAAA) for those nameservers, and the DS derived from the

--- a/v2/delsync_proxy_update.go
+++ b/v2/delsync_proxy_update.go
@@ -237,6 +237,46 @@ func (zd *ZoneData) proxyCurrentDelegationRRs() (newNS, newA, newAAAA, newDS []d
 	return newNS, newA, newAAAA, newDS
 }
 
+// ProxyStartupReconcile runs once when a delegation-sync-proxy zone first
+// loads: it runs the §10.8 precondition state machine and, if UPDATE-proxy is
+// READY, does a one-time parent-vs-child reconcile — `AnalyseZoneDelegation`
+// (the network compare) and, only when out of sync, a proxied UPDATE. This
+// catches delegation drift that accumulated while the agent was down WITHOUT
+// re-sending on every restart (the sync check gates the send even though
+// replace-form would otherwise be harmless to re-send). Steady-state changes
+// after this are handled by the PreRefresh diff + PROXY-SYNC dispatch (U-e),
+// which need no parent round-trip.
+func (zd *ZoneData) ProxyStartupReconcile(ctx context.Context, kdb *KeyDB, imr *Imr) (string, error) {
+	state, err := zd.ProxyUpdatePreconditionCheck(ctx, kdb, imr)
+	if err != nil {
+		return "", err
+	}
+	if state != ProxyUpdateReady {
+		// Not operable via UPDATE (yet). Nothing to reconcile here; the NOTIFY
+		// path and the per-zone warning cover this.
+		return fmt.Sprintf("startup reconcile: UPDATE proxy not ready (%s)", state), nil
+	}
+	if zd.Parent == "" || zd.Parent == "." {
+		if p, perr := imr.ParentZone(zd.ZoneName); perr == nil {
+			zd.Parent = p
+		}
+	}
+	dss, aerr := zd.AnalyseZoneDelegation(imr)
+	if aerr != nil {
+		return "", fmt.Errorf("ProxyStartupReconcile: AnalyseZoneDelegation(%s): %w", zd.ZoneName, aerr)
+	}
+	if dss.InSync {
+		lgDns.Info("delegation-sync-proxy: startup reconcile — parent already in sync", "zone", zd.ZoneName)
+		return "startup reconcile: parent already in sync; nothing sent", nil
+	}
+	lgDns.Info("delegation-sync-proxy: startup reconcile — parent out of sync, sending UPDATE", "zone", zd.ZoneName)
+	msg, _, uerr := zd.ProxyUpdateParent(ctx, kdb, imr)
+	if uerr != nil {
+		return "", fmt.Errorf("ProxyStartupReconcile: %w", uerr)
+	}
+	return "startup reconcile: " + msg, nil
+}
+
 // ProxyDelegationSync is the steady-state dispatcher: on a detected change it
 // picks the scheme the parent advertises and forwards accordingly — a DNS
 // UPDATE (carrying the delegation records) when the parent advertises UPDATE, or

--- a/v2/delsync_proxy_update.go
+++ b/v2/delsync_proxy_update.go
@@ -200,3 +200,134 @@ func (zd *ZoneData) proxyHsyncparamPubkeyRR() string {
 func (zd *ZoneData) clearProxyUpdateWarning() {
 	zd.ClearError(DelegationSyncWarning)
 }
+
+// proxyCurrentDelegationRRs reads the current authoritative delegation RRsets
+// from the SERVED zone (the freshly-transferred data): the apex NS, the in-
+// bailiwick glue (A/AAAA) for those nameservers, and the DS derived from the
+// apex DNSKEY SEP keys. These are the replace-form UPDATE's "new members" — the
+// payload never depends on the parent's state (that is the point of replace).
+// For an unsigned zone newDS is empty (no DNSKEYs), which is correct.
+func (zd *ZoneData) proxyCurrentDelegationRRs() (newNS, newA, newAAAA, newDS []dns.RR) {
+	apex, err := zd.GetOwner(zd.ZoneName)
+	if err != nil || apex == nil {
+		return nil, nil, nil, nil
+	}
+	newNS = apex.RRtypes.GetOnlyRRSet(dns.TypeNS).RRs
+
+	// In-bailiwick glue: A/AAAA for nameservers under the zone.
+	for _, rr := range newNS {
+		ns, ok := rr.(*dns.NS)
+		if !ok || !dns.IsSubDomain(zd.ZoneName, ns.Ns) {
+			continue
+		}
+		if owner, oerr := zd.GetOwner(ns.Ns); oerr == nil && owner != nil {
+			newA = append(newA, owner.RRtypes.GetOnlyRRSet(dns.TypeA).RRs...)
+			newAAAA = append(newAAAA, owner.RRtypes.GetOnlyRRSet(dns.TypeAAAA).RRs...)
+		}
+	}
+
+	// DS from the apex DNSKEY SEP keys (signed zones only).
+	for _, rr := range apex.RRtypes.GetOnlyRRSet(dns.TypeDNSKEY).RRs {
+		if dnskey, ok := rr.(*dns.DNSKEY); ok && dnskey.Flags&dns.SEP != 0 {
+			if ds := dnskey.ToDS(dns.SHA256); ds != nil {
+				newDS = append(newDS, ds)
+			}
+		}
+	}
+	return newNS, newA, newAAAA, newDS
+}
+
+// proxyUpdateMode returns the parent-update form for the proxy: the operator's
+// `parent-update` auth option if set, otherwise REPLACE (the proxy default —
+// replace is idempotent and self-correcting, the right behavior for forwarding
+// on a clueless primary's behalf). This mirrors the tdns-auth child path, which
+// reads the same option but defaults to delta.
+func proxyUpdateMode(kdb *KeyDB) string {
+	if mode, ok := kdb.AuthOption(AuthOptParentUpdate); ok && mode != "" {
+		return mode
+	}
+	return UpdateModeReplace
+}
+
+// ProxyUpdateParent forwards a DNS UPDATE to the parent on behalf of a
+// DSYNC-unaware primary, signed with the agent's SIG(0) key AS the child
+// (SignerName = child zone — the parent trusts it via the KEY published at the
+// child apex, §10.1). The form is REPLACE by default and DELTA if the operator
+// sets `parent-update: delta` (proxyUpdateMode). Replace DELetes the child's
+// delegation RRsets and ADDs the current authoritative members (NS + glue + DS).
+//
+// It is gated on the precondition state machine (§10.8): if the parent does not
+// advertise UPDATE, or the agent's KEY is not published/ours, it does nothing
+// and reports the state — it never sends an UPDATE the parent would REFUSE.
+func (zd *ZoneData) ProxyUpdateParent(ctx context.Context, kdb *KeyDB, imr *Imr) (string, ProxyUpdateState, error) {
+	state, err := zd.ProxyUpdatePreconditionCheck(ctx, kdb, imr)
+	if err != nil {
+		return "", state, err
+	}
+	if state != ProxyUpdateReady {
+		return fmt.Sprintf("UPDATE proxy not ready (%s); nothing sent", state), state, nil
+	}
+
+	// Resolve the parent's UPDATE target.
+	if zd.Parent == "" || zd.Parent == "." {
+		p, perr := imr.ParentZone(zd.ZoneName)
+		if perr != nil {
+			return "", state, fmt.Errorf("ProxyUpdateParent: ParentZone(%s): %w", zd.ZoneName, perr)
+		}
+		zd.Parent = p
+	}
+	target, terr := imr.LookupDSYNCTarget(ctx, zd.ZoneName, dns.TypeANY, core.SchemeUpdate)
+	if terr != nil || target == nil || len(target.Addresses) == 0 {
+		return "", state, fmt.Errorf("ProxyUpdateParent: no UPDATE target for %s: %w", zd.ZoneName, terr)
+	}
+
+	// Build the UPDATE in the configured form (replace by default, delta if the
+	// operator chose it). Replace reads the current authoritative records from
+	// the served zone; delta needs the parent-vs-child diff (AnalyseZoneDelegation).
+	var m *dns.Msg
+	var berr error
+	mode := proxyUpdateMode(kdb)
+	if mode == UpdateModeDelta {
+		dss, aerr := zd.AnalyseZoneDelegation(imr)
+		if aerr != nil {
+			return "", state, fmt.Errorf("ProxyUpdateParent: analyse delegation (delta): %w", aerr)
+		}
+		if dss.InSync {
+			return "delta: parent already in sync; nothing sent", state, nil
+		}
+		var adds, removes []dns.RR
+		adds = append(adds, dss.NsAdds...)
+		adds = append(adds, dss.AAdds...)
+		adds = append(adds, dss.AAAAAdds...)
+		adds = append(adds, dss.DSAdds...)
+		removes = append(removes, dss.NsRemoves...)
+		removes = append(removes, dss.ARemoves...)
+		removes = append(removes, dss.AAAARemoves...)
+		removes = append(removes, dss.DSRemoves...)
+		m, berr = CreateChildUpdate(zd.Parent, zd.ZoneName, adds, removes)
+	} else {
+		newNS, newA, newAAAA, newDS := zd.proxyCurrentDelegationRRs()
+		m, berr = CreateChildReplaceUpdate(zd.Parent, zd.ZoneName, newNS, newA, newAAAA, newDS)
+	}
+	if berr != nil {
+		return "", state, fmt.Errorf("ProxyUpdateParent: build %s UPDATE: %w", mode, berr)
+	}
+
+	// Sign as the child with the agent's SIG(0) key.
+	sak, kerr := kdb.GetSig0Keys(zd.ZoneName, Sig0StateActive)
+	if kerr != nil || sak == nil || len(sak.Keys) == 0 {
+		return "", state, fmt.Errorf("ProxyUpdateParent: no active SIG(0) key for %s", zd.ZoneName)
+	}
+	smsg, serr := SignMsg(*m, zd.ZoneName, sak)
+	if serr != nil || smsg == nil {
+		return "", state, fmt.Errorf("ProxyUpdateParent: sign UPDATE: %w", serr)
+	}
+
+	rcode, _, uerr := SendUpdate(smsg, zd.Parent, target.Addresses)
+	if uerr != nil {
+		return "", state, fmt.Errorf("ProxyUpdateParent: send UPDATE to %s: %w", zd.Parent, uerr)
+	}
+	msg := fmt.Sprintf("proxied %s UPDATE to parent %s (rcode %s)", mode, zd.Parent, dns.RcodeToString[rcode])
+	lgDns.Info("delegation-sync-proxy: "+msg, "zone", zd.ZoneName, "mode", mode)
+	return msg, state, nil
+}

--- a/v2/delsync_proxy_update_test.go
+++ b/v2/delsync_proxy_update_test.go
@@ -1,0 +1,157 @@
+package tdns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// U-a: the UPDATE-proxy precondition + KEY-bootstrap state machine (§10.8).
+// The DSYNC-discovery gate is network and is exercised on the testbed; here we
+// unit-test the post-gate logic: apex-KEY detection, ours-vs-foreign matching,
+// keygen idempotency, and the operator-instruction text.
+
+const proxyUpdZone = "upd.example."
+
+func proxyUpdZoneData(t *testing.T, kdb *KeyDB, zoneStr string) *ZoneData {
+	t.Helper()
+	zd := testZone(t, proxyUpdZone, zoneStr)
+	zd.KeyDB = kdb
+	return zd
+}
+
+// genProxySig0Key generates an active SIG(0) key for the zone and returns its
+// published KEY RR (as it would appear at the apex).
+func genProxySig0Key(t *testing.T, kdb *KeyDB, zone string) *dns.KEY {
+	t.Helper()
+	if err := kdb.ensureSig0KeyForTest(zone); err != nil {
+		t.Fatalf("generate SIG(0) key: %v", err)
+	}
+	sak, err := kdb.GetSig0Keys(zone, Sig0StateActive)
+	if err != nil || sak == nil || len(sak.Keys) == 0 {
+		t.Fatalf("GetSig0Keys after generate: %v (keys=%v)", err, sak)
+	}
+	k := sak.Keys[0].KeyRR
+	k.Hdr.Name = zone
+	return &k
+}
+
+// ensureSig0KeyForTest is a thin wrapper around the keygen path the proxy uses.
+func (kdb *KeyDB) ensureSig0KeyForTest(zone string) error {
+	kp := KeystorePost{
+		Command:    "sig0-mgmt",
+		SubCommand: "generate",
+		Zone:       zone,
+		Keyname:    zone,
+		Algorithm:  dns.ED25519,
+		State:      Sig0StateActive,
+		Creator:    "test",
+	}
+	_, err := kdb.Sig0KeyMgmt(nil, kp)
+	return err
+}
+
+// No KEY at apex + no key in keystore: proxyEnsureSig0Key generates one and is
+// idempotent (a second call does not generate a second key).
+func TestProxyEnsureSig0KeyGeneratesAndIsIdempotent(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := proxyUpdZoneData(t, kdb, proxyUpdBaseZone())
+
+	if err := zd.proxyEnsureSig0Key(kdb); err != nil {
+		t.Fatalf("first proxyEnsureSig0Key: %v", err)
+	}
+	sak, _ := kdb.GetSig0Keys(proxyUpdZone, Sig0StateActive)
+	if sak == nil || len(sak.Keys) != 1 {
+		t.Fatalf("after first ensure: want 1 active SIG(0) key, got %v", sak)
+	}
+	if err := zd.proxyEnsureSig0Key(kdb); err != nil {
+		t.Fatalf("second proxyEnsureSig0Key: %v", err)
+	}
+	sak, _ = kdb.GetSig0Keys(proxyUpdZone, Sig0StateActive)
+	if sak == nil || len(sak.Keys) != 1 {
+		t.Fatalf("after second ensure: still want exactly 1 key (idempotent), got %d", len(sak.Keys))
+	}
+}
+
+// proxyHoldsPrivateKeyFor: true when an apex KEY matches a held key, false for a
+// foreign KEY.
+func TestProxyHoldsPrivateKeyFor(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := proxyUpdZoneData(t, kdb, proxyUpdBaseZone())
+	ourKey := genProxySig0Key(t, kdb, proxyUpdZone)
+
+	if !zd.proxyHoldsPrivateKeyFor(kdb, []dns.RR{ourKey}) {
+		t.Fatal("should hold the private key for our own generated KEY")
+	}
+
+	// A foreign KEY (different key material → different keytag), parsed from
+	// zone-file text.
+	foreignRR, err := dns.NewRR(proxyUpdZone + " 3600 IN KEY 257 3 15 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	if err != nil {
+		t.Fatalf("parse foreign KEY: %v", err)
+	}
+	if zd.proxyHoldsPrivateKeyFor(kdb, []dns.RR{foreignRR}) {
+		t.Fatal("must NOT claim to hold the private key for a foreign KEY")
+	}
+}
+
+// proxyApexKEYs reads the apex KEY RRset.
+func TestProxyApexKEYs(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	// No KEY at apex.
+	zdNoKey := proxyUpdZoneData(t, kdb, proxyUpdBaseZone())
+	if got := zdNoKey.proxyApexKEYs(); len(got) != 0 {
+		t.Fatalf("no-KEY zone should return no apex KEYs, got %d", len(got))
+	}
+	// KEY at apex.
+	ourKey := genProxySig0Key(t, kdb, proxyUpdZone)
+	zdKey := proxyUpdZoneData(t, kdb, proxyUpdBaseZone()+ourKey.String()+"\n")
+	if got := zdKey.proxyApexKEYs(); len(got) != 1 {
+		t.Fatalf("zone with a KEY should return 1 apex KEY, got %d", len(got))
+	}
+}
+
+// The operator instruction is two records: the KEY RR and an HSYNCPARAM pubkey.
+func TestProxyBootstrapInstruction(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := proxyUpdZoneData(t, kdb, proxyUpdBaseZone())
+	if err := zd.proxyEnsureSig0Key(kdb); err != nil {
+		t.Fatalf("ensure key: %v", err)
+	}
+	instr, err := zd.proxyBootstrapInstruction(kdb)
+	if err != nil {
+		t.Fatalf("proxyBootstrapInstruction: %v", err)
+	}
+	if !strings.Contains(instr, "\tKEY\t") && !strings.Contains(instr, " KEY ") {
+		t.Fatalf("instruction missing a KEY record:\n%s", instr)
+	}
+	if !strings.Contains(instr, "HSYNCPARAM") || !strings.Contains(instr, "pubkey") {
+		t.Fatalf("instruction missing HSYNCPARAM pubkey:\n%s", instr)
+	}
+	// Both records name the zone apex.
+	for _, line := range strings.Split(strings.TrimSpace(instr), "\n") {
+		if !strings.HasPrefix(line, proxyUpdZone) {
+			t.Fatalf("instruction line not at apex: %q", line)
+		}
+	}
+}
+
+// The HSYNCPARAM pubkey record renders with the pubkey flag.
+func TestProxyHsyncparamPubkeyRR(t *testing.T) {
+	zd := &ZoneData{ZoneName: proxyUpdZone}
+	rr := zd.proxyHsyncparamPubkeyRR()
+	if !strings.Contains(rr, "HSYNCPARAM") || !strings.Contains(rr, "pubkey") {
+		t.Fatalf("HSYNCPARAM pubkey RR malformed: %q", rr)
+	}
+	if !strings.HasPrefix(rr, proxyUpdZone) {
+		t.Fatalf("HSYNCPARAM RR not at apex: %q", rr)
+	}
+}
+
+func proxyUpdBaseZone() string {
+	return `upd.example.	3600 IN SOA ns1.upd.example. hostmaster.upd.example. 1 7200 1800 604800 3600
+upd.example.	3600 IN NS ns1.upd.example.
+ns1.upd.example.	3600 IN A 192.0.2.1
+`
+}

--- a/v2/delsync_proxy_update_test.go
+++ b/v2/delsync_proxy_update_test.go
@@ -155,3 +155,76 @@ upd.example.	3600 IN NS ns1.upd.example.
 ns1.upd.example.	3600 IN A 192.0.2.1
 `
 }
+
+// U-d: proxyUpdateMode defaults to replace and honors the parent-update option.
+func TestProxyUpdateModeDefaultAndOverride(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// No option set ⇒ replace (the proxy default; differs from the auth-side
+	// delta default).
+	if got := proxyUpdateMode(kdb); got != UpdateModeReplace {
+		t.Fatalf("default proxy update mode = %q, want replace", got)
+	}
+
+	// Operator chooses delta.
+	kdb.SetOptions(map[AuthOption]string{AuthOptParentUpdate: UpdateModeDelta})
+	if got := proxyUpdateMode(kdb); got != UpdateModeDelta {
+		t.Fatalf("with parent-update:delta, mode = %q, want delta", got)
+	}
+
+	// Operator chooses replace explicitly.
+	kdb.SetOptions(map[AuthOption]string{AuthOptParentUpdate: UpdateModeReplace})
+	if got := proxyUpdateMode(kdb); got != UpdateModeReplace {
+		t.Fatalf("with parent-update:replace, mode = %q, want replace", got)
+	}
+}
+
+// U-d: proxyCurrentDelegationRRs reads the current authoritative NS + glue + DS
+// (DS derived from apex DNSKEY SEP keys) from the served zone.
+func TestProxyCurrentDelegationRRs(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	// A signed delegation: NS + in-bailiwick glue + a KSK DNSKEY (SEP) → DS.
+	zoneStr := `upd.example.	3600 IN SOA ns1.upd.example. hostmaster.upd.example. 1 7200 1800 604800 3600
+upd.example.	3600 IN NS ns1.upd.example.
+upd.example.	3600 IN NS ns2.upd.example.
+ns1.upd.example.	3600 IN A 192.0.2.1
+ns1.upd.example.	3600 IN AAAA 2001:db8::1
+ns2.upd.example.	3600 IN A 192.0.2.2
+upd.example.	3600 IN DNSKEY 257 3 15 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaA=
+`
+	zd := proxyUpdZoneData(t, kdb, zoneStr)
+	newNS, newA, newAAAA, newDS := zd.proxyCurrentDelegationRRs()
+	if len(newNS) != 2 {
+		t.Fatalf("NS = %d, want 2", len(newNS))
+	}
+	if len(newA) != 2 {
+		t.Fatalf("A glue = %d, want 2", len(newA))
+	}
+	if len(newAAAA) != 1 {
+		t.Fatalf("AAAA glue = %d, want 1", len(newAAAA))
+	}
+	if len(newDS) != 1 {
+		t.Fatalf("DS (from KSK DNSKEY) = %d, want 1", len(newDS))
+	}
+	if _, ok := newDS[0].(*dns.DS); !ok {
+		t.Fatalf("DS RR has wrong type %T", newDS[0])
+	}
+}
+
+// U-d: an unsigned zone (no DNSKEYs) yields NS + glue but no DS — the case the
+// UPDATE path serves that NOTIFY cannot.
+func TestProxyCurrentDelegationRRsUnsigned(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zoneStr := `upd.example.	3600 IN SOA ns1.upd.example. hostmaster.upd.example. 1 7200 1800 604800 3600
+upd.example.	3600 IN NS ns1.upd.example.
+ns1.upd.example.	3600 IN A 192.0.2.1
+`
+	zd := proxyUpdZoneData(t, kdb, zoneStr)
+	newNS, newA, _, newDS := zd.proxyCurrentDelegationRRs()
+	if len(newNS) != 1 || len(newA) != 1 {
+		t.Fatalf("NS/A = %d/%d, want 1/1", len(newNS), len(newA))
+	}
+	if len(newDS) != 0 {
+		t.Fatalf("unsigned zone must yield no DS, got %d", len(newDS))
+	}
+}

--- a/v2/delsync_proxy_update_test.go
+++ b/v2/delsync_proxy_update_test.go
@@ -69,8 +69,14 @@ func TestProxyEnsureSig0KeyGeneratesAndIsIdempotent(t *testing.T) {
 	if err := zd.proxyEnsureSig0Key(kdb); err != nil {
 		t.Fatalf("second proxyEnsureSig0Key: %v", err)
 	}
-	sak, _ = kdb.GetSig0Keys(proxyUpdZone, Sig0StateActive)
-	if sak == nil || len(sak.Keys) != 1 {
+	sak, err := kdb.GetSig0Keys(proxyUpdZone, Sig0StateActive)
+	if err != nil {
+		t.Fatalf("GetSig0Keys after second ensure: %v", err)
+	}
+	if sak == nil {
+		t.Fatalf("after second ensure: still want exactly 1 key (idempotent), got nil")
+	}
+	if len(sak.Keys) != 1 {
 		t.Fatalf("after second ensure: still want exactly 1 key (idempotent), got %d", len(sak.Keys))
 	}
 }

--- a/v2/delsync_proxy_update_test.go
+++ b/v2/delsync_proxy_update_test.go
@@ -244,3 +244,26 @@ func TestProxyStartupReconcileNotReady(t *testing.T) {
 		t.Fatalf("expected a not-ready message, got %q", msg)
 	}
 }
+
+// U-a2: ProxyKeyStatus reports an error for a non-proxy zone, and the
+// update-unsupported message when no UPDATE target is discoverable (nil imr).
+func TestProxyKeyStatus(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// Zone without the proxy option ⇒ error.
+	zdPlain := proxyUpdZoneData(t, kdb, proxyUpdBaseZone())
+	if _, err := zdPlain.ProxyKeyStatus(context.Background(), kdb, nil); err == nil {
+		t.Fatal("ProxyKeyStatus must error for a non-proxy zone")
+	}
+
+	// Proxy zone, no imr ⇒ update-unsupported message (nothing to publish).
+	zdProxy := proxyUpdZoneData(t, kdb, proxyUpdBaseZone())
+	zdProxy.Options = map[ZoneOption]bool{OptDelSyncProxy: true}
+	msg, err := zdProxy.ProxyKeyStatus(context.Background(), kdb, nil)
+	if err != nil {
+		t.Fatalf("ProxyKeyStatus (proxy, no imr): %v", err)
+	}
+	if !strings.Contains(msg, "not applicable") {
+		t.Fatalf("expected update-unsupported message, got %q", msg)
+	}
+}

--- a/v2/delsync_proxy_update_test.go
+++ b/v2/delsync_proxy_update_test.go
@@ -1,6 +1,7 @@
 package tdns
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -226,5 +227,20 @@ ns1.upd.example.	3600 IN A 192.0.2.1
 	}
 	if len(newDS) != 0 {
 		t.Fatalf("unsigned zone must yield no DS, got %d", len(newDS))
+	}
+}
+
+// U-c: startup reconcile with no imr (no DSYNC discovery possible) reports
+// update-unsupported and does not attempt any parent compare or send. This
+// exercises the not-ready early-return branch without the network.
+func TestProxyStartupReconcileNotReady(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := proxyUpdZoneData(t, kdb, proxyUpdBaseZone())
+	msg, err := zd.ProxyStartupReconcile(context.Background(), kdb, nil)
+	if err != nil {
+		t.Fatalf("ProxyStartupReconcile (nil imr): unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "not ready") {
+		t.Fatalf("expected a not-ready message, got %q", msg)
 	}
 }

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -44,7 +44,8 @@ const (
 	OptCatalogZone
 	OptCatalogMemberAutoCreate
 	OptCatalogMemberAutoDelete
-	OptMultiSigner // Dynamically set by signer when HSYNC shows multiple signers
+	OptMultiSigner  // Dynamically set by signer when HSYNC shows multiple signers
+	OptDelSyncProxy // agent secondary: proxy CDS/CSYNC NOTIFYs upstream for a DSYNC-unaware primary
 	optZoneOptionTdnsSentinel
 )
 
@@ -76,6 +77,7 @@ var ZoneOptionToString = map[ZoneOption]string{
 	OptCatalogMemberAutoCreate: "catalog-member-auto-create",
 	OptCatalogMemberAutoDelete: "catalog-member-auto-delete",
 	OptMultiSigner:             "multi-signer",
+	OptDelSyncProxy:            "delegation-sync-proxy",
 }
 
 var StringToZoneOption = map[string]ZoneOption{
@@ -99,6 +101,7 @@ var StringToZoneOption = map[string]ZoneOption{
 	"catalog-member-auto-create": OptCatalogMemberAutoCreate,
 	"catalog-member-auto-delete": OptCatalogMemberAutoDelete,
 	"multi-signer":               OptMultiSigner,
+	"delegation-sync-proxy":      OptDelSyncProxy,
 }
 
 type ImrOption uint8

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -254,6 +254,13 @@ const (
 	// visibility signal, not a hardfail. Auto-rollover progression
 	// gates here because no scheme means no DS push is possible.
 	RolloverParentBlocker
+	// DelegationSyncWarning: a delegation-sync function is degraded but the
+	// zone is otherwise fine. Used by the delegation-sync-proxy UPDATE path
+	// when it is not operable (parent advertises no UPDATE, a foreign KEY
+	// occupies the apex, or the agent's KEY is not yet published at the
+	// primary). Visibility-only — the zone keeps serving and the NOTIFY proxy
+	// may still apply.
+	DelegationSyncWarning
 )
 
 var ErrorTypeToString = map[ErrorType]string{
@@ -265,6 +272,7 @@ var ErrorTypeToString = map[ErrorType]string{
 	RolloverPolicyViolation: "rollover-policy",
 	RolloverPolicyWarning:   "rollover-policy-warning",
 	RolloverParentBlocker:   "rollover-parent-blocker",
+	DelegationSyncWarning:   "delegation-sync-warning",
 }
 
 // errorTypeReportOrder defines the deterministic order in which the
@@ -281,6 +289,7 @@ var errorTypeReportOrder = []ErrorType{
 	RolloverParentBlocker,
 	DnssecPolicyWarning,
 	RolloverPolicyWarning,
+	DelegationSyncWarning,
 }
 
 // rolloverGatingErrors are categories that the auto-rollover CLI

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -934,7 +934,11 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// matching OnZonePostRefresh callback acts on it (P-3). Mirrors the
 		// tdns-mp MPPreRefresh/PostRefresh pattern (tdns-mp/v2/config.go), for
 		// the non-MP agent path.
-		if options[OptDelSyncProxy] {
+		// Register only on first load: on reload zdp is the existing registry
+		// entry and its OnZone*Refresh slices already carry these hooks, so
+		// appending again would accumulate duplicates (same convention as the
+		// OnFirstLoad-guarded setupSync block above).
+		if options[OptDelSyncProxy] && zdp.FirstZoneLoad {
 			delegationSyncQ := conf.Internal.DelegationSyncQ
 			zdp.OnZonePreRefresh = append(zdp.OnZonePreRefresh,
 				func(zd, new_zd *ZoneData) {

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -898,8 +898,9 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		}
 
 		// Delegation sync setup: DSYNC publication (parent) or
-		// delegation sync monitoring (child).
-		if options[OptDelSyncParent] || options[OptDelSyncChild] {
+		// delegation sync monitoring (child), or proxy forwarding for a
+		// DSYNC-unaware primary (agent secondary).
+		if options[OptDelSyncParent] || options[OptDelSyncChild] || options[OptDelSyncProxy] {
 			capturedOpts := options
 			setupSync := func(zd *ZoneData) {
 				// Skip if the MP HSYNCPARAM callback already set up delegation sync for this zone.
@@ -923,6 +924,26 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			} else {
 				setupSync(zdp)
 			}
+		}
+
+		// delegation-sync-proxy: register the post-transfer change-detection
+		// hook so an agent secondary forwards NOTIFY(CDS/CSYNC) to the parent
+		// when a relevant RRset changes in an incoming transfer. The hook is an
+		// OnZonePreRefresh callback (it needs both old and new zone data to
+		// diff) that records what changed in zd.ProxyRefreshAnalysis; the
+		// matching OnZonePostRefresh callback acts on it (P-3). Mirrors the
+		// tdns-mp MPPreRefresh/PostRefresh pattern (tdns-mp/v2/config.go), for
+		// the non-MP agent path.
+		if options[OptDelSyncProxy] {
+			delegationSyncQ := conf.Internal.DelegationSyncQ
+			zdp.OnZonePreRefresh = append(zdp.OnZonePreRefresh,
+				func(zd, new_zd *ZoneData) {
+					zd.ProxyDelegationPreRefresh(new_zd)
+				})
+			zdp.OnZonePostRefresh = append(zdp.OnZonePostRefresh,
+				func(zd *ZoneData) {
+					zd.ProxyDelegationPostRefresh(delegationSyncQ)
+				})
 		}
 
 		// Note: DelegationBackend wiring is done synchronously above,

--- a/v2/parseoptions.go
+++ b/v2/parseoptions.go
@@ -181,6 +181,7 @@ func parseZoneOptions(conf *Config, zname string, zconf *ZoneConf, zd *ZoneData)
 		switch opt {
 		case OptDelSyncParent,
 			OptDelSyncChild,
+			OptDelSyncProxy,
 			OptAllowUpdates,
 			OptAllowChildUpdates,
 			OptAllowEdits,

--- a/v2/parseoptions.go
+++ b/v2/parseoptions.go
@@ -113,10 +113,10 @@ func (conf *Config) ParseAuthOptions() {
 				val = UpdateModeDelta
 			}
 			switch val {
-			case UpdateModeDelta:
+			case UpdateModeDelta, UpdateModeReplace:
 				clean[authOpt] = val
 			default:
-				lg.Warn("Auth option has invalid value, defaulting", "option", key, "value", optval, "allowed", UpdateModeDelta, "default", UpdateModeDelta)
+				lg.Warn("Auth option has invalid value, defaulting", "option", key, "value", optval, "allowed", UpdateModeDelta+"|"+UpdateModeReplace, "default", UpdateModeDelta)
 				clean[authOpt] = UpdateModeDelta
 			}
 		case AuthOptMinimalResponses:

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -613,6 +613,9 @@ type DelegationSyncRequest struct {
 	NewDnskeys   *core.RRset
 	MsignerGroup *core.RRset
 	Response     chan DelegationSyncStatus // used for API-based requests
+	// ProxyAnalysis is set for the PROXY-NOTIFY command: the changed-dimension
+	// set the proxy NOTIFY action keys on (delegation-sync-proxy).
+	ProxyAnalysis *ProxyDelegationAnalysis
 }
 
 type BumperData struct {

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -166,6 +166,13 @@ type ZoneData struct {
 	// They receive zd which now serves the new data. Used for: queue sends (SyncQ,
 	// DelegationSyncQ) that need the live zone pointer, and any post-flip notifications.
 	OnZonePostRefresh []func(zd *ZoneData)
+
+	// ProxyRefreshAnalysis carries the delegation-sync-proxy change-detection
+	// result from the PreRefresh hook (which sees old+new zone data) to the
+	// PostRefresh hook (which acts). nil when no proxy analysis is pending.
+	// Set/consumed only on the OnZonePreRefresh/PostRefresh path for zones with
+	// OptDelSyncProxy; protected by zd.mu.
+	ProxyRefreshAnalysis *ProxyDelegationAnalysis
 }
 
 // Lock and Unlock expose the mutex for code that moves to

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -885,10 +885,9 @@ func (zd *ZoneData) SetupZoneSync(delsyncq chan<- DelegationSyncRequest) error {
 	// delegation-sync-proxy: a tdns-agent acting as a SECONDARY for a zone
 	// whose primary is DSYNC-unaware (BIND/Knot). The agent inspects incoming
 	// transfers for CDS/CSYNC (and NS/glue/DNSKEY) changes and forwards
-	// NOTIFY(CDS/CSYNC) to the parent on the primary's behalf. Unlike
-	// delegation-sync-child this is NOTIFY-only and needs no local SIG(0) key
-	// (a bare NOTIFY tells the parent to re-scan; it carries no payload we must
-	// sign). Valid only for agent + secondary zones; reject other combinations
+	// NOTIFY(CDS/CSYNC) — and, when the parent advertises UPDATE and the agent's
+	// KEY is published at the apex, DNS UPDATEs — to the parent on the primary's
+	// behalf. Valid only for agent + secondary zones; reject other combinations
 	// so a misconfiguration is loud rather than silently inert.
 	if zd.Options[OptDelSyncProxy] {
 		if Globals.App.Type != AppTypeAgent || zd.ZoneType != Secondary {
@@ -897,9 +896,18 @@ func (zd *ZoneData) SetupZoneSync(delsyncq chan<- DelegationSyncRequest) error {
 			zd.SetError(ConfigError, "delegation-sync-proxy is only valid for an agent secondary zone")
 			return fmt.Errorf("delegation-sync-proxy on zone %s requires a tdns-agent secondary zone", zd.ZoneName)
 		}
-		// The change-detection hook (P-2) and the proxy NOTIFY action (P-3) are
-		// wired separately. P-1 only establishes and validates the gate.
 		lg.Info("SetupZoneSync: delegation-sync-proxy enabled (agent secondary)", "zone", zd.ZoneName)
+		// Run the UPDATE-proxy precondition check (§10.8) off the refresh path,
+		// via the DelegationSyncher: it does DSYNC discovery (network) and may
+		// generate a SIG(0) key, so it must not run inline here. The check is a
+		// no-op for the NOTIFY proxy, which needs no key.
+		if delsyncq != nil {
+			delsyncq <- DelegationSyncRequest{
+				Command:  "PROXY-UPDATE-SETUP",
+				ZoneName: zd.ZoneName,
+				ZoneData: zd,
+			}
+		}
 	}
 
 	return nil

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -796,7 +796,7 @@ func (zd *ZoneData) FetchChildDelegationData(childname string) (*ChildDelegation
 }
 
 func (zd *ZoneData) SetupZoneSync(delsyncq chan<- DelegationSyncRequest) error {
-	wantsSync := zd.Options[OptDelSyncParent] || zd.Options[OptDelSyncChild]
+	wantsSync := zd.Options[OptDelSyncParent] || zd.Options[OptDelSyncChild] || zd.Options[OptDelSyncProxy]
 
 	// Dynamic parentsync=agent detection removed — handled by tdns-mp
 	// MPPostRefresh (hsync_utils.go) and OnFirstLoad (start_agent.go).

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -882,6 +882,26 @@ func (zd *ZoneData) SetupZoneSync(delsyncq chan<- DelegationSyncRequest) error {
 		}
 	}
 
+	// delegation-sync-proxy: a tdns-agent acting as a SECONDARY for a zone
+	// whose primary is DSYNC-unaware (BIND/Knot). The agent inspects incoming
+	// transfers for CDS/CSYNC (and NS/glue/DNSKEY) changes and forwards
+	// NOTIFY(CDS/CSYNC) to the parent on the primary's behalf. Unlike
+	// delegation-sync-child this is NOTIFY-only and needs no local SIG(0) key
+	// (a bare NOTIFY tells the parent to re-scan; it carries no payload we must
+	// sign). Valid only for agent + secondary zones; reject other combinations
+	// so a misconfiguration is loud rather than silently inert.
+	if zd.Options[OptDelSyncProxy] {
+		if Globals.App.Type != AppTypeAgent || zd.ZoneType != Secondary {
+			lg.Error("SetupZoneSync: delegation-sync-proxy is only valid for a tdns-agent secondary zone",
+				"zone", zd.ZoneName, "app", Globals.App.Type, "zonetype", zd.ZoneType)
+			zd.SetError(ConfigError, "delegation-sync-proxy is only valid for an agent secondary zone")
+			return fmt.Errorf("delegation-sync-proxy on zone %s requires a tdns-agent secondary zone", zd.ZoneName)
+		}
+		// The change-detection hook (P-2) and the proxy NOTIFY action (P-3) are
+		// wired separately. P-1 only establishes and validates the gate.
+		lg.Info("SetupZoneSync: delegation-sync-proxy enabled (agent secondary)", "zone", zd.ZoneName)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Lets **tdns-agent**, when running as a SECONDARY for a zone whose PRIMARY is
DSYNC-unaware (BIND9, Knot, NSD), act as a **DSYNC proxy**: it inspects each
incoming AXFR/IXFR for changes to the zone's CDS / CSYNC / NS+glue / DNSKEY and
forwards the matching `NOTIFY(CDS)` / `NOTIFY(CSYNC)` to the parent's advertised
DSYNC NOTIFY receiver on the primary's behalf. The primary is never modified.

This is the missing third leg of delegation sync. The parent side (receive +
scan + apply) and the child-primary side (push on local change) already existed;
this adds the agent-as-proxy path for clueless primaries.

Plan: `docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md`.
Operator guide: `guide/agent-dsync-proxy.md`.

## Design in one line

The incoming CDS/CSYNC is the primary's machine-readable **opt-in signal**, not
a payload to transcribe. A `NOTIFY` is contentless ("come re-scan me"), so the
proxy never reads or signs CDS/CSYNC and needs no SIG(0) key — the parent reads
the zone itself. The heavy machinery (delegation diff, DSYNC discovery, NOTIFY
emission, parent-side scan) is all reused; the new code is the trigger + gate.

## What's implemented (NOTIFY-only first cut, P-1..P-4)

- **P-1** — new `delegation-sync-proxy` zone option (`OptDelSyncProxy`),
  gated to agent + Secondary only (loud ConfigError otherwise).
- **P-2** — wide post-transfer change-detection: an `OnZonePreRefresh` hook
  (mirroring the tdns-mp `MPPreRefresh` pattern) diffs old-vs-new across
  CDS/CSYNC (apex `RRsetDiffer`) + NS/glue/DS (reuse `DelegationDataChangedNG`)
  + DNSKEY (reuse `DnskeysChangedNG`), records it, and `OnZonePostRefresh`
  enqueues a `PROXY-NOTIFY` on change.
- **P-3** — the `PROXY-NOTIFY` action: `BestSyncScheme` discovery, require a
  NOTIFY target (UPDATE-only parent = logged no-op), emit per the act-mapping
  (NOTIFY(CDS) when CDS|DNSKEY changed, NOTIFY(CSYNC) when CSYNC|NS-glue
  changed), no publish/sign.
- **P-4** — self-debounce: the content-edge trigger fires a change exactly once;
  a slow parent is never re-NOTIFYd (proven by test). Operator guide written.

## Decisions (operator-confirmed)

NOTIFY-only first cut; new distinct option (not a widening of
`delegation-sync-child`); wide trigger with an optimistic act-mapping; no special
delete-DS handling (a changed CDS NOTIFYs regardless — the parent reads it); do
NOT gate on "unsigned" (preserves the future UPDATE path, which works for
unsigned zones). The UPDATE-proxy scheme + its SIG(0)-trust question are
explicitly **out of scope** (later work).

## Tests

Unit tests cover every decision path: option mapping/parse, the four-dimension
change detection (each flips its own flag, no-change is a no-op), the act-mapping
(all seven combinations), the PostRefresh enqueue/clear, and the self-debounce
(3 refreshes -> 1 NOTIFY). `go test ./... -race` clean; full `make` builds all
binaries (incl. tdns-agent). The DSYNC-discovery half of `ProxyNotifyParent`
needs the network and is left for testbed validation.

## Docs

- Sample config: `cmd/agent/agent-zones.yaml` gains a `dsync-proxy` template +
  example zone.
- `guide/special-features.md` §1.6 documents the proxy as the third
  delegation-sync role.
- `guide/key-rollover.md` restructured to cover KSK + ZSK + algorithm rollover
  (orthogonal cleanup that rode along: it was KSK-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `delegation-sync-proxy` zone option to detect delegation-relevant changes, self-debounce, and forward parent DSYNC NOTIFYs (CSYNC before CDS).
  * Added proxy UPDATE support with precondition gating and a startup reconcile; falls back to NOTIFY when UPDATE isn’t ready.
  * Added `zone proxy-key` / `proxy-key` API to report UPDATE readiness and publishable apex KEY/HSYNCPARAM pubkey material.
* **Bug Fixes**
  * Fixed child UPDATE “replace” mode by generating the replacement DNS UPDATE instead of refusing it.
* **Tests**
  * Added unit tests for change detection, enqueueing, act-mapping, context cancellation, debouncing, and child replace UPDATE construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->