### PR TITLE
feat: republish apex KEY/CDS at RFC 9615 signal names (HSYNCPARAM pubkey/pubcds consumer)

### DIFF
--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -929,6 +929,20 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// outside the FirstZoneLoad guard, so config-reload picks up
 		// changes to the 'delegationbackend' key.
 
+		// Republish-at-signal-names consumer (RFC 9615 at-NS bootstrap):
+		// every tdns-auth SECONDARY watches incoming transfers for an apex
+		// HSYNCPARAM pubkey/pubcds flag and republishes the customer's apex
+		// KEY / CDS(+CDNSKEY) under the _sig0key/_dsboot signal names owned
+		// by each NS, into whichever local primary zone the signal name
+		// falls in. Always-on, no option gate (see signal_republish.go).
+		// Registered only on first load (the OnZonePostRefresh slice would
+		// otherwise accumulate duplicate callbacks across reloads).
+		if Globals.App.Type == AppTypeAuth && zonetype == Secondary && zdp.FirstZoneLoad {
+			zdp.OnZonePostRefresh = append(zdp.OnZonePostRefresh, func(zd *ZoneData) {
+				zd.RepublishAtSignalNames()
+			})
+		}
+
 		// Leader election OnFirstLoad is registered in StartAgent() (not here)
 		// because LeaderElectionManager doesn't exist until StartAgent runs.
 		// MP zone KEY publication is registered in tdns-mp's StartAgent.

--- a/v2/signal_republish.go
+++ b/v2/signal_republish.go
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+// Republish-at-signal-names consumer (RFC 9615 at-NS bootstrap signaling).
+//
+// When a tdns-auth secondary transfers a customer zone whose apex carries
+// HSYNCPARAM with the pubkey and/or pubcds flag, this consumer republishes
+// the customer's apex SIG(0) KEY / CDS(+CDNSKEY) under the RFC 9615
+// signaling names, owned by each of the customer's nameservers:
+//
+//	pubcds -> CDS(/CDNSKEY) at _dsboot.<child>._signal.<ns>
+//	pubkey -> KEY (SIG0)    at _sig0key.<child>._signal.<ns>
+//
+// The signal record lives UNDER THE NS'S ZONE, not the customer zone, so a
+// parent/validator can find the child's bootstrap data via the child's
+// nameservers and DNSSEC-validate it with those nameservers' own keys. The
+// existing CONSUMERS of these names already live in tdns
+// (queryCDSAtSignalingNames for CDS, LookupChildKeyAtSignal for the KEY);
+// this is the missing PRODUCER on a plain secondary.
+//
+// The publish targets whichever LOCAL PRIMARY zone the signal name falls in
+// (found via FindZone). An NS whose zone we do not locally serve as primary
+// is a non-starter and is skipped. The consumer is change-gated: it diffs
+// the desired content against what is already published at the signal name
+// in the target zone, so a re-transfer of unchanged data is a no-op.
+
+package tdns
+
+import (
+	"fmt"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+var lgSignal = Logger("signal-republish")
+
+// signalSpec describes one HSYNCPARAM flag's republish behaviour: which apex
+// RRtypes feed it and which RFC 9615 owner-name prefix the signal record
+// uses. The two specs are otherwise identical machinery.
+type signalSpec struct {
+	flag    string // "pubkey" | "pubcds" (for logging)
+	prefix  string // "_sig0key" | "_dsboot"
+	rrtypes []uint16
+	active  func(*core.HSYNCPARAM) bool
+}
+
+var signalSpecs = []signalSpec{
+	{
+		flag:    "pubkey",
+		prefix:  "_sig0key",
+		rrtypes: []uint16{dns.TypeKEY},
+		active:  (*core.HSYNCPARAM).HasPubkey,
+	},
+	{
+		flag:    "pubcds",
+		prefix:  "_dsboot",
+		rrtypes: []uint16{dns.TypeCDS, dns.TypeCDNSKEY},
+		active:  (*core.HSYNCPARAM).HasPubcds,
+	},
+}
+
+// RepublishAtSignalNames is the OnZonePostRefresh callback registered on
+// every tdns-auth secondary. After a transfer of childZD's customer zone it
+// republishes the apex bootstrap RRsets under the RFC 9615 signal names if
+// the apex HSYNCPARAM asks for it. It is always-on but acts only when the
+// transferred zone actually carries the relevant flag and this server is
+// locally primary for a parent of the signal name.
+func (childZD *ZoneData) RepublishAtSignalNames() {
+	hp := childZD.apexHsyncparam()
+	if hp == nil {
+		return
+	}
+
+	nsNames := childZD.apexNSNames()
+	if len(nsNames) == 0 {
+		return
+	}
+
+	for _, spec := range signalSpecs {
+		if !spec.active(hp) {
+			continue
+		}
+		childZD.republishOneFlag(spec, nsNames)
+	}
+}
+
+// republishOneFlag handles a single active flag: collect the apex source RRs
+// and, for each NS, publish them re-owned to the signal name into the local
+// primary zone that owns it.
+func (childZD *ZoneData) republishOneFlag(spec signalSpec, nsNames []string) {
+	srcRRs := childZD.apexRRsFor(spec.rrtypes)
+	if len(srcRRs) == 0 {
+		lgSignal.Warn("HSYNCPARAM flag set but apex source RRset is empty",
+			"zone", childZD.ZoneName, "flag", spec.flag)
+		return
+	}
+
+	for _, ns := range nsNames {
+		owner := fmt.Sprintf("%s.%s_signal.%s", spec.prefix, childZD.ZoneName, ns)
+
+		target, _ := FindZone(owner)
+		if target == nil || target.ZoneType != Primary {
+			lgSignal.Debug("skipping NS: not locally primary for signal name",
+				"zone", childZD.ZoneName, "flag", spec.flag, "ns", ns, "signal", owner)
+			continue
+		}
+
+		desired := reownRRs(srcRRs, owner)
+		if signalRRsEqual(target, owner, spec.rrtypes, desired) {
+			continue // already published, change-gated no-op
+		}
+
+		if err := target.publishSignalRRs(owner, spec.rrtypes, desired); err != nil {
+			lgSignal.Error("failed to publish signal RRset",
+				"zone", childZD.ZoneName, "flag", spec.flag, "ns", ns,
+				"signal", owner, "target", target.ZoneName, "err", err)
+			continue
+		}
+		lgSignal.Info("republished apex RRset at signal name",
+			"zone", childZD.ZoneName, "flag", spec.flag, "ns", ns,
+			"signal", owner, "target", target.ZoneName, "rrs", len(desired))
+	}
+}
+
+// publishSignalRRs replaces the signal-name RRsets in the (primary) target
+// zone with the desired RRs. It enqueues a delete-RRset (ClassANY) per
+// rrtype followed by the adds (ClassINET) so the result is exactly the
+// desired set, re-signed by the normal ZONE-UPDATE path if the target is
+// signed.
+func (target *ZoneData) publishSignalRRs(owner string, rrtypes []uint16, desired []dns.RR) error {
+	if target.KeyDB == nil || target.KeyDB.UpdateQ == nil {
+		return fmt.Errorf("target zone %q has no KeyDB.UpdateQ", target.ZoneName)
+	}
+
+	var actions []dns.RR
+	for _, rrtype := range rrtypes {
+		del := new(dns.ANY)
+		del.Hdr = dns.RR_Header{Name: owner, Rrtype: rrtype, Class: dns.ClassANY, Ttl: 0}
+		actions = append(actions, del)
+	}
+	actions = append(actions, desired...)
+
+	target.KeyDB.UpdateQ <- UpdateRequest{
+		Cmd:            "ZONE-UPDATE",
+		ZoneName:       target.ZoneName,
+		Actions:        actions,
+		InternalUpdate: true,
+	}
+	return nil
+}
+
+// apexRRs returns the apex RRs of the given type, or nil. It reads the apex
+// owner directly (not via GetRRset, which panics on a missing apex owner) so
+// it is safe on a not-yet-fully-loaded or malformed zone.
+func (zd *ZoneData) apexRRs(rrtype uint16) []dns.RR {
+	owner, err := zd.GetOwner(zd.ZoneName)
+	if err != nil || owner == nil || owner.RRtypes == nil {
+		return nil
+	}
+	rrset, ok := owner.RRtypes.Get(rrtype)
+	if !ok {
+		return nil
+	}
+	return rrset.RRs
+}
+
+// apexHsyncparam returns the typed apex HSYNCPARAM record, or nil if absent.
+func (zd *ZoneData) apexHsyncparam() *core.HSYNCPARAM {
+	rrs := zd.apexRRs(core.TypeHSYNCPARAM)
+	if len(rrs) == 0 {
+		return nil
+	}
+	prr, ok := rrs[0].(*dns.PrivateRR)
+	if !ok {
+		return nil
+	}
+	hp, ok := prr.Data.(*core.HSYNCPARAM)
+	if !ok {
+		return nil
+	}
+	return hp
+}
+
+// apexNSNames returns the (fqdn) nameserver hostnames from the apex NS RRset.
+func (zd *ZoneData) apexNSNames() []string {
+	var names []string
+	for _, rr := range zd.apexRRs(dns.TypeNS) {
+		if ns, ok := rr.(*dns.NS); ok {
+			names = append(names, ns.Ns)
+		}
+	}
+	return names
+}
+
+// apexRRsFor collects the apex RRs of the given types (in order), skipping
+// types that are absent. Used to gather KEY for pubkey, CDS+CDNSKEY for
+// pubcds.
+func (zd *ZoneData) apexRRsFor(rrtypes []uint16) []dns.RR {
+	var out []dns.RR
+	for _, rrtype := range rrtypes {
+		out = append(out, zd.apexRRs(rrtype)...)
+	}
+	return out
+}
+
+// reownRRs returns copies of src re-owned to the signal name. The TTL is left
+// as-is; the ZONE-UPDATE path clamps it to the target zone's policy TTL.
+func reownRRs(src []dns.RR, owner string) []dns.RR {
+	out := make([]dns.RR, 0, len(src))
+	for _, rr := range src {
+		c := dns.Copy(rr)
+		c.Header().Name = owner
+		out = append(out, c)
+	}
+	return out
+}
+
+// signalRRsEqual reports whether the signal-name RRsets already published in
+// the target zone match desired (same set, ignoring TTL). This is the
+// change gate: equal -> skip the republish.
+func signalRRsEqual(target *ZoneData, owner string, rrtypes []uint16, desired []dns.RR) bool {
+	var current []dns.RR
+	for _, rrtype := range rrtypes {
+		rrset, err := target.GetRRset(owner, rrtype)
+		if err != nil || rrset == nil {
+			continue
+		}
+		current = append(current, rrset.RRs...)
+	}
+	return rrsetContentEqual(current, desired)
+}
+
+// rrsetContentEqual compares two RR slices for equal content, order- and
+// TTL-insensitive, using dns.IsDuplicate (which ignores TTL).
+func rrsetContentEqual(a, b []dns.RR) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	matched := make([]bool, len(b))
+	for _, ra := range a {
+		found := false
+		for i, rb := range b {
+			if matched[i] {
+				continue
+			}
+			if dns.IsDuplicate(ra, rb) {
+				matched[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/v2/signal_republish_test.go
+++ b/v2/signal_republish_test.go
@@ -17,15 +17,7 @@ func init() {
 	_ = core.RegisterHsyncparamRR()
 }
 
-// mustRR parses an RR string or fails the test.
-func mustRR(t *testing.T, s string) dns.RR {
-	t.Helper()
-	rr, err := dns.NewRR(s)
-	if err != nil {
-		t.Fatalf("dns.NewRR(%q): %v", s, err)
-	}
-	return rr
-}
+// mustRR is shared with childsync_replace_test.go (same package).
 
 // newMapZone builds a ready MapZone with the given owners pre-populated. Each
 // entry in owners maps an owner name to its RRs (grouped into RRsets by type).

--- a/v2/signal_republish_test.go
+++ b/v2/signal_republish_test.go
@@ -163,7 +163,10 @@ func drainUpdateQ(q chan UpdateRequest) []UpdateRequest {
 	var out []UpdateRequest
 	for {
 		select {
-		case ur := <-q:
+		case ur, ok := <-q:
+			if !ok {
+				return out
+			}
 			out = append(out, ur)
 		default:
 			return out

--- a/v2/signal_republish_test.go
+++ b/v2/signal_republish_test.go
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"testing"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+func init() {
+	// HSYNCPARAM is a private RR type that must be registered before
+	// dns.NewRR can parse it.
+	_ = core.RegisterHsyncparamRR()
+}
+
+// mustRR parses an RR string or fails the test.
+func mustRR(t *testing.T, s string) dns.RR {
+	t.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		t.Fatalf("dns.NewRR(%q): %v", s, err)
+	}
+	return rr
+}
+
+// newMapZone builds a ready MapZone with the given owners pre-populated. Each
+// entry in owners maps an owner name to its RRs (grouped into RRsets by type).
+func newMapZone(name string, ztype ZoneType, owners map[string][]dns.RR) *ZoneData {
+	zd := &ZoneData{
+		ZoneName:  name,
+		ZoneType:  ztype,
+		ZoneStore: MapZone,
+		Ready:     true,
+		Data:      core.NewCmap[OwnerData](),
+		Options:   map[ZoneOption]bool{},
+	}
+	for oname, rrs := range owners {
+		od := OwnerData{Name: oname, RRtypes: NewRRTypeStore()}
+		byType := map[uint16][]dns.RR{}
+		for _, rr := range rrs {
+			byType[rr.Header().Rrtype] = append(byType[rr.Header().Rrtype], rr)
+		}
+		for rrtype, list := range byType {
+			od.RRtypes.Set(rrtype, core.RRset{Name: oname, RRtype: rrtype, RRs: list})
+		}
+		zd.Data.Set(oname, od)
+	}
+	return zd
+}
+
+// registerZones puts the zones in the global registry for FindZone and removes
+// them on cleanup so tests don't leak into each other.
+func registerZones(t *testing.T, zds ...*ZoneData) {
+	t.Helper()
+	for _, zd := range zds {
+		Zones.Set(zd.ZoneName, zd)
+	}
+	t.Cleanup(func() {
+		for _, zd := range zds {
+			Zones.Remove(zd.ZoneName)
+		}
+	})
+}
+
+func TestApexHsyncparamFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		rr     string
+		pubkey bool
+		pubcds bool
+	}{
+		{"none", "", false, false},
+		{"pubkey", "example. 3600 IN HSYNCPARAM pubkey", true, false},
+		{"pubcds", "example. 3600 IN HSYNCPARAM pubcds", false, true},
+		{"both", "example. 3600 IN HSYNCPARAM pubkey pubcds", true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			owners := map[string][]dns.RR{}
+			if tc.rr != "" {
+				owners["example."] = []dns.RR{mustRR(t, tc.rr)}
+			}
+			zd := newMapZone("example.", Secondary, owners)
+			hp := zd.apexHsyncparam()
+			if tc.rr == "" {
+				if hp != nil {
+					t.Fatalf("expected nil HSYNCPARAM, got %+v", hp)
+				}
+				return
+			}
+			if hp == nil {
+				t.Fatal("expected HSYNCPARAM, got nil")
+			}
+			if hp.HasPubkey() != tc.pubkey {
+				t.Errorf("HasPubkey()=%v, want %v", hp.HasPubkey(), tc.pubkey)
+			}
+			if hp.HasPubcds() != tc.pubcds {
+				t.Errorf("HasPubcds()=%v, want %v", hp.HasPubcds(), tc.pubcds)
+			}
+		})
+	}
+}
+
+func TestApexNSNames(t *testing.T) {
+	zd := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN NS ns1.example."),
+			mustRR(t, "example. 3600 IN NS ns.foobar.com."),
+		},
+	})
+	names := zd.apexNSNames()
+	if len(names) != 2 {
+		t.Fatalf("expected 2 NS names, got %d: %v", len(names), names)
+	}
+	want := map[string]bool{"ns1.example.": true, "ns.foobar.com.": true}
+	for _, n := range names {
+		if !want[n] {
+			t.Errorf("unexpected NS name %q", n)
+		}
+	}
+}
+
+func TestReownRRs(t *testing.T) {
+	src := []dns.RR{mustRR(t, "example. 3600 IN KEY 256 3 15 dGVzdA==")}
+	out := reownRRs(src, "_sig0key.example._signal.ns.foobar.com.")
+	if len(out) != 1 {
+		t.Fatalf("expected 1 RR, got %d", len(out))
+	}
+	if got := out[0].Header().Name; got != "_sig0key.example._signal.ns.foobar.com." {
+		t.Errorf("owner = %q, want re-owned signal name", got)
+	}
+	// Source must be untouched (dns.Copy, not mutation).
+	if src[0].Header().Name != "example." {
+		t.Errorf("source RR was mutated: name = %q", src[0].Header().Name)
+	}
+}
+
+func TestRrsetContentEqual(t *testing.T) {
+	a1 := mustRR(t, "x. 3600 IN KEY 256 3 15 AAAA")
+	a2 := mustRR(t, "x. 3600 IN KEY 257 3 15 BBBB")
+	// Same content, different TTL and order.
+	b1 := mustRR(t, "x. 60 IN KEY 257 3 15 BBBB")
+	b2 := mustRR(t, "x. 60 IN KEY 256 3 15 AAAA")
+
+	if !rrsetContentEqual([]dns.RR{a1, a2}, []dns.RR{b1, b2}) {
+		t.Error("expected equal (TTL- and order-insensitive)")
+	}
+	if rrsetContentEqual([]dns.RR{a1}, []dns.RR{a1, a2}) {
+		t.Error("expected unequal (different cardinality)")
+	}
+	c := mustRR(t, "x. 3600 IN KEY 258 3 15 CCCC")
+	if rrsetContentEqual([]dns.RR{a1, a2}, []dns.RR{a1, c}) {
+		t.Error("expected unequal (different content)")
+	}
+}
+
+// drainUpdateQ collects all pending UpdateRequests without blocking.
+func drainUpdateQ(q chan UpdateRequest) []UpdateRequest {
+	var out []UpdateRequest
+	for {
+		select {
+		case ur := <-q:
+			out = append(out, ur)
+		default:
+			return out
+		}
+	}
+}
+
+// signalTarget builds a primary target zone (foobar.com.) wired with an
+// UpdateQ we can drain.
+func signalTarget(name string, owners map[string][]dns.RR) (*ZoneData, chan UpdateRequest) {
+	q := make(chan UpdateRequest, 16)
+	zd := newMapZone(name, Primary, owners)
+	zd.KeyDB = &KeyDB{UpdateQ: q}
+	return zd, q
+}
+
+func TestRepublishPubkey_PublishesToLocalPrimary(t *testing.T) {
+	child := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN HSYNCPARAM pubkey"),
+			mustRR(t, "example. 3600 IN NS ns.foobar.com."),
+			mustRR(t, "example. 3600 IN KEY 256 3 15 dGVzdGtleQ=="),
+		},
+	})
+	target, q := signalTarget("foobar.com.", nil)
+	registerZones(t, child, target)
+
+	child.RepublishAtSignalNames()
+
+	urs := drainUpdateQ(q)
+	if len(urs) != 1 {
+		t.Fatalf("expected 1 UpdateRequest, got %d", len(urs))
+	}
+	ur := urs[0]
+	if ur.Cmd != "ZONE-UPDATE" || ur.ZoneName != "foobar.com." || !ur.InternalUpdate {
+		t.Fatalf("unexpected UpdateRequest: %+v", ur)
+	}
+	owner := "_sig0key.example._signal.ns.foobar.com."
+	var sawDelete, sawAdd bool
+	for _, rr := range ur.Actions {
+		if rr.Header().Name != owner {
+			t.Errorf("action owner = %q, want %q", rr.Header().Name, owner)
+		}
+		switch rr.Header().Class {
+		case dns.ClassANY:
+			sawDelete = true
+			if rr.Header().Rrtype != dns.TypeKEY {
+				t.Errorf("delete rrtype = %s, want KEY", dns.TypeToString[rr.Header().Rrtype])
+			}
+		case dns.ClassINET:
+			sawAdd = true
+			if _, ok := rr.(*dns.KEY); !ok {
+				t.Errorf("add action is not a KEY: %T", rr)
+			}
+		}
+	}
+	if !sawDelete || !sawAdd {
+		t.Errorf("expected both a delete-RRset and an add (delete=%v add=%v)", sawDelete, sawAdd)
+	}
+}
+
+func TestRepublishPubcds_PublishesCDSAndCDNSKEY(t *testing.T) {
+	child := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN HSYNCPARAM pubcds"),
+			mustRR(t, "example. 3600 IN NS ns.foobar.com."),
+			mustRR(t, "example. 3600 IN CDS 12345 15 2 ABCDEF"),
+			mustRR(t, "example. 3600 IN CDNSKEY 257 3 15 dGVzdA=="),
+		},
+	})
+	target, q := signalTarget("foobar.com.", nil)
+	registerZones(t, child, target)
+
+	child.RepublishAtSignalNames()
+
+	urs := drainUpdateQ(q)
+	if len(urs) != 1 {
+		t.Fatalf("expected 1 UpdateRequest, got %d", len(urs))
+	}
+	owner := "_dsboot.example._signal.ns.foobar.com."
+	var cds, cdnskey, deletes int
+	for _, rr := range urs[0].Actions {
+		if rr.Header().Name != owner {
+			t.Errorf("action owner = %q, want %q", rr.Header().Name, owner)
+		}
+		if rr.Header().Class == dns.ClassANY {
+			deletes++
+			continue
+		}
+		switch rr.(type) {
+		case *dns.CDS:
+			cds++
+		case *dns.CDNSKEY:
+			cdnskey++
+		}
+	}
+	if cds != 1 || cdnskey != 1 {
+		t.Errorf("expected 1 CDS and 1 CDNSKEY add, got cds=%d cdnskey=%d", cds, cdnskey)
+	}
+	if deletes != 2 {
+		t.Errorf("expected 2 delete-RRset actions (CDS + CDNSKEY), got %d", deletes)
+	}
+}
+
+func TestRepublish_SkipsNonPrimaryTarget(t *testing.T) {
+	child := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN HSYNCPARAM pubkey"),
+			mustRR(t, "example. 3600 IN NS ns.foobar.com."),
+			mustRR(t, "example. 3600 IN KEY 256 3 15 dGVzdA=="),
+		},
+	})
+	// Target zone exists but we are only SECONDARY for it: must be skipped.
+	target, q := signalTarget("foobar.com.", nil)
+	target.ZoneType = Secondary
+	registerZones(t, child, target)
+
+	child.RepublishAtSignalNames()
+
+	if urs := drainUpdateQ(q); len(urs) != 0 {
+		t.Fatalf("expected no publish for a non-primary target, got %d", len(urs))
+	}
+}
+
+func TestRepublish_SkipsNSWithNoLocalZone(t *testing.T) {
+	child := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN HSYNCPARAM pubkey"),
+			mustRR(t, "example. 3600 IN NS ns.elsewhere.net."),
+			mustRR(t, "example. 3600 IN KEY 256 3 15 dGVzdA=="),
+		},
+	})
+	registerZones(t, child) // no zone covering ns.elsewhere.net.
+
+	// Should not panic and should produce no updates.
+	child.RepublishAtSignalNames()
+}
+
+func TestRepublish_ChangeGateNoOpWhenAlreadyPublished(t *testing.T) {
+	owner := "_sig0key.example._signal.ns.foobar.com."
+	child := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN HSYNCPARAM pubkey"),
+			mustRR(t, "example. 3600 IN NS ns.foobar.com."),
+			mustRR(t, "example. 3600 IN KEY 256 3 15 dGVzdGtleQ=="),
+		},
+	})
+	// Target ALREADY has the signal KEY (same content, different TTL).
+	target, q := signalTarget("foobar.com.", map[string][]dns.RR{
+		owner: {mustRR(t, owner+" 60 IN KEY 256 3 15 dGVzdGtleQ==")},
+	})
+	registerZones(t, child, target)
+
+	child.RepublishAtSignalNames()
+
+	if urs := drainUpdateQ(q); len(urs) != 0 {
+		t.Fatalf("expected no-op when signal RRset already matches, got %d updates", len(urs))
+	}
+}
+
+func TestRepublish_FlagsGatedIndependently(t *testing.T) {
+	pubkeyOwner := "_sig0key.example._signal.ns.foobar.com."
+	child := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN HSYNCPARAM pubkey pubcds"),
+			mustRR(t, "example. 3600 IN NS ns.foobar.com."),
+			mustRR(t, "example. 3600 IN KEY 256 3 15 dGVzdGtleQ=="),
+			mustRR(t, "example. 3600 IN CDS 12345 15 2 ABCDEF"),
+		},
+	})
+	// pubkey is already published and matches; pubcds is not. Only the
+	// pubcds (_dsboot) update should be emitted.
+	target, q := signalTarget("foobar.com.", map[string][]dns.RR{
+		pubkeyOwner: {mustRR(t, pubkeyOwner+" 3600 IN KEY 256 3 15 dGVzdGtleQ==")},
+	})
+	registerZones(t, child, target)
+
+	child.RepublishAtSignalNames()
+
+	urs := drainUpdateQ(q)
+	if len(urs) != 1 {
+		t.Fatalf("expected exactly 1 update (pubcds only), got %d", len(urs))
+	}
+	sawDsboot := false
+	for _, rr := range urs[0].Actions {
+		if rr.Header().Name == "_dsboot.example._signal.ns.foobar.com." {
+			sawDsboot = true
+		}
+		if rr.Header().Name == pubkeyOwner {
+			t.Error("pubkey should have been change-gated (already published)")
+		}
+	}
+	if !sawDsboot {
+		t.Error("expected a _dsboot (pubcds) action")
+	}
+}
+
+func TestRepublish_NoHsyncparamIsNoOp(t *testing.T) {
+	child := newMapZone("example.", Secondary, map[string][]dns.RR{
+		"example.": {
+			mustRR(t, "example. 3600 IN NS ns.foobar.com."),
+			mustRR(t, "example. 3600 IN KEY 256 3 15 dGVzdA=="),
+		},
+	})
+	target, q := signalTarget("foobar.com.", nil)
+	registerZones(t, child, target)
+
+	child.RepublishAtSignalNames()
+
+	if urs := drainUpdateQ(q); len(urs) != 0 {
+		t.Fatalf("expected no-op without HSYNCPARAM, got %d updates", len(urs))
+	}
+}


### PR DESCRIPTION
## What

Every **tdns-auth secondary** now acts on the `HSYNCPARAM` **`pubkey`** and
**`pubcds`** flags found at a transferred customer zone's apex by republishing
the customer's apex bootstrap RRset under the RFC 9615 at-NS signaling names,
owned by each of the customer's nameservers:

| Flag     | Apex RRset republished | Signal name                       | Existing consumer in tdns                                  |
|----------|------------------------|-----------------------------------|------------------------------------------------------------|
| `pubcds` | CDS (and CDNSKEY)      | `_dsboot.<child>._signal.<ns>`    | `queryCDSAtSignalingNames` (`scanner.go`)                  |
| `pubkey` | KEY (SIG(0))           | `_sig0key.<child>._signal.<ns>`   | `LookupChildKeyAtSignal` / `VerifyChildKey` (`truststore_verify.go`) |

The signal record's owner is built from the NS **hostname**, so it lives under
the NS's zone — a parent/validator finds the child's bootstrap data via the
child's nameservers and DNSSEC-validates it with those nameservers' own keys.
The **consumers** of these names already exist in tdns; this PR adds the missing
**producer** on a plain secondary.

This is the counterpart to the `HSYNCPARAM pubkey` **producer** in the
agent-dsync-proxy work (§10 of the design doc). Note the producer asymmetry: the
proxy only emits `pubkey` (it needs its SIG(0) KEY republished to sign UPDATEs);
`pubcds` is set independently (by an operator or HSYNC tooling), and this
consumer acts on whichever flag it finds regardless of who set it.

## Behaviour

- **Always-on, no option gate.** Acts only when (a) the transferred zone carries
  the relevant `HSYNCPARAM` flag *and* (b) this server is locally **PRIMARY** for
  a parent of the signal name (`FindZone`). An NS whose zone we do not serve as
  primary is skipped. A secondary primary for nothing relevant does nothing.
- **Publishes via the internal `ZONE-UPDATE` path** (delete-RRset + adds), which
  re-signs the new `_signal` RRset if the target zone is inline-signed.
- **Change-gated with no new state:** diffs the desired content against what is
  already published at the signal name in the target zone, so a re-transfer of
  unchanged data is a no-op. The two flags are gated **independently** (a CDS
  change does not force a KEY republish, and vice versa).

## Wiring

An `OnZonePostRefresh` callback on every `AppTypeAuth` secondary, registered
**once** (`FirstZoneLoad`-guarded so the callback slice does not accumulate
duplicates across config reloads — the same reload-safety idiom as the other
per-zone setup blocks).

Reuses `HSYNCPARAM.HasPubkey`/`HasPubcds` from `core`; does **not** depend on
the tdns-mp HSYNC analysis (a plain secondary must not pull in tdns-mp).

## Files

- `v2/signal_republish.go` (new) — the consumer: `RepublishAtSignalNames`,
  table-driven over the `(flag, source RRset, prefix)` triple, nil-safe apex
  accessors, the publish idiom, and the change-gate helpers.
- `v2/signal_republish_test.go` (new) — 8 tests: flag detection, NS extraction,
  re-own (no source mutation), content-equal (TTL/order-insensitive), pubkey
  publish, pubcds publish (CDS + CDNSKEY), skip non-primary target, skip NS with
  no local zone, change-gate no-op, flags gated independently, no-HSYNCPARAM
  no-op.
- `v2/parseconfig.go` — the 14-line registration.

## Verification

- `go test ./... -count=1 -race` green (full v2 suite).
- All 5 binaries build clean (`cd tdns/cmdv2 && make`), gofmt applied.

## Design

§11 of `docs/2026-06-22-agent-dsync-proxy-for-clueless-primary-plan.md` (that
doc lives on the `feat/agent-dsync-proxy` branch / #265; this code branch
deliberately carries only the implementation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RFC 9615 “at-signal-names” republishing for secondary zone refreshes, updating local signal-related DNS records based on HSYNCPARAM settings.
  * Supports publishing for both `pubkey` and `pubcds` signal variants as applicable.

* **Bug Fixes**
  * Ensures republishing logic is only wired once per zone on initial load to avoid duplicate callbacks.
  * Avoids emitting updates when the target RRsets already match (TTL-insensitive comparison).

* **Tests**
  * Added a comprehensive test suite covering parsing, gating behavior, local-primary targeting, no-op scenarios, and update generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->