### PR TITLE
Multi-primary upstreams + hostname resolution

### DIFF
--- a/cmdv2/auth/auth-templates.sample.yaml
+++ b/cmdv2/auth/auth-templates.sample.yaml
@@ -9,8 +9,8 @@
 #                      - map:   Default, general-purpose (recommended for most zones)
 #                      - slice: Experimental alternative (may be faster/use less memory)
 #                      - xfr:   Zone transfer only (AXFR in/out, NO normal queries)
-#   - primary:         Upstream server for secondary zones (IP:port)
-#   - notify:          List of downstream servers to notify (IP:port)
+#   - primaries:       Upstream servers for secondary zones — list of {addr, key}
+#   - notify:          Downstream servers to notify — list of {addr, key}
 #   - options:         List of zone options (see below)
 #   - dnssec_policy:   DNSSEC policy name (from dnssecpolicies section)
 #   - multi_signer:    Multi-signer configuration name
@@ -112,7 +112,7 @@ templates:
    basic-secondary:
       type:            secondary
       store:           map         # Default storage (serves normal DNS queries)
-      # primary: must be set per-zone or overridden
+      # primaries: must be set per-zone or overridden
 
    # Secondary with child sync
    child-secondary:
@@ -144,7 +144,7 @@ templates:
          - catalog-zone                   # RFC 9432 catalog zone
          - catalog-member-auto-create     # Auto-create member zones
          - catalog-member-auto-delete     # Auto-delete removed zones
-      # primary: must be set per-zone
+      # primaries: must be set per-zone
 
    # Read-only catalog (metadata only, no auto-configuration)
    catalog-readonly:
@@ -167,8 +167,10 @@ templates:
       type:            primary
       store:           map
       notify:
-         - "192.0.2.1:53"                 # Notify public secondaries
-         - "192.0.2.2:53"
+         - addr: "192.0.2.1:53"           # Notify public secondaries
+           key:  NOKEY
+         - addr: "192.0.2.2:53"
+           key:  NOKEY
       options:
          - delegation-sync-parent
          - online-signing

--- a/cmdv2/auth/auth-zones.sample.yaml
+++ b/cmdv2/auth/auth-zones.sample.yaml
@@ -12,8 +12,12 @@
 #                    - slice: Experimental alternative (may be faster/use less memory)
 #                    - xfr:   Zone transfer only (AXFR in/out, NO normal queries)
 #   template:        Template name to inherit settings from (optional)
-#   primary:         Upstream server for secondary zones (IP:port)
-#   notify:          List of downstream servers to notify (IP:port list)
+#   primaries:       Upstream servers for secondary zones — a LIST of {addr, key}
+#                    entries (addr is IP:port or host:port; key is a TSIG key name,
+#                    or NOKEY for none). More than one provides redundancy; a host
+#                    name is resolved at load time and may expand to several
+#                    addresses (A + AAAA), each tried in turn on failure.
+#   notify:          Downstream servers to notify — a LIST of {addr, key} entries
 #   downstreams:     Alias for notify (same meaning)
 #   options:         List of zone options (see auth-templates.sample.yaml for complete list)
 #   dnssec_policy:   DNSSEC policy name (from dnssecpolicies: section)
@@ -32,8 +36,10 @@ zones:
      zonefile:        /etc/tdns/zones/example.com.zone
      store:           map
      notify:
-        - "192.0.2.1:53"       # Notify this secondary
-        - "192.0.2.2:53"       # And this one
+        - addr: "192.0.2.1:53"     # Notify this secondary
+          key:  NOKEY
+        - addr: "192.0.2.2:53"     # And this one
+          key:  NOKEY
      options:
         - delegation-sync-parent   # Provide delegation sync for children
         - online-signing           # Sign responses on-the-fly
@@ -46,7 +52,11 @@ zones:
      type:            secondary
      zonefile:        /var/lib/tdns/zones/example.net.zone  # Optional: save transferred zone
      store:           map                                    # Default storage (serves queries)
-     primary:         "203.0.113.1:53"                      # Transfer from this server
+     primaries:                                              # Transfer from these servers (in order, with fallback)
+        - addr: "203.0.113.1:53"
+          key:  NOKEY
+        - addr: "203.0.113.2:53"
+          key:  NOKEY
      options:
         - delegation-sync-child    # Push DS/NS updates to parent
 
@@ -57,8 +67,10 @@ zones:
      zonefile:        /etc/tdns/zones/example.org.zone
      template:        parent-primary    # Inherit from parent-primary template
      notify:                            # Override template's notify list
-        - "192.0.2.10:53"
-        - "192.0.2.11:53"
+        - addr: "192.0.2.10:53"
+          key:  NOKEY
+        - addr: "192.0.2.11:53"
+          key:  NOKEY
      # type, store, options, dnssec_policy inherited from template
 
    # ===========================================================================
@@ -76,7 +88,8 @@ zones:
      zonefile:        /var/lib/tdns/zones/catalog.example.zone
      store:           map
      notify:
-        - "192.0.2.20:53"      # Notify secondaries about catalog changes
+        - addr: "192.0.2.20:53"    # Notify secondaries about catalog changes
+          key:  NOKEY
      options:
         - catalog-zone                    # RFC 9432 catalog zone
         - catalog-member-auto-create      # Auto-create zones from catalog
@@ -89,7 +102,9 @@ zones:
      type:            secondary
      zonefile:        /var/lib/tdns/zones/catalog-upstream.zone  # Optional persistence
      store:           map
-     primary:         "203.0.113.50:5353"      # Fetch catalog from here
+     primaries:                                 # Fetch catalog from here
+        - addr: "203.0.113.50:5353"
+          key:  NOKEY
      options:
         - catalog-zone                         # Parse as catalog zone
         - catalog-member-auto-create           # Auto-configure member zones
@@ -101,7 +116,9 @@ zones:
    - name:            catalog-readonly.
      type:            secondary
      store:           map
-     primary:         "203.0.113.60:5353"
+     primaries:
+        - addr: "203.0.113.60:5353"
+          key:  NOKEY
      options:
         - catalog-zone           # Parse catalog but DON'T auto-configure
                                  # (no catalog-member-auto-create option)
@@ -120,8 +137,10 @@ zones:
      zonefile:        /etc/tdns/zones/stealth.example.zone
      template:        stealth-primary
      notify:                              # Override template notify list
-        - "ns1.public.example:53"
-        - "ns2.public.example:53"
+        - addr: "ns1.public.example:53"
+          key:  NOKEY
+        - addr: "ns2.public.example:53"
+          key:  NOKEY
 
    # ===========================================================================
    # EXAMPLE 10: Fast-rolling DNSSEC zone
@@ -130,7 +149,8 @@ zones:
      zonefile:        /etc/tdns/zones/fastroll.example.zone
      template:        fast-roll-primary
      notify:
-        - "192.0.2.100:53"
+        - addr: "192.0.2.100:53"
+          key:  NOKEY
 
    # ===========================================================================
    # EXAMPLE 11: Zone with dynamic updates enabled

--- a/docs/2026-06-23-dynamic-zones-interface-and-tsig-transfers.md
+++ b/docs/2026-06-23-dynamic-zones-interface-and-tsig-transfers.md
@@ -30,6 +30,53 @@ end with none of Improvement 2's code. Improvement 2 is then layered on with **n
 change and no re-provisioning** of zones added before it, because Improvement 1 already uses the
 final primary/key syntax (the NOKEY model, §5.B0).
 
+## Revision note (2026-06-28) — two model changes supersede parts of this plan
+
+1. **Multi-primary + hostname resolution** (separate PR; see
+   `2026-06-26-multi-primary-and-hostname-resolution-plan.md`). Scalar `primary:` → list
+   **`primaries: []PeerConf`**; `ZoneData.Upstream` → `PrimariesConf` (as-written, persisted) +
+   `Upstreams` (resolved `addr:port`, runtime-only); hostnames resolve via the in-process IMR at
+   parse/load; SOA-probe and AXFR iterate the list with per-primary fallback. **There is no scalar
+   `ZoneData.TsigKeyName`** — the per-peer key is `.Key` on each `primaries[]` / `Upstreams[]`
+   entry, signed per attempt in the loop. Read every singular `primary` / `zd.Upstream` below as
+   the list form.
+
+2. **TSIG is now NSD-aligned, not per-peer** (decided 2026-06-28). The per-peer `(peerIP, name)`
+   keystore is **dropped**; §6 is rewritten, and §3's "why per-peer" plus several §9 decisions are
+   superseded (marked). Headline of the new model:
+   - a **`keys:` block** maps **name → {algorithm, secret}** (globally-unique names; the *only*
+     secret store; = NSD `key:`);
+   - **four directional zone fields**, two per role — "initiate to an endpoint" (carries a key it
+     **uses** to sign) vs "accept from a class" (carries a key it **requires**):
+
+     | field | = NSD | role | entry |
+     |---|---|---|---|
+     | `primaries:` (exists) | request-xfr | secondary: pull from | `{addr, key}` |
+     | `allow-notify:` (new) | allow-notify | secondary: who may NOTIFY me | `{ip-spec, key｜NOKEY｜BLOCKED}` |
+     | `notify:` (exists) | notify | primary: who I notify | `{addr, key}` |
+     | `downstreams:` (back) | provide-xfr | primary: who may AXFR from me | `{ip-spec, key｜NOKEY｜BLOCKED}` |
+
+   - **ip-spec** = single IP, CIDR `1.2.3.4/24`, mask `1.2.3.4&255.255.255.0`, range `a-b`, or
+     `0.0.0.0/0`/`::/0` for any. The ACL is an **ordered list**: a matching `BLOCKED` denies
+     (supersedes), else first address-match wins (`NOKEY` → unsigned accepted; `<name>` → require a
+     valid TSIG under that name). This is what lets you key on **TSIG only** (`0.0.0.0/0 K`) or
+     **address only** (`1.2.3.4 NOKEY`) — key and address are independent conditions.
+   - `downstreams:` **returns** — not as the old `notify:` synonym, but as the **transfer ACL**
+     (provide-xfr). Inbound NOTIFY becomes `allow-notify:` (same shape) — this subsumes the old
+     open question about NOTIFY key selection.
+   - **Defaults:** empty `downstreams:` → **deny** (serve no AXFR — a hard cutover, since tdns
+     serves AXFR to anyone today); empty `allow-notify:` → **accept NOTIFY from the configured
+     `primaries:` set**.
+   - This **dissolves** the "why per-peer" rationale, the persisted per-peer keystore, most of its
+     refcounting, and the hostname-keystore-keying problem entirely.
+   - **Familiar-terminology aliases** (`provide-xfr:`/`allow-transfer:` → `downstreams:`,
+     `request-xfr:`/`upstreams:` → `primaries:`) are a **later, input-only** addition — accepted on
+     input via a small key-normalization pass on the raw decoded map (before mapstructure, where the
+     PeerConf hook lives), canonical name used in docs/output, `alias + canonical on one zone` →
+     per-zone ERROR. **Not in v1.**
+
+   Full model and steps in §6.
+
 ## 1. Current state (verified against the code)
 
 ### Dynamic-zones machinery (exists, internal-only)
@@ -83,7 +130,8 @@ AXFR payload transfer. Today none of these paths apply TSIG:
 | Secondary → primary | AXFR / IXFR request | `ZoneTransferOut` (dnsutils.go:222) via queryresponder.go:816 | No TSIG verify; no ACL |
 
 `ZoneTransferIn` is a `ZoneData` method; `zd.KeyDB` is already on the struct — TSIG lookup does not
-require a signature change, only `zd.TsigKeyName` (§6.A2). The catalog path already *looks up*
+require a signature change (the per-entry key name on `primaries[]`/`Upstreams[]` resolves to a
+secret in the `keys:` store — see §6, revised). The catalog path already *looks up*
 `ConfigGroupConfig.TsigKey` (config.go:395) — only the *application* is a TODO (catalog.go:399-404).
 The one existing TSIG store, `Globals.TsigKeys` (global.go:45), is keyed by bare name and used for
 catalog-config checks and CLI/reporter clients — **not** auth-server replication paths. tdns-auth
@@ -116,28 +164,26 @@ Outbound NOTIFY targets are plain address strings (`ZoneConf.Notify []string`, c
 | Topic | Decision (2026-06-23) | Rationale |
 |---|---|---|
 | **Interface scope** | Full CRUD: `add`/`delete`/`modify`/`list-dynamic`, API + CLI — not a one-off `add`. | A management interface should be reasonably complete; most delete/list primitives already exist, so the marginal cost is small. |
-| **TSIG scope** | **Per-peer**, keyed `(peer address, key name)`. Not global, not per-zone. Applies to **all replication peer messages**: SOA query, AXFR/IXFR, NOTIFY — sign outbound, verify inbound. | A TSIG key is a bilateral agreement between two *servers* (RFC 8945); the secret belongs to the relationship with the remote endpoint. Partial coverage (AXFR only) fails against real primaries that require TSIG on SOA queries too. Matches BIND's `server { keys ... }` model. |
-| **Downstream peer syntax** | Structured `notify: [{addr, key}]`; `key` mandatory, `NOKEY` = unsigned. Hard cutover from bare-string entries (same per-zone ERROR quarantine as `primary:`). **`notify:` is the one canonical name** — the duplicate `downstreams:` field/key is removed in the same migration (§5.B0, §6.A3b). | Primary-side TSIG needs a key per downstream for outbound NOTIFY signing and inbound AXFR verification. Plain `notify: [addr, …]` strings carry no key name. Today `ZoneConf` carries *both* `Notify` and `Downstreams` (structs.go:190-191) — an ambiguity the `PeerConf` migration resolves to one. |
+| **TSIG scope** (revised 2026-06-28) | **NSD-aligned**: secrets keyed by **name** (a `keys:` block, name→secret), peer **authorization** as separate address ACLs (`allow-notify:` / `downstreams:`). Applies to **all replication messages** — SOA query, AXFR/IXFR, NOTIFY — sign outbound (by key name), verify inbound (ACL address-match + key name from the wire). **Reverses the per-peer `(peerIP, name)` keystore** (see §6, §3 "why per-peer"). | A TSIG key name is on the wire and identifies one secret (RFC 8945), so name-keying is the standard model; address authorization is a distinct concern best expressed as an ordered ip-spec ACL (NSD `provide-xfr`/`allow-notify`). Drops the per-peer store, its refcounting, and the hostname-keystore problem. |
+| **Primary-side fields** (revised 2026-06-28) | Two distinct fields: **`notify: [{addr, key}]`** — who I notify (single endpoints, key signs the NOTIFY); and **`downstreams: []AclEntry`** — who may AXFR from me (the provide-xfr ACL: ip-spec + key｜NOKEY｜BLOCKED). `notify:` stays the canonical NOTIFY-target name; **`downstreams:` returns**, but as the **transfer ACL**, not a `notify:` synonym. (Multi-primary already cleaned up the old `Notify`/`Downstreams` duplication; B0's "one canonical name" still holds for the *notify-target* list.) | NSD keeps "who I notify" and "who may transfer from me" as **separate** lists — they genuinely differ (a signer/monitor may pull without being notified; a `/24` may pull). Deriving the xfr-ACL from `notify:` (the old plan) conflates them. |
 | **Direct-API zones gate** | `zone add` is **refused unless `dynamiczones.dynamic.allowed: true`**; persistence uses `dynamiczones.dynamic.storage` (parallel to catalog's `members.storage`). | The config field `DynamicZonesConf.Dynamic.Allowed` already exists and **defaults false** (config.go:419) but is checked nowhere — so today the gate is silently inert. The interface must honour it or it ships an always-on capability the operator believed they had disabled. |
 | **`list-dynamic` scope** | Returns **all persistable dynamic zones** — predicate: `ShouldPersistZone(zd)` (catalog members, catalog zones if persistent, API-managed). **Not** the same predicate as delete/modify: those mutate only `OptApiManagedZone` zones. Catalog members appear in the list (read-only from this API) but cannot be deleted/modified here — use the catalog API for that. | `getDynamicZonesFromZonesMap()` already filters on `ShouldPersistZone`; reusing it is correct once B5 extends that gate for API zones. Using `OptApiManagedZone` for list would hide catalog members and confuse operators who expect to see the full dynamic set. |
 | **API `zone add` scope (v1)** | **Secondary zones only** via API/CLI in Improvement 1. Primary zones with `notify:` peers are static-config (or catalog) only until a later extension; wire structs may carry notify peers for Improvement 2 static YAML, but `ProvisionDynamicZone` rejects `type: primary`. | Avoids half-specifying primary+notify on the API surface before TSIG and `PeerConf` notify migration land; catalog and static config cover primary today. |
 | **`modify` mutable fields (v1)** | **`primary` addr/key and `options` only.** Not notify/downstreams, DNSSEC policy, update policy, store, or rename (rename = delete+add). Matches B1c scope; catalog group options remain catalog-config territory. | Keeps the first `modify` core small; notify/TSIG changes on primaries are static-config or future work. |
 | **Catalog non-map store** | Re-pointing catalog at the map-only core is an **explicit breaking change** for any config group using `store: xfr` or `store: slice`. | `parseZoneStore` silently coerces empty/unknown → map today (catalog.go:474-492), so most groups are unaffected; but an *explicit* non-map store now becomes an ERROR rather than a silent honour. Consistent with no-backwards-compat — but it is a behaviour change, called out here, not buried in a §10 audit. |
-| **Primary/key syntax** | Structured `primary: {addr, key}`; `key` **mandatory and explicit**, built-in sentinel `NOKEY` = unauthenticated. No default. | Makes the "no TSIG" choice deliberate and visible; makes the pre-TSIG phase *structural* rather than a special case (see §5.B0). |
+| **Primary/key syntax** (revised 2026-06-28) | `primaries: [{addr, key}]` — a **list** (multi-primary), each entry `{addr, key}`; `key` **mandatory and explicit**, sentinel `NOKEY` = unauthenticated. The key is the **name** referenced from the `keys:` block. | List for redundancy (multi-primary); mandatory key makes "no TSIG" deliberate; name-referenced secret per the NSD model. (B0 shipped the struct; multi-primary made it a list.) |
 | **Invalid `primary.key` handling** | **Per-zone ERROR quarantine, not a fatal parse error.** A missing/empty `key`, or a key name that doesn't resolve, puts *that zone* into ERROR state; the server still starts and other zones are unaffected. | Matches the project's resilient-config-startup rule (config errors are quarantined per-object, never fatal). "Must fail to parse" would abort the whole server — wrong. |
 | **Zone store for dynamic zones** | **`MapZone` only**, enforced in the shared `ProvisionDynamicZone` core — applies to **catalog-, API-, and CLI-provisioned** zones alike. Any other store requested → reject (ERROR/error). | `slice` is legacy; `xfr` is not wanted for dynamically managed secondaries. One rule in one place removes the whole re-instantiation problem from `modify` (B1c). `parseZoneStore` already defaults empty/unknown → map, so this is a tightening, not a new behaviour. |
 | **Sequencing** | Improvement 1 (interface) first, Improvement 2 (TSIG) second. | One-way dependency: the interface establishes the `PeerConf` syntax TSIG then consumes (doing TSIG first builds those structs twice). The interface also ships standalone value (NOKEY zones work end-to-end with none of TSIG's code). Risk is not the driver — under `risk = probability × consequence` (§7) both halves are Low–Med overall; the one elevated cell is B5b (resurrection race), in the interface half. |
 
-### Why per-peer and not global or per-zone
-- **Global is wrong:** `Globals.TsigKeys` keyed by bare name means two unrelated primaries that both
-  use the name `transfer-key` (with different secrets) collide — the second registration silently
-  overwrites the first.
-- **Per-zone is wrong:** it would duplicate one shared secret across several zones that pull from the
-  same primary, and cannot express "these N zones all transfer from one peer over one key."
-- **Per-peer is right:** the key is a property of the remote endpoint. One upstream may serve many
-  zones over one key; `(upstream, name)` is the natural tuple. Note the existing Sig0/DNSKEY stores
-  in `KeyDB` are legitimately *per-zone* (a signing key belongs to a zone) — TSIG is a different kind
-  of key (transport auth, belongs to a peer), so it gets a sibling store with a different key tuple.
+### Why per-peer and not global or per-zone  *(superseded 2026-06-28 — see §6 "Why name-keyed")*
+
+This subsection argued for a per-peer `(peerIP, name)` keystore. **That decision is reversed.** The
+NSD-aligned model keys the secret by **name** (globally, from the `keys:` block) and expresses peer
+*authorization* separately as an address ACL — which both simplifies the store (no per-peer table, no
+refcounting, no hostname-keystore-keying) and is the standard, operator-familiar decomposition. The
+original concern ("two peers reuse the same wire key-name with different secrets") is avoided by
+naming the two relationships distinctly, and NSD doesn't support it either. Rationale in full at §6.
 
 ## 4. Sequencing & why the split is safe (verified)
 
@@ -280,7 +326,7 @@ phase structural rather than a warned special case.
   persistence (dynamic_zones.go:~311). **`ZoneData.Upstream` STAYS `string`** — it's consumed as a bare
   address by the AXFR machinery (`ZoneTransferIn(zd.Upstream, …)`) and logs (~14 sites); `PeerConf`
   collapses to `.Addr` flowing *into* `Upstream` and rehydrates as `Primary{Addr: zd.Upstream}` on the
-  way out. `TsigKeyName` is added alongside `Upstream` later (Improvement 2 step 2), not here.
+  way out. *(Superseded 2026-06-28: multi-primary made `ZoneData.Upstream` → `PrimariesConf`/`Upstreams []PeerConf`; the per-entry key carries the TSIG key name, and there is **no** scalar `TsigKeyName` — see the revision note.)*
   `ZoneRefresher.Primary`/`Notify` and `RefreshCounter` also carry these — convert in step. Structured
   `notify:` (Improvement 2, A3b) uses the same `PeerConf` type and the same hook — do not introduce a
   second struct. **Also consolidate the duplicate `ZoneConf.Notify`/`ZoneConf.Downstreams` (structs.go:190-191)
@@ -354,20 +400,15 @@ divergence):
   window between `Zones.Set` replacing the entry where a concurrent query for this zone is REFUSED;
   acceptable for a management op on a secondary that is about to re-AXFR regardless (decided
   2026-06-24).
-  - **Key/peer change handling (the keystore must follow the change — A3 gap fix):** changing
-    `primary.addr`-IP and/or `primary.key` changes the keystore tuple `(peerIP, key_name)`. Because
-    `modify` is delete+re-add, the keystore ops attach to the two halves: the new `ZoneData` adds its
-    key, the old tuple is refcount-dropped.
+  - **Key/peer change handling:**
     - *Improvement 1 (no TSIG yet):* the only legal key value is `NOKEY`, so a modify moves only
-      `NOKEY` ↔ `NOKEY` — no keystore op, but the validation (must be `NOKEY`) still runs.
-    - *Improvement 2:* if the modify supplies a new non-`NOKEY` key (with secret via the API
-      `{tsig_*}` fields, or referencing a declared `keys.tsig[]` name), call
-      `AddTsigKey(peerIP(newAddr), newKey, …)` for the new tuple **and** refcount-drop the old via
-      `DeleteTsigKey(peerIP(oldAddr), oldKey)` (drop only if no other live zone still references the
-      old `(peerIP, name)` — same refcount rule as `delete`, step 10). A change to the **IP** or the
-      **key name** re-binds under the new `(peerIP, key)` and refcount-drops the old; a **port-only**
-      change (same IP, same key) is **not** a keystore change — only the send target moves.
-    - Config-declared (`keys:`) keys are never refcount-dropped by a modify (config owns them, step 3).
+      `NOKEY` ↔ `NOKEY` — no key op, but the validation (must be `NOKEY`) still runs.
+    - *Improvement 2 (NSD model — revised 2026-06-28):* a key change just sets a new **key name** on
+      the `primaries[]` entry — the secret lives in the name-keyed `keys:` store, so there is **no
+      per-peer re-bind** (the old `(peerIP, key_name)` rebind/refcount machinery is gone). If the
+      modify carries `{tsig_*}`, it upserts that name→secret; an old API-owned name is dropped by the
+      name-reference scan (§6 step 1) when no live zone still names it (config-owned names are never
+      dropped). A port- or IP-only change touches only the send target, not the key.
 
 ### B2. API request/response
 Extend `ZonePost` (api_structs.go:159) with `Options []string` and the structured primary
@@ -658,246 +699,176 @@ this is a few lines, not infrastructure.
 - parse → a `primary:` with missing/empty `key` puts that zone in ERROR state **but the server still
   starts**; a non-`NOKEY` key is an ERROR-state zone until Improvement 2.
 
-## 6. Improvement 2 — TSIG on zone-replication peer transactions, per-peer scoping  *(do second)*
+## 6. Improvement 2 — TSIG on zone-replication peer transactions  *(do second)* — NSD-aligned (rewritten 2026-06-28)
 
-### Transaction map (full scope — nothing here is optional)
+### Model
 
-A secondary configured with `primary: {addr, key: K}` and a primary configured with
-`notify: [{addr: D, key: K}, …]` share one per-peer keystore entry per remote endpoint. The same
-`(peer_addr, key_name)` tuple is used whether this server is signing an outbound message or
-verifying an inbound one.
+One secret store and four directional fields:
+
+- **`keys:` block** — `name → {algorithm, secret}`, globally-unique names; the **only** secret
+  store. Both sign and verify look the secret up **by name** (the name is on the wire — the TSIG
+  RR owner). `KeyConf.Tsig []TsigDetails{Name, Algorithm, Secret}` already exists (structs.go:809);
+  this just tags + loads it. No per-peer `(peerIP, name)` store.
+- **Secondary:** `primaries: []PeerConf{addr, key}` (multi-primary; the key NAME signs our outbound
+  SOA/AXFR to that primary) and `allow-notify: []AclEntry` (who may NOTIFY us).
+- **Primary:** `notify: []PeerConf{addr, key}` (the key NAME signs our outbound NOTIFY) and
+  `downstreams: []AclEntry` (who may AXFR from us).
+- **`AclEntry{ ip-spec, key }`**, `key ∈ {<name>, NOKEY, BLOCKED}`, `ip-spec` ∈ {IP, CIDR `/24`,
+  mask `&m`, range `a-b`, `0.0.0.0/0`/`::/0`}.
+
+### Transaction map (sign outbound by key-name; verify inbound by ACL + key-name)
 
 ```
 Secondary                              Primary
 ─────────                              ───────
-DoTransfer (SOA query)        ──TSIG──►
-ZoneTransferIn (AXFR/IXFR)    ──TSIG──►
-                              ◄──TSIG──  SendNotify (NOTIFY)
-NotifyResponder (verify)      ◄──TSIG──
-                              ◄──TSIG──  ZoneTransferOut (verify AXFR request)
+DoTransfer (SOA query)        ──TSIG──►            sign with primaries[i].key
+ZoneTransferIn (AXFR/IXFR)    ──TSIG──►            sign with primaries[i].key
+                              ◄──TSIG──  SendNotify   sign with notify[j].key
+NotifyResponder (verify)      ◄──TSIG──            allow-notify ACL, then verify
+                              ◄──TSIG──  ZoneTransferOut
+ZoneTransferOut (serve)       ◄────────            downstreams ACL, then verify
 ```
 
-**Address model — send by `addr:port`, key/match by IP only (decided 2026-06-24).** Two distinct
-uses of a peer address, which the current code conflated:
-- **Send side:** the configured `primary.addr` / `notify[].addr` is a full `host:port` and is used
-  *verbatim* to reach the peer. We must **not** assume the peer listens on `:53` — `DoTransfer`,
-  `ZoneTransferIn`, and `SendNotify` send to the exact configured port. (`NormalizeAddress` may still
-  default a missing port to `:53`, but an explicit non-53 port is honoured.)
-- **Keystore/ACL key side:** the lookup tuple is **`(IP, key_name)` — IP only, port stripped from
-  both sides.** Inbound `RemoteAddr()` carries an ephemeral source port that never equals the
-  configured listen port, so matching on `host:port` would fail every legitimate peer. Define a helper
-  `peerIP(addr) = host-part of net.SplitHostPort(addr)` (bare IP, no port) and use it as the keystore
-  key on **both** store and lookup. The keystore tuple is therefore `(peerIP, name)`, **not**
-  `(addr:port, name)`.
-- **Accepted limitation:** IP-only matching cannot distinguish two replication peers sharing one IP on
-  different ports (e.g. two tdns instances on `192.0.2.1:5301` and `:5302` with different keys) — they
-  resolve to the same `(IP, name)`. This matches BIND's address-based `server`-ACL behaviour and is an
-  accepted constraint, documented rather than worked around.
+- **Outbound:** each peer entry carries a key NAME → look up the secret in `keys:` → sign (NOKEY →
+  plain, today's path). The multi-primary SOA-probe / AXFR loops sign **per attempt** with the
+  current `up.Key`.
+- **Inbound:** match `peerIP(srcAddr)` against the ACL (`allow-notify` / `downstreams`); the matched
+  entry's `key` field decides — `NOKEY` → accept unsigned; `<name>` → the request's TSIG must name
+  that key and verify against the `keys:` secret; `BLOCKED` → deny. The key name for verification
+  comes from the **request's** TSIG RR; the source IP selects the ACL entry (and thus accept/deny +
+  required key).
 
-**Shared signing/verify helpers** (new, e.g. `v2/tsig_peer.go`):
-- `SignForPeer(msg, peerAddr, keyName, kdb)` — if `keyName == NOKEY`, no-op; else
-  `GetTsigKey(peerIP(peerAddr), keyName)`, set `Client.TsigSecret` / `msg.SetTsig(…)`. `peerAddr` here
-  is the configured `addr:port` (send side); only its IP is used for the keystore lookup. Used by all
-  outbound paths.
-- `VerifyFromPeer(msg, remoteAddr, keyName, kdb)` — if `keyName == NOKEY`, accept unsigned; else
-  verify TSIG on `msg` against `(peerIP(remoteAddr), keyName)`. `remoteAddr` is the inbound
-  `RemoteAddr()`; its ephemeral port is discarded by `peerIP`. Used by all inbound paths.
+**Send vs match (unchanged in spirit):** send to the configured full `addr:port` (never assume
+`:53`); match the ACL on **IP only** (`peerIP(srcAddr)` = port stripped), because the inbound source
+port is ephemeral. ip-spec ranges (`/24`, mask, range) match the source IP against the prefix. (The
+old "two peers on one IP, different ports, different keys" limitation is moot — the address ACL and
+the key are now independent, and the key name is carried on the wire.)
 
-Retire `Globals.TsigKeys` for auth replication: load `keys:` block into the per-peer keystore at
-startup (A3); catalog/API provisioning call `AddTsigKey`. CLI reporter may keep its own client-side
-`ParseTsigKeys` path — out of scope for auth.
+### Shared helpers (new, e.g. `v2/tsig_peer.go`)
+
+- `SignForPeer(msg, keyName, kdb)` — if `keyName == NOKEY`, no-op; else look up the secret **by
+  name** in the `keys:`-loaded store, `msg.SetTsig(name, algo, …)` and set the client/transfer
+  `TsigSecret`. Used by all outbound paths. (No `peerAddr` needed — the secret is name-keyed.)
+- `VerifyFromPeer(msg, kdb)` — read the TSIG RR's key name from `msg`, look up the secret by name,
+  verify the MAC; return ok/fail. The caller has already done the ACL address-match (below).
+- `matchACL(acl []AclEntry, srcIP) (allow bool, requiredKey string)` — ordered scan: a `BLOCKED`
+  whose `ip-spec` matches `srcIP` → deny (supersedes); else the first `ip-spec` match → `(true,
+  key)`; no match → deny. ip-spec parsing: `net.ParseCIDR` for CIDR/`/0`; small parsers for mask
+  `a&m` and range `a-b`; a bare IP is a `/32`/`/128`.
+- `peerIP(addr)` — host part of `net.SplitHostPort(addr)` (bare IP, port stripped), used to reduce
+  the inbound `RemoteAddr()` for the ACL match.
+
+Retire `Globals.TsigKeys` for auth replication: the `keys:` block is the name→secret store; catalog/
+API provisioning upsert into it by name. CLI reporter may keep its own client-side `ParseTsigKeys`
+path — out of scope for auth.
 
 ### Implementation steps
 
-> **Step ↔ A-label map** (the §7 assessment table and cross-refs elsewhere use the `A`-labels; the
-> steps below are the same work, numbered): step 1 = **A1**; step 2 = **A2** (+ the structured
-> `notify:` half is **A3b**); step 3 = **A3a** (`keys:` block), with `notify:` cutover = **A3b**;
-> step 4 = **A4**; step 5 = **A5**; step 6 = **A6**; step 7 = **A7**; step 8 = **A8**; step 9 =
-> **A9**; the test list = **A10**.
+> **A-label map** (the §7 assessment table uses `A`-labels): step 1 = **A1**+**A3a** (keystore +
+> `keys:` block, now merged into one name→secret store); step 2 = the new **ACL** machinery; steps
+> 3–7 = **A4–A8**; step 8 = **A9**; step 9 = key/ACL lifecycle. The old **A2** (`PeerConf` struct)
+> shipped with multi-primary + B0 and is no longer a step here.
 
-1. **(A1) Per-peer TSIG keystore** — add a TSIG store in `KeyDB` (struct at structs.go:~719). DB table
-   `TsigKeys(upstream, name, algorithm, secret, owner, …)` UNIQUE(upstream, name), where `owner` ∈
-   {`config`, `api`} (drives the refcount-drop discriminator, step 10) + accessors
-   `GetTsigKey(upstream, name)` / `AddTsigKey(upstream, name, algo, secret, owner)` (upsert) /
-   `DeleteTsigKey(upstream, name)` (scans live `Zones`; drops only when unreferenced and
-   `owner="api"`, step 10). Cache key: `peerIP(upstream)+"+"+name` (mirror the Sig0 cache
-   convention `zonename+"+"+state` at keystore.go:844). **The accessors key on `peerIP` (bare IP, port
-   stripped) — NOT `NormalizeAddress` (which would force `:53`)** — so store and lookup agree
-   regardless of the peer's actual port and the inbound ephemeral source port (see address model
-   above). (Note: `KeyConf.Tsig []TsigDetails{Name, Algorithm, Secret}` already exists at
-   structs.go:809 — that is the *config* shape; the per-peer keystore is the new `(peerIP, name)`
-   runtime store.)
+1. **`keys:` block — the name→secret store.** Tag `Config.Keys` (`yaml:"keys" mapstructure:"keys"`);
+   the shape exists (`KeyConf.Tsig []TsigDetails{Name, Algorithm, Secret}` at structs.go:809). Load
+   `keys.tsig[]` into a **name-keyed** store at startup (auth loads no keys today). Sign and verify
+   both look the secret up **by name** — no `(peerIP, name)` tuple, no per-peer DB table.
+   - `NOKEY` is reserved: a `keys.tsig[]` entry named `NOKEY` (any case) → ERROR.
+   - A peer/ACL referencing a non-`NOKEY` key name with **no matching `keys.tsig[]` entry** → that
+     zone to per-zone ERROR (same quarantine rule as B0).
+   - **API-created keys** (`zone add --tsig-*`) upsert a name→secret entry; persist them with an
+     `owner` discriminator (`config`|`api`) if API-key auto-drop is wanted. Auto-drop, if kept, is a
+     **name-reference scan** of live `Zones` (much simpler than the old per-peer scan): drop an
+     `owner="api"` key when no live zone's `primaries[].key` / `notify[].key` / ACL entry still names
+     it. Config-declared keys are config-owned and never auto-dropped. (Whether to implement
+     auto-drop at all in v1 is a small detail — a never-dropped name store is also acceptable.)
+   - **Config wins on reload** still falls out of load order: DB-load → `keys:` bind (upsert by name)
+     → zone parse. Because the keystore is now name-keyed, the conflict is `name` vs `name` — config,
+     bound last, lands on top.
 
-2. **`PeerConf` struct + runtime refs** — shared `{Addr, Key}` type for both upstream and downstream
-   peers (replaces bare `Primary string` from B0 and bare `Notify []string`):
-   ```yaml
-   # secondary
-   primary:
-     addr: 192.0.2.1:53
-     key:  transfer-key    # NOKEY = unsigned
+2. **ip-spec type + ordered-ACL matcher** (new; shared by `allow-notify:` and `downstreams:`). Parse
+   `1.2.3.4`, `1.2.3.4/24`, `1.2.3.4&255.255.255.0`, `1.2.3.4-1.2.3.25`, and `0.0.0.0/0` / `::/0`
+   (`net.ParseCIDR` does CIDR/`/0`; mask and range are small parsers; a bare IP is a host route).
+   Each `AclEntry` is `{spec, key｜NOKEY｜BLOCKED}`. `matchACL(acl, srcIP)` scans in order: a matching
+   `BLOCKED` denies (supersedes); else the first `spec` match wins. YAML form: a string
+   `"1.2.3.4/24 transfer-key"` reads closest to NSD (or a struct `{spec, key}` — pick one and run it
+   through a decode hook like `stringToPeerConfHook`). `allow-notify:`/`downstreams:` are both
+   `[]AclEntry` on `ZoneConf`/`ZoneData`/`ZoneRefresher`.
 
-   # primary
-   notify:
-     - addr: 192.0.2.2:53
-       key:  transfer-key  # NOKEY = unsigned NOTIFY + accept unsigned AXFR from this peer
-   ```
-   On `ZoneData`: keep `Upstream string` + add `TsigKeyName string` (secondary); replace
-   `Downstreams []string` with **`Notify []PeerConf`** (one canonical name end to end — YAML key
-   `notify:`, `ZoneConf.Notify`, `ZoneData.Notify`; `downstreams`/`DownstreamPeers` are gone, per
-   §3/B0c). `ZoneRefresher` carries the same fields; assign in refreshengine.
+3. **Secondary → primary: SOA probe** — `DoTransfer` already iterates `zd.Upstreams` (multi-primary).
+   For each attempt, `SignForPeer(m, up.Key, kdb)` and move the call onto a `dns.Client{TsigSecret:…}`
+   + `client.Exchange` — the package-level `dns.Exchange` has **no `TsigSecret` and can't verify the
+   response MAC**. `NOKEY` keeps today's plain path (no client, no MAC).
 
-3. **`keys:` config block — explicit binding algorithm.** Tag `Config.Keys`
-   (`yaml:"keys" mapstructure:"keys"`); tdns-auth does not call any key-loading routine at startup
-   today, so add the load. The config shape **already exists** — `Config.Keys.Tsig []TsigDetails`
-   (`KeyConf.Tsig` at structs.go:809, `TsigDetails{Name, Algorithm, Secret}` at structs.go:812-815);
-   `keys.tsig[]` throughout this doc refers to that slice. **Pin `Algorithm` as the field name**
-   (the DB column / accessor args spell it `algorithm`/`algo` — same value, the lowercase DB column
-   maps to the struct's `Algorithm`). No new config struct is defined; only the **load** (parse →
-   keystore bind) is new. Binding rule, spelled out:
-   - **Startup load ordering (decided 2026-06-25): DB first, then config upserts.** The persistent
-     `TsigKeys` table is loaded into the keystore **before** the `keys:` block is bound. The `keys:`
-     bind then runs `AddTsigKey(…, owner="config")` for each declared key, which **upserts** —
-     overwriting any colliding `(peerIP, name)` row (including a prior `owner="api"` row) with the
-     config secret and `owner="config"`. This ordering is what makes **"config wins on reload"**
-     automatic and non-special-cased: config is applied last, so it always lands on top. (API-created
-     `owner="api"` rows for peers the operator manages purely via API have no config entry to collide
-     with and survive untouched.) Concretely: keystore-DB-load → `keys:` bind → zone parse/bind.
-   - For each **secondary** zone: `AddTsigKey(peerIP(zconf.Primary.Addr), zconf.Primary.Key,
-     algo, secret)` where `(algo, secret)` come from the `keys.tsig[]` entry whose `name ==
-     zconf.Primary.Key`. (Keystore keyed by IP; the full `addr:port` is retained on `zd` for sending.)
-   - For each **primary** notify peer: `AddTsigKey(peerIP(peer.Addr), peer.Key, algo, secret)`
-     likewise.
-   - A non-`NOKEY` key name with **no matching `keys.tsig[]` entry** → that zone to per-zone ERROR
-     (same quarantine rule as B0). Bare-string `notify:`/`primary:` → per-zone ERROR (handled by the
-     shared `stringToPeerConfHook` decode hook, B0).
-   - **Config reload:** on `keys.tsig[]` add/change/remove, re-bind — `AddTsigKey` upserts by
-     `(peer, name)`; a removed key whose `(peer, name)` is still referenced by a live zone → leave the
-     zone in ERROR (do not silently keep stale secret). 
-   - **Conflict policy (config vs API):** if an API `AddTsigKey` and a `keys:`-derived bind target the
-     same `(peer, name)` with different secrets, **config wins on reload** — and this falls out of the
-     load ordering above (config binds last, upserting over the `owner="api"` row), not a special-case
-     comparison. The API path is for zones the operator manages entirely via API. Document this; do not
-     merge silently.
-   - **Reference counting:** the keystore entry for `(peerIP, name)` is shared across all zones
-     pulling from that peer IP; `zone delete` / key removal drops it only when no live zone still
-     references it (§ step 10). Static `keys:` entries are owned by config, not refcounted away by API
-     deletes.
-
-4. **Secondary → primary: SOA probe** — `DoTransfer` (zone_utils.go:84). Many primaries require TSIG
-   here; AXFR signing alone is insufficient. **Mechanism caveat (not a one-liner):** the probe today
-   uses the **package-level `dns.Exchange(m, upstream)`** (zone_utils.go:101), which has **no
-   `TsigSecret` field and cannot verify the response MAC.** To sign+verify the probe, `DoTransfer`
-   must switch to a **`dns.Client{TsigSecret: …}`** and call `client.Exchange(m, upstream)`:
-   `SignForPeer` sets `msg.SetTsig(name, algo, …)` **and** populates the client's `TsigSecret` map for
-   the `(keyname → secret)` it resolves. For `NOKEY`, keep today's plain `dns.Exchange` path
-   unchanged (no client, no MAC). So step 4 = "set TSIG on the message **and** move the call onto a
-   `dns.Client` carrying the secret," not merely "call `SignForPeer` before `dns.Exchange`."
-
-5. **Secondary → primary: AXFR/IXFR** — `ZoneTransferIn` (dnsutils.go:54): before `transfer.In`,
-   set `transfer.TsigSecret` and `msg.SetTsig` via `SignForPeer` (same key as DoTransfer). Remove
+4. **Secondary → primary: AXFR/IXFR** — `ZoneTransferIn`, per attempt in `FetchFromUpstream`'s loop:
+   `SignForPeer` sets `transfer.TsigSecret` + `msg.SetTsig` for `up.Key` before `transfer.In`. Remove
    TODO at dnsutils.go:29. *Verify miekg/dns `Transfer.TsigSecret` / `SetTsig` / algorithm constants
-   against the vendored version.* **IXFR scope:** production refresh hardcodes `"axfr"`
-   (`FetchFromUpstream`, zone_utils.go:234), so the only call signed here is AXFR. The same
-   `SignForPeer`/`ZoneTransferIn` helper covers IXFR unchanged **if/when** the IXFR path is ever
-   wired — **no separate IXFR work in this plan.** Titles saying "AXFR/IXFR" mean "the one transfer
-   helper, which both use," not two code paths.
+   against the vendored version.* Production refresh hardcodes `"axfr"` (zone_utils.go:234), so AXFR
+   is the only call signed; IXFR uses the same helper if/when wired.
 
-6. **Secondary ← primary: inbound NOTIFY** — `NotifyResponder` (notifyresponder.go:122): for
-   NOTIFY(SOA) that will trigger a zone refresh, call `VerifyFromPeer(dnr.Msg, remoteAddr,
-   zd.TsigKeyName, kdb)` using the triggering zone's upstream key. **`NotifyResponder` has no `kdb`
-   today (verified) — thread `zd.KeyDB` in** (the zone is already resolved via `FindZone`). If
-   `zd.TsigKeyName == NOKEY`, accept unsigned (today's behaviour); else verify and REFUSE + log on
-   failure.
-   - **Response signing is REQUIRED, not optional (RFC 8945).** When the incoming NOTIFY carried a
-     valid TSIG, the NOTIFY response **must** be signed with the **same `(peerIP, key)`** used to
-     verify it — an unsigned reply to a signed request is treated as forged by the sender. (Confirm
-     the exact miekg/dns server-side mechanism — typically `w.WriteMsg` after `m.SetTsig(...)`, or the
-     server auto-signing when the request's TSIG verified — against the vendored API, §10.) For a
-     `NOKEY` zone the response stays unsigned.
-   - **No address-ACL on NOTIFY (deliberate, asymmetric with A8).** A `NOKEY` secondary accepts and
-     acts on a NOTIFY from **any** source (today's behaviour, preserved) — there is intentionally no
-     "is this a configured primary?" address check here, unlike the inbound-AXFR ACL (A8). Rationale:
-     a NOTIFY only *triggers* a SOA-serial refresh from the secondary's already-configured upstream;
-     it cannot inject data, so a spurious NOTIFY costs at most one SOA probe. Authentication is via
-     TSIG when a non-`NOKEY` key is configured; address-based rejection is not added. State this so the
-     NOTIFY-vs-AXFR asymmetry is a decision, not an oversight.
+5. **Secondary ← primary: inbound NOTIFY** — `NotifyResponder` (notifyresponder.go:122; thread
+   `zd.KeyDB` in — it has none today). Match `peerIP(remoteAddr)` against `allow-notify:`
+   (**empty ⇒ accept from the resolved `primaries:` IPs**, so operators needn't restate their
+   primary list). On `BLOCKED` / no match → **ignore** (NOTIFY is low-stakes — it only triggers a
+   probe against the secondary's own TSIG-protected primaries; log, don't act). On an allow match:
+   `NOKEY` → accept unsigned; `<name>` → `VerifyFromPeer` (REFUSE + log on bad MAC). **Sign the NOTIFY
+   response** with the same key when the request was signed (RFC 8945; for a `NOKEY` path it stays
+   unsigned). The key for verification is named in the request's TSIG RR; the ACL entry only gates
+   accept/deny and which name is *required*.
 
-7. **Primary → secondary: outbound NOTIFY** — `SendNotify` (notifier.go:95): for each target, find
-   the `zd.Notify` entry whose **`peerIP(entry.Addr) == peerIP(target)`** (IP-only match), call
-   `SignForPeer(m, target, peer.Key, kdb)` before `ExchangeContext` — sending to the entry's full
+6. **Primary → secondary: outbound NOTIFY** — `SendNotify` (notifier.go:95): for each `notify[]`
+   target, `SignForPeer(m, entry.Key, kdb)` before `ExchangeContext`, sending to the entry's full
    `addr:port`.
 
-8. **Primary ← secondary: inbound AXFR/IXFR** — `ZoneTransferOut` (dnsutils.go:222), reached from
-   queryresponder.go:816. **The requester address must be plumbed in: today `ZoneTransferOut(w, r)`
-   gets the requester only via `w.RemoteAddr()` and does no ACL (verified) — use that, reduced by
-   `peerIP`.** Before serving, match `peerIP(w.RemoteAddr())` against the `zd.Notify` peer list
-   (IP-only — the requester's ephemeral source port is irrelevant): if no entry matches → REFUSE
-   (closes the open AXFR ACL gap); if the matched entry's key is `NOKEY` → serve unsigned; else
-   `VerifyFromPeer(r, w.RemoteAddr(), peer.Key, kdb)` and serve only on success. **This IP-only match
-   is what makes the ACL work — a `host:port` comparison would reject every real secondary** (its
-   source port is never the configured listen port).
+7. **Primary ← secondary: inbound AXFR/IXFR (the `downstreams:` ACL — the substantive change)** —
+   `ZoneTransferOut` (dnsutils.go:222, reached from queryresponder.go:816, has `w.RemoteAddr()` and
+   does no ACL today). Match `peerIP(w.RemoteAddr())` against `downstreams:`: **empty ⇒ DENY** (closes
+   today's open-AXFR gap — a hard cutover); `BLOCKED` / no match → REFUSE; match key `NOKEY` → serve
+   unsigned; `<name>` → `VerifyFromPeer` and serve only on a valid MAC. This is the NSD `provide-xfr`
+   model — `downstreams: 0.0.0.0/0 transfer-key` (anyone with the key) and `downstreams: 1.2.3.4
+   NOKEY` (this host, no TSIG) both fall out of the ip-spec + key fields.
 
-9. **Wire catalog path + unify `tsig_key` into `primary.key`** — catalog.go:399-404. Today this block
-   looks up `ConfigGroupConfig.TsigKey` against `Globals.TsigKeys`, and on the "found" branch logs
-   `"CATALOG: applied TSIG key"` (catalog.go:403) while the actual apply is a TODO (catalog.go:402) —
-   **the log is a lie; delete it now** (this is a one-line correctness fix worth doing immediately,
-   independent of the rest). Then: map the catalog group's `tsig_key` into the provisioned zone's
-   `primary.key` (a single field — **deprecate the parallel `tsig_key`-only path**, do not keep two
-   ways to specify the same thing), call `AddTsigKey(peerIP(upstream), name, …, owner="config")`, and
-   set `zd.TsigKeyName`.
-   - **Re-point the existing catalog config-check.** Today catalog.go:397 *validates* the group's
-     `tsig_key` against `Globals.TsigKeys`. Once `Globals.TsigKeys` is no longer populated on auth
-     (this step), that check must be re-pointed at the new source of truth — the parsed `keys.tsig[]`
-     names (a name-set built when the `keys:` block loads, A3a) — or it always-fails. Don't leave it
-     reading the now-empty `Globals.TsigKeys`.
+8. **Wire catalog path** — catalog.go:399-404: map the group's `tsig_key` onto the provisioned
+   zone's `primaries[].key` name (the `keys:` store holds the secret); **delete the false "applied
+   TSIG key" log** (catalog.go:403) now (a one-line correctness fix, independent of the rest).
+   Re-point the existing `tsig_key` config-check from the (now-unused-on-auth) `Globals.TsigKeys` to
+   the parsed `keys.tsig[]` name-set, or it always-fails.
 
-10. **Programmatic provisioning + keystore lifecycle (refcounted).** The keystore entry for
-    `(upstream, name)` is shared across all zones pulling from that peer, so create/drop must be
-    reference-counted across all three mutating cores.
-    - **Refcount mechanism (specified — do not store a counter):** there is no `refcount` column and
-      no counter to keep in sync. "Still referenced" is **computed by scanning live `Zones`** at drop
-      time: a `(peerIP, name)` is still in use iff some live `ZoneData` has
-      `peerIP(zd.Primary.Addr)==peerIP && zd.Primary.Key==name`, **or** any `zd.Notify[i]` matches the
-      same tuple. `DeleteTsigKey(peerIP, name)` runs this scan and removes the DB row + cache entry
-      **only when the scan finds no remaining reference.** A scan over the sharded `Zones` map at a
-      management-op cadence (delete/modify) is cheap; this avoids counter-drift bugs entirely.
-    - **Ownership discriminator (config vs API) — one new column.** The `TsigKeys` table gets an
-      `owner` field (`"config"` | `"api"`). Config-declared (`keys:`) entries (`owner="config"`) are
-      **never** dropped by API add/modify/delete — the scan-and-drop applies only to `owner="api"`
-      rows. This is how "config wins / config owns its keys" (step 3 conflict policy) is enforced
-      mechanically rather than by convention. On reload, `keys:` binding re-asserts `owner="config"`
-      (upsert), overwriting any colliding `owner="api"` row (config-wins).
-    - `zone add` with `{tsig_name, tsig_secret, tsig_algo}` → `AddTsigKey(peerIP(upstream), name,
-      algo, secret)` (upsert).
-    - `zone modify` that changes `(addr, key)` → `AddTsigKey` for the new tuple, refcounted
-      `DeleteTsigKey` for the old tuple (B1c key-change handling). Note a port-only change of `addr`
-      does **not** change the keystore tuple (IP unchanged) — only the send target moves.
-    - `zone delete` → refcounted `DeleteTsigKey(peerIP(upstream), name)`: drop the keystore entry
-      **only if no other live zone still references `(peerIP, name)`**.
-    - **Config-declared (`keys:`) entries are never dropped by API add/modify/delete** — config owns
-      them (step 3); the refcount applies to API-created keystore entries.
+9. **API/CLI + key lifecycle.** `zone add`/`modify` carry `{tsig_name, tsig_secret, tsig_algo}` →
+   upsert a `keys:` (name→secret) entry and reference it from `primaries[].key`. Key auto-drop, if
+   implemented, is the name-reference scan from step 1 (`owner="api"` only). ACL flags
+   (`--downstreams` / `--allow-notify`) are added if/when the API surfaces primary-side management;
+   v1 may keep the ACLs static-config-only. Note a port-only change of a primary's `addr` does not
+   change the key (it's name-keyed) — only the send target moves.
+
+### Why name-keyed + address ACLs (supersedes the old "why per-peer")
+
+- The TSIG key name is **on the wire** (the TSIG RR owner) and both sides must agree on it per
+  relationship, so a name identifies **one** secret. Keying secrets by name (NSD `key:`) is the
+  standard model and removes the per-peer store, its refcounting, and the hostname-keystore-keying
+  problem (old decision A) entirely.
+- The old `(peerIP, name)` tuple existed only to disambiguate "two peers using the same wire
+  key-name with different secrets" — a case you avoid by giving the two relationships distinct names,
+  and one NSD can't express either. Dropping it is a net simplification.
+- **Address authorization is a separate concern from the key**, expressed as an ordered ACL of
+  ip-specs (NSD `allow-notify`/`provide-xfr`). That independence is what lets you key on TSIG only
+  (`0.0.0.0/0 K`) **or** address only (`1.2.3.4 NOKEY`).
 
 ### Tests (Improvement 2)
-- End-to-end replication with TSIG on **all** paths: SOA probe, AXFR, NOTIFY trigger, inbound AXFR
-  verify — use miekg/dns test server or two tdns-auth instances.
-- `NOKEY` zone: all paths remain plain/unauthenticated (today's behaviour).
-- **Collision test:** two peers, same key name, different secrets → both directions work.
-- NOTIFY rejected when TSIG required but missing/invalid; AXFR rejected when requester not in peer
-  list or TSIG invalid.
-- **NOTIFY response is TSIG-signed** when the request was signed (RFC 8945) — assert the reply carries
-  a valid TSIG under the same `(peerIP, key)`; a `NOKEY` zone's reply is unsigned.
-- **NOTIFY has no address-ACL:** a `NOKEY` secondary accepts a NOTIFY from an unconfigured source and
-  triggers a SOA probe (deliberate, asymmetric with the AXFR ACL — step 6).
-- **Refcount + ownership:** two API zones share `(peerIP, name)`; deleting one keeps the key (still
-  referenced), deleting both drops it. A `keys:`-declared (`owner=config`) key is **not** dropped by
-  any API delete.
-- **Load ordering / config-wins:** seed the DB with an `owner="api"` entry for `(peerIP, name)` with
-  secret S1, then start/reload with a `keys:` entry for the same `(peerIP, name)` carrying secret S2.
-  After load the keystore holds **S2 with `owner="config"`** (config bound last, upserted over the
-  api row) — proving config-wins is a consequence of DB-first-then-config ordering, not a comparison.
-- **`NOKEY` reserved:** a `keys.tsig[]` entry named `NOKEY` → parse ERROR for that key/zone.
-- Restart: the persistent `TsigKeys` DB loads **before** the `keys:` bind and before the first
-  refresh/NOTIFY; `TsigKeyName` + downstream peer keys are resolvable when the first transfer fires.
+- End-to-end with TSIG on all paths (SOA probe, AXFR, NOTIFY, inbound AXFR verify) — miekg/dns test
+  server or two tdns-auth instances. Multi-primary: the secondary signs **per attempt** with the
+  current primary's key.
+- `NOKEY` end to end stays plain/unauthenticated (today's behaviour).
+- **ACL (`downstreams:`):** `0.0.0.0/0 K` (key-only) admits any source with key K; `1.2.3.4 NOKEY`
+  (addr-only) admits that host unsigned; a `BLOCKED` entry supersedes a following allow; an unmatched
+  source → REFUSE. **Empty `downstreams:` → AXFR REFUSED.**
+- **ACL (`allow-notify:`):** empty ⇒ NOTIFY accepted from a configured primary's IP, ignored from a
+  stranger; an explicit entry with `<name>` requires a valid TSIG.
+- **NOTIFY response is TSIG-signed** when the request was; `NOKEY` reply unsigned.
+- **`keys:` by name:** a `keys.tsig[]` entry named `NOKEY` → ERROR; a peer/ACL referencing an
+  undefined key name → that zone ERROR; config-wins on reload (config bound last upserts the name).
+- Restart: the `keys:` store (DB + config) is loaded before the first refresh/NOTIFY, so every
+  referenced key name resolves when the first transfer fires.
 
 ## 7. Assessment (risk / LOC / Claude implementation time)
 
@@ -948,6 +919,14 @@ adds real wall-clock per tdns build cycle. **Revised 2026-06-25** for the probab
 | **A10** tests: all paths + collision + ACL reject + load-ordering/config-wins + refcount/ownership | Med | Low | **Low–Med** | ~165 | 70–100 min |
 | **Improvement 2 subtotal** | — | — | **Low–Med** (A1/A8 the elevated cells) | **~625** | **6.5–9 h** |
 | **Total** | — | — | **Low–Med** (two elevated cells: B5b, A8; one Med foundation: A1) | **~1285** | **14–18.5 h** |
+
+> **Improvement-2 rows superseded (2026-06-28).** The A1–A10 breakdown above reflects the old
+> per-peer-keystore design; the NSD-aligned model (§6) re-shapes it: **A1** shrinks (a name→secret
+> store, no per-peer DB table / refcount); **A2** is gone (`PeerConf` shipped with B0 + multi-primary;
+> no `TsigKeyName`); a **new ACL row** (ip-spec type + ordered matcher, shared by `allow-notify:` /
+> `downstreams:`) is added; **A8** becomes the `downstreams:` ACL and **A6** the `allow-notify:` ACL.
+> Net direction is **smaller** (the keystore/refcount removals outweigh the ACL additions), but the
+> per-row numbers above should be re-estimated against §6's steps before use.
 
 **What moved after the external review + verification (and why):**
 - **B5 split into B5a/B5b (B5b new, 2026-06-24):** beyond the marker-reload fix, there is a *second*
@@ -1143,22 +1122,29 @@ syntax it depends on, so it cannot ship first regardless of how loud-and-testabl
 - cmdv2/auth/*.sample.yaml (migrate sample `primary:`/`notify:` to structured form; document
   `dynamiczones.dynamic.allowed`)
 
-**Improvement 2:**
-- v2/tsig_peer.go (new: `SignForPeer`, `VerifyFromPeer`, `NOKEY` sentinel)
-- v2/keystore.go + v2/db_schema.go (per-peer TSIG table + accessors)
-- v2/structs.go (`PeerConf`; `ZoneData.TsigKeyName`, `ZoneData.Notify []PeerConf`; `ZoneRefresher` fields)
-- v2/config.go + v2/parseconfig.go (`keys:` tag; structured `notify:`; bind keys at parse)
-- v2/zone_utils.go (`DoTransfer` — A4 sign)
-- v2/dnsutils.go (`ZoneTransferIn` sign — A5; `ZoneTransferOut` verify — A8)
-- v2/notifier.go (`SendNotify` sign — A7)
-- v2/notifyresponder.go (inbound NOTIFY verify — A6)
+**Improvement 2 (NSD-aligned — revised 2026-06-28):**
+- v2/tsig_peer.go (new: `SignForPeer(msg, keyName, kdb)`, `VerifyFromPeer(msg, kdb)`, `peerIP(addr)`,
+  `NOKEY` sentinel)
+- v2/tsig_keys.go (new: the **name→secret** store — load `keys.tsig[]`; `GetTsigKey(name)`;
+  optional persist + `owner` discriminator + name-reference auto-drop for API keys). **No per-peer
+  `(peerIP, name)` table.**
+- v2/acl.go (new: `AclEntry{ip-spec, key}`, ip-spec parse/match (CIDR/mask/range/any), ordered
+  `matchACL`, `BLOCKED`)
+- v2/structs.go (`ZoneConf`/`ZoneData`/`ZoneRefresher`: add `AllowNotify []AclEntry` +
+  `Downstreams []AclEntry`. **No `ZoneData.TsigKeyName`** — keys are on `primaries[]`/`notify[]`.)
+- v2/config.go + v2/parseconfig.go (`keys:` tag + load into the name store; decode/validate
+  `allow-notify:`/`downstreams:`; a referenced-but-undefined key name → zone ERROR)
+- v2/zone_utils.go (`DoTransfer` — sign per `up.Key` in the multi-primary loop)
+- v2/dnsutils.go (`ZoneTransferIn` sign per `up.Key`; `ZoneTransferOut` — `downstreams:` ACL + verify)
+- v2/notifier.go (`SendNotify` — sign with `notify[].key`)
+- v2/notifyresponder.go (inbound NOTIFY — `allow-notify:` ACL (empty ⇒ accept from `primaries:`) +
+  verify; thread `zd.KeyDB`)
 - v2/queryresponder.go (AXFR path: `ZoneTransferOut` already has `w.RemoteAddr()`; reduce via
-  `peerIP` for the ACL/verify — no new param needed)
-- v2/catalog.go (wire TSIG → `primary.key` + keystore — A9)
-- v2/refreshengine.go (assign peer/key fields onto `ZoneData`)
-- v2/dynamic_zones.go (persist `PeerConf{addr,key}` for `primary` + `notify` peers)
-- v2/tsig_peer.go (`peerIP(addr)` helper — bare-IP keystore/ACL key)
-- v2/global.go / v2/tsig_utils.go (stop using `Globals.TsigKeys` on auth replication path)
+  `peerIP` for the `downstreams:` match/verify — no new param)
+- v2/catalog.go (map group `tsig_key` → `primaries[].key` name; delete the false "applied TSIG key"
+  log; re-point the `tsig_key` check at `keys.tsig[]`)
+- v2/refreshengine.go (assign `AllowNotify`/`Downstreams` onto `ZoneData`)
+- v2/global.go / v2/tsig_utils.go (stop using `Globals.TsigKeys` on the auth replication path)
 
 ## 9. Decisions (all resolved 2026-06-23, incl. external-review round)
 - **Static-config migration (B0): hard cutover, resilient.** Bare-string `primary:`/`notify:` values
@@ -1168,8 +1154,9 @@ syntax it depends on, so it cannot ship first regardless of how loud-and-testabl
   mapstructure`, and mapstructure ignores the YAML interface — verified). The hook records a legacy
   marker so the whole-file decode succeeds and per-zone validation quarantines just that zone (without
   it, one legacy value aborts the whole-file decode, verified at parseconfig.go:287-292).
-- **Canonical peer field: `notify:`.** The duplicate `downstreams:` field/key is **removed** in the
-  `PeerConf` migration (B0c) — one name, one `[]PeerConf`.
+- **Canonical NOTIFY-target field: `notify:`** (B0c) — one `[]PeerConf` for *who I notify*.
+  **Revised 2026-06-28:** `downstreams:` returns as a *separate* field — the **transfer ACL**
+  (provide-xfr), not a `notify:` synonym — and `allow-notify:` is added as the inbound-NOTIFY ACL.
 - **Direct-API zones gate:** `zone add` honours `dynamiczones.dynamic.allowed` (default false,
   currently inert) and persists under `dynamiczones.dynamic.storage`.
 - **Marker reload (B5): unified fix for ALL dynamic zone types.** `LoadDynamicZoneFiles` re-derives
@@ -1195,22 +1182,23 @@ syntax it depends on, so it cannot ship first regardless of how loud-and-testabl
   them onto `ZoneStatus` is a future follow-up, not this work.
 - **TSIG transaction scope: full replication cycle.** SOA probe, AXFR/IXFR, NOTIFY — sign outbound,
   verify inbound; not `transfer.In` alone. Shared `SignForPeer`/`VerifyFromPeer`, no one-off TSIG.
-- **Inbound AXFR ACL (A8):** requester must match a configured `notify:` peer; unknown requesters
-  REFUSED (replaces today's open `ZoneTransferOut`). A NOTIFY-only peer still needs a list entry.
-- **Peer address model (B4, decided 2026-06-24):** **send** to the configured full `addr:port` (never
-  assume `:53`); **key the keystore and match the ACL on IP only** (`peerIP(addr)` = port stripped,
-  on both store and lookup), because the inbound source port is ephemeral. Keystore tuple is
-  `(peerIP, key_name)`. Accepted limitation: two peers sharing one IP on different ports cannot be
-  distinguished (matches BIND's address-based `server`-ACL model).
-- **Catalog `tsig_key` → `primary.key`:** single field on provisioned zones; the parallel
-  `tsig_key`-only path is deprecated; the false "applied TSIG key" log is deleted now.
-- **`keys:` conflict policy + load ordering (ordering decided 2026-06-25):** startup loads the
-  persistent `TsigKeys` DB **first**, then binds the `keys:` block (`AddTsigKey(owner="config")`
-  upserts). Because config binds last, on a `(peerIP, name)` collision **config wins on reload**
-  automatically — no special-case comparison. API-set (`owner="api"`) keys are for API-managed zones
-  and survive when no config entry collides; keystore entries are reference-counted across zones
-  sharing a peer IP.
-- **`Globals.TsigKeys` retirement:** auth replication uses **only** the `KeyDB` per-peer store; the
+- **Inbound AXFR ACL (revised 2026-06-28 — the `downstreams:` ACL):** served only if
+  `peerIP(requester)` matches a `downstreams:` entry (ip-spec + key｜NOKEY｜BLOCKED, ordered, BLOCKED
+  supersedes); **empty `downstreams:` ⇒ DENY** (closes today's open `ZoneTransferOut`). This is a
+  *separate* ACL from `notify:` (NSD `provide-xfr`), **not** "match a configured notify peer."
+- **Inbound NOTIFY (revised 2026-06-28 — the `allow-notify:` ACL):** matched against `allow-notify:`;
+  **empty ⇒ accept from the configured `primaries:` IPs**; a non-NOKEY entry requires a valid TSIG.
+  Supersedes the old single-key `zd.TsigKeyName` verify and the "no address-ACL on NOTIFY" stance.
+- **Address model (revised 2026-06-28):** **send** to the configured full `addr:port` (never assume
+  `:53`); **match ACLs on IP only** (`peerIP` = port stripped) via ip-spec (IP/CIDR/mask/range).
+  **Secrets are keyed by name, not `(peerIP, name)`** — the old per-peer keystore tuple is dropped.
+- **Catalog `tsig_key` → `primaries[].key`:** map the group key-name onto the provisioned zone's
+  primary key (name-referenced in `keys:`); delete the false "applied TSIG key" log now.
+- **`keys:` load ordering (decided 2026-06-25, simplified 2026-06-28):** DB-load → `keys:` bind
+  (upsert by **name**) → zone parse. Config binds last, so on a **name** collision config wins on
+  reload — no special-case comparison. API keys (`owner="api"`) survive when no config name collides;
+  optional auto-drop is a **name-reference** scan of live `Zones`.
+- **`Globals.TsigKeys` retirement:** auth replication uses **only** the `keys:` name→secret store; the
   CLI reporter / `notifyreporter` client path may keep `Globals.TsigKeys` (out of scope for auth).
 - **API `zone add` scope (v1):** secondary zones only; `ProvisionDynamicZone` rejects primary.
 - **`modify` scope (v1):** `primary` addr/key + `options` only; no notify, policy, store, or rename.
@@ -1267,5 +1255,18 @@ note + migrated `*.sample.yaml`:
   ```
 - **What an un-migrated zone does:** loads into **ERROR state** (visible via `list-zones`), server
   still starts, other zones unaffected. The ERROR message names the field and the required shape.
-- **Adding TSIG (Improvement 2):** declare a `keys:` block and replace `NOKEY` with the key name on
-  the relevant `primary`/`notify` entries — no other config change, no re-provisioning.
+- **`primary:` → `primaries:` (multi-primary, separate PR).** The struct above became a **list**;
+  see `2026-06-26-multi-primary-and-hostname-resolution-plan.md` for that cutover. Read the `primary:`
+  examples above as a one-element `primaries:` list.
+- **Adding TSIG (Improvement 2, NSD-aligned — revised 2026-06-28):**
+  - declare a **`keys:`** block (`name → {algorithm, secret}`) and replace `NOKEY` with the **key
+    name** on the relevant `primaries[]` / `notify[]` entries (the entry references the name; the
+    secret lives in `keys:`);
+  - add a **`downstreams:`** ACL on every primary that should serve AXFR — **this is a hard cutover:
+    with `downstreams:` empty, AXFR is now REFUSED to everyone** (tdns serves AXFR openly today).
+    Entries are `ip-spec key｜NOKEY｜BLOCKED`, e.g. `203.0.113.0/24 transfer-key`, `192.0.2.9 NOKEY`,
+    `0.0.0.0/0 BLOCKED`;
+  - optionally add **`allow-notify:`** (same shape) to restrict who may NOTIFY a secondary — empty
+    means "accept from the configured `primaries:`."
+  - An un-migrated zone that needs a key it can't resolve, or names an undefined key, → ERROR
+    (visible via `list-zones`), server still starts.

--- a/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
+++ b/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
@@ -401,8 +401,14 @@ catalog, the extra resolution call sites, persist-with-keys, and the NOTIFY guar
   **hostname + key**, NOT the resolved addresses and NOT forced `NOKEY`. Tested at
   the serialization level (`ProvisionDynamicZone` rejects non-NOKEY keys in
   Improvement 1); persisting the hostname is what lets reload re-resolve it.
-- **P6:** `list-zones`/`list-dynamic` render the `primaries` list and surface
-  `config-warning` text for a partially-resolved zone.
+- **P6** (`TestSampleZonesConfigDecodes`, `TestSampleTemplatesConfigIsValidYAML`):
+  the shipped `*.sample.yaml` are migrated to `primaries:`/`notify:` struct lists
+  and decode with no Legacy markers. CLI: `--primaries` is a comma-list building a
+  `[]PeerConf` (one `--primary-key` applied to all); `list-zones`/`list-dynamic`
+  render the as-written `primaries` list and surface `config-warning` *distinctly*
+  from service-impacting errors — a warning zone stays a normal row with an
+  annotation (via the new exported `ErrorTypeIsServiceImpacting`), not an ERROR row,
+  and `list-dynamic` now carries the zone's error/warning state.
 
 ## 11. Verify-before-coding (not blockers — confirm at implementation time)
 
@@ -414,7 +420,14 @@ catalog, the extra resolution call sites, persist-with-keys, and the NOTIFY guar
 - **IXFR:** production refresh hardcodes `"axfr"` (FetchFromUpstream,
   zone_utils.go:234); the loop applies to AXFR. IXFR, when wired, uses the same
   loop via `ZoneTransferIn`.
-- **Sample-config cutover:** like the prior `primary:` struct migration, this is a
-  hard cutover — a bare-string or `primary:`-keyed config entry goes to ERROR; the
-  operator migrates to `primaries:`. Migrate the shipped `*.sample.yaml` in P6 and
-  note the upgrade requirement.
+- **Sample-config cutover (done in P6):** hard cutover — a bare-string or
+  `primary:`-keyed entry goes to ERROR; operators migrate to `primaries:` (a list
+  of `{addr, key}`). The shipped `*.sample.yaml` were migrated, **and their
+  bare-string `notify:` entries too** — those were a leftover from the B0
+  PeerConf migration and would have quarantined the example zones; the same
+  struct form fixes both. `TestSampleZonesConfigDecodes` is a regression guard so
+  the samples can't silently rot out of struct-sync again.
+
+  **Operator upgrade note:** any existing config using `primary: "ip:port"` (or a
+  bare-string `notify:`) must change to the list-of-`{addr, key}` form, e.g.
+  `primaries:\n  - addr: "ip:port"\n    key: NOKEY`.

--- a/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
+++ b/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
@@ -395,9 +395,12 @@ catalog, the extra resolution call sites, persist-with-keys, and the NOTIFY guar
   every primary REFUSED → quiet back-off (no transfer, no error); all unreachable
   → error; no-upstreams → error (both `DoTransfer` and `FetchFromUpstream`). The
   AXFR loop shares the iteration pattern; a full AXFR test server is deferred.
-- **P5:** add a dynamic zone with a hostname primary **carrying a non-NOKEY-shaped
-  key name** → persisted config contains the **hostname AND the key** (not resolved
-  addresses, not forced `NOKEY`); reload re-resolves the hostname.
+- **P5** (`TestZoneDataToZoneConf_PersistsAsWrittenPrimaries`): `zoneDataToZoneConf`
+  on a zone whose as-written primary is a **hostname with a non-NOKEY key** and
+  whose resolved `Upstreams` are addresses → the persisted `Primaries` is the
+  **hostname + key**, NOT the resolved addresses and NOT forced `NOKEY`. Tested at
+  the serialization level (`ProvisionDynamicZone` rejects non-NOKEY keys in
+  Improvement 1); persisting the hostname is what lets reload re-resolve it.
 - **P6:** `list-zones`/`list-dynamic` render the `primaries` list and surface
   `config-warning` text for a partially-resolved zone.
 

--- a/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
+++ b/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
@@ -100,7 +100,7 @@ is left untouched.
 | **Scalar → list** | `primary: PeerConf` → **`primaries: []PeerConf`** everywhere (config, refresher, input, wire). YAML key renamed; **no siblings**. | The actual defect: a primary is a redundant *set*, not one thing. A list makes hostname-expansion trivial. |
 | **Resolution timing** | **At config-parse/load time**, re-resolved on every startup/reload — NOT at transfer time, NOT cached once-and-for-all. | Honours "infra must not depend on resolution at runtime" while picking up address changes over time. A parse-time failure can be quarantined loudly. |
 | **Hostname allowed** | A `primaries:` entry's `addr` may be an IP **or** a hostname (both with `:port`). Hostname → all resolved `addr:port`, **v4 before v6**. | The software offers the freedom; operators choose IPs. v4-first directly fixes the broken-outbound-v6 case (the working family is tried first) and is harmless on healthy dual-stack. |
-| **Resolution source** | `net.LookupHost` (the system stub resolver), matching existing code (childsync_utils.go:457, dsync_lookup.go:407). NOT the in-process IMR. | The operator wrote a name expecting it to resolve the way the box resolves names. Using the IMR would resolve differently from the rest of the OS — a debugging trap. |
+| **Resolution source** (revised 2026-06-28) | **The in-process IMR** — `conf.Internal.ImrEngine.DefaultRRsetFetcher` for A + AAAA — NOT `net.LookupHost`. Because the IMR engine goroutine starts *after* `ParseZones`/`LoadDynamicZoneFiles` in `MainInit`, `MainInit` now calls `conf.InitImrEngine()` synchronously before `ParseZones` (idempotent, first-init-wins; the per-app `StartXxx` reuses the instance and adds trust anchors + listeners). | Primaries must resolve the way **tdns itself** resolves names — through its own recursive resolver, with the root hints / stubs / validation tdns is configured with — not via the OS stub resolver, whose configuration tdns does not control. **This reverses the original `net.LookupHost` decision** (the earlier rationale — "resolve the way the box's OS resolves" — was rejected: the relevant resolver is tdns's, not the OS's). |
 | **Partial resolution** | Some entries resolve, some don't, **≥1 address results → zone is SERVED** + a visibility-only **`ConfigWarning`** naming the unresolved entries. **Zero addresses → `ConfigError`** (service-impacting, zone quarantined). | Get the server running and the zone served. One dead name must not kill a zone with working primaries. The warning makes the degradation visible without degrading service. |
 | **Two ZoneData fields** | `ZoneData.PrimariesConf []PeerConf` (as-written, **persisted**, re-resolved each load) **and** `ZoneData.Upstreams []PeerConf` (resolved `addr:port`, **runtime-only**). | The hostname is the durable thing; addresses are derived and ephemeral. Persisting resolved addresses would freeze them and contradict re-resolution on restart. |
 | **Transfer fallback** | SOA probe and AXFR **iterate `Upstreams`**, advancing to the next on **transport errors only** (no route / conn refused / timeout / network unreachable). A **DNS response** (any rcode, incl. REFUSED/SERVFAIL) is honoured as-is. All-transport-failed → error. | A transport error means "this *address* is unreachable" → try a sibling. A DNS response means "a server answered" → that's not an address problem; trying siblings of the same logical server is pointless or harmful (e.g. it would convert today's quiet REFUSED back-off into a noisy double-failure). |
@@ -125,6 +125,19 @@ is left untouched.
   (5) catalog auto-config (the single scalar, per the catalog row).
   Missing any one leaves hostname primaries broken on that path only. Phase
   ownership is called out in §9.
+
+- **IMR availability at parse time (added 2026-06-28).** Resolution uses the
+  in-process IMR (`conf.Internal.ImrEngine`). In `MainInit` the resolve sites run
+  *before* the per-app `StartXxx` brings up the IMR engine goroutine, so `MainInit`
+  calls `conf.InitImrEngine()` synchronously before `ParseZones`. `InitImrEngine`
+  primes the cache with root hints and is idempotent; the later
+  `StartEngine("ImrEngine", …)` reuses the instance and adds trust anchors +
+  listeners. The early init is gated on `conf.Imr.Active` and is non-fatal: if the
+  IMR is disabled or fails to init, `resolvePrimaries` gets a nil IMR and reports
+  hostname entries as unresolved (literal-IP primaries are unaffected — they are
+  never queried). Consequence to document for operators: **with the IMR disabled,
+  primaries must be IP literals.** Resolution still depends only on init-time
+  IMR availability, not on runtime resolution during transfers (principle 1 holds).
 
 - **NOTIFY-triggered refresh must NOT blank `Upstreams`/`PrimariesConf`.** An inbound
   NOTIFY enqueues a **minimal** `ZoneRefresher` (no primary fields). The refreshengine
@@ -199,8 +212,10 @@ ones are spelled out in the phases):
 - **G. `DynamicZoneInput.Primary`** in the cores: 11 sites — **plus a
   `resolvePrimaries` call in `ProvisionDynamicZone` and `ModifyDynamicZone`** so an
   API-added hostname primary resolves at add time, not only on the next restart.
-- **H. Helpers**: none new needed beyond `resolvePrimaries` — `net.LookupHost`,
-  `net.ParseIP`, `net.JoinHostPort`/`SplitHostPort` all already in use.
+- **H. Helpers**: `resolvePrimaries` + `expandPrimaryEntry` (IMR A/AAAA lookup),
+  `sortV4First`, `buildUpstreams` — built on `imr.DefaultRRsetFetcher`,
+  `net.ParseIP`, `net.JoinHostPort`/`SplitHostPort` (all already in use). Plus
+  the early `conf.InitImrEngine()` in `MainInit` before `ParseZones`.
 - **I. `ErrorType` enum**: 4 edits to add `ConfigWarning` (const,
   `ErrorTypeToString`, `errorTypeReportOrder`; **NOT** `serviceImpactingErrors`).
 - **J. Catalog** (`catalog.go:382`, the auto-config `&ZoneData{Upstream: …}` and the
@@ -258,15 +273,18 @@ loop iterates `zd.Upstreams`; persistence writes `zd.PrimariesConf`.
 ```go
 // resolvePrimaries expands each as-written entry into one-or-more addr:port
 // tuples, copying the per-entry key to each. A literal IP passes through
-// unchanged (no lookup). Returns the resolved list plus the list of entries
-// that produced NO address (for the ConfigWarning / ConfigError decision).
-func resolvePrimaries(primaries []PeerConf) (resolved []PeerConf, unresolved []string)
+// unchanged (no lookup). Hostnames resolve via the in-process IMR (A then
+// AAAA). Returns Resolved plus Unresolved (entries that produced NO address)
+// plus KeyCollisions (for the ConfigWarning / ConfigError decision).
+func resolvePrimaries(ctx context.Context, imr *Imr, primaries []PeerConf) PrimaryResolveResult
 ```
 
 - Split `host:port` (default `:53`). If `net.ParseIP(host) != nil` → emit
-  `{host:port, key}` unchanged.
-- Else `net.LookupHost(host)`; emit `{addr:port, key}` per result, **v4 first**.
-  An entry that resolves to nothing (or errors) is appended to `unresolved`.
+  `{host:port, key}` unchanged (literal IP, never queried).
+- Else resolve through the IMR: `imr.DefaultRRsetFetcher(ctx, fqdn, A)` and
+  `… AAAA`, collect the addresses **v4 first**, emit `{addr:port, key}` per
+  result. A name that resolves to nothing (lookup error, empty, or no IMR
+  available) is appended to `Unresolved`. A 10s per-entry timeout bounds startup.
 - **Dedup** the resolved tuples on `addr:port`, keeping the first occurrence (so
   v4-first ordering and the first-seen key survive). If a later duplicate carries a
   **different key** than the kept one, drop it and record it for a `ConfigWarning`

--- a/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
+++ b/docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md
@@ -103,7 +103,7 @@ is left untouched.
 | **Resolution source** (revised 2026-06-28) | **The in-process IMR** — `conf.Internal.ImrEngine.DefaultRRsetFetcher` for A + AAAA — NOT `net.LookupHost`. Because the IMR engine goroutine starts *after* `ParseZones`/`LoadDynamicZoneFiles` in `MainInit`, `MainInit` now calls `conf.InitImrEngine()` synchronously before `ParseZones` (idempotent, first-init-wins; the per-app `StartXxx` reuses the instance and adds trust anchors + listeners). | Primaries must resolve the way **tdns itself** resolves names — through its own recursive resolver, with the root hints / stubs / validation tdns is configured with — not via the OS stub resolver, whose configuration tdns does not control. **This reverses the original `net.LookupHost` decision** (the earlier rationale — "resolve the way the box's OS resolves" — was rejected: the relevant resolver is tdns's, not the OS's). |
 | **Partial resolution** | Some entries resolve, some don't, **≥1 address results → zone is SERVED** + a visibility-only **`ConfigWarning`** naming the unresolved entries. **Zero addresses → `ConfigError`** (service-impacting, zone quarantined). | Get the server running and the zone served. One dead name must not kill a zone with working primaries. The warning makes the degradation visible without degrading service. |
 | **Two ZoneData fields** | `ZoneData.PrimariesConf []PeerConf` (as-written, **persisted**, re-resolved each load) **and** `ZoneData.Upstreams []PeerConf` (resolved `addr:port`, **runtime-only**). | The hostname is the durable thing; addresses are derived and ephemeral. Persisting resolved addresses would freeze them and contradict re-resolution on restart. |
-| **Transfer fallback** | SOA probe and AXFR **iterate `Upstreams`**, advancing to the next on **transport errors only** (no route / conn refused / timeout / network unreachable). A **DNS response** (any rcode, incl. REFUSED/SERVFAIL) is honoured as-is. All-transport-failed → error. | A transport error means "this *address* is unreachable" → try a sibling. A DNS response means "a server answered" → that's not an address problem; trying siblings of the same logical server is pointless or harmful (e.g. it would convert today's quiet REFUSED back-off into a noisy double-failure). |
+| **Transfer fallback** (revised 2026-06-28) | Both paths **iterate `Upstreams`** until one yields what's needed. **AXFR**: advance on ANY failure — transport error, a REFUSED/NOTAUTH/SERVFAIL xfr rcode, or bad zone data; stop on the first success; all-failed → error. **SOA probe**: advance on a transport error OR a non-usable rcode (REFUSED/SERVFAIL/NXDOMAIN/empty); stop on a usable NOERROR+SOA; if every primary answered but none was usable → quiet back-off (no transfer, no error); all-unreachable → hard error. | Multiple **primaries** are independent servers, not addresses of one server: `allow-transfer` ACLs routinely differ per primary, so a REFUSED from one says nothing about a sibling. Terminating on REFUSED would defeat the very redundancy multi-primary exists to provide. **Reverses the earlier "retry on transport errors only, honour any DNS response" decision** — which wrongly conflated multiple distinct primaries with multiple addresses of one server, and so dropped the `isTransportError` distinction entirely. |
 | **Loop location** | The fallback loop lives in the **callers** (`DoTransfer`, `FetchFromUpstream`); `ZoneTransferIn` keeps its single-`upstream string` signature. | Smaller change; `clarifyXfrError` and the envelope-read loop stay intact. |
 | **Scope** | The transfer-path fix (the resolved-list loop) benefits EVERY secondary — static config, catalog, **and** API-added — because they all reach `DoTransfer`/`FetchFromUpstream` via `zd.Upstreams`. **Multi-*primary*** (a list the operator writes) is added for **static + API** zones; **catalog members get multi-*address* only** (see catalog row). | The latent bug was never dynamic-zones-specific; the interface just made it easy to trip. Fix it where it actually lives. |
 | **Catalog scope (minimal — decided 2026-06-26)** | `ConfigGroupConfig.Upstream` stays a **single scalar `string`** (no config-group schema change, no catalog-YAML cutover). At catalog auto-config (`catalog.go:382`) that scalar is run through **`resolvePrimaries`** to populate `zd.Upstreams`, **and `zd.PrimariesConf` is set to `[{scalarUpstream, NOKEY}]`** (the as-written form, so the catalog member persists + re-resolves like any dynamic zone). Note: catalog does not map `tsig_key` into that key today — it is `NOKEY` until TSIG lands. | Catalog members are edge secondaries that pull from *one* provider primary — per-member multi-primary lists are a redundancy model nobody deploys (same over-engineering rejected for the catalog notify-API in Improvement 1). But the **reported bug** (hostname → one address, no fallback) absolutely hits catalog members, so they need the multi-*address* expansion. This delivers the fix where it's needed without the part that's overkill. |
@@ -296,32 +296,50 @@ func resolvePrimaries(ctx context.Context, imr *Imr, primaries []PeerConf) Prima
   paths (§3.1): `ParseZones`, `LoadDynamicZoneFiles`, `ProvisionDynamicZone`,
   `ModifyDynamicZone`, and catalog auto-config (on the catalog scalar).
 
-## 7. Transfer fallback (the behaviour fix)
+## 7. Transfer fallback (the behaviour fix) — revised 2026-06-28
 
-Both `DoTransfer` (SOA) and `FetchFromUpstream` (AXFR) loop over `zd.Upstreams`:
+Both `DoTransfer` (SOA) and `FetchFromUpstream` (AXFR) loop over `zd.Upstreams`,
+but the **stop condition differs** because multiple primaries are independent
+servers (per-primary ACLs differ), so a refusal from one is not a refusal from
+all. There is **no `isTransportError` distinction** — that idea was dropped (it
+wrongly treated a REFUSED as "honour, don't retry," which defeats redundancy).
+
+**AXFR** (`FetchFromUpstream`) — retry on *any* failure:
 
 ```
 for _, up := range zd.Upstreams:
-    r/err = attempt(up)            // dns.Exchange (SOA) or ZoneTransferIn (AXFR)
-    if isTransportError(err):      // no route / refused / timeout / net unreachable
-        record err; continue       // try the next address
-    return <result>                // any DNS response (incl. REFUSED) — honour it
-return all-transport-failed-error  // only when every address had a transport error
+    new_zd = fresh ZoneData                 // per-attempt, so a failed try can't pollute
+    err = new_zd.ZoneTransferIn(up.Addr, …) // transport err, REFUSED/NOTAUTH rcode, or bad data
+    if err != nil: record err; continue     // a sibling may still serve us
+    success; break
+if !transferred: return all-failed-error    // every primary failed
 ```
 
-- **SOA probe** classification is clean: `dns.Exchange` returns `err != nil` for
-  transport failures and `(*dns.Msg, nil)` for any DNS response. So `err != nil` →
-  try next; `err == nil` → honour the rcode via the existing `switch` (REFUSED /
-  SERVFAIL / NXDOMAIN keep today's "never mind, not ready" semantics).
-- **AXFR** transport failure can surface at `transfer.In` itself or as an
-  `envelope.Error` mid-stream; treat a connection-level error from either as
-  "try next." `zd.Data` is reset at the start of each attempt (it already is, at
-  dnsutils.go:68-71) so a partial failed transfer does not pollute the next try.
-- `isTransportError` matches `net.Error`/`*net.OpError` / `syscall` connection
-  errors (`ECONNREFUSED`, `EHOSTUNREACH`, `ENETUNREACH`, timeout). Confirm the
-  exact set against the vendored dialer at implementation time (§11).
-- `clarifyXfrError` should name the **address that failed** (per-attempt), not a
-  single configured upstream.
+**SOA probe** (`DoTransfer`) — advance until a *usable* SOA:
+
+```
+sawResponse = false
+for _, up := range zd.Upstreams:
+    r, err = dns.Exchange(SOA, up.Addr)
+    if err != nil: record err; continue            // transport: try next
+    sawResponse = true
+    if NOERROR && answer[0] is SOA: return decision(serial)   // usable → stop
+    else: continue                                 // REFUSED/SERVFAIL/NXDOMAIN/empty → try next
+if sawResponse: return false, 0, nil               // all answered, none usable → quiet back-off
+return all-unreachable-error                        // nobody answered
+```
+
+- `dns.Exchange` returns `err != nil` only for transport failures; any DNS
+  response (incl. REFUSED) is `(*dns.Msg, nil)`. So `err != nil` → next address;
+  a response is inspected for a usable SOA, else we move on.
+- AXFR transport failure can surface at `transfer.In` or as an `envelope.Error`
+  mid-stream; both come back as the `ZoneTransferIn` error, so both retry.
+  `zd.Data` is reset at the start of each `ZoneTransferIn` (dnsutils.go:68-71) and
+  `new_zd` is rebuilt per attempt, so a partial/failed transfer cannot pollute the
+  next try **or** the live zone — `zd.IncomingSerial` is only updated in the hard
+  flip, after a success.
+- `clarifyXfrError` already names the **address that failed** (per-attempt) — it
+  is passed the current `up.Addr` each iteration.
 
 ## 8. `ConfigWarning` error type
 
@@ -347,7 +365,7 @@ model).
 | **P1** | `ConfigWarning` enum (4 edits) + `resolvePrimaries` helper (incl. dedup) + unit test | ~80 | Low | Low | **Low** |
 | **P2** | Struct migration `Primary`→`Primaries`/`PrimariesConf`/`Upstreams`; delete dead `RefreshCounter` fields; all mechanical rename sites (A/C/F/G non-transfer) | ~120 | Low | Low | **Low** (compiler-guided; tree won't build until complete) |
 | **P3** | Resolution on **all five ingress paths**: parseconfig secondary-zone block (per-element Legacy/empty/key loops + resolve + ConfigWarning/ConfigError), `LoadDynamicZoneFiles`, **`ProvisionDynamicZone` + `ModifyDynamicZone`**, **catalog auto-config scalar (J)**; **`ZoneRefresher` carries both `PrimariesConf` (as-written) + `Primaries` (resolved); refreshengine merge sets `zd.PrimariesConf` + `zd.Upstreams` when `len(zr.PrimariesConf) > 0`, preserves both when empty (NOTIFY)** | ~130 | Med | Med | **Med** — resolution logic + partial-fail semantics + the both-fields merge/NOTIFY-preservation guard |
-| **P4** | Transfer fallback loops in `DoTransfer` + `FetchFromUpstream`; transport-vs-DNS classification; per-attempt error messages (`clarifyXfrError` names the failed address); list-rendering logs; confirm a failed attempt does not corrupt `IncomingSerial` | ~80 | Med | Med | **Med** — the actual bug fix; transport-error classification is the fiddly part |
+| **P4** | Transfer fallback loops in `DoTransfer` + `FetchFromUpstream`: AXFR retries on ANY failure (incl. REFUSED — per-primary ACLs differ); SOA advances until a usable answer; per-attempt error messages (`clarifyXfrError` names the failed address); fresh `new_zd` per attempt keeps a failed try from corrupting `IncomingSerial` | ~90 | Med | Med | **Med** — the actual bug fix; the stop-condition (which failures retry vs honour) is the subtle part |
 | **P5** | Persistence: `zoneDataToZoneConf` writes **`PrimariesConf` with per-entry keys** (as-written, NOT resolved, NOT hardcoded `NOKEY`); round-trip test asserts hostname + key survive and re-resolve on reload | ~35 | Low | Med | **Low–Med** — must persist as-written *with keys* |
 | **P6** | API/CLI: `--primaries` comma-list (one key for all), `RunZoneAdd/Modify` build `[]PeerConf`, **list-zones / list-dynamic render the as-written `PrimariesConf` list (the hostnames the operator wrote, not resolved addresses) + surface `config-warning`**; migrate `*.sample.yaml` `primary:`→`primaries:` | ~80 | Low | Low | **Low** |
 
@@ -370,11 +388,13 @@ catalog, the extra resolution call sites, persist-with-keys, and the NOTIFY guar
   resolves at add time** (not only on the next restart). **A NOTIFY-triggered refresh
   (minimal `ZoneRefresher`, no primaries) does NOT blank `zd.Upstreams`.** **A
   catalog member with a hostname upstream expands to multiple addresses.**
-- **P4:** transfer fallback — first `Upstreams` address gives a transport error,
-  second succeeds → transfer succeeds (use a closed port + a working test server, or
-  two addresses one of which refuses). A DNS REFUSED from the first address is
-  honoured (not retried against the second). A failed first attempt does not corrupt
-  `IncomingSerial`.
+- **P4:** transfer fallback (`transfer_fallback_test.go`, SOA path with a real
+  UDP test server) — first address gives a transport error (closed port), second
+  succeeds → probe succeeds; **a REFUSED from the first primary advances to the
+  second** (the bug fix: per-primary ACLs differ, so REFUSED must not terminate);
+  every primary REFUSED → quiet back-off (no transfer, no error); all unreachable
+  → error; no-upstreams → error (both `DoTransfer` and `FetchFromUpstream`). The
+  AXFR loop shares the iteration pattern; a full AXFR test server is deferred.
 - **P5:** add a dynamic zone with a hostname primary **carrying a non-NOKEY-shaped
   key name** → persisted config contains the **hostname AND the key** (not resolved
   addresses, not forced `NOKEY`); reload re-resolves the hostname.
@@ -383,10 +403,11 @@ catalog, the extra resolution call sites, persist-with-keys, and the NOTIFY guar
 
 ## 11. Verify-before-coding (not blockers — confirm at implementation time)
 
-- **`isTransportError` classification:** confirm the exact error set the vendored
-  `johanix/dns` dialer surfaces for `dns.Exchange` and `transfer.In` (net.Error
-  timeout, `*net.OpError` with `ECONNREFUSED`/`EHOSTUNREACH`/`ENETUNREACH`). The
-  loop's correctness hinges on classifying these vs DNS-level errors.
+- **Stop condition (resolved 2026-06-28):** AXFR retries on *every* failure, so
+  no transport-vs-DNS error classification is needed. The SOA probe only needs
+  `dns.Exchange`'s clean split (`err != nil` ⟺ transport failure; any DNS response
+  is `(*dns.Msg, nil)`), which holds for the vendored dialer. The earlier
+  `isTransportError` helper was dropped.
 - **IXFR:** production refresh hardcodes `"axfr"` (FetchFromUpstream,
   zone_utils.go:234); the loop applies to AXFR. IXFR, when wired, uses the same
   loop via `ZoneTransferIn`.

--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -165,10 +165,10 @@ type ZonePost struct {
 	Wait       bool
 	Timeout    string
 	// Dynamic-zones management (add/modify). No Store field — dynamic zones are
-	// map-only. Primary carries the structured {addr, key}; key must be NOKEY
+	// map-only. Primaries carries the structured {addr, key} list; key must be NOKEY
 	// until TSIG keys land (Improvement 2). Options are ZoneOption strings.
-	Primary PeerConf
-	Options []string
+	Primaries []PeerConf
+	Options   []string
 	// TSIG secret-bearing fields are accepted now but inert in Improvement 1:
 	// a non-NOKEY key is rejected by ProvisionDynamicZone, so these are
 	// carried-on-the-wire-for-later, not silently dropped. Consumed in

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -303,6 +303,12 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 				if zd, ok := Zones.Get(zc.Name); ok {
 					zc.Provisioning = zoneProvisioning(zd)
 					zc.ApiManaged = zd.Options[OptApiManagedZone]
+					// Surface the zone's error/warning state (e.g. ConfigWarning
+					// for a partially-resolved primary set) — zoneDataToZoneConf
+					// deliberately omits runtime error fields.
+					zc.Error = zd.Error
+					zc.ErrorType = zd.ErrorType
+					zc.ErrorMsg = zd.ErrorMsg
 				}
 				zones[zc.Name] = zc
 			}

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -195,12 +195,8 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 					}
 				}
 
-				// For secondary zones, Primary should be the Upstream address, not Parent
-				primary := ""
-				if zd.ZoneType == Secondary {
-					primary = zd.Upstream
-				}
-				// For primary zones, we could show Parent if needed, but typically Primary field is for secondary zones
+				// For secondary zones, list as-written primaries from runtime state.
+				primaries := clonePeerConfs(zd.PrimariesConf)
 
 				// Snapshot the notify slice under the lock — the catalog notify
 				// add/remove handlers mutate zd.Notify under zd.mu, so an
@@ -247,7 +243,7 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 					ApiManaged:             zd.Options[OptApiManagedZone],
 					Provisioning:           zoneProvisioning(zd),
 					Zonefile:               zd.Zonefile,
-					Primary:                PeerConf{Addr: primary, Key: NOKEY},
+					Primaries:              primaries,
 					Notify:                 notifySnapshot, // Notify addresses (displayed by CLI)
 					EffectiveDnssecPolicy:  zd.DnssecPolicyName,
 					DnssecPolicyOverridden: overridden,
@@ -259,10 +255,10 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 
 		case "add":
 			msg, err := Conf.ProvisionDynamicZone(r.Context(), DynamicZoneInput{
-				Name:    zp.Zone,
-				Type:    Secondary,
-				Primary: zp.Primary,
-				Options: zoneOptionsFromStrings(zp.Options),
+				Name:      zp.Zone,
+				Type:      Secondary,
+				Primaries: zp.Primaries,
+				Options:   zoneOptionsFromStrings(zp.Options),
 			}, true)
 			if err != nil {
 				resp.Error = true
@@ -284,10 +280,10 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 
 		case "modify":
 			msg, err := Conf.ModifyDynamicZone(r.Context(), DynamicZoneInput{
-				Name:    zp.Zone,
-				Type:    Secondary,
-				Primary: zp.Primary,
-				Options: zoneOptionsFromStrings(zp.Options),
+				Name:      zp.Zone,
+				Type:      Secondary,
+				Primaries: zp.Primaries,
+				Options:   zoneOptionsFromStrings(zp.Options),
 			})
 			if err != nil {
 				resp.Error = true

--- a/v2/cache/rrset_cache.go
+++ b/v2/cache/rrset_cache.go
@@ -662,7 +662,7 @@ func (rrcache *RRsetCacheT) IsPrimed() bool {
 	return rrcache.Primed
 }
 
-func (rrcache *RRsetCacheT) PrimeWithHints(hintsfile string, fetcher RRsetFetcher) error {
+func (rrcache *RRsetCacheT) PrimeWithHints(ctx context.Context, hintsfile string, fetcher RRsetFetcher) error {
 	var data []byte
 	var err error
 	var source string
@@ -818,7 +818,7 @@ func (rrcache *RRsetCacheT) PrimeWithHints(hintsfile string, fetcher RRsetFetche
 	rrcache.ServerMap.Set(".", authMap)
 	rrcache.Servers.Set(".", servers)
 
-	rrset, err := fetcher(context.Background(), ".", dns.TypeNS, authMap) // force re-query bypassing cache
+	rrset, err := fetcher(ctx, ".", dns.TypeNS, authMap) // force re-query bypassing cache (cancellable via ctx)
 	if err != nil {
 		return fmt.Errorf("Error priming RRsetCache with root hints: %v", err)
 	}

--- a/v2/catalog.go
+++ b/v2/catalog.go
@@ -376,7 +376,13 @@ func AutoConfigureZonesFromCatalog(ctx context.Context, update *CatalogZoneUpdat
 		lg.Info("CATALOG: auto-configuring zone", "zone", zoneName, "group", member.MetaGroup, "upstream", configGroupConfig.Upstream, "store", "map")
 
 		primariesConf := []PeerConf{{Addr: configGroupConfig.Upstream, Key: NOKEY}}
-		upstreams := normalizePrimaries(primariesConf)
+		res := resolvePrimaries(ctx, conf.Internal.ImrEngine, primariesConf)
+		if len(res.Resolved) == 0 {
+			lg.Error("CATALOG: upstream did not resolve to an address, skipping zone", "zone", zoneName, "group", member.MetaGroup, "upstream", configGroupConfig.Upstream, "unresolved", res.Unresolved)
+			skippedCount++
+			continue
+		}
+		upstreams := res.Resolved
 
 		zd := &ZoneData{
 			ZoneName:      zoneName,

--- a/v2/catalog.go
+++ b/v2/catalog.go
@@ -375,11 +375,15 @@ func AutoConfigureZonesFromCatalog(ctx context.Context, update *CatalogZoneUpdat
 		// RULE 4: Auto-configure zone using config group
 		lg.Info("CATALOG: auto-configuring zone", "zone", zoneName, "group", member.MetaGroup, "upstream", configGroupConfig.Upstream, "store", "map")
 
+		primariesConf := []PeerConf{{Addr: configGroupConfig.Upstream, Key: NOKEY}}
+		upstreams := normalizePrimaries(primariesConf)
+
 		zd := &ZoneData{
 			ZoneName:      zoneName,
 			ZoneType:      Secondary,
 			ZoneStore:     MapZone, // dynamic zones are map-only (§3)
-			Upstream:      NormalizeAddress(configGroupConfig.Upstream),
+			PrimariesConf: primariesConf,
+			Upstreams:     upstreams,
 			Logger:        log.Default(),
 			SourceCatalog: update.CatalogZone,
 			Options: map[ZoneOption]bool{
@@ -425,7 +429,6 @@ func AutoConfigureZonesFromCatalog(ctx context.Context, update *CatalogZoneUpdat
 		zr := ZoneRefresher{
 			Name:      zoneName,
 			ZoneType:  Secondary,
-			Primary:   PeerConf{Addr: NormalizeAddress(configGroupConfig.Upstream), Key: NOKEY},
 			ZoneStore: zd.ZoneStore,
 			Options:   zd.Options,
 		}

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -157,25 +157,25 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 	// Dynamic-zones management (add/delete/modify/list-dynamic). No --store
 	// flag: dynamic zones are map-only. The --tsig-* flags are accepted now but
 	// inert in Improvement 1 (a non-NOKEY key is rejected server-side).
-	var dzPrimaryAddr, dzPrimaryKey, dzTsigName, dzTsigSecret, dzTsigAlgo string
-	var dzOptions []string
+	var dzPrimaryKey, dzTsigName, dzTsigSecret, dzTsigAlgo string
+	var dzPrimaries, dzOptions []string
 
 	add := &cobra.Command{
 		Use:   "add",
 		Short: "Add a dynamic secondary zone at runtime (persists across restart)",
 		Run: func(cmd *cobra.Command, args []string) {
-			RunZoneAdd(role, dzPrimaryAddr, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigAlgo)
+			RunZoneAdd(role, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigAlgo)
 		},
 	}
 	add.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to add")
-	add.Flags().StringVar(&dzPrimaryAddr, "primary-addr", "", "Primary (upstream) address [host:port]")
-	add.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "Primary TSIG key name (NOKEY for none)")
+	add.Flags().StringSliceVar(&dzPrimaries, "primaries", nil, "Primary (upstream) addresses [host:port], comma-separated")
+	add.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "Primary TSIG key name applied to all primaries (NOKEY for none)")
 	add.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated)")
 	add.Flags().StringVar(&dzTsigName, "tsig-name", "", "TSIG key name (inert until TSIG support lands)")
 	add.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "TSIG secret (inert until TSIG support lands)")
 	add.Flags().StringVar(&dzTsigAlgo, "tsig-algo", "", "TSIG algorithm (inert until TSIG support lands)")
 	add.MarkFlagRequired("zone")
-	add.MarkFlagRequired("primary-addr")
+	add.MarkFlagRequired("primaries")
 
 	del := &cobra.Command{
 		Use:   "delete",
@@ -191,12 +191,12 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 		Use:   "modify",
 		Short: "Modify a dynamic (API-managed) zone's primary or options",
 		Run: func(cmd *cobra.Command, args []string) {
-			RunZoneModify(role, dzPrimaryAddr, dzPrimaryKey, dzOptions)
+			RunZoneModify(role, dzPrimaries, dzPrimaryKey, dzOptions)
 		},
 	}
 	modify.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to modify")
-	modify.Flags().StringVar(&dzPrimaryAddr, "primary-addr", "", "New primary (upstream) address [host:port]")
-	modify.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "New primary TSIG key name (NOKEY for none)")
+	modify.Flags().StringSliceVar(&dzPrimaries, "primaries", nil, "New primary (upstream) addresses [host:port], comma-separated")
+	modify.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "New primary TSIG key name applied to all primaries (NOKEY for none)")
 	modify.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated)")
 	modify.MarkFlagRequired("zone")
 
@@ -423,7 +423,22 @@ func RunZoneBump(parent string, args []string) {
 	}
 }
 
-func RunZoneAdd(role, primaryAddr, primaryKey string, options []string, tsigName, tsigSecret, tsigAlgo string) {
+// peerConfsFromAddrs builds a []PeerConf from comma-listed addresses, applying
+// the single CLI key to each. Per-primary keys remain expressible via the
+// structured YAML/API paths.
+func peerConfsFromAddrs(addrs []string, key string) []tdns.PeerConf {
+	out := make([]tdns.PeerConf, 0, len(addrs))
+	for _, a := range addrs {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		out = append(out, tdns.PeerConf{Addr: a, Key: key})
+	}
+	return out
+}
+
+func RunZoneAdd(role string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigAlgo string) {
 	if tdns.Globals.Zonename == "" {
 		fmt.Println("Error: zone name not specified")
 		os.Exit(1)
@@ -435,7 +450,7 @@ func RunZoneAdd(role, primaryAddr, primaryKey string, options []string, tsigName
 	cr, err := SendZoneCommand(api, tdns.ZonePost{
 		Command:    "add",
 		Zone:       dns.Fqdn(tdns.Globals.Zonename),
-		Primaries:  []tdns.PeerConf{{Addr: primaryAddr, Key: primaryKey}},
+		Primaries:  peerConfsFromAddrs(primaries, primaryKey),
 		Options:    options,
 		TsigName:   tsigName,
 		TsigSecret: tsigSecret,
@@ -472,7 +487,7 @@ func RunZoneDelete(role string) {
 	}
 }
 
-func RunZoneModify(role, primaryAddr, primaryKey string, options []string) {
+func RunZoneModify(role string, primaries []string, primaryKey string, options []string) {
 	if tdns.Globals.Zonename == "" {
 		fmt.Println("Error: zone name not specified")
 		os.Exit(1)
@@ -486,8 +501,8 @@ func RunZoneModify(role, primaryAddr, primaryKey string, options []string) {
 		Zone:    dns.Fqdn(tdns.Globals.Zonename),
 		Options: options,
 	}
-	if primaryAddr != "" {
-		post.Primaries = []tdns.PeerConf{{Addr: primaryAddr, Key: primaryKey}}
+	if peers := peerConfsFromAddrs(primaries, primaryKey); len(peers) > 0 {
+		post.Primaries = peers
 	}
 	cr, err := SendZoneCommand(api, post)
 	if err != nil {
@@ -579,7 +594,11 @@ func ListZones(cr tdns.ZoneResponse) {
 	}
 	zoneLines := []string{}
 	for zname, zconf := range cr.Zones {
-		if zconf.Error {
+		// Service-impacting errors collapse to a single ERROR row. A
+		// non-service-impacting error (e.g. ConfigWarning: serving from a subset
+		// of primaries) leaves the zone serving, so render it normally and
+		// annotate it below rather than masquerading as an ERROR.
+		if zconf.Error && tdns.ErrorTypeIsServiceImpacting(zconf.ErrorType) {
 			line := fmt.Sprintf("%s|%s||||Error[%s]: %s", zname, "ERROR", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
 			zoneLines = append(zoneLines, line)
 			continue
@@ -600,6 +619,9 @@ func ListZones(cr tdns.ZoneResponse) {
 			line += fmt.Sprintf("%s|", zconf.Zonefile)
 		}
 		line += fmt.Sprintf("%t|%t|%v", zconf.Frozen, zconf.Dirty, opts)
+		if zconf.Error { // non-service-impacting => a warning; the zone still serves
+			line += fmt.Sprintf(" [%s: %s]", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
+		}
 		zoneLines = append(zoneLines, line)
 	}
 	sort.Slice(zoneLines, func(i, j int) bool {

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -647,7 +647,14 @@ func VerboseListZone(cr tdns.ZoneResponse) {
 	for zname, zconf := range cr.Zones {
 		line := fmt.Sprintf("zone: %s\n", zname)
 		if zconf.Error {
-			line += fmt.Sprintf("\tState: ERROR ErrorType: %s ErrorMsg: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
+			// A service-impacting error is ERROR; a non-service-impacting
+			// warning (e.g. ConfigWarning) leaves the zone serving — render it
+			// as such, matching ListZones rather than masquerading as ERROR.
+			if tdns.ErrorTypeIsServiceImpacting(zconf.ErrorType) {
+				line += fmt.Sprintf("\tState: ERROR ErrorType: %s ErrorMsg: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
+			} else {
+				line += fmt.Sprintf("\tState: serving Warning[%s]: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
+			}
 		}
 		opts := []string{}
 		for _, opt := range zconf.Options {

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -435,7 +435,7 @@ func RunZoneAdd(role, primaryAddr, primaryKey string, options []string, tsigName
 	cr, err := SendZoneCommand(api, tdns.ZonePost{
 		Command:    "add",
 		Zone:       dns.Fqdn(tdns.Globals.Zonename),
-		Primary:    tdns.PeerConf{Addr: primaryAddr, Key: primaryKey},
+		Primaries:  []tdns.PeerConf{{Addr: primaryAddr, Key: primaryKey}},
 		Options:    options,
 		TsigName:   tsigName,
 		TsigSecret: tsigSecret,
@@ -481,12 +481,15 @@ func RunZoneModify(role, primaryAddr, primaryKey string, options []string) {
 	if err != nil {
 		log.Fatalf("Error getting API client for %s: %v", role, err)
 	}
-	cr, err := SendZoneCommand(api, tdns.ZonePost{
+	post := tdns.ZonePost{
 		Command: "modify",
 		Zone:    dns.Fqdn(tdns.Globals.Zonename),
-		Primary: tdns.PeerConf{Addr: primaryAddr, Key: primaryKey},
 		Options: options,
-	})
+	}
+	if primaryAddr != "" {
+		post.Primaries = []tdns.PeerConf{{Addr: primaryAddr, Key: primaryKey}}
+	}
+	cr, err := SendZoneCommand(api, post)
 	if err != nil {
 		fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
 		os.Exit(1)
@@ -527,7 +530,7 @@ func RunZoneListDynamic(role string) {
 			errStr = zc.ErrorMsg
 		}
 		out = append(out, fmt.Sprintf("%s|%s|%s|%s|%s|%s",
-			name, zc.Type, zc.Provisioning, managed, zc.Primary.Addr, errStr))
+			name, zc.Type, zc.Provisioning, managed, peerConfAddrsString(zc.Primaries), errStr))
 	}
 	fmt.Println(columnize.SimpleFormat(out))
 }
@@ -588,7 +591,7 @@ func ListZones(cr tdns.ZoneResponse) {
 		sort.Strings(opts)
 		line := fmt.Sprintf("%s|%s|%s|", zname, zconf.Type, zconf.Store)
 		if showprimary {
-			line += fmt.Sprintf("%s|", zconf.Primary.Addr)
+			line += fmt.Sprintf("%s|", peerConfAddrsString(zconf.Primaries))
 		}
 		if shownotify {
 			line += fmt.Sprintf("%s|", peerConfAddrsString(zconf.Notify))
@@ -643,7 +646,7 @@ func VerboseListZone(cr tdns.ZoneResponse) {
 			line += fmt.Sprintf("\tDNSSEC policy: %s\n", pol)
 		}
 
-		line += fmt.Sprintf("\tPrimary: %s\tNotify: %s\tFile: %s\n", zconf.Primary.Addr, peerConfAddrsString(zconf.Notify), zconf.Zonefile)
+		line += fmt.Sprintf("\tPrimary: %s\tNotify: %s\tFile: %s\n", peerConfAddrsString(zconf.Primaries), peerConfAddrsString(zconf.Notify), zconf.Zonefile)
 
 		// Check for catalog zone flags
 		isCatalogZone := false

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -625,8 +625,7 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 	// Partial resolution: the zone is served from the addresses that resolved,
 	// with a visibility-only ConfigWarning naming the rest.
 	if len(res.Unresolved) > 0 || len(res.KeyCollisions) > 0 {
-		served := len(in.Primaries) - len(res.Unresolved)
-		zd.SetError(ConfigWarning, "serving from %d of %d primaries (unresolved: %v, key-collisions: %v)", served, len(in.Primaries), res.Unresolved, res.KeyCollisions)
+		zd.SetError(ConfigWarning, "serving from %d resolved upstream(s) of %d configured primaries (unresolved: %v, key-collisions: %v)", len(res.Resolved), len(in.Primaries), res.Unresolved, res.KeyCollisions)
 	}
 
 	// Enqueue the initial transfer — fire-and-forget (no Wait, no Response). If
@@ -746,7 +745,14 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	// (2) Build a fresh ZoneData carrying the changed params; (3) replace.
 	options := in.Options
 	if options == nil {
-		options = oldZd.Options
+		// Carry the old options forward into a FRESH map — newZd must not share a
+		// mutable map with oldZd, or the B5 replace-not-mutate strategy breaks
+		// (an in-flight refresh on oldZd and later updates on newZd would race on
+		// one map guarded by two different mutexes).
+		options = make(map[ZoneOption]bool, len(oldZd.Options))
+		for k, v := range oldZd.Options {
+			options[k] = v
+		}
 	} else {
 		options[OptApiManagedZone] = true
 	}
@@ -774,8 +780,7 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	// Partial resolution of the new primaries: served from what resolved, with
 	// a visibility-only ConfigWarning naming the rest.
 	if len(modRes.Unresolved) > 0 || len(modRes.KeyCollisions) > 0 {
-		served := len(in.Primaries) - len(modRes.Unresolved)
-		newZd.SetError(ConfigWarning, "serving from %d of %d primaries (unresolved: %v, key-collisions: %v)", served, len(in.Primaries), modRes.Unresolved, modRes.KeyCollisions)
+		newZd.SetError(ConfigWarning, "serving from %d resolved upstream(s) of %d configured primaries (unresolved: %v, key-collisions: %v)", len(modRes.Resolved), len(in.Primaries), modRes.Unresolved, modRes.KeyCollisions)
 	}
 	// (5) Force a re-pull from the new upstream.
 	zr := ZoneRefresher{

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -238,15 +238,17 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 		}
 
 		// Create ZoneRefresher and enqueue to RefreshEngine (same as ParseZones does)
+		primariesConf, resolved := refresherPrimariesFromConf(zconf.Primaries)
 		zr := ZoneRefresher{
-			Name:      zoneName,
-			Force:     true, // Force refresh on startup to load from disk
-			ZoneType:  zoneType,
-			Primary:   zconf.Primary,
-			ZoneStore: zoneStore,
-			Notify:    zconf.Notify,
-			Zonefile:  zconf.Zonefile,
-			Options:   options,
+			Name:          zoneName,
+			Force:         true, // Force refresh on startup to load from disk
+			ZoneType:      zoneType,
+			PrimariesConf: primariesConf,
+			Primaries:     resolved,
+			ZoneStore:     zoneStore,
+			Notify:        zconf.Notify,
+			Zonefile:      zconf.Zonefile,
+			Options:       options,
 		}
 
 		// Attempt non-blocking send (same pattern as ParseZones)
@@ -314,19 +316,12 @@ func zoneDataToZoneConf(zd *ZoneData, zoneDirectory string) ZoneConf {
 		typeStr = "secondary" // Default
 	}
 
-	// Get primary/upstream
-	primary := zd.Upstream
-	if primary == "" && zd.ZoneType == Secondary {
-		// Try to get from parent or other sources if available
-		primary = zd.Parent
-	}
-
 	zconf := ZoneConf{
 		Name:          zd.ZoneName,
 		Zonefile:      zoneFilePath,
 		Type:          typeStr,
 		Store:         storeStr,
-		Primary:       PeerConf{Addr: primary, Key: NOKEY},
+		Primaries:     clonePeerConfs(zd.PrimariesConf),
 		Notify:        zd.Notify,
 		OptionsStrs:   optionsStrs,
 		SourceCatalog: zd.SourceCatalog,
@@ -529,10 +524,10 @@ func (conf *Config) CheckDynamicConfigFileIncluded(includedFiles []string) bool 
 // DynamicZoneInput carries the parameters for the shared add/modify cores. There
 // is no Store field: dynamic zones are always MapZone (enforced in the cores).
 type DynamicZoneInput struct {
-	Name    string
-	Type    ZoneType
-	Primary PeerConf
-	Options map[ZoneOption]bool
+	Name      string
+	Type      ZoneType
+	Primaries []PeerConf
+	Options   map[ZoneOption]bool
 }
 
 // ProvisionDynamicZone is the shared *add* core, called by both the catalog
@@ -567,11 +562,13 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 	// resolvable key name (any other is an unknown-key error until the keys:
 	// block lands).
 	if in.Type == Secondary {
-		if in.Primary.Addr == "" {
+		if len(in.Primaries) == 0 || in.Primaries[0].Addr == "" {
 			return "", fmt.Errorf("secondary zone %s requires a primary address", name)
 		}
-		if in.Primary.Key != NOKEY {
-			return "", fmt.Errorf("unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", in.Primary.Key)
+		for _, p := range in.Primaries {
+			if p.Key != NOKEY {
+				return "", fmt.Errorf("unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", p.Key)
+			}
 		}
 	}
 
@@ -583,18 +580,22 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 		options[OptApiManagedZone] = true
 	}
 
+	primariesConf := clonePeerConfs(in.Primaries)
+	upstreams := normalizePrimaries(in.Primaries)
+
 	// Store is always map for dynamic zones — single chokepoint for the map-only
 	// rule (also covers the catalog re-point).
 	zd := &ZoneData{
-		ZoneName:  name,
-		ZoneType:  in.Type,
-		ZoneStore: MapZone,
-		Upstream:  NormalizeAddress(in.Primary.Addr),
-		Logger:    log.Default(),
-		Options:   options,
-		Status:    ZoneStatusPending,
-		Data:      core.NewCmap[OwnerData](),
-		KeyDB:     conf.Internal.KeyDB,
+		ZoneName:      name,
+		ZoneType:      in.Type,
+		ZoneStore:     MapZone,
+		PrimariesConf: primariesConf,
+		Upstreams:     upstreams,
+		Logger:        log.Default(),
+		Options:       options,
+		Status:        ZoneStatusPending,
+		Data:          core.NewCmap[OwnerData](),
+		KeyDB:         conf.Internal.KeyDB,
 	}
 
 	// Register, then persist; roll back the live registration if persist fails
@@ -611,11 +612,12 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 	// with no AXFR. Surface that rather than reporting success; the zone is
 	// reachable via list-dynamic and the operator can retry modify/delete.
 	zr := ZoneRefresher{
-		Name:      name,
-		ZoneType:  in.Type,
-		Primary:   PeerConf{Addr: NormalizeAddress(in.Primary.Addr), Key: in.Primary.Key},
-		ZoneStore: MapZone,
-		Options:   options,
+		Name:          name,
+		ZoneType:      in.Type,
+		PrimariesConf: primariesConf,
+		Primaries:     upstreams,
+		ZoneStore:     MapZone,
+		Options:       options,
 	}
 	if err := conf.enqueueRefresh(ctx, zr); err != nil {
 		return "", fmt.Errorf("zone %s registered but failed to schedule initial transfer: %w", name, err)
@@ -680,7 +682,7 @@ func (conf *Config) RemoveDynamicZone(name string) (string, error) {
 
 // ModifyDynamicZone is the shared *modify* core. Implemented as
 // stale-old + build-new + replace (NOT in-place mutation) so the modify/refresh
-// data race is gone by construction: the refresh reads the old zd.Upstream
+// data race is gone by construction: the refresh reads the old zd.Upstreams
 // without a lock, so the changed params live on a fresh ZoneData and the old one
 // is only ever read by its now-doomed refresh. Scope: primary addr/key and
 // options; store is fixed at map; rename is out of scope (= delete+add).
@@ -693,8 +695,10 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	if !oldZd.Options[OptApiManagedZone] {
 		return "", fmt.Errorf("zone %s is not API-managed and cannot be modified here", name)
 	}
-	if in.Primary.Addr != "" && in.Primary.Key != NOKEY {
-		return "", fmt.Errorf("unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", in.Primary.Key)
+	for _, p := range in.Primaries {
+		if p.Key != "" && p.Key != NOKEY {
+			return "", fmt.Errorf("unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", p.Key)
+		}
 	}
 
 	// (1) Bump the old generation so any in-flight refresh on the captured
@@ -708,20 +712,23 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	} else {
 		options[OptApiManagedZone] = true
 	}
-	newUpstream := oldZd.Upstream
-	if in.Primary.Addr != "" {
-		newUpstream = NormalizeAddress(in.Primary.Addr)
+	primariesConf := oldZd.PrimariesConf
+	upstreams := oldZd.Upstreams
+	if len(in.Primaries) > 0 {
+		primariesConf = clonePeerConfs(in.Primaries)
+		upstreams = normalizePrimaries(in.Primaries)
 	}
 	newZd := &ZoneData{
-		ZoneName:  name,
-		ZoneType:  oldZd.ZoneType,
-		ZoneStore: MapZone,
-		Upstream:  newUpstream,
-		Logger:    log.Default(),
-		Options:   options,
-		Status:    ZoneStatusPending,
-		Data:      core.NewCmap[OwnerData](),
-		KeyDB:     conf.Internal.KeyDB,
+		ZoneName:      name,
+		ZoneType:      oldZd.ZoneType,
+		ZoneStore:     MapZone,
+		PrimariesConf: primariesConf,
+		Upstreams:     upstreams,
+		Logger:        log.Default(),
+		Options:       options,
+		Status:        ZoneStatusPending,
+		Data:          core.NewCmap[OwnerData](),
+		KeyDB:         conf.Internal.KeyDB,
 	}
 	Zones.Set(name, newZd)
 
@@ -734,12 +741,13 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	}
 	// (5) Force a re-pull from the new upstream.
 	zr := ZoneRefresher{
-		Name:      name,
-		ZoneType:  newZd.ZoneType,
-		Primary:   PeerConf{Addr: newUpstream, Key: in.Primary.Key},
-		ZoneStore: MapZone,
-		Options:   options,
-		Force:     true,
+		Name:          name,
+		ZoneType:      newZd.ZoneType,
+		PrimariesConf: primariesConf,
+		Primaries:     upstreams,
+		ZoneStore:     MapZone,
+		Options:       options,
+		Force:         true,
 	}
 	if err := conf.enqueueRefresh(ctx, zr); err != nil {
 		return "", fmt.Errorf("zone %s modified but failed to schedule refresh: %w", name, err)

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -237,14 +237,24 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 			lg.Debug("enqueuing zone for refresh", "zone", zoneName, "type", zconf.Type)
 		}
 
+		// Re-resolve the persisted as-written primaries (hostnames -> addresses)
+		// on every load. Zero resolved is logged and still enqueued so the zone
+		// is created and visible (it surfaces a refresh error rather than
+		// silently vanishing); partial is logged and served from the rest.
+		res := resolvePrimaries(ctx, conf.Internal.ImrEngine, zconf.Primaries)
+		if zoneType == Secondary && len(res.Resolved) == 0 {
+			lg.Error("dynamic zone: no primary resolved to an address (enqueuing anyway, will surface as refresh error)", "zone", zoneName, "unresolved", res.Unresolved)
+		} else if len(res.Unresolved) > 0 || len(res.KeyCollisions) > 0 {
+			lg.Warn("dynamic zone: some primaries unavailable, serving from the rest", "zone", zoneName, "unresolved", res.Unresolved, "key_collisions", res.KeyCollisions, "serving", len(res.Resolved))
+		}
+
 		// Create ZoneRefresher and enqueue to RefreshEngine (same as ParseZones does)
-		primariesConf, resolved := refresherPrimariesFromConf(zconf.Primaries)
 		zr := ZoneRefresher{
 			Name:          zoneName,
 			Force:         true, // Force refresh on startup to load from disk
 			ZoneType:      zoneType,
-			PrimariesConf: primariesConf,
-			Primaries:     resolved,
+			PrimariesConf: clonePeerConfs(zconf.Primaries),
+			Primaries:     res.Resolved,
 			ZoneStore:     zoneStore,
 			Notify:        zconf.Notify,
 			Zonefile:      zconf.Zonefile,
@@ -580,8 +590,14 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 		options[OptApiManagedZone] = true
 	}
 
+	// Resolve hostname primaries to addresses via the IMR at add time (not only
+	// on the next restart). Zero resolved on a secondary -> reject the add.
+	res := resolvePrimaries(ctx, conf.Internal.ImrEngine, in.Primaries)
+	if in.Type == Secondary && len(res.Resolved) == 0 {
+		return "", fmt.Errorf("zone %s: no primary resolved to an address (unresolved: %v)", name, res.Unresolved)
+	}
 	primariesConf := clonePeerConfs(in.Primaries)
-	upstreams := normalizePrimaries(in.Primaries)
+	upstreams := res.Resolved
 
 	// Store is always map for dynamic zones — single chokepoint for the map-only
 	// rule (also covers the catalog re-point).
@@ -604,6 +620,13 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 	if err := conf.AddDynamicZoneToConfig(zd); err != nil {
 		Zones.Remove(name)
 		return "", fmt.Errorf("failed to persist dynamic zone %s: %w", name, err)
+	}
+
+	// Partial resolution: the zone is served from the addresses that resolved,
+	// with a visibility-only ConfigWarning naming the rest.
+	if len(res.Unresolved) > 0 || len(res.KeyCollisions) > 0 {
+		served := len(in.Primaries) - len(res.Unresolved)
+		zd.SetError(ConfigWarning, "serving from %d of %d primaries (unresolved: %v, key-collisions: %v)", served, len(in.Primaries), res.Unresolved, res.KeyCollisions)
 	}
 
 	// Enqueue the initial transfer — fire-and-forget (no Wait, no Response). If
@@ -701,6 +724,21 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		}
 	}
 
+	// Resolve any new primaries up front, before mutating state, so a
+	// zero-resolution modify is rejected cleanly with no side effects. When no
+	// new primaries are supplied, carry the old as-written + resolved forward.
+	primariesConf := oldZd.PrimariesConf
+	upstreams := oldZd.Upstreams
+	var modRes PrimaryResolveResult
+	if len(in.Primaries) > 0 {
+		modRes = resolvePrimaries(ctx, conf.Internal.ImrEngine, in.Primaries)
+		if len(modRes.Resolved) == 0 {
+			return "", fmt.Errorf("zone %s: no primary resolved to an address (unresolved: %v)", name, modRes.Unresolved)
+		}
+		primariesConf = clonePeerConfs(in.Primaries)
+		upstreams = modRes.Resolved
+	}
+
 	// (1) Bump the old generation so any in-flight refresh on the captured
 	// pointer self-aborts at its pre-persist guard (B5b).
 	oldZd.generation.Add(1)
@@ -711,12 +749,6 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		options = oldZd.Options
 	} else {
 		options[OptApiManagedZone] = true
-	}
-	primariesConf := oldZd.PrimariesConf
-	upstreams := oldZd.Upstreams
-	if len(in.Primaries) > 0 {
-		primariesConf = clonePeerConfs(in.Primaries)
-		upstreams = normalizePrimaries(in.Primaries)
 	}
 	newZd := &ZoneData{
 		ZoneName:      name,
@@ -738,6 +770,12 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	// now has the new params but they would be lost on restart.
 	if err := conf.AddDynamicZoneToConfig(newZd); err != nil {
 		return "", fmt.Errorf("zone %s modified in memory but failed to persist (change will be lost on restart): %w", name, err)
+	}
+	// Partial resolution of the new primaries: served from what resolved, with
+	// a visibility-only ConfigWarning naming the rest.
+	if len(modRes.Unresolved) > 0 || len(modRes.KeyCollisions) > 0 {
+		served := len(in.Primaries) - len(modRes.Unresolved)
+		newZd.SetError(ConfigWarning, "serving from %d of %d primaries (unresolved: %v, key-collisions: %v)", served, len(in.Primaries), modRes.Unresolved, modRes.KeyCollisions)
 	}
 	// (5) Force a re-pull from the new upstream.
 	zr := ZoneRefresher{

--- a/v2/dynamic_zones_b5_test.go
+++ b/v2/dynamic_zones_b5_test.go
@@ -41,6 +41,43 @@ func TestZoneDataToZoneConf_WritesApiManaged(t *testing.T) {
 	}
 }
 
+// TestZoneDataToZoneConf_PersistsAsWrittenPrimaries verifies P5: persistence
+// writes the as-written PrimariesConf (hostnames + per-entry keys), NOT the
+// resolved Upstreams and NOT a hardcoded NOKEY. Persisting the hostname (rather
+// than whatever it resolved to once) is what lets reload re-resolve it.
+func TestZoneDataToZoneConf_PersistsAsWrittenPrimaries(t *testing.T) {
+	zd := &ZoneData{
+		ZoneName: "rt.example.",
+		ZoneType: Secondary,
+		// As-written: a hostname carrying a non-NOKEY-shaped key name.
+		PrimariesConf: []PeerConf{{Addr: "ns.example.org:53", Key: "transfer-key"}},
+		// Resolved (runtime-only): the addresses the hostname expanded to. These
+		// must NOT be what gets persisted.
+		Upstreams: []PeerConf{
+			{Addr: "192.0.2.1:53", Key: "transfer-key"},
+			{Addr: "[2001:db8::1]:53", Key: "transfer-key"},
+		},
+		Options: map[ZoneOption]bool{OptApiManagedZone: true},
+	}
+	zc := zoneDataToZoneConf(zd, "/tmp")
+
+	if len(zc.Primaries) != 1 {
+		t.Fatalf("want 1 persisted primary (the as-written entry), got %d: %+v", len(zc.Primaries), zc.Primaries)
+	}
+	got := zc.Primaries[0]
+	if got.Addr != "ns.example.org:53" {
+		t.Errorf("persisted the resolved address, not the hostname: %q", got.Addr)
+	}
+	if got.Key != "transfer-key" {
+		t.Errorf("per-entry key not preserved (forced to NOKEY?): %q", got.Key)
+	}
+	for _, p := range zc.Primaries {
+		if p.Addr == "192.0.2.1:53" || p.Addr == "[2001:db8::1]:53" {
+			t.Errorf("a resolved address leaked into the persisted config: %q", p.Addr)
+		}
+	}
+}
+
 // TestShouldPersistZone_DynamicBranch verifies the B5a third branch: an
 // API-managed zone is persistable iff dynamic.{allowed && storage==persistent}.
 func TestShouldPersistZone_DynamicBranch(t *testing.T) {

--- a/v2/dynamic_zones_b5_test.go
+++ b/v2/dynamic_zones_b5_test.go
@@ -8,10 +8,11 @@ import "testing"
 // OptAutomaticZone is re-derived from SourceCatalog).
 func TestZoneDataToZoneConf_WritesApiManaged(t *testing.T) {
 	zd := &ZoneData{
-		ZoneName: "api.example.",
-		ZoneType: Secondary,
-		Upstream: "192.0.2.1:53",
-		Options:  map[ZoneOption]bool{OptApiManagedZone: true},
+		ZoneName:      "api.example.",
+		ZoneType:      Secondary,
+		PrimariesConf: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}},
+		Upstreams:     []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}},
+		Options:       map[ZoneOption]bool{OptApiManagedZone: true},
 	}
 	zc := zoneDataToZoneConf(zd, "/tmp")
 	if !zc.ApiManaged {

--- a/v2/dynamic_zones_cores_test.go
+++ b/v2/dynamic_zones_cores_test.go
@@ -30,7 +30,7 @@ func TestProvisionDynamicZone_Gate(t *testing.T) {
 	conf, _ := newTestConfigForCores(t)
 	conf.DynamicZones.Dynamic.Allowed = false
 
-	in := DynamicZoneInput{Name: "gated.example", Type: Secondary, Primary: PeerConf{Addr: "192.0.2.1:53", Key: NOKEY}}
+	in := DynamicZoneInput{Name: "gated.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err == nil {
 		t.Fatal("expected add to be refused when dynamic.allowed=false")
 	}
@@ -45,13 +45,13 @@ func TestProvisionDynamicZone_RejectsPrimaryAndBadKey(t *testing.T) {
 	conf, _ := newTestConfigForCores(t)
 
 	// type: primary is rejected on the API path (v1 secondary-only).
-	prim := DynamicZoneInput{Name: "prim.example", Type: Primary, Primary: PeerConf{Addr: "192.0.2.1:53", Key: NOKEY}}
+	prim := DynamicZoneInput{Name: "prim.example", Type: Primary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), prim, true); err == nil {
 		t.Error("expected type: primary to be rejected on API path")
 	}
 
 	// non-NOKEY key is rejected until TSIG keys exist.
-	badKey := DynamicZoneInput{Name: "badkey.example", Type: Secondary, Primary: PeerConf{Addr: "192.0.2.1:53", Key: "transfer-key"}}
+	badKey := DynamicZoneInput{Name: "badkey.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: "transfer-key"}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), badKey, true); err == nil {
 		t.Error("expected non-NOKEY key to be rejected")
 	}
@@ -61,7 +61,7 @@ func TestProvisionDynamicZone_HappyPathAndDuplicate(t *testing.T) {
 	resetZonesForTest()
 	conf, ch := newTestConfigForCores(t)
 
-	in := DynamicZoneInput{Name: "ok.example", Type: Secondary, Primary: PeerConf{Addr: "192.0.2.1", Key: NOKEY}}
+	in := DynamicZoneInput{Name: "ok.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1", Key: NOKEY}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err != nil {
 		t.Fatalf("happy-path add failed: %v", err)
 	}
@@ -78,8 +78,8 @@ func TestProvisionDynamicZone_HappyPathAndDuplicate(t *testing.T) {
 	if zd.GetStatus() != ZoneStatusPending {
 		t.Errorf("fresh add status = %v, want Pending", zd.GetStatus())
 	}
-	if zd.Upstream != "192.0.2.1:53" {
-		t.Errorf("upstream not normalized: got %q", zd.Upstream)
+	if firstUpstreamAddr(zd.Upstreams) != "192.0.2.1:53" {
+		t.Errorf("upstream not normalized: got %q", firstUpstreamAddr(zd.Upstreams))
 	}
 	// A ZoneRefresher was enqueued.
 	select {
@@ -106,7 +106,7 @@ func TestRemoveDynamicZone_GuardAndGenerationBump(t *testing.T) {
 	}
 
 	// An API-managed zone is deleted and its generation bumped.
-	in := DynamicZoneInput{Name: "del.example", Type: Secondary, Primary: PeerConf{Addr: "192.0.2.1:53", Key: NOKEY}}
+	in := DynamicZoneInput{Name: "del.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestModifyDynamicZone_ReplacesAndBumps(t *testing.T) {
 	resetZonesForTest()
 	conf, ch := newTestConfigForCores(t)
 
-	in := DynamicZoneInput{Name: "mod.example", Type: Secondary, Primary: PeerConf{Addr: "192.0.2.1:53", Key: NOKEY}}
+	in := DynamicZoneInput{Name: "mod.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err != nil {
 		t.Fatalf("add failed: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestModifyDynamicZone_ReplacesAndBumps(t *testing.T) {
 	gen0 := oldZd.generation.Load()
 
 	// Modify the upstream.
-	mod := DynamicZoneInput{Name: "mod.example", Type: Secondary, Primary: PeerConf{Addr: "192.0.2.9:53", Key: NOKEY}}
+	mod := DynamicZoneInput{Name: "mod.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.9:53", Key: NOKEY}}}
 	if _, err := conf.ModifyDynamicZone(context.Background(), mod); err != nil {
 		t.Fatalf("modify failed: %v", err)
 	}
@@ -149,8 +149,8 @@ func TestModifyDynamicZone_ReplacesAndBumps(t *testing.T) {
 	if newZd == oldZd {
 		t.Error("modify should replace the ZoneData pointer (delete+re-add), not mutate in place")
 	}
-	if newZd.Upstream != "192.0.2.9:53" {
-		t.Errorf("modify did not apply new upstream: got %q", newZd.Upstream)
+	if firstUpstreamAddr(newZd.Upstreams) != "192.0.2.9:53" {
+		t.Errorf("modify did not apply new upstream: got %q", firstUpstreamAddr(newZd.Upstreams))
 	}
 	if oldZd.generation.Load() != gen0+1 {
 		t.Errorf("old generation not bumped on modify: got %d, want %d", oldZd.generation.Load(), gen0+1)
@@ -171,7 +171,7 @@ func TestModifyDynamicZone_ReplacesAndBumps(t *testing.T) {
 	// Modify on a static zone is refused.
 	static := &ZoneData{ZoneName: "static2.example.", ZoneType: Secondary, Options: map[ZoneOption]bool{}}
 	Zones.Set("static2.example.", static)
-	if _, err := conf.ModifyDynamicZone(context.Background(), DynamicZoneInput{Name: "static2.example", Type: Secondary, Primary: PeerConf{Addr: "192.0.2.1:53", Key: NOKEY}}); err == nil {
+	if _, err := conf.ModifyDynamicZone(context.Background(), DynamicZoneInput{Name: "static2.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}); err == nil {
 		t.Error("expected refusal to modify a non-API-managed zone")
 	}
 }

--- a/v2/dynamic_zones_cores_test.go
+++ b/v2/dynamic_zones_cores_test.go
@@ -15,6 +15,9 @@ func newTestConfigForCores(t *testing.T) (*Config, chan ZoneRefresher) {
 	conf := &Config{}
 	conf.Internal.RefreshZoneCh = ch
 	conf.DynamicZones.Dynamic.Allowed = true
+	// A real (empty-cache) IMR so hostname primaries route through the resolver;
+	// literal-IP primaries short-circuit before any lookup.
+	conf.Internal.ImrEngine = newTestImr(t)
 	return conf, ch
 }
 
@@ -54,6 +57,21 @@ func TestProvisionDynamicZone_RejectsPrimaryAndBadKey(t *testing.T) {
 	badKey := DynamicZoneInput{Name: "badkey.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: "transfer-key"}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), badKey, true); err == nil {
 		t.Error("expected non-NOKEY key to be rejected")
+	}
+}
+
+func TestProvisionDynamicZone_HostnameNoResolve(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+
+	// The empty-cache test IMR cannot resolve a hostname, so a secondary whose
+	// only primary is a name resolves to zero addresses and the add is rejected.
+	in := DynamicZoneInput{Name: "hn.example", Type: Secondary, Primaries: []PeerConf{{Addr: "ns.unresolvable.invalid", Key: NOKEY}}}
+	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err == nil {
+		t.Fatal("expected add to be rejected when no primary resolves to an address")
+	}
+	if _, ok := Zones.Get("hn.example."); ok {
+		t.Fatal("zone should not be registered when the add is rejected")
 	}
 }
 

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -351,6 +351,19 @@ var serviceImpactingErrors = []ErrorType{
 	DnssecError,
 }
 
+// ErrorTypeIsServiceImpacting reports whether an error category makes a zone
+// unable to serve (so it should render as an ERROR) versus a visibility-only
+// warning under which the zone keeps serving (e.g. ConfigWarning). Exported for
+// CLI display, which renders the two differently.
+func ErrorTypeIsServiceImpacting(t ErrorType) bool {
+	for _, e := range serviceImpactingErrors {
+		if t == e {
+			return true
+		}
+	}
+	return false
+}
+
 // ZoneError is one entry in the per-zone error registry. Use SetError
 // to upsert and ClearError to remove.
 type ZoneError struct {

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -283,6 +283,10 @@ const (
 	// primary). Visibility-only — the zone keeps serving and the NOTIFY proxy
 	// may still apply.
 	DelegationSyncWarning
+	// ConfigWarning: zone config is degraded but the zone is still served
+	// (e.g. some primaries failed to resolve while others succeeded).
+	// Visibility-only.
+	ConfigWarning
 )
 
 var ErrorTypeToString = map[ErrorType]string{
@@ -295,6 +299,7 @@ var ErrorTypeToString = map[ErrorType]string{
 	RolloverPolicyWarning:   "rollover-policy-warning",
 	RolloverParentBlocker:   "rollover-parent-blocker",
 	DelegationSyncWarning:   "delegation-sync-warning",
+	ConfigWarning:           "config-warning",
 }
 
 // errorTypeReportOrder defines the deterministic order in which the
@@ -312,6 +317,7 @@ var errorTypeReportOrder = []ErrorType{
 	DnssecPolicyWarning,
 	RolloverPolicyWarning,
 	DelegationSyncWarning,
+	ConfigWarning,
 }
 
 // rolloverGatingErrors are categories that the auto-rollover CLI

--- a/v2/imrengine.go
+++ b/v2/imrengine.go
@@ -104,7 +104,13 @@ type ImrResponse struct {
 // this, the *tdnsmp.Imr embedding wraps a nil *tdns.Imr and promoted method
 // calls panic. Do not fold InitImrEngine back into ImrEngine without updating
 // tdns-mp/v2/start_agent.go.
-func (conf *Config) InitImrEngine(quiet bool) error {
+//
+// ctx is threaded into root-hints priming (PrimeWithHints' "." NS fetch), so a
+// stalled prime can be cancelled rather than blocking startup. tdns-mp pins a
+// published tdns/v2 and so is unaffected until it bumps the dependency; when it
+// does, its two call sites (tdns-mp/v2/start_agent.go:35, start_auditor.go:41)
+// must pass their already-in-scope ctx: InitImrEngine(ctx, true).
+func (conf *Config) InitImrEngine(ctx context.Context, quiet bool) error {
 	// Idempotency guard: IMR is a process singleton. Subsequent calls are
 	// no-ops; first-init wins.
 	if conf.Internal.ImrEngine != nil {
@@ -189,7 +195,7 @@ func (conf *Config) InitImrEngine(quiet bool) error {
 	}
 
 	if !rrcache.IsPrimed() {
-		err := rrcache.PrimeWithHints(conf.Imr.RootHints, imr.IterativeDNSQueryFetcher())
+		err := rrcache.PrimeWithHints(ctx, conf.Imr.RootHints, imr.IterativeDNSQueryFetcher())
 		if err != nil {
 			return fmt.Errorf("failed to initialize RecursorCache w/ root hints: %v", err)
 		}
@@ -242,7 +248,7 @@ func (conf *Config) ImrEngine(ctx context.Context, quiet bool) error {
 	// Shutdowner here — that would leave conf.Internal.ImrEngine nil and the
 	// dereference below would panic.
 	if conf.Internal.ImrEngine == nil {
-		if err := conf.InitImrEngine(quiet); err != nil {
+		if err := conf.InitImrEngine(ctx, quiet); err != nil {
 			return fmt.Errorf("ImrEngine: InitImrEngine failed: %w", err)
 		}
 	}

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -189,6 +189,21 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	// if Globals.Debug {
 	//	log.Printf("*** MainInit: 5 ***")
 	// }
+	// The in-process IMR is the resolver for hostname primaries, which are
+	// resolved at parse/load time (ParseZones, LoadDynamicZoneFiles below).
+	// Those run before the per-app StartXxx brings up the ImrEngine goroutine,
+	// so initialize the IMR synchronously now. InitImrEngine primes the cache
+	// with root hints and is idempotent (first-init wins) — the later
+	// StartEngine("ImrEngine", ...) reuses this instance and just adds trust
+	// anchors + listeners. Non-fatal: if the IMR is disabled or fails to init,
+	// resolvePrimaries degrades (a hostname primary is reported unresolved),
+	// it does not abort startup.
+	if conf.Imr.Active == nil || *conf.Imr.Active {
+		if err := conf.InitImrEngine(false); err != nil {
+			lgConfig.Warn("early IMR init failed; hostname primaries will not resolve at parse time", "err", err)
+		}
+	}
+
 	// Parse all configured zones
 	all_zones, _, err := conf.ParseZones(ctx, false) // false = initial load, not reload
 	if err != nil {

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -199,7 +199,7 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	// resolvePrimaries degrades (a hostname primary is reported unresolved),
 	// it does not abort startup.
 	if conf.Imr.Active == nil || *conf.Imr.Active {
-		if err := conf.InitImrEngine(false); err != nil {
+		if err := conf.InitImrEngine(ctx, false); err != nil {
 			lgConfig.Warn("early IMR init failed; hostname primaries will not resolve at parse time", "err", err)
 		}
 	}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -631,6 +631,10 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		}
 
 		var zonetype ZoneType
+		// resolvedPrimaries holds the addr:port tuples for a secondary zone's
+		// upstreams, resolved (hostnames -> addresses) at parse time. nil for
+		// primary zones. Carried to the ZoneRefresher build below.
+		var resolvedPrimaries []PeerConf
 
 		switch strings.ToLower(zconf.Type) {
 		case "primary":
@@ -681,6 +685,25 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				broken_zones = append(broken_zones, zname)
 				continue
 			}
+
+			// Resolve the as-written primaries to addr:port tuples (hostnames
+			// -> addresses via the IMR), re-resolved on every parse/reload.
+			// Zero resolved -> ConfigError (quarantine); partial -> ConfigWarning
+			// (serve from the rest). A prior parse's ConfigWarning was already
+			// cleared by the SetError(NoError) reset at the top of the loop.
+			res := resolvePrimaries(ctx, conf.Internal.ImrEngine, zconf.Primaries)
+			if len(res.Resolved) == 0 {
+				lgConfig.Error("secondary zone: no primary resolved to an address, zone in error state", "zone", zname, "unresolved", res.Unresolved)
+				zd.SetError(ConfigError, "no primary resolved to an address (unresolved: %v)", res.Unresolved)
+				broken_zones = append(broken_zones, zname)
+				continue
+			}
+			if len(res.Unresolved) > 0 || len(res.KeyCollisions) > 0 {
+				served := len(zconf.Primaries) - len(res.Unresolved)
+				lgConfig.Warn("secondary zone: some primaries unavailable, serving from the rest", "zone", zname, "unresolved", res.Unresolved, "key_collisions", res.KeyCollisions, "serving", served, "of", len(zconf.Primaries))
+				zd.SetError(ConfigWarning, "serving from %d of %d primaries (unresolved: %v, key-collisions: %v)", served, len(zconf.Primaries), res.Unresolved, res.KeyCollisions)
+			}
+			resolvedPrimaries = res.Resolved
 
 		default:
 			lgConfig.Error("unknown zone type, zone in error state", "zone", zname, "type", zconf.Type)
@@ -1035,13 +1058,12 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				lgConfig.Error("refresh channel is not configured, zones will not be refreshed, terminating")
 				return nil, nil, errors.New("parseZones: error: refresh channel is not configured, zones will not be refreshed, terminating")
 			}
-			primariesConf, resolved := refresherPrimariesFromConf(zconf.Primaries)
 			zr := ZoneRefresher{
 				Name:          zname,
 				Force:         true,     // force refresh, ignoring SOA serial, when reloading from file
 				ZoneType:      zonetype, // primary | secondary
-				PrimariesConf: primariesConf,
-				Primaries:     resolved,
+				PrimariesConf: clonePeerConfs(zconf.Primaries),
+				Primaries:     resolvedPrimaries,
 				ZoneStore:     zonestore,
 				Notify:        zconf.Notify,
 				Zonefile:      zconf.Zonefile,

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -638,42 +638,48 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			_ = append([]string{}, zname) // primary_zones was unused
 		case "secondary":
 			zonetype = Secondary
-			// Legacy bare-string primary: (pre-migration shape) — the decode
-			// hook recorded it as a Legacy marker; quarantine just this zone.
-			if zconf.Primary.Legacy != "" {
-				lgConfig.Error("secondary zone uses legacy bare-string primary, zone in error state", "zone", zname, "primary", zconf.Primary.Legacy)
-				zd.SetError(ConfigError, "primary now requires {addr, key} (got bare string %q)", zconf.Primary.Legacy)
-				broken_zones = append(broken_zones, zname)
-				continue
-			}
-			if zconf.Primary.Addr == "" {
+			if len(zconf.Primaries) == 0 {
 				lgConfig.Error("secondary zone has no primary configured, zone in error state", "zone", zname)
 				zd.SetError(ConfigError, "secondary zone but has no primary (upstream) configured")
 				broken_zones = append(broken_zones, zname)
 				continue
 			}
-			// Key is mandatory and explicit — no default to NOKEY.
-			if zconf.Primary.Key == "" {
-				lgConfig.Error("secondary zone primary has no key, zone in error state", "zone", zname)
-				zd.SetError(ConfigError, "primary requires an explicit key (use key: NOKEY for no TSIG)")
+			secondaryOK := true
+			for i := range zconf.Primaries {
+				p := &zconf.Primaries[i]
+				if p.Legacy != "" {
+					lgConfig.Error("secondary zone uses legacy bare-string primary, zone in error state", "zone", zname, "primary", p.Legacy)
+					zd.SetError(ConfigError, "primary now requires {addr, key} (got bare string %q)", p.Legacy)
+					secondaryOK = false
+					break
+				}
+				if p.Addr == "" {
+					lgConfig.Error("secondary zone primary has no address, zone in error state", "zone", zname)
+					zd.SetError(ConfigError, "secondary zone but has no primary (upstream) configured")
+					secondaryOK = false
+					break
+				}
+				if p.Key == "" {
+					lgConfig.Error("secondary zone primary has no key, zone in error state", "zone", zname)
+					zd.SetError(ConfigError, "primary requires an explicit key (use key: NOKEY for no TSIG)")
+					secondaryOK = false
+					break
+				}
+				if p.Key != NOKEY {
+					lgConfig.Error("secondary zone primary references unknown key, zone in error state", "zone", zname, "key", p.Key)
+					zd.SetError(ConfigError, "unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", p.Key)
+					secondaryOK = false
+					break
+				}
+				origPrimary := p.Addr
+				p.Addr = NormalizeAddress(p.Addr)
+				if origPrimary != p.Addr {
+					lgConfig.Warn("primary has no port specified, using default :53", "zone", zname, "primary", origPrimary)
+				}
+			}
+			if !secondaryOK {
 				broken_zones = append(broken_zones, zname)
 				continue
-			}
-			// Improvement 1 phase: NOKEY is the only resolvable key name. Any
-			// other name is an unknown-key error until the keys: block exists
-			// (Improvement 2). NOKEY comparison is case-sensitive.
-			if zconf.Primary.Key != NOKEY {
-				lgConfig.Error("secondary zone primary references unknown key, zone in error state", "zone", zname, "key", zconf.Primary.Key)
-				zd.SetError(ConfigError, "unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", zconf.Primary.Key)
-				broken_zones = append(broken_zones, zname)
-				continue
-			}
-
-			// Normalize primary address to include port if not specified
-			origPrimary := zconf.Primary.Addr
-			zconf.Primary.Addr = NormalizeAddress(zconf.Primary.Addr)
-			if origPrimary != zconf.Primary.Addr {
-				lgConfig.Warn("primary has no port specified, using default :53", "zone", zname, "primary", origPrimary)
 			}
 
 		default:
@@ -728,7 +734,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		}
 		lgConfig.Debug("zone outgoing options", "zone", zname, "options", outopts)
 
-		lgConfig.Info("zone configuration", "zone", zname, "type", zconf.Type, "store", zconf.Store, "primary", zconf.Primary, "notify", zconf.Notify, "zonefile", zconf.Zonefile)
+		lgConfig.Info("zone configuration", "zone", zname, "type", zconf.Type, "store", zconf.Store, "primaries", zconf.Primaries, "notify", zconf.Notify, "zonefile", zconf.Zonefile)
 
 		lgConfig.Debug("zone incoming update policy", "zone", zname, "policy", fmt.Sprintf("%+v", zconf.UpdatePolicy))
 
@@ -1029,17 +1035,19 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				lgConfig.Error("refresh channel is not configured, zones will not be refreshed, terminating")
 				return nil, nil, errors.New("parseZones: error: refresh channel is not configured, zones will not be refreshed, terminating")
 			}
+			primariesConf, resolved := refresherPrimariesFromConf(zconf.Primaries)
 			zr := ZoneRefresher{
-				Name:         zname,
-				Force:        true,     // force refresh, ignoring SOA serial, when reloading from file
-				ZoneType:     zonetype, // primary | secondary
-				Primary:      zconf.Primary,
-				ZoneStore:    zonestore,
-				Notify:       zconf.Notify,
-				Zonefile:     zconf.Zonefile,
-				Options:      options,
-				UpdatePolicy: policy,
-				DnssecPolicy: zconf.DnssecPolicy,
+				Name:          zname,
+				Force:         true,     // force refresh, ignoring SOA serial, when reloading from file
+				ZoneType:      zonetype, // primary | secondary
+				PrimariesConf: primariesConf,
+				Primaries:     resolved,
+				ZoneStore:     zonestore,
+				Notify:        zconf.Notify,
+				Zonefile:      zconf.Zonefile,
+				Options:       options,
+				UpdatePolicy:  policy,
+				DnssecPolicy:  zconf.DnssecPolicy,
 			}
 			select {
 			case conf.Internal.RefreshZoneCh <- zr:
@@ -1067,8 +1075,8 @@ func ExpandTemplate(zconf ZoneConf, tmpl *ZoneConf, appMode AppType) (ZoneConf, 
 		// fmt.Printf("ExpandTemplate: zone %s now uses the \"%s\" storage alternative.\n", zconf.Name, tmpl.Store)
 		zconf.Store = tmpl.Store
 	}
-	if tmpl.Primary.Addr != "" {
-		zconf.Primary = tmpl.Primary
+	if len(tmpl.Primaries) > 0 {
+		zconf.Primaries = tmpl.Primaries
 	}
 	if len(tmpl.Zonefile) > 0 {
 		// H26: Validate zone name doesn't contain format specifiers

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -699,9 +699,12 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				continue
 			}
 			if len(res.Unresolved) > 0 || len(res.KeyCollisions) > 0 {
-				served := len(zconf.Primaries) - len(res.Unresolved)
-				lgConfig.Warn("secondary zone: some primaries unavailable, serving from the rest", "zone", zname, "unresolved", res.Unresolved, "key_collisions", res.KeyCollisions, "serving", served, "of", len(zconf.Primaries))
-				zd.SetError(ConfigWarning, "serving from %d of %d primaries (unresolved: %v, key-collisions: %v)", served, len(zconf.Primaries), res.Unresolved, res.KeyCollisions)
+				// Count resolved addresses actually usable for transfer — not
+				// entries-minus-unresolved, which over-counts when a key
+				// collision drops an otherwise-resolved address.
+				served := len(res.Resolved)
+				lgConfig.Warn("secondary zone: some primaries unavailable, serving from the rest", "zone", zname, "unresolved", res.Unresolved, "key_collisions", res.KeyCollisions, "resolved_upstreams", served, "configured_primaries", len(zconf.Primaries))
+				zd.SetError(ConfigWarning, "serving from %d resolved upstream(s) of %d configured primaries (unresolved: %v, key-collisions: %v)", served, len(zconf.Primaries), res.Unresolved, res.KeyCollisions)
 			}
 			resolvedPrimaries = res.Resolved
 
@@ -1098,7 +1101,10 @@ func ExpandTemplate(zconf ZoneConf, tmpl *ZoneConf, appMode AppType) (ZoneConf, 
 		zconf.Store = tmpl.Store
 	}
 	if len(tmpl.Primaries) > 0 {
-		zconf.Primaries = tmpl.Primaries
+		// Clone — ParseZones normalizes zconf.Primaries[i].Addr in place, so an
+		// alias of the template slice would let the first zone using this
+		// template mutate the shared template state for every later zone.
+		zconf.Primaries = clonePeerConfs(tmpl.Primaries)
 	}
 	if len(tmpl.Zonefile) > 0 {
 		// H26: Validate zone name doesn't contain format specifiers

--- a/v2/peerconf_decode_test.go
+++ b/v2/peerconf_decode_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestStringToPeerConfHook_ResilientDecode is the B0a regression guard: a
-// config carrying a legacy bare-string primary:/notify: among modern struct
+// config carrying a legacy bare-string primaries:/notify: among modern struct
 // entries must decode the WHOLE file successfully (no abort), with the legacy
 // values captured as PeerConf{Legacy: ...} markers that per-zone validation
 // later quarantines — rather than failing the entire decode on the
@@ -24,12 +24,13 @@ func TestStringToPeerConfHook_ResilientDecode(t *testing.T) {
 zones:
   modern.example.:
     type: secondary
-    primary:
-      addr: 192.0.2.1:53
-      key: NOKEY
+    primaries:
+      - addr: 192.0.2.1:53
+        key: NOKEY
   legacy-primary.example.:
     type: secondary
-    primary: 192.0.2.2:53
+    primaries:
+      - 192.0.2.2:53
   legacy-notify.example.:
     type: primary
     notify:
@@ -62,7 +63,7 @@ zones:
 	}
 
 	// Modern zone: real PeerConf, no Legacy marker.
-	mod := result.Zones["modern.example."].Primary
+	mod := result.Zones["modern.example."].Primaries[0]
 	if mod.Legacy != "" {
 		t.Errorf("modern primary wrongly flagged legacy: %+v", mod)
 	}
@@ -72,7 +73,7 @@ zones:
 
 	// Legacy bare-string primary: captured as a Legacy marker (validation will
 	// quarantine this zone to ERROR), Addr/Key empty.
-	leg := result.Zones["legacy-primary.example."].Primary
+	leg := result.Zones["legacy-primary.example."].Primaries[0]
 	if leg.Legacy != "192.0.2.2:53" {
 		t.Errorf("legacy primary not captured as marker: got %+v", leg)
 	}

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -565,11 +565,11 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						}
 					}
 					msc := conf.MultiSigner[zr.MultiSigner]
+					// Resolution happens at every ingress path (parse/load/add/
+					// modify/catalog), so a config-bearing refresher always carries
+					// the resolved Primaries alongside the as-written PrimariesConf.
 					primariesConf := clonePeerConfs(zr.PrimariesConf)
 					upstreams := clonePeerConfs(zr.Primaries)
-					if len(upstreams) == 0 {
-						upstreams = normalizePrimaries(primariesConf)
-					}
 					zd := &ZoneData{
 						ZoneName:         zone,
 						ZoneStore:        zr.ZoneStore,

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -43,8 +43,6 @@ type RefreshCounter struct {
 	SOARefresh     uint32
 	CurRefresh     uint32
 	IncomingSerial uint32
-	Upstream       string
-	Notify         []PeerConf
 	Zonefile       string
 }
 
@@ -68,8 +66,6 @@ func initialLoadZone(ctx context.Context, zd *ZoneData, zone string, zr ZoneRefr
 		Name:       zone,
 		SOARefresh: refresh,
 		CurRefresh: refresh,
-		Upstream:   NormalizeAddress(zr.Primary.Addr),
-		Notify:     normalizePeerAddrs(zr.Notify),
 	})
 
 	// Check if this is a catalog zone and parse it
@@ -244,7 +240,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 
 							zd.mu.Lock()
 							zd.ZoneStore = zr.ZoneStore
-							zd.Upstream = NormalizeAddress(zr.Primary.Addr)
+							if len(zr.PrimariesConf) > 0 {
+								zd.PrimariesConf = clonePeerConfs(zr.PrimariesConf)
+								zd.Upstreams = clonePeerConfs(zr.Primaries)
+							}
 							zd.Notify = normalizePeerAddrs(zr.Notify)
 							zd.Zonefile = zr.Zonefile
 							zd.ZoneType = zr.ZoneType
@@ -314,9 +313,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						if zr.Notify != nil {
 							zd.Notify = normalizePeerAddrs(zr.Notify)
 						}
-						// Update upstream only if provided
-						if zr.Primary.Addr != "" {
-							zd.Upstream = NormalizeAddress(zr.Primary.Addr)
+						// Update primaries only if provided (config-bearing refresher).
+						if len(zr.PrimariesConf) > 0 {
+							zd.PrimariesConf = clonePeerConfs(zr.PrimariesConf)
+							zd.Upstreams = clonePeerConfs(zr.Primaries)
 						}
 						// Update zonefile only if provided
 						if zr.Zonefile != "" {
@@ -390,7 +390,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false, conf.IsLargeAlgorithm)
 							triggerResign(conf, zone)
 						}
-						lgEngine.Debug("updated configuration for zone", "zone", zone, "notify", zd.Notify, "upstream", zd.Upstream, "zonefile", zd.Zonefile, "store", ZoneStoreToString[zd.ZoneStore])
+						lgEngine.Debug("updated configuration for zone", "zone", zone, "notify", zd.Notify, "primaries", zd.PrimariesConf, "upstreams", zd.Upstreams, "zonefile", zd.Zonefile, "store", ZoneStoreToString[zd.ZoneStore])
 
 						// Update or create refreshCounter with current config values
 						var refresh uint32 = 300 // 5 minutes, must have something even if we don't get SOA
@@ -404,8 +404,6 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						}
 						if rc, haveParams := refreshCounters.Get(zone); haveParams {
 							// Update existing refreshCounter with new config values
-							rc.Upstream = NormalizeAddress(zr.Primary.Addr)
-							rc.Notify = normalizePeerAddrs(zr.Notify)
 							rc.Zonefile = zr.Zonefile
 							rc.SOARefresh = refresh
 							rc.CurRefresh = refresh // immediate refresh handled by goroutine below
@@ -415,8 +413,6 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 								Name:       zone,
 								SOARefresh: refresh,
 								CurRefresh: refresh, // immediate refresh handled by goroutine below
-								Upstream:   NormalizeAddress(zr.Primary.Addr),
-								Notify:     normalizePeerAddrs(zr.Notify),
 								Zonefile:   zr.Zonefile,
 							})
 						}
@@ -569,11 +565,17 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						}
 					}
 					msc := conf.MultiSigner[zr.MultiSigner]
+					primariesConf := clonePeerConfs(zr.PrimariesConf)
+					upstreams := clonePeerConfs(zr.Primaries)
+					if len(upstreams) == 0 {
+						upstreams = normalizePrimaries(primariesConf)
+					}
 					zd := &ZoneData{
 						ZoneName:         zone,
 						ZoneStore:        zr.ZoneStore,
 						Logger:           log.Default(),
-						Upstream:         NormalizeAddress(zr.Primary.Addr),
+						PrimariesConf:    primariesConf,
+						Upstreams:        upstreams,
 						Notify:           normalizePeerAddrs(zr.Notify),
 						Zonefile:         zr.Zonefile,
 						ZoneType:         zr.ZoneType,

--- a/v2/resolve_primaries.go
+++ b/v2/resolve_primaries.go
@@ -74,3 +74,29 @@ func splitHostPortDefault(addr string) (host, port string) {
 	}
 	return host, port
 }
+
+func clonePeerConfs(in []PeerConf) []PeerConf {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]PeerConf, len(in))
+	copy(out, in)
+	return out
+}
+
+// normalizePrimaries returns a copy with NormalizeAddress applied to each entry.
+// No DNS lookup — resolvePrimaries is wired in P3.
+func normalizePrimaries(in []PeerConf) []PeerConf {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]PeerConf, len(in))
+	for i, p := range in {
+		out[i] = PeerConf{Addr: NormalizeAddress(p.Addr), Key: p.Key, Legacy: p.Legacy}
+	}
+	return out
+}
+
+func refresherPrimariesFromConf(primaries []PeerConf) (primariesConf, resolved []PeerConf) {
+	return clonePeerConfs(primaries), normalizePrimaries(primaries)
+}

--- a/v2/resolve_primaries.go
+++ b/v2/resolve_primaries.go
@@ -1,8 +1,16 @@
 package tdns
 
 import (
+	"context"
 	"net"
+	"time"
+
+	"github.com/miekg/dns"
 )
+
+// primaryResolveTimeout bounds a single primary's IMR resolution so a dead
+// name cannot stall config parsing / startup indefinitely.
+const primaryResolveTimeout = 10 * time.Second
 
 // PrimaryResolveResult holds the output of resolvePrimaries.
 type PrimaryResolveResult struct {
@@ -13,15 +21,16 @@ type PrimaryResolveResult struct {
 
 // resolvePrimaries expands each as-written entry into one-or-more addr:port
 // tuples, copying the per-entry key to each. A literal IP passes through
-// unchanged (no lookup). Hostnames are resolved via net.LookupHost with v4
-// addresses before v6. Resolved tuples are deduplicated on addr:port, keeping
-// the first occurrence.
-func resolvePrimaries(primaries []PeerConf) PrimaryResolveResult {
+// unchanged (no lookup). Hostnames are resolved via the in-process IMR (NOT
+// the OS stub resolver), A before AAAA, so primaries resolve the same way the
+// rest of tdns resolves names. Resolved tuples are deduplicated on addr:port,
+// keeping the first occurrence.
+func resolvePrimaries(ctx context.Context, imr *Imr, primaries []PeerConf) PrimaryResolveResult {
 	var result PrimaryResolveResult
 	seen := make(map[string]string) // addr:port -> key kept
 
 	for _, p := range primaries {
-		expanded, ok := expandPrimaryEntry(p)
+		expanded, ok := expandPrimaryEntry(ctx, imr, p)
 		if !ok {
 			result.Unresolved = append(result.Unresolved, p.Addr)
 			continue
@@ -40,17 +49,53 @@ func resolvePrimaries(primaries []PeerConf) PrimaryResolveResult {
 	return result
 }
 
-func expandPrimaryEntry(p PeerConf) ([]PeerConf, bool) {
+func expandPrimaryEntry(ctx context.Context, imr *Imr, p PeerConf) ([]PeerConf, bool) {
 	host, port := splitHostPortDefault(p.Addr)
 	if ip := net.ParseIP(host); ip != nil {
 		return []PeerConf{{Addr: net.JoinHostPort(host, port), Key: p.Key}}, true
 	}
 
-	addrs, err := net.LookupHost(host)
-	if err != nil || len(addrs) == 0 {
+	// Hostname. Resolution is the IMR's job; without one (e.g. imr disabled)
+	// the name cannot be resolved here and the entry is reported unresolved.
+	if imr == nil {
 		return nil, false
 	}
+	addrs := imrLookupAddrs(ctx, imr, host)
+	if len(addrs) == 0 {
+		return nil, false
+	}
+	return buildUpstreams(addrs, port, p.Key), true
+}
 
+// imrLookupAddrs returns host's A and AAAA addresses resolved through the IMR,
+// v4 before v6. Empty if neither type resolves (or the lookup errors/times out).
+func imrLookupAddrs(ctx context.Context, imr *Imr, host string) []string {
+	cctx, cancel := context.WithTimeout(ctx, primaryResolveTimeout)
+	defer cancel()
+
+	fqdn := dns.Fqdn(host)
+	var addrs []string
+	if rrset, err := imr.DefaultRRsetFetcher(cctx, fqdn, dns.TypeA); err == nil && rrset != nil {
+		for _, rr := range rrset.RRs {
+			if a, ok := rr.(*dns.A); ok {
+				addrs = append(addrs, a.A.String())
+			}
+		}
+	}
+	if rrset, err := imr.DefaultRRsetFetcher(cctx, fqdn, dns.TypeAAAA); err == nil && rrset != nil {
+		for _, rr := range rrset.RRs {
+			if aaaa, ok := rr.(*dns.AAAA); ok {
+				addrs = append(addrs, aaaa.AAAA.String())
+			}
+		}
+	}
+	return sortV4First(addrs)
+}
+
+// sortV4First returns addrs reordered so every IPv4 literal precedes every
+// IPv6 literal, preserving relative order within each family. v4-first is what
+// fixes the broken-outbound-v6 case: the working family is tried first.
+func sortV4First(addrs []string) []string {
 	var v4s, v6s []string
 	for _, a := range addrs {
 		if ip := net.ParseIP(a); ip != nil && ip.To4() != nil {
@@ -59,12 +104,17 @@ func expandPrimaryEntry(p PeerConf) ([]PeerConf, bool) {
 			v6s = append(v6s, a)
 		}
 	}
-	ordered := append(v4s, v6s...)
-	out := make([]PeerConf, 0, len(ordered))
-	for _, a := range ordered {
-		out = append(out, PeerConf{Addr: net.JoinHostPort(a, port), Key: p.Key})
+	return append(v4s, v6s...)
+}
+
+// buildUpstreams turns resolved IP literals into addr:port PeerConfs, copying
+// key to each and preserving input order.
+func buildUpstreams(addrs []string, port, key string) []PeerConf {
+	out := make([]PeerConf, 0, len(addrs))
+	for _, a := range addrs {
+		out = append(out, PeerConf{Addr: net.JoinHostPort(a, port), Key: key})
 	}
-	return out, true
+	return out
 }
 
 func splitHostPortDefault(addr string) (host, port string) {
@@ -82,21 +132,4 @@ func clonePeerConfs(in []PeerConf) []PeerConf {
 	out := make([]PeerConf, len(in))
 	copy(out, in)
 	return out
-}
-
-// normalizePrimaries returns a copy with NormalizeAddress applied to each entry.
-// No DNS lookup — resolvePrimaries is wired in P3.
-func normalizePrimaries(in []PeerConf) []PeerConf {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]PeerConf, len(in))
-	for i, p := range in {
-		out[i] = PeerConf{Addr: NormalizeAddress(p.Addr), Key: p.Key, Legacy: p.Legacy}
-	}
-	return out
-}
-
-func refresherPrimariesFromConf(primaries []PeerConf) (primariesConf, resolved []PeerConf) {
-	return clonePeerConfs(primaries), normalizePrimaries(primaries)
 }

--- a/v2/resolve_primaries.go
+++ b/v2/resolve_primaries.go
@@ -1,0 +1,76 @@
+package tdns
+
+import (
+	"net"
+)
+
+// PrimaryResolveResult holds the output of resolvePrimaries.
+type PrimaryResolveResult struct {
+	Resolved      []PeerConf
+	Unresolved    []string // as-written addr values that produced no address
+	KeyCollisions []string // addr:port dropped because a duplicate carried a different key
+}
+
+// resolvePrimaries expands each as-written entry into one-or-more addr:port
+// tuples, copying the per-entry key to each. A literal IP passes through
+// unchanged (no lookup). Hostnames are resolved via net.LookupHost with v4
+// addresses before v6. Resolved tuples are deduplicated on addr:port, keeping
+// the first occurrence.
+func resolvePrimaries(primaries []PeerConf) PrimaryResolveResult {
+	var result PrimaryResolveResult
+	seen := make(map[string]string) // addr:port -> key kept
+
+	for _, p := range primaries {
+		expanded, ok := expandPrimaryEntry(p)
+		if !ok {
+			result.Unresolved = append(result.Unresolved, p.Addr)
+			continue
+		}
+		for _, up := range expanded {
+			if prevKey, exists := seen[up.Addr]; exists {
+				if prevKey != up.Key {
+					result.KeyCollisions = append(result.KeyCollisions, up.Addr)
+				}
+				continue
+			}
+			seen[up.Addr] = up.Key
+			result.Resolved = append(result.Resolved, up)
+		}
+	}
+	return result
+}
+
+func expandPrimaryEntry(p PeerConf) ([]PeerConf, bool) {
+	host, port := splitHostPortDefault(p.Addr)
+	if ip := net.ParseIP(host); ip != nil {
+		return []PeerConf{{Addr: net.JoinHostPort(host, port), Key: p.Key}}, true
+	}
+
+	addrs, err := net.LookupHost(host)
+	if err != nil || len(addrs) == 0 {
+		return nil, false
+	}
+
+	var v4s, v6s []string
+	for _, a := range addrs {
+		if ip := net.ParseIP(a); ip != nil && ip.To4() != nil {
+			v4s = append(v4s, a)
+		} else {
+			v6s = append(v6s, a)
+		}
+	}
+	ordered := append(v4s, v6s...)
+	out := make([]PeerConf, 0, len(ordered))
+	for _, a := range ordered {
+		out = append(out, PeerConf{Addr: net.JoinHostPort(a, port), Key: p.Key})
+	}
+	return out, true
+}
+
+func splitHostPortDefault(addr string) (host, port string) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr, "53"
+	}
+	return host, port
+}

--- a/v2/resolve_primaries_test.go
+++ b/v2/resolve_primaries_test.go
@@ -1,0 +1,94 @@
+package tdns
+
+import (
+	"net"
+	"testing"
+)
+
+func TestResolvePrimaries_literalIP(t *testing.T) {
+	res := resolvePrimaries([]PeerConf{{Addr: "192.0.2.1", Key: "K1"}})
+	if len(res.Unresolved) != 0 || len(res.KeyCollisions) != 0 {
+		t.Fatalf("unexpected warnings: unresolved=%v collisions=%v", res.Unresolved, res.KeyCollisions)
+	}
+	if len(res.Resolved) != 1 {
+		t.Fatalf("want 1 resolved, got %d", len(res.Resolved))
+	}
+	if res.Resolved[0].Addr != "192.0.2.1:53" || res.Resolved[0].Key != "K1" {
+		t.Fatalf("got %+v", res.Resolved[0])
+	}
+}
+
+func TestResolvePrimaries_preservesPort(t *testing.T) {
+	res := resolvePrimaries([]PeerConf{{Addr: "192.0.2.1:5353", Key: NOKEY}})
+	if len(res.Resolved) != 1 || res.Resolved[0].Addr != "192.0.2.1:5353" {
+		t.Fatalf("got %+v", res.Resolved)
+	}
+}
+
+func TestResolvePrimaries_dedupSameAddr(t *testing.T) {
+	res := resolvePrimaries([]PeerConf{
+		{Addr: "192.0.2.1:53", Key: "K1"},
+		{Addr: "192.0.2.1:53", Key: "K1"},
+	})
+	if len(res.Resolved) != 1 {
+		t.Fatalf("want dedup to 1, got %d: %+v", len(res.Resolved), res.Resolved)
+	}
+	if len(res.KeyCollisions) != 0 {
+		t.Fatalf("same key should not collide: %v", res.KeyCollisions)
+	}
+}
+
+func TestResolvePrimaries_keyCollision(t *testing.T) {
+	res := resolvePrimaries([]PeerConf{
+		{Addr: "192.0.2.1:53", Key: "K1"},
+		{Addr: "192.0.2.1:53", Key: "K2"},
+	})
+	if len(res.Resolved) != 1 || res.Resolved[0].Key != "K1" {
+		t.Fatalf("want first key kept, got %+v", res.Resolved)
+	}
+	if len(res.KeyCollisions) != 1 || res.KeyCollisions[0] != "192.0.2.1:53" {
+		t.Fatalf("want key collision recorded, got %v", res.KeyCollisions)
+	}
+}
+
+func TestResolvePrimaries_unresolvedHostname(t *testing.T) {
+	res := resolvePrimaries([]PeerConf{{Addr: "tdns-nonexistent-test.invalid", Key: NOKEY}})
+	if len(res.Resolved) != 0 {
+		t.Fatalf("want no resolved addresses, got %+v", res.Resolved)
+	}
+	if len(res.Unresolved) != 1 || res.Unresolved[0] != "tdns-nonexistent-test.invalid" {
+		t.Fatalf("want unresolved entry, got %v", res.Unresolved)
+	}
+}
+
+func TestResolvePrimaries_localhostExpands(t *testing.T) {
+	res := resolvePrimaries([]PeerConf{{Addr: "localhost", Key: "K1"}})
+	if len(res.Unresolved) != 0 {
+		t.Fatalf("localhost should resolve: unresolved=%v", res.Unresolved)
+	}
+	if len(res.Resolved) == 0 {
+		t.Fatal("localhost produced no addresses")
+	}
+	for _, up := range res.Resolved {
+		if up.Key != "K1" {
+			t.Fatalf("key not copied: %+v", up)
+		}
+	}
+	// v4 entries must precede any v6 entry.
+	sawV6 := false
+	for _, up := range res.Resolved {
+		host, _, err := net.SplitHostPort(up.Addr)
+		if err != nil {
+			t.Fatalf("bad addr %q: %v", up.Addr, err)
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			t.Fatalf("not an IP: %q", up.Addr)
+		}
+		if ip.To4() == nil {
+			sawV6 = true
+		} else if sawV6 {
+			t.Fatalf("v4 address %q after v6 in ordering", up.Addr)
+		}
+	}
+}

--- a/v2/resolve_primaries_test.go
+++ b/v2/resolve_primaries_test.go
@@ -1,12 +1,12 @@
 package tdns
 
 import (
-	"net"
+	"context"
 	"testing"
 )
 
 func TestResolvePrimaries_literalIP(t *testing.T) {
-	res := resolvePrimaries([]PeerConf{{Addr: "192.0.2.1", Key: "K1"}})
+	res := resolvePrimaries(context.Background(), nil, []PeerConf{{Addr: "192.0.2.1", Key: "K1"}})
 	if len(res.Unresolved) != 0 || len(res.KeyCollisions) != 0 {
 		t.Fatalf("unexpected warnings: unresolved=%v collisions=%v", res.Unresolved, res.KeyCollisions)
 	}
@@ -19,14 +19,14 @@ func TestResolvePrimaries_literalIP(t *testing.T) {
 }
 
 func TestResolvePrimaries_preservesPort(t *testing.T) {
-	res := resolvePrimaries([]PeerConf{{Addr: "192.0.2.1:5353", Key: NOKEY}})
+	res := resolvePrimaries(context.Background(), nil, []PeerConf{{Addr: "192.0.2.1:5353", Key: NOKEY}})
 	if len(res.Resolved) != 1 || res.Resolved[0].Addr != "192.0.2.1:5353" {
 		t.Fatalf("got %+v", res.Resolved)
 	}
 }
 
 func TestResolvePrimaries_dedupSameAddr(t *testing.T) {
-	res := resolvePrimaries([]PeerConf{
+	res := resolvePrimaries(context.Background(), nil, []PeerConf{
 		{Addr: "192.0.2.1:53", Key: "K1"},
 		{Addr: "192.0.2.1:53", Key: "K1"},
 	})
@@ -39,7 +39,7 @@ func TestResolvePrimaries_dedupSameAddr(t *testing.T) {
 }
 
 func TestResolvePrimaries_keyCollision(t *testing.T) {
-	res := resolvePrimaries([]PeerConf{
+	res := resolvePrimaries(context.Background(), nil, []PeerConf{
 		{Addr: "192.0.2.1:53", Key: "K1"},
 		{Addr: "192.0.2.1:53", Key: "K2"},
 	})
@@ -52,43 +52,53 @@ func TestResolvePrimaries_keyCollision(t *testing.T) {
 }
 
 func TestResolvePrimaries_unresolvedHostname(t *testing.T) {
-	res := resolvePrimaries([]PeerConf{{Addr: "tdns-nonexistent-test.invalid", Key: NOKEY}})
+	// With no IMR a hostname cannot be resolved here and is reported unresolved.
+	res := resolvePrimaries(context.Background(), nil, []PeerConf{{Addr: "ns.example.invalid", Key: NOKEY}})
 	if len(res.Resolved) != 0 {
 		t.Fatalf("want no resolved addresses, got %+v", res.Resolved)
 	}
-	if len(res.Unresolved) != 1 || res.Unresolved[0] != "tdns-nonexistent-test.invalid" {
+	if len(res.Unresolved) != 1 || res.Unresolved[0] != "ns.example.invalid" {
 		t.Fatalf("want unresolved entry, got %v", res.Unresolved)
 	}
 }
 
-func TestResolvePrimaries_localhostExpands(t *testing.T) {
-	res := resolvePrimaries([]PeerConf{{Addr: "localhost", Key: "K1"}})
-	if len(res.Unresolved) != 0 {
-		t.Fatalf("localhost should resolve: unresolved=%v", res.Unresolved)
+func TestResolvePrimaries_partialResolution(t *testing.T) {
+	// A literal IP (no lookup) plus an unresolvable hostname (no IMR): the zone
+	// is served from the IP, the hostname is reported unresolved.
+	res := resolvePrimaries(context.Background(), nil, []PeerConf{
+		{Addr: "192.0.2.1:53", Key: NOKEY},
+		{Addr: "ns.example.invalid", Key: NOKEY},
+	})
+	if len(res.Resolved) != 1 || res.Resolved[0].Addr != "192.0.2.1:53" {
+		t.Fatalf("want the IP served, got %+v", res.Resolved)
 	}
-	if len(res.Resolved) == 0 {
-		t.Fatal("localhost produced no addresses")
+	if len(res.Unresolved) != 1 || res.Unresolved[0] != "ns.example.invalid" {
+		t.Fatalf("want the hostname unresolved, got %v", res.Unresolved)
 	}
-	for _, up := range res.Resolved {
-		if up.Key != "K1" {
-			t.Fatalf("key not copied: %+v", up)
+}
+
+func TestSortV4First(t *testing.T) {
+	got := sortV4First([]string{"2001:db8::1", "192.0.2.1", "2001:db8::2", "192.0.2.2"})
+	want := []string{"192.0.2.1", "192.0.2.2", "2001:db8::1", "2001:db8::2"}
+	if len(got) != len(want) {
+		t.Fatalf("len: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order: got %v want %v", got, want)
 		}
 	}
-	// v4 entries must precede any v6 entry.
-	sawV6 := false
-	for _, up := range res.Resolved {
-		host, _, err := net.SplitHostPort(up.Addr)
-		if err != nil {
-			t.Fatalf("bad addr %q: %v", up.Addr, err)
-		}
-		ip := net.ParseIP(host)
-		if ip == nil {
-			t.Fatalf("not an IP: %q", up.Addr)
-		}
-		if ip.To4() == nil {
-			sawV6 = true
-		} else if sawV6 {
-			t.Fatalf("v4 address %q after v6 in ordering", up.Addr)
-		}
+}
+
+func TestBuildUpstreams(t *testing.T) {
+	got := buildUpstreams([]string{"192.0.2.1", "2001:db8::1"}, "5353", "K1")
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %+v", got)
+	}
+	if got[0].Addr != "192.0.2.1:5353" || got[0].Key != "K1" {
+		t.Fatalf("v4 tuple wrong: %+v", got[0])
+	}
+	if got[1].Addr != "[2001:db8::1]:5353" || got[1].Key != "K1" {
+		t.Fatalf("v6 tuple wrong: %+v", got[1])
 	}
 }

--- a/v2/sample_config_test.go
+++ b/v2/sample_config_test.go
@@ -16,7 +16,7 @@ import (
 func TestSampleZonesConfigDecodes(t *testing.T) {
 	data, err := os.ReadFile("../cmdv2/auth/auth-zones.sample.yaml")
 	if err != nil {
-		t.Skipf("sample not found (%v)", err)
+		t.Fatalf("checked-in sample not found (%v)", err)
 	}
 	var raw map[string]interface{}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
@@ -65,7 +65,7 @@ func TestSampleZonesConfigDecodes(t *testing.T) {
 func TestSampleTemplatesConfigIsValidYAML(t *testing.T) {
 	data, err := os.ReadFile("../cmdv2/auth/auth-templates.sample.yaml")
 	if err != nil {
-		t.Skipf("sample not found (%v)", err)
+		t.Fatalf("checked-in sample not found (%v)", err)
 	}
 	var raw map[string]interface{}
 	if err := yaml.Unmarshal(data, &raw); err != nil {

--- a/v2/sample_config_test.go
+++ b/v2/sample_config_test.go
@@ -1,0 +1,74 @@
+package tdns
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v3"
+)
+
+// TestSampleZonesConfigDecodes guards the shipped auth-zones sample against
+// drifting out of sync with the PeerConf struct form. It runs the same
+// yaml -> map -> mapstructure(+hook) pipeline ParseConfig uses and asserts no
+// bare-string (Legacy) primaries/notify entries survive — a legacy entry would
+// quarantine the example zone, making the sample a broken example.
+func TestSampleZonesConfigDecodes(t *testing.T) {
+	data, err := os.ReadFile("../cmdv2/auth/auth-zones.sample.yaml")
+	if err != nil {
+		t.Skipf("sample not found (%v)", err)
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("sample is not valid YAML: %v", err)
+	}
+	var result struct {
+		Zones []ZoneConf `yaml:"zones"`
+	}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName:    "yaml",
+		Result:     &result,
+		DecodeHook: stringToPeerConfHook(),
+	})
+	if err != nil {
+		t.Fatalf("decoder: %v", err)
+	}
+	if err := decoder.Decode(raw); err != nil {
+		t.Fatalf("sample failed to decode: %v", err)
+	}
+	if len(result.Zones) == 0 {
+		t.Fatal("no zones decoded from sample")
+	}
+	sawPrimaries := false
+	for _, z := range result.Zones {
+		if len(z.Primaries) > 0 {
+			sawPrimaries = true
+		}
+		for _, p := range z.Primaries {
+			if p.Legacy != "" {
+				t.Errorf("zone %s: legacy bare-string primary %q (migrate to {addr, key})", z.Name, p.Legacy)
+			}
+		}
+		for _, n := range z.Notify {
+			if n.Legacy != "" {
+				t.Errorf("zone %s: legacy bare-string notify %q (migrate to {addr, key})", z.Name, n.Legacy)
+			}
+		}
+	}
+	if !sawPrimaries {
+		t.Error("expected at least one zone with a primaries: list in the sample")
+	}
+}
+
+// TestSampleTemplatesConfigIsValidYAML is a syntactic guard for the templates
+// sample (its template entries are a map, decoded separately at runtime).
+func TestSampleTemplatesConfigIsValidYAML(t *testing.T) {
+	data, err := os.ReadFile("../cmdv2/auth/auth-templates.sample.yaml")
+	if err != nil {
+		t.Skipf("sample not found (%v)", err)
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("templates sample is not valid YAML: %v", err)
+	}
+}

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -118,7 +118,8 @@ type ZoneData struct {
 	Verbose           bool
 	Debug             bool
 	IxfrChain         []Ixfr
-	Upstream          string     // primary address from where zone is xfrred (bare addr; key on TsigKeyName)
+	PrimariesConf     []PeerConf // as-written primaries; persisted; re-resolved each load (P3)
+	Upstreams         []PeerConf // resolved addr:port tuples; runtime-only; used for transfer
 	Notify            []PeerConf // downstream secondaries that we notify (addr + key)
 	Zonefile          string
 	DelegationSyncQ   chan DelegationSyncRequest
@@ -212,9 +213,9 @@ type PeerConf struct {
 type ZoneConf struct {
 	Name              string `validate:"required"`
 	Zonefile          string
-	Type              string `validate:"required"`
-	Store             string // xfr | map | slice | reg (defaults to "map" if not specified)
-	Primary           PeerConf // upstream, for secondary zones
+	Type              string     `validate:"required"`
+	Store             string     // xfr | map | slice | reg (defaults to "map" if not specified)
+	Primaries         []PeerConf `yaml:"primaries" mapstructure:"primaries"` // upstream set, for secondary zones
 	Notify            []PeerConf
 	OptionsStrs       []string     `yaml:"options" mapstructure:"options"`
 	Options           []ZoneOption `yaml:"-" mapstructure:"-"` // Ignore during both yaml and mapstructure decoding
@@ -570,20 +571,21 @@ func rrsToStrings(rrs []dns.RR) []string {
 }
 
 type ZoneRefresher struct {
-	Name         string
-	ZoneType     ZoneType // primary | secondary
-	Primary      PeerConf
-	Notify       []PeerConf
-	ZoneStore    ZoneStore // 1=xfr, 2=map, 3=slice
-	Zonefile     string
-	Options      map[ZoneOption]bool
-	Edns0Options *edns0.MsgOptions
-	UpdatePolicy UpdatePolicy
-	DnssecPolicy string
-	MultiSigner  string
-	Force        bool // force refresh, ignoring SOA serial
-	Wait         bool // wait for refresh to complete before responding
-	Response     chan RefresherResponse
+	Name          string
+	ZoneType      ZoneType   // primary | secondary
+	PrimariesConf []PeerConf // as-written; copied to zd.PrimariesConf on merge
+	Primaries     []PeerConf // resolved; copied to zd.Upstreams on merge
+	Notify        []PeerConf
+	ZoneStore     ZoneStore // 1=xfr, 2=map, 3=slice
+	Zonefile      string
+	Options       map[ZoneOption]bool
+	Edns0Options  *edns0.MsgOptions
+	UpdatePolicy  UpdatePolicy
+	DnssecPolicy  string
+	MultiSigner   string
+	Force         bool // force refresh, ignoring SOA serial
+	Wait          bool // wait for refresh to complete before responding
+	Response      chan RefresherResponse
 }
 
 type RefresherResponse struct {

--- a/v2/transfer_fallback_test.go
+++ b/v2/transfer_fallback_test.go
@@ -1,0 +1,129 @@
+package tdns
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// startTestSOAServer starts a UDP DNS responder on 127.0.0.1 that answers SOA
+// queries for zone with the given serial and rcode. Returns its addr:port and a
+// shutdown func.
+func startTestSOAServer(t *testing.T, zone string, serial uint32, rcode int) (string, func()) {
+	t.Helper()
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := pc.LocalAddr().String()
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Rcode = rcode
+		if rcode == dns.RcodeSuccess {
+			m.Answer = append(m.Answer, &dns.SOA{
+				Hdr:     dns.RR_Header{Name: zone, Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 60},
+				Ns:      "ns." + zone,
+				Mbox:    "hostmaster." + zone,
+				Serial:  serial,
+				Refresh: 3600, Retry: 600, Expire: 86400, Minttl: 60,
+			})
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	started := make(chan struct{})
+	srv := &dns.Server{PacketConn: pc, Handler: mux, NotifyStartedFunc: func() { close(started) }}
+	go func() { _ = srv.ActivateAndServe() }()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test DNS server did not start")
+	}
+	return addr, func() { _ = srv.Shutdown() }
+}
+
+func TestDoTransfer_NoUpstreams(t *testing.T) {
+	zd := &ZoneData{ZoneName: "example.test."}
+	if _, _, err := zd.DoTransfer(); err == nil {
+		t.Fatal("expected an error when no upstreams are configured")
+	}
+}
+
+// A REFUSED from the first primary must NOT terminate the probe: a sibling
+// primary may have a different allow-transfer/query ACL. We must advance.
+func TestDoTransfer_RefusedAdvancesToNextPrimary(t *testing.T) {
+	zone := "example.test."
+	refusing, stop1 := startTestSOAServer(t, zone, 0, dns.RcodeRefused)
+	defer stop1()
+	good, stop2 := startTestSOAServer(t, zone, 99, dns.RcodeSuccess)
+	defer stop2()
+
+	zd := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: refusing}, {Addr: good}}}
+	xfr, serial, err := zd.DoTransfer()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if serial != 99 {
+		t.Fatalf("serial: got %d, want 99 (should have retried past REFUSED)", serial)
+	}
+	if !xfr {
+		t.Fatal("expected a transfer to be warranted (serial 99 > incoming 0)")
+	}
+}
+
+// A transport failure (nothing listening) on the first address advances to a
+// working sibling.
+func TestDoTransfer_TransportErrorAdvancesToNextPrimary(t *testing.T) {
+	zone := "example.test."
+	good, stop := startTestSOAServer(t, zone, 7, dns.RcodeSuccess)
+	defer stop()
+
+	// 127.0.0.1:1 has no listener -> connection refused / timeout (transport).
+	zd := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: "127.0.0.1:1"}, {Addr: good}}}
+	_, serial, err := zd.DoTransfer()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if serial != 7 {
+		t.Fatalf("serial: got %d, want 7 (should have skipped the dead address)", serial)
+	}
+}
+
+// When every primary answers but none gives a usable SOA (all REFUSED), back
+// off quietly: no transfer, no error.
+func TestDoTransfer_AllRefusedQuietBackoff(t *testing.T) {
+	zone := "example.test."
+	r1, s1 := startTestSOAServer(t, zone, 0, dns.RcodeRefused)
+	defer s1()
+	r2, s2 := startTestSOAServer(t, zone, 0, dns.RcodeRefused)
+	defer s2()
+
+	zd := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: r1}, {Addr: r2}}}
+	xfr, _, err := zd.DoTransfer()
+	if err != nil {
+		t.Fatalf("all-REFUSED should back off quietly, got error: %v", err)
+	}
+	if xfr {
+		t.Fatal("no transfer expected when every primary refused")
+	}
+}
+
+// When no primary is reachable at all, surface a hard error.
+func TestDoTransfer_AllUnreachableIsError(t *testing.T) {
+	zd := &ZoneData{ZoneName: "example.test.", Upstreams: []PeerConf{{Addr: "127.0.0.1:1"}, {Addr: "127.0.0.1:2"}}}
+	if _, _, err := zd.DoTransfer(); err == nil {
+		t.Fatal("expected an error when every upstream is unreachable")
+	}
+}
+
+func TestFetchFromUpstream_NoUpstreams(t *testing.T) {
+	zd := &ZoneData{ZoneName: "example.test."}
+	if _, err := zd.FetchFromUpstream(false, false, nil); err == nil {
+		t.Fatal("expected an error when no upstreams are configured")
+	}
+}

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -65,7 +65,7 @@ func (zd *ZoneData) Refresh(verbose, debug, force bool, conf *Config) (bool, err
 			}
 			updated, err = zd.FetchFromUpstream(verbose, debug, dynamicRRs)
 			if err != nil {
-				lg.Error("FetchZone failed", "zone", zd.ZoneName, "upstream", zd.Upstream, "err", err)
+				lg.Error("FetchZone failed", "zone", zd.ZoneName, "upstream", firstUpstreamAddr(zd.Upstreams), "err", err)
 				return false, err
 			}
 			return updated, nil // zone updated, no error
@@ -80,6 +80,14 @@ func (zd *ZoneData) Refresh(verbose, debug, force bool, conf *Config) (bool, err
 	return false, nil
 }
 
+// firstUpstreamAddr returns the first transfer target, or "" if none configured.
+func firstUpstreamAddr(upstreams []PeerConf) string {
+	if len(upstreams) == 0 {
+		return ""
+	}
+	return upstreams[0].Addr
+}
+
 // Return shouldTransfer, new upstream serial, error
 func (zd *ZoneData) DoTransfer() (bool, uint32, error) {
 	var upstream_serial uint32
@@ -92,11 +100,11 @@ func (zd *ZoneData) DoTransfer() (bool, uint32, error) {
 	m := new(dns.Msg)
 	m.SetQuestion(zd.ZoneName, dns.TypeSOA)
 
-	upstream := zd.Upstream
+	upstream := firstUpstreamAddr(zd.Upstreams)
 	if _, _, err := net.SplitHostPort(upstream); err != nil {
 		// If error, assume no port was specified
 		upstream = net.JoinHostPort(upstream, "53")
-		lg.Debug("DoTransfer: no port specified for upstream, using default port 53", "zone", zd.ZoneName, "upstream", zd.Upstream)
+		lg.Debug("DoTransfer: no port specified for upstream, using default port 53", "zone", zd.ZoneName, "upstream", upstream)
 	}
 	r, err := dns.Exchange(m, upstream)
 	if err != nil {
@@ -216,7 +224,7 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 // Return updated, err
 func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RRset) (bool, error) {
 
-	lg.Info("transferring zone via AXFR", "zone", zd.ZoneName, "upstream", zd.Upstream)
+	lg.Info("transferring zone via AXFR", "zone", zd.ZoneName, "upstream", firstUpstreamAddr(zd.Upstreams))
 	zd.SetStatus(ZoneStatusLoading)
 
 	new_zd := ZoneData{
@@ -234,7 +242,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 		// FoldCase:       zd.FoldCase, // Must be here, as this is an instruction to the zone reader
 	}
 
-	_, err := new_zd.ZoneTransferIn(zd.Upstream, zd.IncomingSerial, "axfr")
+	_, err := new_zd.ZoneTransferIn(firstUpstreamAddr(zd.Upstreams), zd.IncomingSerial, "axfr")
 	if err != nil {
 		lg.Error("ZoneTransfer failed", "zone", zd.ZoneName, "err", err)
 		return false, err

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -89,53 +89,76 @@ func firstUpstreamAddr(upstreams []PeerConf) string {
 }
 
 // Return shouldTransfer, new upstream serial, error
+//
+// The SOA probe iterates zd.Upstreams, advancing to the next address whenever
+// the current one does not yield a usable SOA — a transport error OR a
+// non-usable rcode (REFUSED/SERVFAIL/NXDOMAIN/empty). Different primaries are
+// independent servers that may answer differently (e.g. per-primary ACLs), so
+// one primary refusing does not mean the zone is unavailable from a sibling.
+// A usable NOERROR+SOA from any primary is honoured (transfer decided on
+// serial). If every primary answered but none gave a usable SOA, we back off
+// quietly (no transfer, no error); only all-unreachable is a hard error.
 func (zd *ZoneData) DoTransfer() (bool, uint32, error) {
-	var upstream_serial uint32
-
 	if zd == nil {
 		panic("DoTransfer: zd == nil")
+	}
+
+	if len(zd.Upstreams) == 0 {
+		return false, 0, fmt.Errorf("DoTransfer: zone %s has no upstreams configured", zd.ZoneName)
 	}
 
 	// log.Printf("%s: known zone, current incoming serial %d", zd.ZoneName, zd.IncomingSerial)
 	m := new(dns.Msg)
 	m.SetQuestion(zd.ZoneName, dns.TypeSOA)
 
-	upstream := firstUpstreamAddr(zd.Upstreams)
-	if _, _, err := net.SplitHostPort(upstream); err != nil {
-		// If error, assume no port was specified
-		upstream = net.JoinHostPort(upstream, "53")
-		lg.Debug("DoTransfer: no port specified for upstream, using default port 53", "zone", zd.ZoneName, "upstream", upstream)
-	}
-	r, err := dns.Exchange(m, upstream)
-	if err != nil {
-		lg.Error("dns.Exchange failed", "zone", zd.ZoneName, "qtype", "SOA", "err", err)
-		return false, 0, err
-	}
-
-	rcode := r.MsgHdr.Rcode
-	switch rcode {
-	case dns.RcodeRefused, dns.RcodeServerFailure, dns.RcodeNameError:
-		return false, 0, nil // never mind
-	case dns.RcodeSuccess:
-		if len(r.Answer) == 0 {
-			lg.Debug("DoTransfer: NOERROR but empty answer section", "zone", zd.ZoneName, "upstream", upstream)
-			return false, 0, nil
+	sawResponse := false
+	var lastErr error
+	for _, up := range zd.Upstreams {
+		upstream := up.Addr
+		if _, _, err := net.SplitHostPort(upstream); err != nil {
+			// If error, assume no port was specified
+			upstream = net.JoinHostPort(upstream, "53")
+			lg.Debug("DoTransfer: no port specified for upstream, using default port 53", "zone", zd.ZoneName, "upstream", upstream)
 		}
-		if soa, ok := r.Answer[0].(*dns.SOA); ok {
-			lg.Info("DoTransfer: serial check", "zone", zd.ZoneName, "notify_serial", soa.Serial, "incoming_serial", zd.IncomingSerial, "current_serial", zd.CurrentSerial)
-			if soa.Serial <= zd.IncomingSerial {
-				// log.Printf("New upstream serial for %s (%d) is <= old incoming serial (%d)",
-				// 	zd.ZoneName, soa.Serial, zd.IncomingSerial)
-				return false, soa.Serial, nil
+		r, err := dns.Exchange(m, upstream)
+		if err != nil {
+			// Transport failure for this address — try the next sibling.
+			lg.Warn("DoTransfer: SOA probe transport error, trying next upstream", "zone", zd.ZoneName, "upstream", upstream, "err", err)
+			lastErr = err
+			continue
+		}
+		sawResponse = true
+		switch r.MsgHdr.Rcode {
+		case dns.RcodeSuccess:
+			if len(r.Answer) == 0 {
+				lg.Debug("DoTransfer: NOERROR but empty answer section, trying next upstream", "zone", zd.ZoneName, "upstream", upstream)
+				continue
 			}
-			// log.Printf("New upstream serial for %s (%d) is > current serial (%d)",
-			// 	zd.ZoneName, soa.Serial, zd.IncomingSerial)
-			return true, soa.Serial, nil
+			if soa, ok := r.Answer[0].(*dns.SOA); ok {
+				lg.Info("DoTransfer: serial check", "zone", zd.ZoneName, "upstream", upstream, "notify_serial", soa.Serial, "incoming_serial", zd.IncomingSerial, "current_serial", zd.CurrentSerial)
+				if soa.Serial <= zd.IncomingSerial {
+					return false, soa.Serial, nil
+				}
+				return true, soa.Serial, nil
+			}
+			// NOERROR but the first answer is not a SOA — try the next sibling.
+			continue
+		default:
+			// REFUSED / SERVFAIL / NXDOMAIN / etc. This primary will not give a
+			// usable SOA, but a sibling may (e.g. differing per-primary ACLs).
+			lg.Debug("DoTransfer: non-usable SOA rcode, trying next upstream", "zone", zd.ZoneName, "upstream", upstream, "rcode", dns.RcodeToString[r.MsgHdr.Rcode])
+			continue
 		}
-	default:
 	}
 
-	return false, upstream_serial, nil
+	if sawResponse {
+		// At least one primary answered, but none gave a usable SOA (e.g. all
+		// REFUSED). Back off quietly — no transfer this cycle, not an error.
+		return false, 0, nil
+	}
+	// No primary was even reachable.
+	lg.Error("DoTransfer: SOA probe failed on all upstreams (unreachable)", "zone", zd.ZoneName, "count", len(zd.Upstreams), "err", lastErr)
+	return false, 0, fmt.Errorf("SOA probe of %s failed: all %d upstream(s) unreachable: %w", zd.ZoneName, len(zd.Upstreams), lastErr)
 }
 
 // Return updated, error
@@ -224,28 +247,48 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 // Return updated, err
 func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RRset) (bool, error) {
 
-	lg.Info("transferring zone via AXFR", "zone", zd.ZoneName, "upstream", firstUpstreamAddr(zd.Upstreams))
+	if len(zd.Upstreams) == 0 {
+		return false, fmt.Errorf("FetchFromUpstream: zone %s has no upstreams configured", zd.ZoneName)
+	}
 	zd.SetStatus(ZoneStatusLoading)
 
-	new_zd := ZoneData{
-		ZoneName:       zd.ZoneName,
-		ZoneType:       zd.ZoneType,
-		ZoneStore:      zd.ZoneStore,
-		XfrType:        zd.XfrType,
-		IncomingSerial: zd.IncomingSerial,
-		CurrentSerial:  zd.CurrentSerial,
-		Logger:         zd.Logger,
-		Verbose:        zd.Verbose,
-		Debug:          zd.Debug,
-		Options:        zd.Options,
-		Ready:          true, // this is only used by the checks for changes to DNSKEYs, HSYNC, etc.
-		// FoldCase:       zd.FoldCase, // Must be here, as this is an instruction to the zone reader
+	// Iterate the resolved upstreams, advancing to the next on ANY failure —
+	// a transport error, a REFUSED/NOTAUTH/SERVFAIL xfr rcode, or bad zone data.
+	// allow-transfer ACLs commonly differ per primary, so one primary refusing
+	// us says nothing about a sibling. A fresh new_zd per attempt keeps a failed
+	// transfer from polluting the next try; the live zd.IncomingSerial is only
+	// touched in the hard flip below, after a success.
+	var new_zd ZoneData
+	transferred := false
+	var lastErr error
+	for _, up := range zd.Upstreams {
+		upstream := up.Addr
+		lg.Info("transferring zone via AXFR", "zone", zd.ZoneName, "upstream", upstream)
+		new_zd = ZoneData{
+			ZoneName:       zd.ZoneName,
+			ZoneType:       zd.ZoneType,
+			ZoneStore:      zd.ZoneStore,
+			XfrType:        zd.XfrType,
+			IncomingSerial: zd.IncomingSerial,
+			CurrentSerial:  zd.CurrentSerial,
+			Logger:         zd.Logger,
+			Verbose:        zd.Verbose,
+			Debug:          zd.Debug,
+			Options:        zd.Options,
+			Ready:          true, // this is only used by the checks for changes to DNSKEYs, HSYNC, etc.
+			// FoldCase:       zd.FoldCase, // Must be here, as this is an instruction to the zone reader
+		}
+		if _, err := new_zd.ZoneTransferIn(upstream, zd.IncomingSerial, "axfr"); err != nil {
+			lg.Warn("FetchFromUpstream: AXFR from upstream failed, trying next", "zone", zd.ZoneName, "upstream", upstream, "err", err)
+			lastErr = err
+			continue
+		}
+		transferred = true
+		break
 	}
-
-	_, err := new_zd.ZoneTransferIn(firstUpstreamAddr(zd.Upstreams), zd.IncomingSerial, "axfr")
-	if err != nil {
-		lg.Error("ZoneTransfer failed", "zone", zd.ZoneName, "err", err)
-		return false, err
+	if !transferred {
+		lg.Error("FetchFromUpstream: AXFR failed on all upstreams", "zone", zd.ZoneName, "count", len(zd.Upstreams), "err", lastErr)
+		return false, fmt.Errorf("AXFR of %s failed: tried all %d upstream(s): %w", zd.ZoneName, len(zd.Upstreams), lastErr)
 	}
 
 	if new_zd.IncomingSerial == zd.IncomingSerial {

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -164,7 +164,7 @@ func (zd *ZoneData) DoTransfer() (bool, uint32, error) {
 // Return updated, error
 func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core.RRset) (bool, error) {
 
-	// log.Printf("Reading zone %s from file %s\n", zd.ZoneName, zd.Upstream)
+	// log.Printf("Reading zone %s from file %s\n", zd.ZoneName, zd.Zonefile)
 	zd.SetStatus(ZoneStatusLoading)
 
 	new_zd := ZoneData{


### PR DESCRIPTION
## Multi-primary upstreams + hostname resolution

Follow-on to the dynamic-zones management interface (#267) — **this PR targets `dynamic-zones-mgmt`, not `main`**, and stacks on top of it.

### Why

Today a secondary zone has exactly one primary (`ZoneData.Upstream`, a scalar string) handed straight to the SOA probe / AXFR, which connects to a single address. Two problems follow:

1. **No redundancy** — real DNS infrastructure always has more than one primary; tdns could only express one.
2. **A hostname primary that resolves to several addresses (A + AAAA) only ever tried one and gave up on failure** — observed on a box with no outbound IPv6: `nsa.johani.org:53` picked the AAAA, hit `no route to host`, and never fell back to the working A.

The real defect is that `Primary` was a *scalar when it should be a list*. Once it is a list, expanding a hostname into several `addr:port` tuples is trivial — there is already a slist to hold them.

### What changed (per phase)

- **P2 — data model.** `ZoneData.Upstream string` → `PrimariesConf []PeerConf` (as-written, persisted, re-resolved each load) + `Upstreams []PeerConf` (resolved `addr:port`, runtime-only). `ZoneConf.Primary` → `Primaries` (YAML `primaries:`). `ZoneRefresher` carries both forms. Dead `RefreshCounter.Upstream/.Notify` deleted.
- **P3 — resolution.** Hostnames resolve via the **in-process IMR** (A + AAAA, v4-first), at parse/load/add/modify/catalog ingress — re-resolved each load, never at transfer time. Partial resolution → `ConfigWarning` (zone served from the rest); zero → `ConfigError` (quarantine). `MainInit` initialises the IMR before `ParseZones` so it is available at parse time.
- **P4 — transfer fallback.** `DoTransfer` (SOA) and `FetchFromUpstream` (AXFR) iterate `Upstreams` with per-primary fallback (see design note below).
- **P5 — persistence.** `zoneDataToZoneConf` persists the as-written `PrimariesConf` (hostnames + per-entry keys), not the resolved addresses, so reload re-resolves.
- **P6 — API/CLI/samples.** `--primaries` comma-list (one `--primary-key` for all); `list-zones`/`list-dynamic` render the as-written list and surface `config-warning` distinctly from service-impacting errors; `*.sample.yaml` migrated to the `{addr, key}` struct form (primaries + notify).

### Two design decisions reversed from the original plan (reviewers note)

- **Resolution uses the in-process IMR, not `net.LookupHost`.** Primaries resolve the way tdns itself resolves names (its own recursor / root hints / stubs), not via the OS stub resolver. Consequence: with the IMR disabled, primaries must be IP literals.
- **AXFR retries on REFUSED (and any failure), not just transport errors.** Multiple primaries are independent servers whose `allow-transfer` ACLs routinely differ, so a REFUSED from one says nothing about a sibling. Terminating on it would defeat the redundancy multi-primary exists for. This removed the `isTransportError` transport-vs-DNS distinction entirely.

Both reversals (and their rationale) are written into `docs/2026-06-26-multi-primary-and-hostname-resolution-plan.md`.

### Tests / verification

`make` clean, `go test -race ./...` green, `go vet` clean. New tests cover: resolver (literal-IP passthrough, dedup, key-collision, v4-first ordering, port/key, unresolved, partial), SOA-probe fallback against a real UDP test server (transport error → next, **REFUSED → next**, all-refused → quiet back-off, all-unreachable → error), persistence round-trip, and sample-config decode guards. A full AXFR-serving integration test is deferred (tracked separately).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic secondary zones now support multiple primary endpoints instead of a single upstream.
  * Zone listings and CLI output now show all configured primaries, with clearer status messages for non-critical issues.
  * Zone transfer checks can automatically try alternate primaries if one is unavailable.

* **Bug Fixes**
  * Improved handling of partially resolvable primaries and configuration warnings.
  * More reliable zone loading, saving, and refresh behavior for dynamic zones.
  * Added better validation to reject invalid primary configurations earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->