### PR TITLE
TSIG on zone replication (Improvement 2)

### DIFF
--- a/docs/2026-06-23-dynamic-zones-interface-and-tsig-transfers.md
+++ b/docs/2026-06-23-dynamic-zones-interface-and-tsig-transfers.md
@@ -30,6 +30,33 @@ end with none of Improvement 2's code. Improvement 2 is then layered on with **n
 change and no re-provisioning** of zones added before it, because Improvement 1 already uses the
 final primary/key syntax (the NOKEY model, §5.B0).
 
+## Implementation status (2026-06-28) — Improvement 2 (§6) COMPLETE
+
+All nine §6 steps are implemented on branch `tsig-on-replication` (one commit per
+step; each builds, passes `go test -race ./...`, and is `go vet`-clean):
+
+| Step | Commit | Note |
+|------|--------|------|
+| 1 keys: store | `ce5edcd` | name→secret `TsigKeyStore`, NOKEY/BLOCKED reserved |
+| 2 ip-spec ACL | `a11b0fb`,`05ca2a8` | `net/netip`; BLOCKED supersedes, first-match-wins |
+| — helpers | `946486d` | keystore-backed `TsigProvider`, `SignForPeer`, `peerIP` |
+| 3 SOA probe sign | `0437828` | `DoTransfer` per-attempt `up.Key` |
+| 4 AXFR/IXFR sign | `f58c205` | `ZoneTransferIn` |
+| 6 outbound NOTIFY sign | `7890be5` | `SendNotify`; threads `conf` (tdns-mp deferred-break) |
+| **5+7 inbound verify** | `d68acff` | NOTIFY(SOA) `allow-notify` + AXFR `downstreams`; one provider on the auth `dns.Server` does verify + RFC 8945 response signing. **Combined** because they share all wiring. |
+| 8 catalog wiring | `1a92b0d` | `tsig_key` → `primaries[].key`; false "applied" log deleted |
+| 9 API/CLI + lifecycle | `5c9f771` | inline `tsig_name/secret/algo` on `zone add`/`modify`, upsert + **persist** to the dynamic config file's `keys:` block (survives restart) |
+
+**Operator-visible behaviour change (hard cutover, step 7):** an empty
+`downstreams:` ACL now **denies all AXFR/IXFR** (tdns previously served transfers
+to anyone). Every zone that should serve transfers needs an explicit
+`downstreams:` after deploy. See §11 migration.
+
+**Deferred (per this plan):** ACL flags on the API (`--allow-notify`/`--downstreams`
+are static-config-only in v1); TSIG key auto-drop (a never-dropped name store is
+acceptable). tdns-mp must update its 4 `Notifier` call sites + the `DoTransfer`/
+`FetchFromUpstream`/`ZoneTransferIn` callers when it bumps the pinned `tdns/v2`.
+
 ## Revision note (2026-06-28) — two model changes supersede parts of this plan
 
 1. **Multi-primary + hostname resolution** (separate PR; see

--- a/docs/2026-06-27-zsk-alg-rollover-dual-model-design.md
+++ b/docs/2026-06-27-zsk-alg-rollover-dual-model-design.md
@@ -1,0 +1,215 @@
+# Dual-model ZSK algorithm rollover: FIFO and double-signature
+
+Status: DESIGN / DECISION-PENDING. This is a design and cost
+assessment, not an approved build plan. It exists to support the
+decision of whether to implement a second ZSK-algorithm-rollover model
+(double-signature) alongside the FIFO model that is already built.
+
+Companion docs:
+- `2026-06-17-algorithm-rollover-evaluation.md` — the as-built FIFO
+  (relaxed-completeness) ZSK algorithm rollover. This doc does NOT
+  re-derive that; it builds on it.
+- `2026-06-21-ksk-algorithm-rollover-plan.md` — KSK side (out of scope
+  here; KSK alg rollover is parent-coordinated and unaffected).
+- Draft `draft-johani-dnsop-dnssec-alg-split-01` — the IETF draft this
+  code is measured against. The relevant tension is between the draft's
+  Part 1 (|Z|>1) text and the code's FIFO behaviour.
+
+
+## 0. The two models in one paragraph each
+
+FIFO (built, gated behind `dnssec.completeness: relaxed`). ZSKs form a
+single-file queue. A ZSK algorithm change is incidental: ZSK n+1 simply
+carries a different algorithm than ZSK n. At the roll, the new ZSK
+becomes active and the old one is retired in the same atomic step
+(`kdb.RolloverKey`). Old-algorithm RRSIGs are kept only until they age
+past validity, then drop. There is NO instant at which every non-DNSKEY
+RRset is guaranteed to carry both algorithms' signatures.
+
+Double-signature (not built; this doc specs it). A ZSK algorithm change
+runs as a conventional RFC 6781 conservative rollover: the new-algorithm
+ZSK is promoted to active ALONGSIDE the old one, the zone is re-signed so
+that every non-DNSKEY RRset carries an RRSIG from BOTH algorithms, and
+only after that completion is reached is the old-algorithm ZSK retired.
+At every instant during the window, completeness within Z holds.
+
+The draft's Part 1 |Z|>1 text describes the double-signature model
+("every non-DNSKEY RRset carries a signature from each old and new ZSK
+algorithm during the rollover window"). The code implements FIFO. That
+is the divergence this doc is about.
+
+
+## 1. Is FIFO safe? (summary of the prior analysis)
+
+Yes, for the intended deployment, and no weaker than the draft's own
+stated guarantees for the transitional deployment. Two properties:
+
+a. Validation correctness — unconditionally preserved. The invariant
+   FIFO maintains is: every RRSIG in the zone is covered by a ZSK
+   currently in the apex DNSKEY RRset, and a signing key's RRSIGs are
+   not dropped until past their validity. A resolver validates with any
+   single supported Z algorithm (RFC 6840 §5.11). FIFO never produces
+   bogus/SERVFAIL.
+
+b. Forgery resistance — the only thing double-sig adds is a transient
+   window in which a both-algorithm-aware validator could DEMAND the
+   stronger Z algorithm on a given RRset. The draft's own Part 2 /
+   Security Considerations argue that this demand-the-stronger fallback
+   is gone in steady state (|Z|=1) anyway, and that the split's safety
+   rests on the K-over-Z structural asymmetry (identical under both
+   models) plus bounded ZSK rotation, NOT on Z-internal redundancy.
+   FIFO merely extends "can't demand the stronger Z on every RRset"
+   from steady state into the rollover window.
+
+The one genuine difference: in a classical-ZSK → PQ-ZSK transition,
+double-sig gives a both-algorithm-aware validator PQ coverage of bulk
+data immediately at roll start; FIFO reaches it after ~one max-TTL drain.
+The draft already concedes the transitional case provides no long-term
+bulk-data integrity and bounds exposure by ZSK lifetime; a one-TTL
+convergence delay is negligible against a ZSK-lifetime-scale window.
+
+Conclusion: FIFO is safe. Double-sig buys a transient redundancy the
+draft argues is unnecessary, at the cost of a second permanent model.
+
+
+## 2. Why FIFO is FIFO: the load-bearing primitive
+
+`rolloverZskForZone` (zsk_rollover.go:469) rolls via
+`kdb.RolloverKey(zone, "ZSK", nil)` (keystore.go:1341), which ATOMICALLY
+does old-active → retired and standby → active. One in, one out, never
+two algorithms active at once. This atomicity IS the FIFO model.
+
+Double-signature needs the opposite shape: standby → active WITHOUT
+retiring the old active (additive promote), then a DEFERRED retire once
+the zone is fully double-signed. So double-sig is not a branch inside the
+existing roll; it is a second rollover path that sits beside
+`RolloverKey`. `PromoteDnssecKey(zone, keyid, oldstate, newstate)`
+(keystore.go:1036) already provides the additive promote primitive —
+call it standby→active and simply do NOT retire the old active.
+
+
+## 3. The completion gate: the only genuinely new concept
+
+FIFO never asks "is the zone fully re-signed under the new algorithm
+yet?" — it doesn't need to. Double-sig's correctness depends on NOT
+retiring the old-algorithm active ZSK until that is true. This gate has
+no equivalent in the current code.
+
+Definition (cheapest correct form). For a zone in double-sig-in-progress
+with old-algorithm active ZSK O and new-algorithm active ZSK N, the old
+active O MAY be retired when BOTH hold:
+
+1. Coverage: every non-DNSKEY authoritative RRset in the zone now
+   carries an RRSIG from algorithm(N). In an inline/online signer this
+   is guaranteed once a full re-sign pass has completed after N became
+   active — so the gate can be expressed as "a re-sign pass has run to
+   completion with N active" rather than walking every RRset.
+
+2. Drain: every RRSIG made by O is now past its validity (so no resolver
+   holds a cached O-signature it still needs O in the DNSKEY RRset to
+   validate). Equivalently: at least max(RRSIG validity remaining at roll
+   start) has elapsed, OR the zone has been fully re-signed AND the old
+   RRSIGs purged.
+
+Note the asymmetry with FIFO: FIFO can drop O's DNSKEY as soon as O's
+RRSIGs have aged out, because nothing replaced them mid-flight. Double-sig
+must additionally ensure N's coverage is complete first — otherwise
+retiring O could strand an RRset that N has not yet signed. Condition (1)
+is the part FIFO never needed.
+
+Where it runs: a per-zone check each KeyStateWorker tick for zones whose
+state is double-sig-in-progress; on success, the deferred retire of O.
+This requires a small amount of persistent per-zone state to mark
+"double-sig in progress, old active = O, started at T" — the natural home
+is the existing rollover zone-state row (ksk_rollover_zone_state.go),
+reused for ZSK, or a sibling ZSK row. (FIFO keeps no such state; this is
+new.)
+
+
+## 4. Per-site change map and LOC
+
+Selection is the EXISTING `dnssec.completeness: strict|relaxed` knob
+(2026-06-17 doc, STEP 1). `relaxed` → FIFO (built). `strict` → currently
+REFUSES a ZSK alg roll (sign.go:329-332); double-sig fills in that branch
+so `strict` MEANS double-sig instead of "unsupported".
+
+| # | Site | File | Today | Change | LOC |
+|---|------|------|-------|--------|-----|
+| 1 | reconcile strict branch | sign.go:329-336 | returns error | detect double-sig-in-progress; don't refuse; let both actives flow | 30-50 |
+| 1b| leftover sweep | sign.go:349-382 | relaxed skips old-alg ZSK | add strict case: old-alg active mid-double-sig is legit, not leftover | (incl above) |
+| 2 | additive promote | keystore.go | `PromoteDnssecKey` exists | thin caller: standby→active, no retire of old | 10-20 |
+| 3 | double-sig rollover fn | zsk_rollover.go | `rolloverZskForZone` (FIFO) | sibling: on roll-due in strict, additive-promote instead of `RolloverKey`; factor shared lock/heal/due/standby checks | 50-70 |
+| 4 | completion gate + deferred retire + wiring | zsk_rollover.go / key_state_worker.go | none | §3 gate, per-tick check, retire-O-on-complete | 60-90 |
+| 5 | persistent in-progress state | ksk_rollover_zone_state.go (reuse) or new | none for ZSK | mark/clear double-sig-in-progress + old-active | 20-40 |
+| 6 | standby maintenance | key_state_worker.go:282-299 | already per-(role,alg) for strict | guard so new-alg standby is staged before the roll | 0-15 |
+| 7 | config selection | — | knob exists, routed | none / trivial | 0-10 |
+
+Production subtotal: ~170-295 LOC. (PromoteDnssecKey existing trims #2;
+the new persistent-state line #5 is the offsetting addition vs the
+earlier estimate — net roughly the same band.)
+
+Tests. `zsk_alg_rollover_test.go` is already 750 lines for the FIFO
+(T1-T9) matrix. Double-sig needs a PARALLEL matrix asserting the OPPOSITE
+invariants — both actives present mid-roll, every RRset double-signed, O
+NOT retired before the gate, O retired AFTER. These cases do not reuse the
+FIFO assertions (they often contradict them). Realistically ~400-700 LOC
+of new tests.
+
+All-in: ~170-295 LOC production + ~400-700 LOC tests ≈ 600-1000 LOC,
+concentrated in sign.go, zsk_rollover.go, the keystore, the rollover
+zone-state, and a new test file.
+
+
+## 5. The cost that is not LOC
+
+The LOC is modest. The durable cost is two permanently-live correctness
+models sharing one signing/key-state path: `SignRRset`, `RolloverKey` and
+its additive sibling, the standby cap, the KSK rollover interaction, and
+`asap` manual rolls. Every future change to that path must be reasoned
+under BOTH models, and BOTH test matrices must stay green forever. The
+in-progress-state machine (§3/§5-row) is the easiest place for a subtle
+retire-too-early bug — exactly the bug class that produces (1a) failures.
+
+This ongoing maintenance tax, not the ~600-1000 LOC, is the real price.
+It is the cost the project's "no dual-format / keep it simple" convention
+is pointed at.
+
+
+## 6. Recommendation
+
+Given (a) FIFO is safe, (b) the draft's own Part 2 / Security argument
+says Z-internal redundancy is unnecessary, and (c) the two-model tax in
+§5 — the recommended path is to keep FIFO as the SINGLE model and revise
+the draft's |Z|>1 language to permit (or prefer) a sequential
+ZSK-algorithm rollover, justified from the bounded-rotation argument the
+draft already makes in Part 2. That resolves the draft's internal tension
+and keeps the code simple.
+
+Build double-sig in parallel only for a concrete external reason FIFO
+cannot satisfy:
+- a reviewer/operator constituency that insists on RFC 6781 conservative
+  semantics for the rollover window; or
+- a real classical→PQ transitional deployment that needs IMMEDIATE PQ
+  coverage of bulk data at roll start rather than after one max-TTL.
+
+If such a reason exists, this doc is the build plan: the scaffolding
+(`completeness` knob, per-(role,alg) standby counting, `PromoteDnssecKey`,
+the rollover zone-state row) is largely in place; the genuinely new work
+is the completion gate (§3) and its in-progress state (§5-row). If no such
+reason exists, building double-sig pays the §5 tax to satisfy a property
+the draft itself says is moot.
+
+
+## 7. Open questions
+
+- Completion gate, coverage condition (§3.1): is "a full re-sign pass has
+  completed with N active" a sound proxy for "every RRset carries an N
+  RRSIG" in BOTH the inline and online signing paths? Online signing has
+  no zone-wide pass — coverage there is per-query-lazy, which weakens the
+  proxy. Needs confirmation before this is buildable for online signers.
+- Should double-sig reuse the KSK rollover zone-state row (§5) or get a
+  ZSK-specific sibling? Reuse risks coupling two state machines that are
+  otherwise independent (KSK alg roll is parent-coordinated; ZSK is not).
+- Interaction with `asap --zsk` during an in-progress double-sig roll: a
+  manual roll mid-window must not promote a THIRD active ZSK. The FIFO
+  manual path (zsk_rollover.go:439-479) needs a guard under double-sig.

--- a/docs/2026-06-29-first-class-tsig-keystore-plan.md
+++ b/docs/2026-06-29-first-class-tsig-keystore-plan.md
@@ -1,289 +1,440 @@
-# First-class TSIG keystore — plan (2026-06-29)
+# First-class TSIG keystore — implementation plan (consolidated 2026-06-29)
+
+Consolidates the original plan, the critical review
+([…-plan-review.md](./2026-06-29-first-class-tsig-keystore-plan-review.md)), and the
+follow-up design discussion into an implementation-ready spec. **All code refs are
+against `tsig-on-replication` @ `6dd2a2b`** and were re-verified (line numbers
+shifted since the review — e.g. `6dd2a2b` grew `dynamic_zones.go`).
 
 ## Summary
 
-Make TSIG keys **first-class, DB-backed keystore members**, managed the same way
-SIG(0) and DNSSEC keys already are (`Sig0KeyStore` / `DnssecKeyStore` tables, a
-`keystore` CLI group, the `KeystorePost`/`KeystoreResponse` API). Today TSIG keys
-live in an in-memory `map[name]TsigDetails` populated from the `keys.tsig` config
-block plus a side-channel `keys:` block in the dynamic-zones YAML file. That is
-inconsistent with every other key type, and the reload path has to rebuild the
-in-memory store from config and re-merge the dynamic keys (commit `bf53aef`,
-review finding #4), which leaves a small swap window.
+Make TSIG keys **first-class, DB-backed keystore members**, managed like SIG(0)
+and DNSSEC (`Sig0KeyStore`/`DnssecKeyStore` tables, the `keystore` CLI group, the
+`KeystorePost`/`KeystoreResponse` API). Today TSIG keys live in an in-memory
+`map[name]TsigDetails` populated from `keys.tsig` plus a side-channel `keys:` block
+in the dynamic-zones YAML — the only key type not in the DB. This work moves them
+into the DB with an explicit `origin`/`owner` model, a `keystore tsig` command set,
+in-place reconcile-on-reload, no auto-drop, and advisory reference counting.
 
-This plan replaces that with a single DB-backed store and a `keystore tsig`
-command set, plus a key model that distinguishes **how a key is managed**
-(`origin`) from **what it is for** (`owner`).
+Layered onto `tsig-on-replication` (PR #269 → `dynamic-zones-mgmt`).
 
-It is layered onto branch `tsig-on-replication` (PR #269 → base
-`dynamic-zones-mgmt`). **It supersedes the interim #4 reload fix** in `bf53aef`.
+## 0. Already landed in #269 (so the plan doesn't re-propose it)
 
-## 1. Current state (verified against the code)
+- **Multi-key inbound ACL** (`9f84831`): `matchACL` returns the **set** of approved
+  keys for a source (union of matching entries, N keys), `checkInboundTSIG` accepts
+  **any** of them. `v2/acl.go:40`, `v2/tsig_peer.go:139`. This **closes the old
+  "dual-key rotation ACL gap"** — rotation's remaining work is operational docs
+  only (§11), not inbound-verify code. *(Review #1.)*
+- **ACL validation on the dynamic load path** + **full modify rollback** (`6dd2a2b`):
+  `v2/dynamic_zones.go` LoadDynamicZoneFiles ValidateACL; ModifyDynamicZone restores
+  `oldZd` on persist failure.
+- **Inbound TSIG verify, signing, `allow-notify:`/`downstreams:` ACLs** (earlier #269).
 
-### TSIG keys today
-- `v2/tsig_keys.go`: `TsigKeyStore { mu; keys map[string]TsigDetails }`,
-  `TsigDetails {Name, Algorithm, Secret}`. In-memory only.
-- Read path (must keep working unchanged): `TsigKeyStore.Get/Has`, used by
-  `tsigKeyProvider.hmac` (inbound verify), `SignForPeer` (outbound sign),
-  `tsigKeyDefined` (config validation) — `v2/tsig_peer.go`, `v2/tsig_keys.go`.
-- Config keys: `LoadTsigKeys()` builds a fresh store from `conf.Keys.Tsig` and
-  swaps it in.
-- Dynamic keys: API `stageInlineTsigKey`/`commitStagedTsigKey` add to the store,
-  and the secret is persisted into the dynamic-zones YAML file's `keys:` block
-  (`getDynamicTsigKeysFromZones` / `loadDynamicTsigKeys`).
-- Reload (`ReloadConfig`, `bf53aef`): on a successful parse, `LoadTsigKeys()`
-  rebuilds config-only, then re-merges persisted dynamic keys. Correct but has a
-  brief window where the swapped-in store is config-only.
-- Catalog: a config group's `tsig_key` **references a key by name only**
-  (`catalog.go`, validated via `tsigKeyDefined`). It does **not** distribute key
-  material.
+## 1. Current state (verified, with refs)
 
-### How SIG(0)/DNSSEC keys are managed (the pattern to mirror)
-- DB: `v2/db.go` — `KeyDB { DB *sql.DB; … }`, `Tx`, `kdb.Begin(ctx)` /
-  `tx.Commit()` / `tx.Rollback()`.
-- Schema: `v2/db_schema.go` — `DefaultTables` map of `CREATE TABLE IF NOT EXISTS`;
-  `dbSetupTables()` applies them; `dbMigrateSchema()` adds later columns via
-  `ALTER TABLE ADD COLUMN`; `dbMigrateData()` runs one-shot data migrations.
-- CRUD: `v2/keystore.go` — `Sig0KeyMgmt(tx, kp)`, `DnssecKeyMgmt(ctx, tx, kp)`;
-  `INSERT OR REPLACE` / `SELECT … rows.Scan` / `DELETE`, with a per-key in-memory
-  cache invalidated on write.
-- CLI: `v2/cli/keystore_cmds.go` — `keystore sig0 {…}` and `keystore dnssec {…}`
-  subtrees; handler builds a `KeystorePost` and `SendKeystoreCmd`s it.
-- API: `v2/apihandler_funcs.go` `APIkeystore`; `v2/api_structs.go`
-  `KeystorePost{Command, SubCommand, …}` / `KeystoreResponse`. Dispatch on
-  `Command` (`"sig0-mgmt"`, `"dnssec-mgmt"`), transaction opened per request.
-- Secret/key generation: `v2/sig0_utils.go` `GenerateKeyMaterial` (asymmetric,
-  via miekg/dns + `crypto/rand`). **No TSIG secret generator exists yet.**
+| Thing | Ref |
+|------|-----|
+| In-memory `TsigKeyStore{mu; keys map[string]TsigDetails}` + `Get/Has/Add/Delete` | `v2/tsig_keys.go:22,33,44,50,61` |
+| `TsigDetails{Name,Algorithm,Secret}` | `v2/structs.go:862` |
+| Hot path: `tsigKeyProvider` / `SignForPeer` | `v2/tsig_peer.go:31,100` |
+| `LoadTsigKeys()` builds store from `conf.Keys.Tsig`, swaps; rejects NOKEY/BLOCKED | `v2/tsig_keys.go:91,97` |
+| `validateTsigKeySpec` / `knownTsigAlgo` / `tsigKeyDefined` | `v2/tsig_keys.go:142,131,115` |
+| Reload: rebuild config keys then re-merge dynamic YAML keys | `v2/config.go:554,568,571` |
+| Dynamic keys persisted in dynamic-zones YAML `keys:` block | `v2/dynamic_zones.go:316` (`DynamicConfigFile`), `:432,509,536` |
+| Inline `stageInlineTsigKey`/`commitStagedTsigKey` | `v2/dynamic_zones.go:667,690` |
+| Provision/Modify dynamic zone | `v2/dynamic_zones.go:710,891` |
+| Catalog `tsig_key` name-only, validated via `tsigKeyDefined` | `v2/catalog.go:383,384`; `ConfigGroupConfig.TsigKey` `config.go:395`; `Catalog.ConfigGroups` `config.go:371` |
+| CLI client keystore `ParseTsigKeys(*KeyConf)` → `Globals.TsigKeys` | `v2/tsig_utils.go:10,21` |
+| KeyDB + `Tx` + `Begin` | `v2/db.go:283,63`; CRUD `v2/keystore.go:18,302` |
+| Schema map + table DDL | `v2/db_schema.go:11,51,68`; `dbSetupTables/dbMigrateSchema/dbMigrateData` `v2/db.go:97,164,120` |
+| `keystore` CLI tree (`sig0`/`dnssec`, verbs incl. `generate`,`purge`) | `v2/cli/keystore_cmds.go:48,160,84,196,369` |
+| `APIkeystore` (commit in `defer` after handler) | `v2/apihandler_funcs.go:20,35,37,42,59,69` |
+| `KeystorePost{Algorithm uint8, KeyType string, Force bool}` / `KeystoreResponse{Dnskeys,Sig0keys}` | `v2/api_structs.go:18,26,25,34,37,42,43` |
+| `/keystore` behind shared API key + TLS, Auth+Agent only | `v2/apirouters.go:19,99,100` |
+| Boot order (see §5) | `v2/main_initfuncs.go:123,130,215,228` |
 
-### Important structural difference
-SIG(0)/DNSSEC keys are **per-zone**, keyed `(zonename, keyid)`, and their CLI
-takes `--zone`. **TSIG keys are global** — one secret per name, zone-independent.
-So `keystore tsig` operates on a **global key namespace** (no `--zone`). This is a
-deliberate UX departure from `keystore sig0/dnssec`.
+**Structural difference:** SIG(0)/DNSSEC are **per-zone** (`(zonename,keyid)` PK,
+`--zone` CLI). TSIG is **global** (one secret per name). `keystore tsig` therefore
+takes **no `--zone`** — a deliberate UX departure.
 
-## 2. The key model: `origin` vs `owner`
+## 2. Key model: `origin` vs `owner`
 
-A TSIG key carries two orthogonal attributes (decided after design discussion):
+A TSIG key carries two orthogonal attributes:
 
-- **`origin`** — *how the key is managed*. Values today: `config` | `api`.
-  - `config`: declared in `keys.tsig` YAML; the DB row is a materialization,
-    reconciled against the YAML on reload. **Not** CLI-deletable (edit YAML).
-  - `api`: created/managed via the API/CLI; the DB row is authoritative. **Is**
-    CLI-deletable and purgeable.
-  - (Catalog does not create keys today, so `origin` is never `catalog`. If a
-    future key-distribution mechanism *pushes* secrets, it adds an `origin` value.)
+- **`origin`** — *how it's managed*: `config` | `api`.
+  - `config`: declared in `keys.tsig`; DB row is a materialization, reconciled
+    against the YAML on reload (§6). Not CLI-deletable (edit YAML).
+  - `api`: created/managed via the API/CLI; DB row authoritative. CLI-deletable,
+    purgeable.
+  - Catalog does **not** create keys, so `origin` is never `catalog`.
+- **`owner`** — *what it's for*: an **open string** (seed `config|api|catalog`).
+  Governs how a **zero-reference** key is interpreted and audit grouping. Defaults
+  to `origin`. **Mutable** post-creation via `keystore tsig setowner` (api-origin)
+  or the YAML `owner:` field (config-origin) — never delete+recreate.
 
-- **`owner`** — *what the key is for / who consumes it*. An **open enum**:
-  `config` | `api` | `catalog` | `{future key-dist infra}` | …. Operator-assignable.
-  Governs how a **zero-reference** key is interpreted and how keys are grouped for
-  audit. Defaults to `origin` when unspecified.
-
-They are orthogonal. The case that proves it:
-
-| `origin` (managed via) | `owner` (for) | meaning |
+| `origin` | `owner` | meaning |
 |---|---|---|
-| config | config | plain static key for local config zones |
-| api | api | plain dynamic key for local API zones |
-| **config** | **catalog** | declared in `keys.tsig`, reconciled on reload — but its purpose is catalog consumers, so **0 local refs is expected**, never flagged or purged as an orphan |
+| config | config | static key for config zones |
+| api | api | dynamic key for local API zones |
+| **config** | **catalog** | declared in `keys.tsig`, reconciled — but for catalog consumers, so 0 local refs is expected, never an orphan |
 | api | catalog | created via API, earmarked for catalog consumers |
 
-### Consequences for management
-- **No auto-drop.** A zero-reference key is valid for *both* config and dynamic
-  keys — it may be pre-provisioned for an upcoming `zone add` or for future
-  catalog consumers. Removal is always explicit.
-- **Reference counting is advisory only** — shown in `list`, warned on `delete`;
-  never an automatic deletion trigger.
-- **`delete`** gates on `origin`: only `origin=api` keys are CLI-deletable.
-- **`purge`** is strict: candidate = `origin=api` **and** `owner=api` **and**
-  zero references. Anything owned by catalog/agent/future, or `origin=config`, is
-  never an orphan and is never purged.
-- **Revocation:** a `config` key → remove from `keys.tsig` + reload (reconcile
-  drops it). An `api` key → `keystore tsig delete`/`purge`. Restart always rebuilds
-  from the authoritative sources (YAML + DB), so it is the universal reset.
+**Consequences:**
+- **No auto-drop.** A zero-ref key is valid for both kinds (may be pre-provisioned
+  for an upcoming `zone add` or for catalog consumers). Removal is always explicit.
+- **Reference counting is advisory only** (§8) — shown in `list`; never an automatic
+  deletion trigger. *(Resolves review #3: §2 now says "advisory/shown", not
+  "warned on delete"; delete is **refused** while referenced — §9.)*
+- **Secrets immutable by default; override is break-glass `--force`** (§7).
+- **`delete`/`purge` gate on `origin=api`**; `purge` additionally on `owner=api` and
+  zero references.
 
-## 3. Storage: the `TsigKeyStore` table
+## 3. Storage: the `TsigKeystore` table
 
-New table in `db_schema.go`, name-keyed (global), modelled on the existing key
-tables but without the per-zone / rollover-state machinery:
+New table in `v2/db_schema.go` `DefaultTables` (`:11`), modelled on
+`Sig0KeyStore`/`DnssecKeyStore` (`:51,68`) but name-keyed and without the per-zone /
+rollover-state machinery:
 
 ```sql
-CREATE TABLE IF NOT EXISTS 'TsigKeyStore' (
+CREATE TABLE IF NOT EXISTS 'TsigKeystore' (
     id          INTEGER PRIMARY KEY,
-    keyname     TEXT NOT NULL,          -- canonical (lowercase FQDN), matches the wire name
-    algorithm   TEXT NOT NULL,          -- "hmac-sha256", "hmac-sha512", …
-    secret      TEXT NOT NULL,          -- base64 (std) raw HMAC secret
-    origin      TEXT NOT NULL,          -- 'config' | 'api'        (management authority)
-    owner       TEXT NOT NULL,          -- open enum               (purpose; defaults to origin)
-    creator     TEXT,                   -- audit: which tool/user created it (cf. Sig0/Dnssec)
+    keyname     TEXT NOT NULL,   -- canonical (lowercase FQDN), matches the wire name
+    algorithm   TEXT NOT NULL,   -- "hmac-sha256", …
+    secret      TEXT NOT NULL,   -- base64(std) raw HMAC secret
+    origin      TEXT NOT NULL,   -- 'config' | 'api'
+    owner       TEXT NOT NULL DEFAULT '',  -- open string; '' resolves to origin at read
+    creator     TEXT DEFAULT '', -- audit: tool/user (cf. Sig0/Dnssec 'creator')
     created_at  TEXT DEFAULT '',
     comment     TEXT DEFAULT '',
     UNIQUE (keyname)
 )
 ```
 
-- `keyname` is canonicalised (`dns.CanonicalName`) on write and lookup, matching
-  the in-memory store today.
-- `origin` drives reconcile + deletability; `owner` drives zero-ref interpretation
-  + audit (both stored explicitly so cleanup has ground truth even when invariants
-  break — a deliberate decision).
-- `creator` is the existing audit notion (e.g. `"tdns-cli"`), kept distinct from
-  `origin`/`owner`.
+- **Naming (review #13):** SQL table is **`TsigKeystore`** (lowercase `s`) to avoid
+  colliding with the Go type `TsigKeyStore` (the in-memory cache). Logs/CRUD refer
+  to the table as `TsigKeystore`, the cache as `TsigKeyStore`.
+- `keyname` canonicalised via `dns.CanonicalName` on every write/lookup (as the
+  cache does today, `tsig_keys.go:38,55`).
+- `created_at` text timestamp like `DnssecKeyStore.published_at` (`db_schema.go`).
+  Stamp at insert (`time.Now().Format(...)`).
 
-The in-memory `TsigKeyStore` becomes a **read-through cache** of this table:
-populated from the DB at load, write-through on every mutation. All HMAC
-sign/verify paths keep reading it via `Get/Has` (no change to the hot path).
+## 4. In-memory cache & lock discipline (review #14)
 
-## 4. Lifecycle & reconcile
+The Go `TsigKeyStore` (`tsig_keys.go:22`) stays as the **read-through cache**; the
+hot path (`Get`/`Has`, `tsigKeyProvider`, `SignForPeer`) is unchanged. New rule for
+all mutating paths:
 
-- **Startup:** open KeyDB (table auto-created), load all rows into the in-memory
-  cache, then **sync `keys.tsig` → DB** (upsert each as `origin=config`, with the
-  declared `owner`), and reconcile (drop `origin=config` rows no longer in the
-  YAML). `api` rows are authoritative and loaded as-is. Catalog `tsig_key`
-  references are validated (name must resolve to a defined key).
-- **Reload:** reconcile `origin=config` rows against `keys.tsig` **in place** under
-  one lock — drop removed, upsert changed — leaving `origin=api` rows untouched. No
-  store swap → **no window** (this is the proper fix that supersedes `bf53aef`).
-- **Mutations** (`create`/`add`/`import`/`delete`/`purge`): DB write inside a `Tx`,
-  then update the in-memory cache. `delete`/`purge` honour the `origin`/`owner`
-  rules above.
-- **Config-key secret duplication:** a `config` key's secret lives in both the YAML
-  (the operator's editable declaration) and the DB (the materialized runtime store
-  + origin/owner metadata). Intentional: YAML declares, DB materialises.
+- **Update the cache only AFTER a successful DB commit.** `APIkeystore` commits in a
+  `defer` *after* the handler returns (`apihandler_funcs.go:37–46`), so the handler
+  (`TsigKeyMgmt`) must **not** mutate the cache inline — instead it returns the
+  changed rows and the cache is refreshed in the `defer` on `tx.Commit()` success
+  (mirroring how SIG(0)/DNSSEC invalidate their caches on write). Simplest concrete
+  approach: collect changed/deleted key names during the tx; after commit succeeds,
+  re-`Get` those rows from the DB into the cache (or `Delete` from the cache).
+- **Config reconcile** (§6) runs under `confMu` (as `ReloadConfig` already does,
+  `config.go:555`) and mutates the cache under `TsigKeyStore.mu` (`tsig_keys.go:23`)
+  — it must not interleave a half-built set into the live cache; reconcile in place
+  (add/update/delete diff), never swap.
 
-## 5. Reference counting (advisory)
+## 5. Boot order (review #9) — explicit
 
-A key's reference count = number of live references to its (canonical) name across
-**every** field that holds a TSIG key name:
+Today (`v2/main_initfuncs.go`): `LoadTsigKeys()` (`:123`) runs **before**
+`InitializeKeyDB()` (`:130`), then `ParseZones()` (`:215`), then
+`LoadDynamicZoneFiles()` (`:228`). For a DB-backed store this **must change**:
 
-- `ZoneData.PrimariesConf[].Key`, `ZoneData.Upstreams[].Key`, `ZoneData.Notify[].Key`
-  (all `PeerConf.Key`)
-- `ZoneData.AllowNotify[].Key`, `ZoneData.Downstreams[].Key` (both `AclEntry.Key`)
-- catalog config groups' `tsig_key`
+1. **`InitializeKeyDB()`** — move to run **before** TSIG load; creates the
+   `TsigKeystore` table via `dbSetupTables` (`db.go:97`).
+2. **`LoadTsigKeys()` (rewritten)** — was "build map from `conf.Keys.Tsig` + swap"
+   (`tsig_keys.go:91`). Now:
+   a. load every `TsigKeystore` row into the cache (incl. `origin=api`);
+   b. **sync `conf.Keys.Tsig` → DB** as `origin=config` and **reconcile** (drop
+      `origin=config` rows no longer in the YAML; upsert changed — §6);
+   c. cache now reflects **config ∪ api**.
+3. **`ParseZones()`** — validates references via `tsigKeyDefined` (`tsig_keys.go:115`,
+   used at `parseconfig.go:674` and ACL checks `:738,744`). Because step 2 loaded
+   `api` rows into the cache, **static zones referencing an api-origin key validate
+   correctly** instead of quarantining.
+4. **`LoadDynamicZoneFiles()`** — runs the one-time **legacy migration** (§13) first
+   (import any YAML `keys:` block → DB, rewrite file), then enqueues dynamic zones.
+   Their keys are already in the cache from step 2, so the old per-zone key re-merge
+   (`config.go:571`, `loadDynamicTsigKeys`) is **removed**.
 
-Used only to inform `list` and to warn on `delete`. Never triggers deletion.
+## 6. Reconcile-on-reload — three-mode, no silent overwrite (review #10)
 
-## 6. CLI: `keystore tsig {list, create, import, add, delete, purge}`
+`ReloadConfig` (`config.go:554`) currently rebuilds config keys then re-merges the
+dynamic YAML keys (`:568,571`). New behaviour (replaces that block) applies the
+**same three-mode model as `import`/`purge`** (§9) — a config reload must **never
+silently overwrite an existing keystore secret**:
 
-Global (no `--zone`). Mirrors the `keystore sig0/dnssec` command/handler structure.
+- **Default reload** (a full `config reload`, signal, or `config reload-tsig` with no
+  flags), on a **successful** parse only (guard present, `config.go:557`),
+  reconciles `origin=config` keys **in place** under `TsigKeyStore.mu` (no swap → no
+  window):
+  - **Apply the safe subset:** add new config keys (`origin=config`); drop config
+    keys removed from the YAML **that are unreferenced**; identical secret = no-op.
+  - **Withhold + flag (WARN), apply nothing for these:**
+    1. a config key whose **secret/algorithm differs** from the stored row (api- or
+       config-origin) — *no silent overwrite*; and
+    2. a config key **removed** from the YAML but **still referenced** by a live
+       zone (§8) — a referenced key can't be dropped (§9 delete rule).
+- **`config reload-tsig --force | --interactive`** resolves the withheld
+  **secret-conflicts** (case 1): `--force` overwrites all (sets `origin=config`,
+  secret←YAML); `--interactive` prompts per conflict (`overwrite "X"? [y/N]`). This
+  is the dedicated command — sibling of the existing **`config reload-zones`**
+  (`cli/config_cmds.go:34`) — that carries the flags the signal-driven reload can't.
+- Case 2 (removed-but-referenced) is **always** withheld — no `--force` escape;
+  the operator must remove the zone's reference first (consistent with delete). The
+  zone keeps serving with the old key until then.
+- **Collision precedence is thus "config wins via the explicit override", not
+  silently:** declaring `foo` in `keys.tsig` when an `origin=api foo` exists with a
+  different secret is a case-1 conflict — withheld + flagged on default reload,
+  taken over (→ `origin=config`) only on `config reload-tsig --force`/`--interactive`.
+  (Identical secret: quiet no-op; the row's `origin` flips to `config` since config
+  now declares it.)
+
+## 7. Immutability + override (no silent replace)
+
+- A key's secret/algorithm is **not changed in place by default**. On `add`/`import`
+  a name collision with a **differing** secret/algorithm is **withheld and reported**
+  (WARN: *"key X has a different secret/algorithm than the stored key; not updated —
+  use --force / --interactive"*); an **identical** re-add is an idempotent no-op.
+- **`--force`** is the **break-glass** in-place override (see the three-mode model,
+  §9). The **preferred** way to roll a key is the **dual-key rotation procedure**
+  (§11), which needs no overwrite.
+- **Behaviour change to call out (review #2):** today `commitStagedTsigKey`
+  (`dynamic_zones.go:690`) **always overwrites** an existing name, and CLI help
+  advertises rotation via `zone modify` (`v2/cli/zone_cmds.go`). Under this plan the
+  inline `zone add/modify --tsig-*` path becomes **create-if-absent / error on
+  differing secret** (§14). Update CLI help and the test that currently *expects*
+  overwrite+rollback (`v2/tsig_dynzone_test.go` `TestStageInlineTsigKey`).
+
+## 8. Reference counting (advisory) (review #15)
+
+Refcount of a key = number of live references to its canonical name across **every**
+field that holds a TSIG key name. Scan the live **`Zones` map** (not just parsed
+config) plus catalog config:
+
+- `PeerConf.Key` in `ZoneData.PrimariesConf` / `Upstreams` / `Notify`
+  (`structs.go:208`).
+- `AclEntry.Key` in `ZoneData.AllowNotify` / `Downstreams` (`acl.go:25`).
+- Catalog: `conf.Catalog.ConfigGroups[].TsigKey` (`config.go:371,395`) — config-level,
+  not per-zone.
+
+Rules:
+- **Dedupe `Upstreams` vs `PrimariesConf`** (the same key appears in both after
+  resolve): count **distinct (zone, field-site)** edges, and report **# zones
+  referencing the name** in `list` (a single human-meaningful number).
+- Static zones in main config are in the `Zones` map after `ParseZones`; scanning
+  `Zones` covers them. (No separate `conf.Zones` scan needed at list time.)
+- Used only for `list` display and the `delete` refuse-while-referenced gate (§9).
+- **Atomicity caveat (delete).** The refuse-while-referenced check scans the live
+  `Zones` map, then deletes. The keystore delete holds `confMu` (§4), **but the
+  dynamic-zone mutators (`ProvisionDynamicZone`/`ModifyDynamicZone`/`RemoveDynamicZone`,
+  `dynamic_zones.go:710,891` + delete) do NOT take `confMu` today** — verified;
+  they mutate the thread-safe `Zones` map directly. So a concurrent
+  `zone add … --primary-key K` can start referencing `K` between the check and the
+  delete. The outcome is a **recoverable dangling reference** (the new zone fails to
+  sign / quarantines on its next reload; fixed by re-adding `K` or repointing the
+  zone) — an accepted **low-severity admin-vs-admin race**, no security impact.
+  Fully closing it would require the dynamic-zone mutators to also acquire `confMu`;
+  **out of scope here** (call out if/when those mutators are revisited).
+
+## 9. CLI: `keystore tsig { list, generate, import, add, setowner, delete, purge }`
+
+Global (no `--zone`). Mirrors `keystore sig0/dnssec` structure
+(`cli/keystore_cmds.go:48,160`). **`generate`, not `create`** (review #7 — matches
+existing UX, `:84,196`).
 
 | Subcommand | Flags | Behaviour |
 |---|---|---|
-| `list` | — | name, algorithm, origin, owner, #refs, created. |
-| `create` | `--name`, `--algorithm`, `[--owner]` | server **generates** the secret (random bytes sized to the algorithm, base64); user supplies no secret. `origin=api`. |
-| `import` | `--file`, `[--owner]` | bring in an existing key from a standard format (see §9). `origin=api`. |
-| `add` | `--name`, `--algorithm`, `--secret` \| `--secret-file`, `[--owner]` | add with a known secret. `--secret-file` preferred; `--secret` kept (exposed; see [#3 decision]). `origin=api`. |
-| `delete` | `--name`, `[--force]` | only `origin=api`; warn/refuse if referenced (override with `--force`). |
-| `purge` | `[--force]` | drop all `origin=api` **and** `owner=api` **and** zero-ref keys. Never touches config/catalog/other-owner keys. |
+| `list` | — | name, algorithm, origin, owner, #refs, created. Never the secret. |
+| `generate` | `--name`, `--algorithm`, `[--owner]` | server generates the secret (§12). `origin=api`. |
+| `import` | `--file`, `--format bind\|nsd`, `[--owner]`, `[--interactive]`, `[--force]`, `[-v]` | extract keys from a config file; three-mode conflicts (§10). `origin=api`. |
+| `add` | `--name`, `--algorithm`, `--secret`\|`--secret-file`, `[--owner]`, `[--force]` | add with a known secret. `--secret-file` preferred ([[additive-hardening-keep-cli-paths]]); conflict = error unless `--force` (§7). `origin=api`. |
+| `setowner` | `--name`, `--owner` | change `owner` (api-origin only; config via YAML `owner:`). Mirrors `setstate`. |
+| `delete` | `--name`, `[-y]` | api-origin only. **Refused while referenced** by any zone (no override; remove the reference first). `-y` skips the confirm prompt. |
+| `purge` | `[--interactive]`, `[--force]`, `[-y]` | **dry-run by default** (lists candidates, deletes nothing); candidates = `origin=api` ∧ `owner=api` ∧ zero-ref; three-mode (§10). |
 
-Config-origin keys appear in `list` but are not `add/delete/purge`-able here (manage
-via `keys.tsig`).
+**Three-mode model (the consistency rule for *every* multi-key op — `import`,
+`purge`, and config-key reconcile-on-reload, §6):**
+- **default** → apply only the **unambiguous / non-destructive** subset; **withhold**
+  anything that would clobber/delete an existing key; report; exit non-zero if
+  anything withheld. (`import`: imports new keys, withholds conflicts.
+  `purge`: every candidate is a delete ⇒ nothing in the safe subset ⇒ pure
+  **dry-run**, consistent with DNSSEC purge. **config reload** (§6): add new /
+  drop-removed-unreferenced config keys, withhold secret-conflicts + removed-but-
+  referenced; the dedicated **`config reload-tsig`** command carries the flags.)
+- **`--force`** → apply everything, no prompts.
+- **`--interactive`** → prompt per withheld item (`overwrite "X"? [y/N]` /
+  `purge "X" (api, 0 refs)? [y/N]`). Requires a TTY; error in non-interactive
+  contexts. Mutually exclusive with `--force`.
 
-## 7. API: extend `KeystorePost` / `KeystoreResponse`
+`purge` reuses the existing **`KeystorePost.Force`** dry-run plumbing
+(`api_structs.go:34`, the DNSSEC purge pattern `keystore.go:677`,
+`cli/keystore_cmds.go:369`'s "Dry-run by default … --force").
 
-- New `Command: "tsig-mgmt"`, `SubCommand` ∈ `list|create|import|add|delete|purge`.
-- Request fields (add to `KeystorePost` or a focused struct): `Keyname`,
-  `Algorithm` (string, e.g. `hmac-sha256`), `Secret`, `Owner`, `Force`.
-  `Secret` is request-only, never echoed back.
-- Handler `kdb.TsigKeyMgmt(tx, kp)` in `keystore.go`, dispatched from `APIkeystore`.
-- Response carries the key list (name, algorithm, origin, owner, refcount,
-  created) — **never the secret**.
-- **Authz:** same gate as the existing `keystore sig0/dnssec` mutations. *(Confirm
-  what that gate is and that it is sufficient for secret-bearing ops.)*
+## 10. `import` — formats, extraction, three-mode conflicts (review #21)
 
-## 8. Secret generation (`create`)
+- **Formats:** `--format bind` (`key "name" { algorithm …; secret "…"; };`) and
+  `--format nsd` (`key:` blocks). Explicit `--format` (auto-detect is a later
+  nicety). `tsig-keygen` emits the BIND form.
+- **Extractor, not a config parser:** scans the input for key declarations, ignores
+  everything else — a bare snippet *or* a whole `named.conf`/`nsd.conf` are the same
+  input. Does **not** follow `include`/macros. (95% case: inline key blocks.)
+- **Batch:** one file → 0..N keys.
+- **Three-mode conflicts (§9):** default imports new + identical-no-op, withholds
+  conflicts (report, exit non-zero); `--interactive` prompts per conflict; `--force`
+  overwrites all. Conflict detection is **server-side** (CLI lacks the stored secret
+  to compare), so `--interactive` is a **two-phase round-trip**: (1) server applies
+  the safe subset and returns the conflicting names; (2) CLI prompts, re-submits the
+  approved subset with force. The prompt names the key only (no secrets shown).
+- **`-v`** lists every found key with its disposition (`imported` / `unchanged` /
+  `conflict`). This requires per-key disposition in the API response (§11).
+- Reject reserved names `NOKEY`/`BLOCKED` (§12, review #17).
 
-New helper (e.g. `tsig_keys.go`):
+## 11. API wire model (review #12) — exact
+
+Extend `KeystorePost` (`api_structs.go:18`) and `KeystoreResponse` (`:37`). **Do not
+overload `Algorithm uint8`** (`:26`, a DNSSEC codepoint).
+
+- `KeystorePost` additions: `TsigKeyname string`, `TsigAlgorithm string`
+  (`"hmac-sha256"`), `TsigSecret string` (request-only, never echoed), `Owner string`,
+  `Interactive bool`. Reuse existing `Force bool` (`:34`) and `Command/SubCommand`.
+- New `Command: "tsig-mgmt"`, `SubCommand ∈ {list,generate,import,add,setowner,delete,purge}`.
+  Handler **`kdb.TsigKeyMgmt(tx, kp)`** in `v2/keystore.go` (next to `Sig0KeyMgmt`
+  `:18` / `DnssecKeyMgmt` `:302`), dispatched from `APIkeystore` (`apihandler_funcs.go:59,69`).
+- `KeystoreResponse` additions (alongside `Dnskeys`/`Sig0keys` maps `:42,43`):
+  - `TsigKeys []TsigKeyInfo` — list/result. `TsigKeyInfo{Name, Algorithm, Origin,
+    Owner, RefCount int, Created string}` — **no secret**.
+  - `TsigImport []TsigKeyDisposition` — per-key import outcome.
+    `TsigKeyDisposition{Name, Status string /* imported|unchanged|conflict */}`.
+- Authz: inherited `/keystore` gate — shared API key (`apiKeyAuthMiddleware`
+  `apirouters.go:19`) over TLS, Auth+Agent (`:99,100`); identical to sig0/dnssec.
+  **No mTLS** (server cert only); cross-cutting hardening, its own change (§16).
+
+## 12. Secret generation (`generate`)
+
+New helper in `v2/tsig_keys.go`:
 
 ```go
 func GenerateTsigSecret(algorithm string) (string, error) // base64(std) of N random bytes
 ```
 
-`crypto/rand`, N sized to the HMAC algorithm's natural block/output:
+`crypto/rand`, N sized to the HMAC output (sha1→20, sha224→28, sha256→32,
+sha384→48, sha512→64; matches `tsig-keygen`). Validate `algorithm` via
+`knownTsigAlgo` (`tsig_keys.go:131`). **Reject reserved names** `NOKEY`/`BLOCKED` in
+`generate`/`add`/`import` and the DB insert path, reusing `validateTsigKeySpec`
+(`tsig_keys.go:142,147`) — same rule `LoadTsigKeys` enforces (`:97`) (review #17).
 
-| algorithm | bytes |
-|---|---|
-| hmac-sha1 | 20 |
-| hmac-sha224 | 28 |
-| hmac-sha256 | 32 |
-| hmac-sha384 | 48 |
-| hmac-sha512 | 64 |
+## 13. Migration (review #11) — placement + idempotency
 
-(Matches `tsig-keygen` conventions.)
+`6dd2a2b`-era code persists dynamic keys in the dynamic-zones YAML `keys:` block
+(`DynamicConfigFile`, `dynamic_zones.go:316`; written by `writeDynamicConfigFile`
+`:432`, read by `loadDynamicTsigKeys` `:536`). One-shot, automatic migration.
 
-## 9. Wiring the existing paths onto the keystore
+- **Placement:** **not** `dbMigrateData` (`db.go:120` is SQL-only, no `Config`).
+  Put it in a startup hook inside **`LoadDynamicZoneFiles`** (`dynamic_zones.go:153`),
+  which already has `conf`, the dynamic-config mutex, and `dynamicConfigBroken`
+  (`:335`) handling.
+- **Steps:** if the loaded `DynamicConfigFile.Keys` is non-empty, import each into
+  `TsigKeystore` as `origin=api, owner=api` (idempotent — skip names already in the
+  store, e.g. config keys), then **rewrite the dynamic-zones file once** via
+  `writeDynamicConfigFile` (which, post-migration, emits no `keys:` block) so
+  plaintext secrets don't linger in two places. On a *successful* import only; if
+  import fails, leave the block for a retry next start.
+- **Idempotent detection:** "already migrated" ⇔ the file has no `keys:` block. No
+  separate marker needed.
+- Low risk: the YAML `keys:` block is new on this branch; nothing in production
+  depends on it.
 
-- **`keys.tsig` (config):** synced to DB as `origin=config` at load + reconciled on
-  reload (§4). Gains an optional per-entry `owner:` field (so a config key can be
-  declared `owner: catalog`).
-- **Inline `zone add/modify --tsig-*`:** becomes a thin wrapper that creates/adds
-  an `origin=api, owner=api` key (via the keystore path) and references it from the
-  zone. **Create-if-absent guard:** supplying a secret for an existing name with a
-  *different* value is an **error** (rotation is an explicit `zone modify` /
-  `keystore tsig add`), to avoid silently rotating a name shared by other zones
-  (keys are name-keyed / global, NSD-style).
-- **Catalog `tsig_key`:** unchanged — a name reference, validated against the
-  store. No key material created. (`owner=catalog` keys are how an operator
-  pre-provisions for catalog consumers.)
-- **Retire** the dynamic-zones YAML `keys:` block once keys live in the DB (§11
-  migration).
+## 14. Wiring the existing paths
 
-## 10. Implementation steps (staged commits)
+- **`keys.tsig` (config):** synced to DB `origin=config` + reconciled on reload
+  (§5/§6). Gains an optional per-entry `owner:` field on `TsigDetails`
+  (`structs.go:862`) — `yaml:"owner"`, validated as a free string; empty ⇒ defaults
+  to `origin`; an *invalid* (non-string/none today) `owner` never blocks the key
+  (advisory metadata). Stored in the DB on first sync and updated on reconcile when
+  the YAML changes. *(Review #16.)*
+- **Inline `zone add/modify --tsig-*`:** thin wrapper that creates/adds an
+  `origin=api, owner=api` key via the keystore path and references it. **Create-if-
+  absent / error on differing secret** (§7) — the behaviour change in `commitStagedTsigKey`
+  (`dynamic_zones.go:690`); update CLI help and `tsig_dynzone_test.go`.
+- **Catalog `tsig_key`:** unchanged — a name reference validated against the store
+  (`catalog.go:383,384`); creates no key. (`owner=catalog` keys are how an operator
+  pre-provisions.)
+- **Retire** the dynamic-zones YAML `keys:` block (§13 migration); drop the reload
+  re-merge (`config.go:571`).
+- **Operator-facing strings (review #18):** errors that say `keys.tsig` (e.g.
+  `parseconfig.go:674`, `catalog.go:388`) should also reference the keystore /
+  `keystore tsig`. Sweep these in step 9/CLI.
+- **CLI client parser (review #19, §12 F):** `ParseTsigKeys` (`tsig_utils.go:10`)
+  already takes `*KeyConf` (same shape as the server's `keys.tsig`), so the **type
+  is already shared**; the divergence is **strictness** — `ParseTsigKeys` silently
+  skips incomplete entries with no reserved-name/algo checks, while `LoadTsigKeys`
+  uses `validateTsigKeySpec`. Unify by having `ParseTsigKeys` call the same
+  `validateTsigKeySpec` (`tsig_keys.go:142`). CLI keys stay **file-based** in
+  `tdns-cli.yaml` (no DB connection — short-lived client). Own, mostly-orthogonal
+  step.
 
-Each step builds, passes `go test -race ./...`, and is `go vet`-clean; committed
-separately.
+## 15. Implementation steps (staged commits)
+
+Each builds, passes `go test -race ./...`, `go vet`-clean; one commit each.
+Reconciled with §9 (review #6).
 
 | # | Step | Risk | ~LOC |
 |---|---|---|---|
-| 1 | `TsigKeyStore` table in `db_schema.go` + creation/migration scaffolding | Low | ~40 |
-| 2 | DB CRUD `TsigKeyMgmt` + in-memory store as read-through cache (load-from-DB, write-through) | Med | ~200 |
-| 3 | Startup: load from DB + sync `keys.tsig`→DB (`origin=config`) with reconcile; replace `LoadTsigKeys` build+swap | Med | ~120 |
-| 4 | Reload: in-place config reconcile (supersede `bf53aef`); drop the YAML re-merge + window | Med | ~60 |
-| 5 | Reference-count scan helper (all key-name fields + catalog) | Low | ~50 |
-| 6 | API: `tsig-mgmt` command + handler dispatch | Low–Med | ~120 |
-| 7 | CLI: `keystore tsig {list,add,import,delete,purge}` | Med | ~200 |
-| 8 | `create` + `GenerateTsigSecret` | Low | ~60 |
-| 9 | Rewire inline `zone add/modify --tsig-*` onto the keystore + create-if-absent guard | Med | ~120 |
-| 10 | Migrate YAML-persisted dynamic keys → DB; retire the `keys:` block | Med | ~90 |
-| 11 | `owner` end-to-end: `keys.tsig` `owner:`, `--owner`, list/purge logic | Low–Med | ~80 |
-| 12 | Tests across the above | — | ~400 |
+| 1 | `TsigKeystore` table in `db_schema.go` + creation; reserved-name/`validateTsigKeySpec` on DB insert | Low | ~50 |
+| 2 | DB CRUD `TsigKeyMgmt` + cache-after-commit discipline (§4); in-memory store loads from DB | Med | ~220 |
+| 3 | Boot reorder (§5): KeyDB before `LoadTsigKeys`; `LoadTsigKeys` = load DB + sync `keys.tsig` (`main_initfuncs.go:123,130`) | Med | ~120 |
+| 4 | Reload reconcile in place, three-mode/no-silent-overwrite (§6); drop YAML re-merge; add **`config reload-tsig [--force\|--interactive]`** (sibling of `config reload-zones`, `cli/config_cmds.go:34`) | Med | ~130 |
+| 5 | Reference-count scan over `Zones` + catalog groups (§8) | Low | ~70 |
+| 6 | API: `tsig-mgmt` command, `KeystorePost`/`KeystoreResponse` TSIG fields + `TsigKeyInfo`/`TsigKeyDisposition` (§11) | Med | ~140 |
+| 7 | CLI `keystore tsig {list, add, setowner, delete}` + operator-string sweep (§14) | Med | ~200 |
+| 8 | `generate` + `GenerateTsigSecret` (§12) | Low | ~70 |
+| 9 | `import` extractor (BIND/NSD) + three-mode (default/`--interactive`/`--force`) + `-v` (§10) | Med–High | ~250 |
+| 10 | `purge` three-mode (reuse `Force` dry-run) (§9) | Low | ~70 |
+| 11 | Inline `zone add/modify --tsig-*` → create-if-absent (§7/§14); update CLI help + `tsig_dynzone_test.go` | Med | ~120 |
+| 12 | Legacy migration hook in `LoadDynamicZoneFiles`; retire YAML `keys:` block (§13) | Med | ~110 |
+| 13 | `owner` end-to-end: `keys.tsig owner:`, `--owner`, `setowner`, list/purge logic (§2/§9) | Low–Med | ~90 |
+| 14 | CLI `ParseTsigKeys` strictness unification (§14, review #19) | Low | ~40 |
+| 15 | Tests across all of the above | — | ~600 |
 
-Rough total: ~1.1–1.4k LOC incl. tests. (Sequencing keeps a working build at each
-step: steps 1–4 make the store DB-backed without changing behaviour; 5–8 add the
-management surface; 9–11 rewire and migrate.)
+Rough total ~2.2k LOC incl. tests (tests bumped from the original ~400 estimate —
+review #18 polish — given import extractors, reconcile, migration, refcount,
+immutability, three-mode). **Sequencing keeps a working build:** steps 1–4 make the
+store DB-backed with **no behaviour change** *provided* migration + inline path stay
+on old semantics until steps 11–12 (state this explicitly in each commit).
 
-## 11. Migration
+## 16. Open / deferred
 
-Existing branches persist dynamic TSIG keys in the dynamic-zones YAML `keys:`
-block (from `bf53aef`). One-shot migration:
+- **mTLS** — server has TLS, CLI uses the API key alone (no client cert). API-wide
+  hardening (`apirouters.go:19`), its own change. *(Review #20: SQLite holds
+  plaintext TSIG secrets — consistent with SIG(0)/DNSSEC private keys today; one
+  line, accepted.)*
+- **`comment` field (review #22):** column exists; v1 sets only `creator`
+  (`"tdns-cli"` / API caller). `comment` populated by an optional later `--comment`
+  flag; omit from v1.
+- **Agent app-type scope (review #23):** `/keystore` is on Auth **and** Agent
+  (`apirouters.go:99`). `keystore tsig` ops are available on both for consistency
+  with sig0/dnssec; whether tdns-agent meaningfully *uses* TSIG keys is out of scope
+  (no behaviour gated on it here).
+- **`getDynamicTsigKeysFromZones` walks primaries only** (`dynamic_zones.go:509`):
+  after the YAML `keys:` block is retired (§13) this function is **removed**; keys
+  referenced only from `allow-notify`/`downstreams` must pre-exist in the store
+  anyway (they're never persisted to dynamic YAML). Footnote, no action.
 
-- On first start with the new code, if the dynamic-zones YAML carries a `keys:`
-  block, import each into `TsigKeyStore` as `origin=api, owner=api` (idempotent;
-  skip names already present from config), then stop writing/reading that block.
-- `dbMigrateData()` is the natural home for the DB side; the YAML side is a
-  read-once-then-ignore.
-- No production deployments depend on the YAML `keys:` block yet (it is new on this
-  feature branch), so this is low-risk.
+## 17. Rotation (operational — no code)
 
-## 12. Open decisions (to confirm before / during implementation)
+The dual-key procedure, using existing primitives (the multi-key ACL is already in
+the code, §0):
 
-1. **`import` format** — proposed: BIND `key "name" { algorithm …; secret "…"; };`
-   (named.conf snippet — the natural interchange when peering with BIND/NSD).
-   Optionally also `dnssec-keygen` `Khmac…` files. *Pick one to start.*
-2. **`owner` assignment surface** — `keys.tsig[].owner:` for config keys, `--owner`
-   for CLI; default `owner = origin`. Confirm the value set we seed
-   (`config|api|catalog`) and that it is a free string (open enum).
-3. **Migration trigger** — automatic on first start (proposed) vs an explicit
-   `keystore tsig import-legacy` command.
-4. **Authz** — confirm the existing keystore mutation gate and that it is adequate
-   for secret-bearing TSIG ops.
-5. **Catalog** — confirmed for now: references names only, does **not** distribute
-   secrets. (If that changes later, it adds an `origin` value and a reconcile
-   source; out of scope here.)
+1. `keystore tsig generate/add/import` a **new** key.
+2. Add it to the relevant ACL(s) **alongside** the old — `downstreams:` for AXFR,
+   `allow-notify:` for NOTIFY — so the server accepts **either** (N-key,
+   `matchACL` union `acl.go:40`).
+3. Migrate clients/secondaries to sign with the new key (flip `primaries[].key`).
+4. When all use the new key, remove the old from the ACL, then `keystore tsig delete`
+   it (now unreferenced).
 
-## 13. Relationship to PR #269
-
-- #269 ships the on-the-wire TSIG machinery (sign/verify on replication) and the
-  interim reload fix (`bf53aef`).
-- This work folds onto the same branch (per decision) and **replaces** the interim
-  reload fix with the DB-backed in-place reconcile (step 4). Until step 4 lands,
-  `bf53aef` remains correct (self-healing, tiny window).
+`--force` in-place replacement (§7) exists as a break-glass alternative, not the
+recommended path.

--- a/docs/2026-06-29-first-class-tsig-keystore-plan.md
+++ b/docs/2026-06-29-first-class-tsig-keystore-plan.md
@@ -1,0 +1,289 @@
+# First-class TSIG keystore — plan (2026-06-29)
+
+## Summary
+
+Make TSIG keys **first-class, DB-backed keystore members**, managed the same way
+SIG(0) and DNSSEC keys already are (`Sig0KeyStore` / `DnssecKeyStore` tables, a
+`keystore` CLI group, the `KeystorePost`/`KeystoreResponse` API). Today TSIG keys
+live in an in-memory `map[name]TsigDetails` populated from the `keys.tsig` config
+block plus a side-channel `keys:` block in the dynamic-zones YAML file. That is
+inconsistent with every other key type, and the reload path has to rebuild the
+in-memory store from config and re-merge the dynamic keys (commit `bf53aef`,
+review finding #4), which leaves a small swap window.
+
+This plan replaces that with a single DB-backed store and a `keystore tsig`
+command set, plus a key model that distinguishes **how a key is managed**
+(`origin`) from **what it is for** (`owner`).
+
+It is layered onto branch `tsig-on-replication` (PR #269 → base
+`dynamic-zones-mgmt`). **It supersedes the interim #4 reload fix** in `bf53aef`.
+
+## 1. Current state (verified against the code)
+
+### TSIG keys today
+- `v2/tsig_keys.go`: `TsigKeyStore { mu; keys map[string]TsigDetails }`,
+  `TsigDetails {Name, Algorithm, Secret}`. In-memory only.
+- Read path (must keep working unchanged): `TsigKeyStore.Get/Has`, used by
+  `tsigKeyProvider.hmac` (inbound verify), `SignForPeer` (outbound sign),
+  `tsigKeyDefined` (config validation) — `v2/tsig_peer.go`, `v2/tsig_keys.go`.
+- Config keys: `LoadTsigKeys()` builds a fresh store from `conf.Keys.Tsig` and
+  swaps it in.
+- Dynamic keys: API `stageInlineTsigKey`/`commitStagedTsigKey` add to the store,
+  and the secret is persisted into the dynamic-zones YAML file's `keys:` block
+  (`getDynamicTsigKeysFromZones` / `loadDynamicTsigKeys`).
+- Reload (`ReloadConfig`, `bf53aef`): on a successful parse, `LoadTsigKeys()`
+  rebuilds config-only, then re-merges persisted dynamic keys. Correct but has a
+  brief window where the swapped-in store is config-only.
+- Catalog: a config group's `tsig_key` **references a key by name only**
+  (`catalog.go`, validated via `tsigKeyDefined`). It does **not** distribute key
+  material.
+
+### How SIG(0)/DNSSEC keys are managed (the pattern to mirror)
+- DB: `v2/db.go` — `KeyDB { DB *sql.DB; … }`, `Tx`, `kdb.Begin(ctx)` /
+  `tx.Commit()` / `tx.Rollback()`.
+- Schema: `v2/db_schema.go` — `DefaultTables` map of `CREATE TABLE IF NOT EXISTS`;
+  `dbSetupTables()` applies them; `dbMigrateSchema()` adds later columns via
+  `ALTER TABLE ADD COLUMN`; `dbMigrateData()` runs one-shot data migrations.
+- CRUD: `v2/keystore.go` — `Sig0KeyMgmt(tx, kp)`, `DnssecKeyMgmt(ctx, tx, kp)`;
+  `INSERT OR REPLACE` / `SELECT … rows.Scan` / `DELETE`, with a per-key in-memory
+  cache invalidated on write.
+- CLI: `v2/cli/keystore_cmds.go` — `keystore sig0 {…}` and `keystore dnssec {…}`
+  subtrees; handler builds a `KeystorePost` and `SendKeystoreCmd`s it.
+- API: `v2/apihandler_funcs.go` `APIkeystore`; `v2/api_structs.go`
+  `KeystorePost{Command, SubCommand, …}` / `KeystoreResponse`. Dispatch on
+  `Command` (`"sig0-mgmt"`, `"dnssec-mgmt"`), transaction opened per request.
+- Secret/key generation: `v2/sig0_utils.go` `GenerateKeyMaterial` (asymmetric,
+  via miekg/dns + `crypto/rand`). **No TSIG secret generator exists yet.**
+
+### Important structural difference
+SIG(0)/DNSSEC keys are **per-zone**, keyed `(zonename, keyid)`, and their CLI
+takes `--zone`. **TSIG keys are global** — one secret per name, zone-independent.
+So `keystore tsig` operates on a **global key namespace** (no `--zone`). This is a
+deliberate UX departure from `keystore sig0/dnssec`.
+
+## 2. The key model: `origin` vs `owner`
+
+A TSIG key carries two orthogonal attributes (decided after design discussion):
+
+- **`origin`** — *how the key is managed*. Values today: `config` | `api`.
+  - `config`: declared in `keys.tsig` YAML; the DB row is a materialization,
+    reconciled against the YAML on reload. **Not** CLI-deletable (edit YAML).
+  - `api`: created/managed via the API/CLI; the DB row is authoritative. **Is**
+    CLI-deletable and purgeable.
+  - (Catalog does not create keys today, so `origin` is never `catalog`. If a
+    future key-distribution mechanism *pushes* secrets, it adds an `origin` value.)
+
+- **`owner`** — *what the key is for / who consumes it*. An **open enum**:
+  `config` | `api` | `catalog` | `{future key-dist infra}` | …. Operator-assignable.
+  Governs how a **zero-reference** key is interpreted and how keys are grouped for
+  audit. Defaults to `origin` when unspecified.
+
+They are orthogonal. The case that proves it:
+
+| `origin` (managed via) | `owner` (for) | meaning |
+|---|---|---|
+| config | config | plain static key for local config zones |
+| api | api | plain dynamic key for local API zones |
+| **config** | **catalog** | declared in `keys.tsig`, reconciled on reload — but its purpose is catalog consumers, so **0 local refs is expected**, never flagged or purged as an orphan |
+| api | catalog | created via API, earmarked for catalog consumers |
+
+### Consequences for management
+- **No auto-drop.** A zero-reference key is valid for *both* config and dynamic
+  keys — it may be pre-provisioned for an upcoming `zone add` or for future
+  catalog consumers. Removal is always explicit.
+- **Reference counting is advisory only** — shown in `list`, warned on `delete`;
+  never an automatic deletion trigger.
+- **`delete`** gates on `origin`: only `origin=api` keys are CLI-deletable.
+- **`purge`** is strict: candidate = `origin=api` **and** `owner=api` **and**
+  zero references. Anything owned by catalog/agent/future, or `origin=config`, is
+  never an orphan and is never purged.
+- **Revocation:** a `config` key → remove from `keys.tsig` + reload (reconcile
+  drops it). An `api` key → `keystore tsig delete`/`purge`. Restart always rebuilds
+  from the authoritative sources (YAML + DB), so it is the universal reset.
+
+## 3. Storage: the `TsigKeyStore` table
+
+New table in `db_schema.go`, name-keyed (global), modelled on the existing key
+tables but without the per-zone / rollover-state machinery:
+
+```sql
+CREATE TABLE IF NOT EXISTS 'TsigKeyStore' (
+    id          INTEGER PRIMARY KEY,
+    keyname     TEXT NOT NULL,          -- canonical (lowercase FQDN), matches the wire name
+    algorithm   TEXT NOT NULL,          -- "hmac-sha256", "hmac-sha512", …
+    secret      TEXT NOT NULL,          -- base64 (std) raw HMAC secret
+    origin      TEXT NOT NULL,          -- 'config' | 'api'        (management authority)
+    owner       TEXT NOT NULL,          -- open enum               (purpose; defaults to origin)
+    creator     TEXT,                   -- audit: which tool/user created it (cf. Sig0/Dnssec)
+    created_at  TEXT DEFAULT '',
+    comment     TEXT DEFAULT '',
+    UNIQUE (keyname)
+)
+```
+
+- `keyname` is canonicalised (`dns.CanonicalName`) on write and lookup, matching
+  the in-memory store today.
+- `origin` drives reconcile + deletability; `owner` drives zero-ref interpretation
+  + audit (both stored explicitly so cleanup has ground truth even when invariants
+  break — a deliberate decision).
+- `creator` is the existing audit notion (e.g. `"tdns-cli"`), kept distinct from
+  `origin`/`owner`.
+
+The in-memory `TsigKeyStore` becomes a **read-through cache** of this table:
+populated from the DB at load, write-through on every mutation. All HMAC
+sign/verify paths keep reading it via `Get/Has` (no change to the hot path).
+
+## 4. Lifecycle & reconcile
+
+- **Startup:** open KeyDB (table auto-created), load all rows into the in-memory
+  cache, then **sync `keys.tsig` → DB** (upsert each as `origin=config`, with the
+  declared `owner`), and reconcile (drop `origin=config` rows no longer in the
+  YAML). `api` rows are authoritative and loaded as-is. Catalog `tsig_key`
+  references are validated (name must resolve to a defined key).
+- **Reload:** reconcile `origin=config` rows against `keys.tsig` **in place** under
+  one lock — drop removed, upsert changed — leaving `origin=api` rows untouched. No
+  store swap → **no window** (this is the proper fix that supersedes `bf53aef`).
+- **Mutations** (`create`/`add`/`import`/`delete`/`purge`): DB write inside a `Tx`,
+  then update the in-memory cache. `delete`/`purge` honour the `origin`/`owner`
+  rules above.
+- **Config-key secret duplication:** a `config` key's secret lives in both the YAML
+  (the operator's editable declaration) and the DB (the materialized runtime store
+  + origin/owner metadata). Intentional: YAML declares, DB materialises.
+
+## 5. Reference counting (advisory)
+
+A key's reference count = number of live references to its (canonical) name across
+**every** field that holds a TSIG key name:
+
+- `ZoneData.PrimariesConf[].Key`, `ZoneData.Upstreams[].Key`, `ZoneData.Notify[].Key`
+  (all `PeerConf.Key`)
+- `ZoneData.AllowNotify[].Key`, `ZoneData.Downstreams[].Key` (both `AclEntry.Key`)
+- catalog config groups' `tsig_key`
+
+Used only to inform `list` and to warn on `delete`. Never triggers deletion.
+
+## 6. CLI: `keystore tsig {list, create, import, add, delete, purge}`
+
+Global (no `--zone`). Mirrors the `keystore sig0/dnssec` command/handler structure.
+
+| Subcommand | Flags | Behaviour |
+|---|---|---|
+| `list` | — | name, algorithm, origin, owner, #refs, created. |
+| `create` | `--name`, `--algorithm`, `[--owner]` | server **generates** the secret (random bytes sized to the algorithm, base64); user supplies no secret. `origin=api`. |
+| `import` | `--file`, `[--owner]` | bring in an existing key from a standard format (see §9). `origin=api`. |
+| `add` | `--name`, `--algorithm`, `--secret` \| `--secret-file`, `[--owner]` | add with a known secret. `--secret-file` preferred; `--secret` kept (exposed; see [#3 decision]). `origin=api`. |
+| `delete` | `--name`, `[--force]` | only `origin=api`; warn/refuse if referenced (override with `--force`). |
+| `purge` | `[--force]` | drop all `origin=api` **and** `owner=api` **and** zero-ref keys. Never touches config/catalog/other-owner keys. |
+
+Config-origin keys appear in `list` but are not `add/delete/purge`-able here (manage
+via `keys.tsig`).
+
+## 7. API: extend `KeystorePost` / `KeystoreResponse`
+
+- New `Command: "tsig-mgmt"`, `SubCommand` ∈ `list|create|import|add|delete|purge`.
+- Request fields (add to `KeystorePost` or a focused struct): `Keyname`,
+  `Algorithm` (string, e.g. `hmac-sha256`), `Secret`, `Owner`, `Force`.
+  `Secret` is request-only, never echoed back.
+- Handler `kdb.TsigKeyMgmt(tx, kp)` in `keystore.go`, dispatched from `APIkeystore`.
+- Response carries the key list (name, algorithm, origin, owner, refcount,
+  created) — **never the secret**.
+- **Authz:** same gate as the existing `keystore sig0/dnssec` mutations. *(Confirm
+  what that gate is and that it is sufficient for secret-bearing ops.)*
+
+## 8. Secret generation (`create`)
+
+New helper (e.g. `tsig_keys.go`):
+
+```go
+func GenerateTsigSecret(algorithm string) (string, error) // base64(std) of N random bytes
+```
+
+`crypto/rand`, N sized to the HMAC algorithm's natural block/output:
+
+| algorithm | bytes |
+|---|---|
+| hmac-sha1 | 20 |
+| hmac-sha224 | 28 |
+| hmac-sha256 | 32 |
+| hmac-sha384 | 48 |
+| hmac-sha512 | 64 |
+
+(Matches `tsig-keygen` conventions.)
+
+## 9. Wiring the existing paths onto the keystore
+
+- **`keys.tsig` (config):** synced to DB as `origin=config` at load + reconciled on
+  reload (§4). Gains an optional per-entry `owner:` field (so a config key can be
+  declared `owner: catalog`).
+- **Inline `zone add/modify --tsig-*`:** becomes a thin wrapper that creates/adds
+  an `origin=api, owner=api` key (via the keystore path) and references it from the
+  zone. **Create-if-absent guard:** supplying a secret for an existing name with a
+  *different* value is an **error** (rotation is an explicit `zone modify` /
+  `keystore tsig add`), to avoid silently rotating a name shared by other zones
+  (keys are name-keyed / global, NSD-style).
+- **Catalog `tsig_key`:** unchanged — a name reference, validated against the
+  store. No key material created. (`owner=catalog` keys are how an operator
+  pre-provisions for catalog consumers.)
+- **Retire** the dynamic-zones YAML `keys:` block once keys live in the DB (§11
+  migration).
+
+## 10. Implementation steps (staged commits)
+
+Each step builds, passes `go test -race ./...`, and is `go vet`-clean; committed
+separately.
+
+| # | Step | Risk | ~LOC |
+|---|---|---|---|
+| 1 | `TsigKeyStore` table in `db_schema.go` + creation/migration scaffolding | Low | ~40 |
+| 2 | DB CRUD `TsigKeyMgmt` + in-memory store as read-through cache (load-from-DB, write-through) | Med | ~200 |
+| 3 | Startup: load from DB + sync `keys.tsig`→DB (`origin=config`) with reconcile; replace `LoadTsigKeys` build+swap | Med | ~120 |
+| 4 | Reload: in-place config reconcile (supersede `bf53aef`); drop the YAML re-merge + window | Med | ~60 |
+| 5 | Reference-count scan helper (all key-name fields + catalog) | Low | ~50 |
+| 6 | API: `tsig-mgmt` command + handler dispatch | Low–Med | ~120 |
+| 7 | CLI: `keystore tsig {list,add,import,delete,purge}` | Med | ~200 |
+| 8 | `create` + `GenerateTsigSecret` | Low | ~60 |
+| 9 | Rewire inline `zone add/modify --tsig-*` onto the keystore + create-if-absent guard | Med | ~120 |
+| 10 | Migrate YAML-persisted dynamic keys → DB; retire the `keys:` block | Med | ~90 |
+| 11 | `owner` end-to-end: `keys.tsig` `owner:`, `--owner`, list/purge logic | Low–Med | ~80 |
+| 12 | Tests across the above | — | ~400 |
+
+Rough total: ~1.1–1.4k LOC incl. tests. (Sequencing keeps a working build at each
+step: steps 1–4 make the store DB-backed without changing behaviour; 5–8 add the
+management surface; 9–11 rewire and migrate.)
+
+## 11. Migration
+
+Existing branches persist dynamic TSIG keys in the dynamic-zones YAML `keys:`
+block (from `bf53aef`). One-shot migration:
+
+- On first start with the new code, if the dynamic-zones YAML carries a `keys:`
+  block, import each into `TsigKeyStore` as `origin=api, owner=api` (idempotent;
+  skip names already present from config), then stop writing/reading that block.
+- `dbMigrateData()` is the natural home for the DB side; the YAML side is a
+  read-once-then-ignore.
+- No production deployments depend on the YAML `keys:` block yet (it is new on this
+  feature branch), so this is low-risk.
+
+## 12. Open decisions (to confirm before / during implementation)
+
+1. **`import` format** — proposed: BIND `key "name" { algorithm …; secret "…"; };`
+   (named.conf snippet — the natural interchange when peering with BIND/NSD).
+   Optionally also `dnssec-keygen` `Khmac…` files. *Pick one to start.*
+2. **`owner` assignment surface** — `keys.tsig[].owner:` for config keys, `--owner`
+   for CLI; default `owner = origin`. Confirm the value set we seed
+   (`config|api|catalog`) and that it is a free string (open enum).
+3. **Migration trigger** — automatic on first start (proposed) vs an explicit
+   `keystore tsig import-legacy` command.
+4. **Authz** — confirm the existing keystore mutation gate and that it is adequate
+   for secret-bearing TSIG ops.
+5. **Catalog** — confirmed for now: references names only, does **not** distribute
+   secrets. (If that changes later, it adds an `origin` value and a reconcile
+   source; out of scope here.)
+
+## 13. Relationship to PR #269
+
+- #269 ships the on-the-wire TSIG machinery (sign/verify on replication) and the
+  interim reload fix (`bf53aef`).
+- This work folds onto the same branch (per decision) and **replaces** the interim
+  reload fix with the DB-backed in-place reconcile (step 4). Until step 4 lands,
+  `bf53aef` remains correct (self-healing, tiny window).

--- a/v2/acl.go
+++ b/v2/acl.go
@@ -111,6 +111,12 @@ func parseIPSpec(spec string) (pfx netip.Prefix, lo, hi netip.Addr, isRange bool
 		if e1 != nil || e2 != nil {
 			return pfx, lo, hi, false, fmt.Errorf("bad masked spec %q", spec)
 		}
+		// Reject a family mismatch before building the prefix: a v6 base with a v4
+		// mask (or vice versa) would otherwise silently produce a wrong-scope prefix
+		// (e.g. 2001:db8::&255.255.255.0 -> a /24 of the v6 address).
+		if base.Unmap().Is4() != maskAddr.Unmap().Is4() {
+			return pfx, lo, hi, false, fmt.Errorf("masked spec %q mixes IPv4 and IPv6", spec)
+		}
 		// Size returns (0, 0) for a non-canonical (non-contiguous) mask.
 		ones, bits := net.IPMask(maskAddr.AsSlice()).Size()
 		if bits == 0 {

--- a/v2/acl.go
+++ b/v2/acl.go
@@ -5,9 +5,9 @@
 package tdns
 
 import (
-	"bytes"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 )
 
@@ -34,7 +34,7 @@ type AclEntry struct {
 // ACL) -> (false, ""); callers layer their empty-ACL defaults on top (downstreams
 // empty => deny; allow-notify empty => accept from primaries). A malformed
 // prefix never matches; it is rejected at config time by ValidateACL.
-func matchACL(acl []AclEntry, ip net.IP) (allowed bool, requiredKey string) {
+func matchACL(acl []AclEntry, ip netip.Addr) (allowed bool, requiredKey string) {
 	for _, e := range acl { // BLOCKED supersedes — scan all first
 		if e.Key == BLOCKED && ipSpecMatch(e.Prefix, ip) {
 			return false, ""
@@ -52,22 +52,26 @@ func matchACL(acl []AclEntry, ip net.IP) (allowed bool, requiredKey string) {
 }
 
 // ipSpecMatch reports whether ip falls within the ip-spec. A spec that fails to
-// parse (or a nil ip) returns false.
-func ipSpecMatch(spec string, ip net.IP) bool {
-	ipnet, lo, hi, err := parseIPSpec(spec)
-	if err != nil || ip == nil {
+// parse (or an invalid ip) returns false.
+func ipSpecMatch(spec string, ip netip.Addr) bool {
+	pfx, lo, hi, isRange, err := parseIPSpec(spec)
+	if err != nil || !ip.IsValid() {
 		return false
 	}
-	if ipnet != nil {
-		return ipnet.Contains(ip)
+	a := ip.Unmap()
+	if isRange {
+		// Same-family comparison only; a v4 addr never falls in a v6 range.
+		if a.Is4() != lo.Is4() {
+			return false
+		}
+		return a.Compare(lo) >= 0 && a.Compare(hi) <= 0
 	}
-	ip16 := ip.To16()
-	return ip16 != nil && bytes.Compare(ip16, lo) >= 0 && bytes.Compare(ip16, hi) <= 0
+	return pfx.Contains(a)
 }
 
 // ValidateIPSpec returns an error if spec is not a valid ip-spec.
 func ValidateIPSpec(spec string) error {
-	_, _, _, err := parseIPSpec(spec)
+	_, _, _, _, err := parseIPSpec(spec)
 	return err
 }
 
@@ -86,54 +90,60 @@ func ValidateACL(acl []AclEntry, keyDefined func(string) bool) error {
 	return nil
 }
 
-// parseIPSpec parses an ip-spec into either an *net.IPNet (CIDR / mask / bare IP
-// host-route) or a [lo, hi] range (lo/hi in 16-byte form). Exactly one of ipnet
-// or (lo,hi) is non-nil on success.
-func parseIPSpec(spec string) (ipnet *net.IPNet, lo, hi net.IP, err error) {
+// parseIPSpec parses an ip-spec into either a netip.Prefix (CIDR / mask / bare-IP
+// host route) or a [lo, hi] netip.Addr range (isRange). lo/hi are Unmap'd and of
+// the same family. The string spellings a&m and a-b have no netip parser, so the
+// splitting is by hand; the addresses and matching are netip.
+func parseIPSpec(spec string) (pfx netip.Prefix, lo, hi netip.Addr, isRange bool, err error) {
 	spec = strings.TrimSpace(spec)
 	switch {
 	case strings.Contains(spec, "/"): // CIDR (incl. 0.0.0.0/0, ::/0)
-		_, n, e := net.ParseCIDR(spec)
+		p, e := netip.ParsePrefix(spec)
 		if e != nil {
-			return nil, nil, nil, fmt.Errorf("bad CIDR %q: %w", spec, e)
+			return pfx, lo, hi, false, fmt.Errorf("bad CIDR %q: %w", spec, e)
 		}
-		return n, nil, nil, nil
+		return p.Masked(), lo, hi, false, nil
+
 	case strings.Contains(spec, "&"): // mask: ip&netmask
 		parts := strings.SplitN(spec, "&", 2)
-		base := net.ParseIP(strings.TrimSpace(parts[0]))
-		maskIP := net.ParseIP(strings.TrimSpace(parts[1]))
-		if base == nil || maskIP == nil {
-			return nil, nil, nil, fmt.Errorf("bad masked spec %q", spec)
+		base, e1 := netip.ParseAddr(strings.TrimSpace(parts[0]))
+		maskAddr, e2 := netip.ParseAddr(strings.TrimSpace(parts[1]))
+		if e1 != nil || e2 != nil {
+			return pfx, lo, hi, false, fmt.Errorf("bad masked spec %q", spec)
 		}
-		var mask net.IPMask
-		if v4 := maskIP.To4(); v4 != nil {
-			mask = net.IPMask(v4)
-		} else {
-			mask = net.IPMask(maskIP.To16())
+		// Size returns (0, 0) for a non-canonical (non-contiguous) mask.
+		ones, bits := net.IPMask(maskAddr.AsSlice()).Size()
+		if bits == 0 {
+			return pfx, lo, hi, false, fmt.Errorf("non-contiguous netmask in %q", spec)
 		}
-		return &net.IPNet{IP: base.Mask(mask), Mask: mask}, nil, nil, nil
+		p, e := base.Prefix(ones)
+		if e != nil {
+			return pfx, lo, hi, false, fmt.Errorf("bad masked spec %q: %w", spec, e)
+		}
+		return p, lo, hi, false, nil
+
 	case strings.Contains(spec, "-"): // range: lo-hi
 		parts := strings.SplitN(spec, "-", 2)
-		loIP := net.ParseIP(strings.TrimSpace(parts[0]))
-		hiIP := net.ParseIP(strings.TrimSpace(parts[1]))
-		if loIP == nil || hiIP == nil {
-			return nil, nil, nil, fmt.Errorf("bad range %q", spec)
+		loA, e1 := netip.ParseAddr(strings.TrimSpace(parts[0]))
+		hiA, e2 := netip.ParseAddr(strings.TrimSpace(parts[1]))
+		if e1 != nil || e2 != nil {
+			return pfx, lo, hi, false, fmt.Errorf("bad range %q", spec)
 		}
-		lo16, hi16 := loIP.To16(), hiIP.To16()
-		if lo16 == nil || hi16 == nil || bytes.Compare(lo16, hi16) > 0 {
-			return nil, nil, nil, fmt.Errorf("bad range bounds %q", spec)
+		loA, hiA = loA.Unmap(), hiA.Unmap()
+		if loA.Is4() != hiA.Is4() {
+			return pfx, lo, hi, false, fmt.Errorf("range %q mixes IPv4 and IPv6", spec)
 		}
-		return nil, lo16, hi16, nil
+		if loA.Compare(hiA) > 0 {
+			return pfx, lo, hi, false, fmt.Errorf("range %q: low > high", spec)
+		}
+		return pfx, loA, hiA, true, nil
+
 	default: // bare IP -> host route
-		ip := net.ParseIP(spec)
-		if ip == nil {
-			return nil, nil, nil, fmt.Errorf("bad ip-spec %q", spec)
+		a, e := netip.ParseAddr(spec)
+		if e != nil {
+			return pfx, lo, hi, false, fmt.Errorf("bad ip-spec %q", spec)
 		}
-		bits := 128
-		base := ip.To16()
-		if v4 := ip.To4(); v4 != nil {
-			bits, base = 32, v4
-		}
-		return &net.IPNet{IP: base, Mask: net.CIDRMask(bits, len(base)*8)}, nil, nil, nil
+		a = a.Unmap()
+		return netip.PrefixFrom(a, a.BitLen()), lo, hi, false, nil
 	}
 }

--- a/v2/acl.go
+++ b/v2/acl.go
@@ -28,27 +28,33 @@ type AclEntry struct {
 }
 
 // matchACL applies an ordered ACL to a source IP, NSD-style: a matching BLOCKED
-// entry denies (it supersedes any allow, regardless of order); otherwise the
-// first entry whose prefix matches wins. Returns (allowed, requiredKeyName) —
-// requiredKeyName is NOKEY when no TSIG is required. No match (incl. an empty
-// ACL) -> (false, ""); callers layer their empty-ACL defaults on top (downstreams
-// empty => deny; allow-notify empty => accept from primaries). A malformed
-// prefix never matches; it is rejected at config time by ValidateACL.
-func matchACL(acl []AclEntry, ip netip.Addr) (allowed bool, requiredKey string) {
+// entry denies (it supersedes any allow, regardless of order); otherwise the source
+// is approved for the SET of keys named by EVERY matching non-BLOCKED entry (a key
+// may be NOKEY = unsigned accepted). Returning the full set — not just the first
+// match — is what lets two entries for one source name two different keys, so the
+// server accepts EITHER during a dual-key rotation (add the new key alongside the
+// old, migrate clients, then drop the old). Returns (allowed, approvedKeys); no
+// match (incl. an empty ACL) -> (false, nil); callers layer their empty-ACL defaults
+// on top (downstreams empty => deny; allow-notify empty => accept from primaries).
+// A malformed prefix never matches; it is rejected at config time by ValidateACL.
+func matchACL(acl []AclEntry, ip netip.Addr) (allowed bool, approvedKeys []string) {
 	for _, e := range acl { // BLOCKED supersedes — scan all first
 		if e.Key == BLOCKED && ipSpecMatch(e.Prefix, ip) {
-			return false, ""
+			return false, nil
 		}
 	}
-	for _, e := range acl { // first non-BLOCKED prefix match wins
+	for _, e := range acl { // collect EVERY non-BLOCKED prefix match
 		if e.Key == BLOCKED {
 			continue
 		}
 		if ipSpecMatch(e.Prefix, ip) {
-			return true, e.Key
+			approvedKeys = append(approvedKeys, e.Key)
 		}
 	}
-	return false, ""
+	if len(approvedKeys) == 0 {
+		return false, nil
+	}
+	return true, approvedKeys
 }
 
 // ipSpecMatch reports whether ip falls within the ip-spec. A spec that fails to

--- a/v2/acl.go
+++ b/v2/acl.go
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// BLOCKED is the ACL key-field sentinel meaning "deny this address-spec". It
+// supersedes any allow entry (NSD semantics). It is a reserved name — a
+// keys.tsig entry may not be named BLOCKED (see LoadTsigKeys).
+const BLOCKED = "BLOCKED"
+
+// AclEntry is one entry in an allow-notify: / downstreams: address ACL (NSD
+// allow-notify / provide-xfr). Prefix is an ip-spec — a bare IP, CIDR
+// (1.2.3.4/24), mask (1.2.3.4&255.255.255.0), range (1.2.3.4-1.2.3.25), or
+// 0.0.0.0/0 / ::/0 for "any". Key is a keys.tsig name (TSIG required), NOKEY
+// (unsigned accepted), or BLOCKED (deny). The struct shape matches PeerConf
+// ({addr, key}) so the config keeps one entry style.
+type AclEntry struct {
+	Prefix string `yaml:"prefix" mapstructure:"prefix"`
+	Key    string `yaml:"key" mapstructure:"key"`
+}
+
+// matchACL applies an ordered ACL to a source IP, NSD-style: a matching BLOCKED
+// entry denies (it supersedes any allow, regardless of order); otherwise the
+// first entry whose prefix matches wins. Returns (allowed, requiredKeyName) —
+// requiredKeyName is NOKEY when no TSIG is required. No match (incl. an empty
+// ACL) -> (false, ""); callers layer their empty-ACL defaults on top (downstreams
+// empty => deny; allow-notify empty => accept from primaries). A malformed
+// prefix never matches; it is rejected at config time by ValidateACL.
+func matchACL(acl []AclEntry, ip net.IP) (allowed bool, requiredKey string) {
+	for _, e := range acl { // BLOCKED supersedes — scan all first
+		if e.Key == BLOCKED && ipSpecMatch(e.Prefix, ip) {
+			return false, ""
+		}
+	}
+	for _, e := range acl { // first non-BLOCKED prefix match wins
+		if e.Key == BLOCKED {
+			continue
+		}
+		if ipSpecMatch(e.Prefix, ip) {
+			return true, e.Key
+		}
+	}
+	return false, ""
+}
+
+// ipSpecMatch reports whether ip falls within the ip-spec. A spec that fails to
+// parse (or a nil ip) returns false.
+func ipSpecMatch(spec string, ip net.IP) bool {
+	ipnet, lo, hi, err := parseIPSpec(spec)
+	if err != nil || ip == nil {
+		return false
+	}
+	if ipnet != nil {
+		return ipnet.Contains(ip)
+	}
+	ip16 := ip.To16()
+	return ip16 != nil && bytes.Compare(ip16, lo) >= 0 && bytes.Compare(ip16, hi) <= 0
+}
+
+// ValidateIPSpec returns an error if spec is not a valid ip-spec.
+func ValidateIPSpec(spec string) error {
+	_, _, _, err := parseIPSpec(spec)
+	return err
+}
+
+// ValidateACL checks an ACL at config time: every prefix must parse and every
+// key must be BLOCKED or accepted by keyDefined (NOKEY or a defined keys.tsig
+// name). Returns the first error, for per-zone quarantine.
+func ValidateACL(acl []AclEntry, keyDefined func(string) bool) error {
+	for _, e := range acl {
+		if err := ValidateIPSpec(e.Prefix); err != nil {
+			return fmt.Errorf("acl entry %q: %w", e.Prefix, err)
+		}
+		if e.Key != BLOCKED && !keyDefined(e.Key) {
+			return fmt.Errorf("acl entry %q: unknown key %q (use a keys.tsig name, NOKEY, or BLOCKED)", e.Prefix, e.Key)
+		}
+	}
+	return nil
+}
+
+// parseIPSpec parses an ip-spec into either an *net.IPNet (CIDR / mask / bare IP
+// host-route) or a [lo, hi] range (lo/hi in 16-byte form). Exactly one of ipnet
+// or (lo,hi) is non-nil on success.
+func parseIPSpec(spec string) (ipnet *net.IPNet, lo, hi net.IP, err error) {
+	spec = strings.TrimSpace(spec)
+	switch {
+	case strings.Contains(spec, "/"): // CIDR (incl. 0.0.0.0/0, ::/0)
+		_, n, e := net.ParseCIDR(spec)
+		if e != nil {
+			return nil, nil, nil, fmt.Errorf("bad CIDR %q: %w", spec, e)
+		}
+		return n, nil, nil, nil
+	case strings.Contains(spec, "&"): // mask: ip&netmask
+		parts := strings.SplitN(spec, "&", 2)
+		base := net.ParseIP(strings.TrimSpace(parts[0]))
+		maskIP := net.ParseIP(strings.TrimSpace(parts[1]))
+		if base == nil || maskIP == nil {
+			return nil, nil, nil, fmt.Errorf("bad masked spec %q", spec)
+		}
+		var mask net.IPMask
+		if v4 := maskIP.To4(); v4 != nil {
+			mask = net.IPMask(v4)
+		} else {
+			mask = net.IPMask(maskIP.To16())
+		}
+		return &net.IPNet{IP: base.Mask(mask), Mask: mask}, nil, nil, nil
+	case strings.Contains(spec, "-"): // range: lo-hi
+		parts := strings.SplitN(spec, "-", 2)
+		loIP := net.ParseIP(strings.TrimSpace(parts[0]))
+		hiIP := net.ParseIP(strings.TrimSpace(parts[1]))
+		if loIP == nil || hiIP == nil {
+			return nil, nil, nil, fmt.Errorf("bad range %q", spec)
+		}
+		lo16, hi16 := loIP.To16(), hiIP.To16()
+		if lo16 == nil || hi16 == nil || bytes.Compare(lo16, hi16) > 0 {
+			return nil, nil, nil, fmt.Errorf("bad range bounds %q", spec)
+		}
+		return nil, lo16, hi16, nil
+	default: // bare IP -> host route
+		ip := net.ParseIP(spec)
+		if ip == nil {
+			return nil, nil, nil, fmt.Errorf("bad ip-spec %q", spec)
+		}
+		bits := 128
+		base := ip.To16()
+		if v4 := ip.To4(); v4 != nil {
+			bits, base = 32, v4
+		}
+		return &net.IPNet{IP: base, Mask: net.CIDRMask(bits, len(base)*8)}, nil, nil, nil
+	}
+}

--- a/v2/acl_test.go
+++ b/v2/acl_test.go
@@ -1,0 +1,100 @@
+package tdns
+
+import (
+	"net"
+	"testing"
+)
+
+func aclIP(s string) net.IP { return net.ParseIP(s) }
+
+func TestIpSpecMatch(t *testing.T) {
+	cases := []struct {
+		spec string
+		ip   string
+		want bool
+	}{
+		{"192.0.2.1", "192.0.2.1", true},
+		{"192.0.2.1", "192.0.2.2", false},
+		{"192.0.2.0/24", "192.0.2.55", true},
+		{"192.0.2.0/24", "192.0.3.1", false},
+		{"192.0.2.0&255.255.255.0", "192.0.2.99", true},
+		{"192.0.2.0&255.255.255.0", "192.0.3.99", false},
+		{"192.0.2.10-192.0.2.20", "192.0.2.15", true},
+		{"192.0.2.10-192.0.2.20", "192.0.2.10", true}, // lo boundary
+		{"192.0.2.10-192.0.2.20", "192.0.2.20", true}, // hi boundary
+		{"192.0.2.10-192.0.2.20", "192.0.2.21", false},
+		{"192.0.2.10-192.0.2.20", "192.0.2.9", false},
+		{"0.0.0.0/0", "203.0.113.7", true},
+		{"::/0", "2001:db8::1", true},
+		{"2001:db8::/32", "2001:db8:1::5", true},
+		{"2001:db8::/32", "2001:db9::5", false},
+		{"not-an-ip", "192.0.2.1", false}, // malformed -> false
+	}
+	for _, c := range cases {
+		if got := ipSpecMatch(c.spec, aclIP(c.ip)); got != c.want {
+			t.Errorf("ipSpecMatch(%q, %q) = %v, want %v", c.spec, c.ip, got, c.want)
+		}
+	}
+}
+
+func TestMatchACL(t *testing.T) {
+	if ok, _ := matchACL(nil, aclIP("192.0.2.1")); ok {
+		t.Error("empty ACL should deny")
+	}
+	acl := []AclEntry{
+		{Prefix: "192.0.2.5", Key: BLOCKED},           // deny this host
+		{Prefix: "192.0.2.0/24", Key: "transfer-key"}, // allow the /24 with key
+		{Prefix: "0.0.0.0/0", Key: NOKEY},             // catch-all, unsigned
+	}
+	if ok, _ := matchACL(acl, aclIP("192.0.2.5")); ok {
+		t.Error("BLOCKED entry should deny 192.0.2.5")
+	}
+	if ok, k := matchACL(acl, aclIP("192.0.2.9")); !ok || k != "transfer-key" {
+		t.Errorf("192.0.2.9: got ok=%v key=%q, want true/transfer-key", ok, k)
+	}
+	if ok, k := matchACL(acl, aclIP("203.0.113.1")); !ok || k != NOKEY {
+		t.Errorf("203.0.113.1: got ok=%v key=%q, want true/NOKEY", ok, k)
+	}
+}
+
+func TestMatchACL_BlockedSupersedesLaterOrder(t *testing.T) {
+	acl := []AclEntry{
+		{Prefix: "192.0.2.0/24", Key: "k"},
+		{Prefix: "192.0.2.5", Key: BLOCKED}, // listed after the allow, still supersedes
+	}
+	if ok, _ := matchACL(acl, aclIP("192.0.2.5")); ok {
+		t.Error("BLOCKED should supersede a preceding allow")
+	}
+	if ok, k := matchACL(acl, aclIP("192.0.2.6")); !ok || k != "k" {
+		t.Errorf("192.0.2.6 should be allowed with k, got ok=%v key=%q", ok, k)
+	}
+}
+
+func TestValidateACL(t *testing.T) {
+	defined := func(name string) bool { return name == NOKEY || name == "good" }
+	good := []AclEntry{
+		{Prefix: "192.0.2.0/24", Key: "good"},
+		{Prefix: "10.0.0.0&255.0.0.0", Key: NOKEY},
+		{Prefix: "0.0.0.0/0", Key: BLOCKED},
+	}
+	if err := ValidateACL(good, defined); err != nil {
+		t.Errorf("valid ACL rejected: %v", err)
+	}
+	if err := ValidateACL([]AclEntry{{Prefix: "garbage", Key: NOKEY}}, defined); err == nil {
+		t.Error("bad prefix accepted")
+	}
+	if err := ValidateACL([]AclEntry{{Prefix: "192.0.2.1", Key: "undefined"}}, defined); err == nil {
+		t.Error("unknown key accepted")
+	}
+}
+
+func TestLoadTsigKeys_BlockedReserved(t *testing.T) {
+	conf := &Config{}
+	conf.Keys.Tsig = []TsigDetails{{Name: "BLOCKED", Algorithm: "hmac-sha256", Secret: "S"}}
+	if err := conf.LoadTsigKeys(); err == nil {
+		t.Error("a key named BLOCKED should be rejected")
+	}
+	if conf.Internal.TsigKeyStore.Has("BLOCKED") {
+		t.Error("BLOCKED key should not be stored")
+	}
+}

--- a/v2/acl_test.go
+++ b/v2/acl_test.go
@@ -1,11 +1,11 @@
 package tdns
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 )
 
-func aclIP(s string) net.IP { return net.ParseIP(s) }
+func aclIP(s string) netip.Addr { return netip.MustParseAddr(s) }
 
 func TestIpSpecMatch(t *testing.T) {
 	cases := []struct {

--- a/v2/acl_test.go
+++ b/v2/acl_test.go
@@ -70,6 +70,18 @@ func TestMatchACL_BlockedSupersedesLaterOrder(t *testing.T) {
 	}
 }
 
+func TestValidateIPSpec_MixedFamilyMask(t *testing.T) {
+	for _, s := range []string{"2001:db8::&255.255.255.0", "192.0.2.1&ffff:ffff::"} {
+		if err := ValidateIPSpec(s); err == nil {
+			t.Errorf("ValidateIPSpec(%q) = nil, want error (mixed IPv4/IPv6 mask)", s)
+		}
+	}
+	// A same-family mask still parses.
+	if err := ValidateIPSpec("192.0.2.0&255.255.255.0"); err != nil {
+		t.Errorf("same-family mask rejected: %v", err)
+	}
+}
+
 func TestValidateACL(t *testing.T) {
 	defined := func(name string) bool { return name == NOKEY || name == "good" }
 	good := []AclEntry{

--- a/v2/acl_test.go
+++ b/v2/acl_test.go
@@ -49,11 +49,35 @@ func TestMatchACL(t *testing.T) {
 	if ok, _ := matchACL(acl, aclIP("192.0.2.5")); ok {
 		t.Error("BLOCKED entry should deny 192.0.2.5")
 	}
-	if ok, k := matchACL(acl, aclIP("192.0.2.9")); !ok || k != "transfer-key" {
-		t.Errorf("192.0.2.9: got ok=%v key=%q, want true/transfer-key", ok, k)
+	// 192.0.2.9 matches the /24 (transfer-key) AND the catch-all (NOKEY): the source
+	// is approved for BOTH (union of matching entries), not just the first.
+	if ok, keys := matchACL(acl, aclIP("192.0.2.9")); !ok || !keysContain(keys, "transfer-key") || !keysContain(keys, NOKEY) {
+		t.Errorf("192.0.2.9: got ok=%v keys=%v, want both transfer-key and NOKEY", ok, keys)
 	}
-	if ok, k := matchACL(acl, aclIP("203.0.113.1")); !ok || k != NOKEY {
-		t.Errorf("203.0.113.1: got ok=%v key=%q, want true/NOKEY", ok, k)
+	if ok, keys := matchACL(acl, aclIP("203.0.113.1")); !ok || !keysContain(keys, NOKEY) {
+		t.Errorf("203.0.113.1: got ok=%v keys=%v, want NOKEY", ok, keys)
+	}
+}
+
+func keysContain(keys []string, want string) bool {
+	for _, k := range keys {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Two entries for the same source naming different keys (the rotation overlap):
+// the source is approved for BOTH, so the server accepts either.
+func TestMatchACL_DualKey(t *testing.T) {
+	acl := []AclEntry{
+		{Prefix: "192.0.2.0/24", Key: "oldkey"},
+		{Prefix: "192.0.2.0/24", Key: "newkey"},
+	}
+	ok, keys := matchACL(acl, aclIP("192.0.2.10"))
+	if !ok || !keysContain(keys, "oldkey") || !keysContain(keys, "newkey") {
+		t.Errorf("dual-key: got ok=%v keys=%v, want both oldkey and newkey", ok, keys)
 	}
 }
 
@@ -65,8 +89,8 @@ func TestMatchACL_BlockedSupersedesLaterOrder(t *testing.T) {
 	if ok, _ := matchACL(acl, aclIP("192.0.2.5")); ok {
 		t.Error("BLOCKED should supersede a preceding allow")
 	}
-	if ok, k := matchACL(acl, aclIP("192.0.2.6")); !ok || k != "k" {
-		t.Errorf("192.0.2.6 should be allowed with k, got ok=%v key=%q", ok, k)
+	if ok, keys := matchACL(acl, aclIP("192.0.2.6")); !ok || !keysContain(keys, "k") {
+		t.Errorf("192.0.2.6 should be allowed with k, got ok=%v keys=%v", ok, keys)
 	}
 }
 

--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -165,14 +165,15 @@ type ZonePost struct {
 	Wait       bool
 	Timeout    string
 	// Dynamic-zones management (add/modify). No Store field — dynamic zones are
-	// map-only. Primaries carries the structured {addr, key} list; key must be NOKEY
-	// until TSIG keys land (Improvement 2). Options are ZoneOption strings.
+	// map-only. Primaries carries the structured {addr, key} list; each key is a
+	// keys.tsig name, an inline TsigName (below), or NOKEY. Options are ZoneOption
+	// strings.
 	Primaries []PeerConf
 	Options   []string
-	// TSIG secret-bearing fields are accepted now but inert in Improvement 1:
-	// a non-NOKEY key is rejected by ProvisionDynamicZone, so these are
-	// carried-on-the-wire-for-later, not silently dropped. Consumed in
-	// Improvement 2. TsigSecret is request-only and never echoed back.
+	// Inline TSIG key for the add/modify: when TsigName is set the server upserts
+	// {name, algo, secret} into its keys: store, points keyless primaries at it,
+	// and persists it with the zone (survives restart). TsigAlgo defaults to
+	// hmac-sha256. TsigSecret is request-only and never echoed back in a response.
 	TsigName   string
 	TsigSecret string
 	TsigAlgo   string

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -255,10 +255,13 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 
 		case "add":
 			msg, err := Conf.ProvisionDynamicZone(r.Context(), DynamicZoneInput{
-				Name:      zp.Zone,
-				Type:      Secondary,
-				Primaries: zp.Primaries,
-				Options:   zoneOptionsFromStrings(zp.Options),
+				Name:       zp.Zone,
+				Type:       Secondary,
+				Primaries:  zp.Primaries,
+				Options:    zoneOptionsFromStrings(zp.Options),
+				TsigName:   zp.TsigName,
+				TsigSecret: zp.TsigSecret,
+				TsigAlgo:   zp.TsigAlgo,
 			}, true)
 			if err != nil {
 				resp.Error = true
@@ -280,10 +283,13 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 
 		case "modify":
 			msg, err := Conf.ModifyDynamicZone(r.Context(), DynamicZoneInput{
-				Name:      zp.Zone,
-				Type:      Secondary,
-				Primaries: zp.Primaries,
-				Options:   zoneOptionsFromStrings(zp.Options),
+				Name:       zp.Zone,
+				Type:       Secondary,
+				Primaries:  zp.Primaries,
+				Options:    zoneOptionsFromStrings(zp.Options),
+				TsigName:   zp.TsigName,
+				TsigSecret: zp.TsigSecret,
+				TsigAlgo:   zp.TsigAlgo,
 			})
 			if err != nil {
 				resp.Error = true

--- a/v2/catalog.go
+++ b/v2/catalog.go
@@ -381,11 +381,15 @@ func AutoConfigureZonesFromCatalog(ctx context.Context, update *CatalogZoneUpdat
 		// against the keys: store, not the retired Globals.TsigKeys.
 		primaryKey := NOKEY
 		if configGroupConfig.TsigKey != "" {
-			if conf.tsigKeyDefined(configGroupConfig.TsigKey) {
-				primaryKey = configGroupConfig.TsigKey
-			} else {
-				lg.Warn("CATALOG: tsig_key not defined in keys.tsig, provisioning zone unsigned", "key", configGroupConfig.TsigKey, "zone", zoneName)
+			if !conf.tsigKeyDefined(configGroupConfig.TsigKey) {
+				// Fail closed: a configured-but-undefined tsig_key must not silently
+				// downgrade to unsigned transfers. Skip the member until the key is
+				// defined (mirrors the static primary-key validation in ParseZones).
+				lg.Error("CATALOG: tsig_key not defined in keys.tsig, skipping zone (fail closed, not unsigned)", "key", configGroupConfig.TsigKey, "zone", zoneName, "group", member.MetaGroup)
+				skippedCount++
+				continue
 			}
+			primaryKey = configGroupConfig.TsigKey
 		}
 		primariesConf := []PeerConf{{Addr: configGroupConfig.Upstream, Key: primaryKey}}
 		res := resolvePrimaries(ctx, conf.Internal.ImrEngine, primariesConf)

--- a/v2/catalog.go
+++ b/v2/catalog.go
@@ -375,7 +375,19 @@ func AutoConfigureZonesFromCatalog(ctx context.Context, update *CatalogZoneUpdat
 		// RULE 4: Auto-configure zone using config group
 		lg.Info("CATALOG: auto-configuring zone", "zone", zoneName, "group", member.MetaGroup, "upstream", configGroupConfig.Upstream, "store", "map")
 
-		primariesConf := []PeerConf{{Addr: configGroupConfig.Upstream, Key: NOKEY}}
+		// The group's tsig_key (if any) names a key in the keys: store; put that
+		// name on the primary so the SOA probe / AXFR is signed with it (the
+		// secret is resolved by name at transfer time, SignForPeer). Validate
+		// against the keys: store, not the retired Globals.TsigKeys.
+		primaryKey := NOKEY
+		if configGroupConfig.TsigKey != "" {
+			if conf.tsigKeyDefined(configGroupConfig.TsigKey) {
+				primaryKey = configGroupConfig.TsigKey
+			} else {
+				lg.Warn("CATALOG: tsig_key not defined in keys.tsig, provisioning zone unsigned", "key", configGroupConfig.TsigKey, "zone", zoneName)
+			}
+		}
+		primariesConf := []PeerConf{{Addr: configGroupConfig.Upstream, Key: primaryKey}}
 		res := resolvePrimaries(ctx, conf.Internal.ImrEngine, primariesConf)
 		if len(res.Resolved) == 0 {
 			lg.Error("CATALOG: upstream did not resolve to an address, skipping zone", "zone", zoneName, "group", member.MetaGroup, "upstream", configGroupConfig.Upstream, "unresolved", res.Unresolved)
@@ -404,17 +416,8 @@ func AutoConfigureZonesFromCatalog(ctx context.Context, update *CatalogZoneUpdat
 			}
 		}
 
-		// Configure TSIG if specified
-		if configGroupConfig.TsigKey != "" {
-			_, ok := Globals.TsigKeys[configGroupConfig.TsigKey]
-			if !ok {
-				lg.Warn("CATALOG: TSIG key not found", "key", configGroupConfig.TsigKey, "zone", zoneName)
-			} else {
-				// Apply TSIG configuration to zone
-				// TODO: Set zd.TsigKey = tsigDetails (depends on TSIG implementation)
-				lg.Info("CATALOG: applied TSIG key", "key", configGroupConfig.TsigKey, "zone", zoneName)
-			}
-		}
+		// (TSIG for the upstream is now carried by primariesConf[].Key above and
+		// resolved by name from the keys: store at transfer time.)
 
 		// Add to Zones map
 		Zones.Set(zoneName, zd)

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -171,9 +171,9 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 	add.Flags().StringSliceVar(&dzPrimaries, "primaries", nil, "Primary (upstream) addresses [host:port], comma-separated")
 	add.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "Primary TSIG key name applied to all primaries (NOKEY for none)")
 	add.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated)")
-	add.Flags().StringVar(&dzTsigName, "tsig-name", "", "TSIG key name (inert until TSIG support lands)")
-	add.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "TSIG secret (inert until TSIG support lands)")
-	add.Flags().StringVar(&dzTsigAlgo, "tsig-algo", "", "TSIG algorithm (inert until TSIG support lands)")
+	add.Flags().StringVar(&dzTsigName, "tsig-name", "", "Inline TSIG key name; upserted into keys: and applied to keyless primaries")
+	add.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "Inline TSIG secret (base64); required with --tsig-name")
+	add.Flags().StringVar(&dzTsigAlgo, "tsig-algo", "", "Inline TSIG algorithm (default hmac-sha256)")
 	add.MarkFlagRequired("zone")
 	add.MarkFlagRequired("primaries")
 
@@ -191,13 +191,16 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 		Use:   "modify",
 		Short: "Modify a dynamic (API-managed) zone's primary or options",
 		Run: func(cmd *cobra.Command, args []string) {
-			RunZoneModify(role, dzPrimaries, dzPrimaryKey, dzOptions)
+			RunZoneModify(role, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigAlgo)
 		},
 	}
 	modify.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to modify")
 	modify.Flags().StringSliceVar(&dzPrimaries, "primaries", nil, "New primary (upstream) addresses [host:port], comma-separated")
 	modify.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "New primary TSIG key name applied to all primaries (NOKEY for none)")
 	modify.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated)")
+	modify.Flags().StringVar(&dzTsigName, "tsig-name", "", "Inline TSIG key name; upserted into keys: and applied to keyless primaries (also rotates the secret for an existing name)")
+	modify.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "Inline TSIG secret (base64); required with --tsig-name")
+	modify.Flags().StringVar(&dzTsigAlgo, "tsig-algo", "", "Inline TSIG algorithm (default hmac-sha256)")
 	modify.MarkFlagRequired("zone")
 
 	listDynamic := &cobra.Command{
@@ -487,7 +490,7 @@ func RunZoneDelete(role string) {
 	}
 }
 
-func RunZoneModify(role string, primaries []string, primaryKey string, options []string) {
+func RunZoneModify(role string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigAlgo string) {
 	if tdns.Globals.Zonename == "" {
 		fmt.Println("Error: zone name not specified")
 		os.Exit(1)
@@ -497,9 +500,12 @@ func RunZoneModify(role string, primaries []string, primaryKey string, options [
 		log.Fatalf("Error getting API client for %s: %v", role, err)
 	}
 	post := tdns.ZonePost{
-		Command: "modify",
-		Zone:    dns.Fqdn(tdns.Globals.Zonename),
-		Options: options,
+		Command:    "modify",
+		Zone:       dns.Fqdn(tdns.Globals.Zonename),
+		Options:    options,
+		TsigName:   tsigName,
+		TsigSecret: tsigSecret,
+		TsigAlgo:   tsigAlgo,
 	}
 	if peers := peerConfsFromAddrs(primaries, primaryKey); len(peers) > 0 {
 		post.Primaries = peers

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -157,14 +157,14 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 	// Dynamic-zones management (add/delete/modify/list-dynamic). No --store
 	// flag: dynamic zones are map-only. The --tsig-* flags are accepted now but
 	// inert in Improvement 1 (a non-NOKEY key is rejected server-side).
-	var dzPrimaryKey, dzTsigName, dzTsigSecret, dzTsigAlgo string
+	var dzPrimaryKey, dzTsigName, dzTsigSecret, dzTsigSecretFile, dzTsigAlgo string
 	var dzPrimaries, dzOptions []string
 
 	add := &cobra.Command{
 		Use:   "add",
 		Short: "Add a dynamic secondary zone at runtime (persists across restart)",
 		Run: func(cmd *cobra.Command, args []string) {
-			RunZoneAdd(role, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigAlgo)
+			RunZoneAdd(role, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigSecretFile, dzTsigAlgo)
 		},
 	}
 	add.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to add")
@@ -172,7 +172,8 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 	add.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "Primary TSIG key name applied to all primaries (NOKEY for none)")
 	add.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated)")
 	add.Flags().StringVar(&dzTsigName, "tsig-name", "", "Inline TSIG key name; upserted into keys: and applied to keyless primaries")
-	add.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "Inline TSIG secret (base64); required with --tsig-name")
+	add.Flags().StringVar(&dzTsigSecretFile, "tsig-secret-file", "", "File containing the inline TSIG secret (base64); preferred over --tsig-secret")
+	add.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "Inline TSIG secret (base64). WARNING: visible in shell history / process list; prefer --tsig-secret-file")
 	add.Flags().StringVar(&dzTsigAlgo, "tsig-algo", "", "Inline TSIG algorithm (default hmac-sha256)")
 	add.MarkFlagRequired("zone")
 	add.MarkFlagRequired("primaries")
@@ -191,7 +192,7 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 		Use:   "modify",
 		Short: "Modify a dynamic (API-managed) zone's primary or options",
 		Run: func(cmd *cobra.Command, args []string) {
-			RunZoneModify(role, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigAlgo)
+			RunZoneModify(role, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigSecretFile, dzTsigAlgo)
 		},
 	}
 	modify.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to modify")
@@ -199,7 +200,8 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 	modify.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "New primary TSIG key name applied to all primaries (NOKEY for none)")
 	modify.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated)")
 	modify.Flags().StringVar(&dzTsigName, "tsig-name", "", "Inline TSIG key name; upserted into keys: and applied to keyless primaries (also rotates the secret for an existing name)")
-	modify.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "Inline TSIG secret (base64); required with --tsig-name")
+	modify.Flags().StringVar(&dzTsigSecretFile, "tsig-secret-file", "", "File containing the inline TSIG secret (base64); preferred over --tsig-secret")
+	modify.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "Inline TSIG secret (base64). WARNING: visible in shell history / process list; prefer --tsig-secret-file")
 	modify.Flags().StringVar(&dzTsigAlgo, "tsig-algo", "", "Inline TSIG algorithm (default hmac-sha256)")
 	modify.MarkFlagRequired("zone")
 
@@ -441,9 +443,31 @@ func peerConfsFromAddrs(addrs []string, key string) []tdns.PeerConf {
 	return out
 }
 
-func RunZoneAdd(role string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigAlgo string) {
+// resolveTsigSecret returns the inline TSIG secret from --tsig-secret-file
+// (preferred — not exposed in shell history or process listings) or the literal
+// --tsig-secret flag. Setting both is an error.
+func resolveTsigSecret(literal, file string) (string, error) {
+	if file == "" {
+		return literal, nil
+	}
+	if literal != "" {
+		return "", fmt.Errorf("set only one of --tsig-secret or --tsig-secret-file")
+	}
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("reading --tsig-secret-file %q: %w", file, err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func RunZoneAdd(role string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigSecretFile, tsigAlgo string) {
 	if tdns.Globals.Zonename == "" {
 		fmt.Println("Error: zone name not specified")
+		os.Exit(1)
+	}
+	secret, err := resolveTsigSecret(tsigSecret, tsigSecretFile)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}
 	api, err := GetApiClient(role, true)
@@ -456,7 +480,7 @@ func RunZoneAdd(role string, primaries []string, primaryKey string, options []st
 		Primaries:  peerConfsFromAddrs(primaries, primaryKey),
 		Options:    options,
 		TsigName:   tsigName,
-		TsigSecret: tsigSecret,
+		TsigSecret: secret,
 		TsigAlgo:   tsigAlgo,
 	})
 	if err != nil {
@@ -490,9 +514,14 @@ func RunZoneDelete(role string) {
 	}
 }
 
-func RunZoneModify(role string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigAlgo string) {
+func RunZoneModify(role string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigSecretFile, tsigAlgo string) {
 	if tdns.Globals.Zonename == "" {
 		fmt.Println("Error: zone name not specified")
+		os.Exit(1)
+	}
+	secret, err := resolveTsigSecret(tsigSecret, tsigSecretFile)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}
 	api, err := GetApiClient(role, true)
@@ -504,7 +533,7 @@ func RunZoneModify(role string, primaries []string, primaryKey string, options [
 		Zone:       dns.Fqdn(tdns.Globals.Zonename),
 		Options:    options,
 		TsigName:   tsigName,
-		TsigSecret: tsigSecret,
+		TsigSecret: secret,
 		TsigAlgo:   tsigAlgo,
 	}
 	if peers := peerConfsFromAddrs(primaries, primaryKey); len(peers) > 0 {

--- a/v2/config.go
+++ b/v2/config.go
@@ -558,10 +558,19 @@ func (conf *Config) ReloadConfig() (string, error) {
 	if err != nil {
 		lgConfig.Error("error parsing config", "err", err)
 	}
-	// Rebuild the TSIG key store so a keys: edit is picked up on reload (config
-	// binds last → "config wins"). Bad entries are skipped + logged.
-	if kerr := conf.LoadTsigKeys(); kerr != nil {
-		lgConfig.Error("TSIG keys: config error on reload (affected keys skipped)", "err", kerr)
+	// Rebuild the TSIG key store ONLY after a successful parse (a failed reload
+	// must not swap in a half-parsed config), then RE-MERGE the persisted
+	// dynamic/API keys. LoadTsigKeys repopulates from conf.Keys.Tsig only, so
+	// without the re-merge a reload would silently drop API-created keys and break
+	// dynamic secondaries' next signed SOA/AXFR/NOTIFY lookup. Config keys win
+	// (loadDynamicTsigKeys skips names already defined).
+	if err == nil {
+		if kerr := conf.LoadTsigKeys(); kerr != nil {
+			lgConfig.Error("TSIG keys: config error on reload (affected keys skipped)", "err", kerr)
+		}
+		if cf, derr := conf.loadDynamicConfigFile(); derr == nil && cf != nil && cf.Keys != nil {
+			conf.loadDynamicTsigKeys(cf.Keys.Tsig)
+		}
 	}
 	Globals.App.ServerConfigTime = time.Now()
 	return "Config reloaded.", err

--- a/v2/config.go
+++ b/v2/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	Zones        []ZoneConf                 `yaml:"zones"`
 	Templates    []ZoneConf                 `yaml:"templates"`
 	Dnssec       DnssecConf                 `yaml:"dnssec" mapstructure:"dnssec"`
-	Keys         KeyConf
+	Keys         KeyConf                    `yaml:"keys" mapstructure:"keys"`
 	Db           DbConf
 	Registrars   map[string][]string
 	Log          LogConf
@@ -463,7 +463,8 @@ type InternalDnsConf struct {
 	ResignQ             chan *ZoneData     // the names of zones that should be kept re-signed should be sent into this channel
 	RRsetCache          *cache.RRsetCacheT // ConcurrentMap of cached RRsets from queries
 	ImrEngine           *Imr
-	Scanner             *Scanner // Scanner instance for async job tracking
+	Scanner             *Scanner      // Scanner instance for async job tracking
+	TsigKeyStore        *TsigKeyStore // name->secret store for replication TSIG (Improvement 2)
 }
 
 // InternalConf holds DNS-internal state (channels, engine references).
@@ -556,6 +557,11 @@ func (conf *Config) ReloadConfig() (string, error) {
 	err := conf.ParseConfig(true) // true: reload, not initial parsing
 	if err != nil {
 		lgConfig.Error("error parsing config", "err", err)
+	}
+	// Rebuild the TSIG key store so a keys: edit is picked up on reload (config
+	// binds last → "config wins"). Bad entries are skipped + logged.
+	if kerr := conf.LoadTsigKeys(); kerr != nil {
+		lgConfig.Error("TSIG keys: config error on reload (affected keys skipped)", "err", kerr)
 	}
 	Globals.App.ServerConfigTime = time.Now()
 	return "Config reloaded.", err

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -51,7 +51,7 @@ func clarifyXfrError(zone, upstream string, err error) error {
 	return err
 }
 
-func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype string) (uint32, error) {
+func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype, keyName string, conf *Config) (uint32, error) {
 
 	if upstream == "" {
 		Fatal("ZoneTransfer: upstream not set")
@@ -72,6 +72,13 @@ func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype string)
 	lgDns.Info("ZoneTransferIn", "zone", zd.ZoneName, "store", ZoneStoreToString[zd.ZoneStore])
 
 	transfer := new(dns.Transfer)
+	// Sign the AXFR/IXFR request under this upstream's key (NOKEY => unsigned).
+	// The provider also verifies the TSIG on the inbound envelopes.
+	provider, serr := SignForPeer(msg, keyName, conf)
+	if serr != nil {
+		return 0, fmt.Errorf("ZoneTransferIn %s: TSIG sign setup: %w", zd.ZoneName, serr)
+	}
+	transfer.TsigProvider = provider
 	answerChan, err := transfer.In(msg, upstream)
 	if err != nil {
 		zd.Logger.Printf("Error from transfer.In: %v\n", err)

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -229,6 +229,22 @@ func estimateEnvelopeSize(rrs []dns.RR) int {
 func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	zone := dns.Fqdn(zd.ZoneName)
 
+	// downstreams (provide-xfr) ACL: who may AXFR/IXFR from us. An empty ACL
+	// DENIES — a hard cutover that closes the legacy open-AXFR default. On a
+	// denied or unverifiable requester, REFUSE and serve no zone data. The
+	// server's TsigProvider (do53.go) has verified any TSIG MAC already; here
+	// we enforce the source ACL and that the required key is the one on the wire.
+	if src, ok := peerIP(w.RemoteAddr().String()); !ok {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, unparseable source %q", zone, w.RemoteAddr())
+		return zd.refuseTransfer(w, r)
+	} else if allowed, requiredKey := zd.downstreamsDecision(src); !allowed {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer to %s (not permitted by downstreams ACL)", zone, src)
+		return zd.refuseTransfer(w, r)
+	} else if err := checkInboundTSIG(w, r, requiredKey); err != nil {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer to %s: %v", zone, src, err)
+		return zd.refuseTransfer(w, r)
+	}
+
 	if zd.Verbose {
 		zd.Logger.Printf("ZoneTransferOut: Will try to serve zone %s", zone)
 	}
@@ -427,6 +443,18 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 	zd.Logger.Printf("ZoneTransferOut: %s: Sent %d RRs.", zone, total_sent)
 
 	return total_sent, nil
+}
+
+// refuseTransfer writes a REFUSED reply to an AXFR/IXFR request (signed when the
+// request itself carried a verified TSIG, per RFC 8945) and reports zero RRs sent.
+func (zd *ZoneData) refuseTransfer(w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	m := new(dns.Msg)
+	m.SetRcode(r, dns.RcodeRefused)
+	signResponseLikeRequest(w, r, m)
+	if err := w.WriteMsg(m); err != nil {
+		zd.Logger.Printf("ZoneTransferOut: %s: WriteMsg on REFUSED failed: %v", dns.Fqdn(zd.ZoneName), err)
+	}
+	return 0, nil
 }
 
 func (zd *ZoneData) ReadZoneFile(filename string, force bool) (bool, uint32, error) {

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -237,10 +237,10 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 	if src, ok := peerIP(w.RemoteAddr().String()); !ok {
 		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, unparseable source %q", zone, w.RemoteAddr())
 		return zd.refuseTransfer(w, r)
-	} else if allowed, requiredKey := zd.downstreamsDecision(src); !allowed {
+	} else if allowed, approvedKeys := zd.downstreamsDecision(src); !allowed {
 		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer to %s (not permitted by downstreams ACL)", zone, src)
 		return zd.refuseTransfer(w, r)
-	} else if err := checkInboundTSIG(w, r, requiredKey); err != nil {
+	} else if err := checkInboundTSIG(w, r, approvedKeys); err != nil {
 		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer to %s: %v", zone, src, err)
 		return zd.refuseTransfer(w, r)
 	}

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -59,6 +59,11 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 				Net:           transport,
 				Handler:       dnsMux,        // Use local mux instead of global handler
 				MsgAcceptFunc: MsgAcceptFunc, // We need a tweaked version for DNS UPDATE
+				// Keystore-backed TSIG provider: verifies inbound TSIG on
+				// replication traffic (NOTIFY, AXFR/IXFR) and signs responses
+				// to signed requests (RFC 8945). tdns UPDATEs are SIG(0)-signed
+				// (a SIG RR, not a TSIG RR), so this never touches them.
+				TsigProvider: conf.tsigProvider(),
 			}
 			// Must bump the buffer size of incoming UDP msgs, as updates
 			// may be much larger then queries

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -265,6 +265,9 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 			Primaries:     res.Resolved,
 			ZoneStore:     zoneStore,
 			Notify:        zconf.Notify,
+			AllowNotify:   zconf.AllowNotify,
+			Downstreams:   zconf.Downstreams,
+			ConfigUpdate:  true, // config-bearing (persisted dynamic zone)
 			Zonefile:      zconf.Zonefile,
 			Options:       options,
 		}
@@ -347,6 +350,8 @@ func zoneDataToZoneConf(zd *ZoneData, zoneDirectory string) ZoneConf {
 		Store:         storeStr,
 		Primaries:     clonePeerConfs(zd.PrimariesConf),
 		Notify:        zd.Notify,
+		AllowNotify:   zd.AllowNotify,
+		Downstreams:   zd.Downstreams,
 		OptionsStrs:   optionsStrs,
 		SourceCatalog: zd.SourceCatalog,
 		ApiManaged:    zd.Options[OptApiManagedZone],
@@ -470,10 +475,16 @@ func (conf *Config) getDynamicTsigKeysFromZones(zones []ZoneConf) []TsigDetails 
 	var out []TsigDetails
 	for _, z := range zones {
 		for _, p := range z.Primaries {
-			if p.Key == "" || p.Key == NOKEY || seen[p.Key] {
+			if p.Key == "" || p.Key == NOKEY {
 				continue
 			}
-			seen[p.Key] = true
+			// Dedup by the canonical name (TsigKeyStore.Get canonicalises), so
+			// mixed-case / trailing-dot variants of one key aren't written twice.
+			canon := dns.CanonicalName(p.Key)
+			if seen[canon] {
+				continue
+			}
+			seen[canon] = true
 			if d, ok := conf.Internal.TsigKeyStore.Get(p.Key); ok {
 				out = append(out, d)
 			}
@@ -612,29 +623,44 @@ type DynamicZoneInput struct {
 	TsigAlgo   string
 }
 
-// applyInlineTsigKey upserts an inline TSIG key supplied with an add/modify
-// request into the keys: store and points every keyless primary (NOKEY/empty) at
-// it. It is a no-op when no inline key name was given. Must run before the primary
-// key-validation loop (so the new name validates) and before persistence (so the
-// secret is written out by getDynamicTsigKeysFromZones).
-func (conf *Config) applyInlineTsigKey(in *DynamicZoneInput) error {
+// stageInlineTsigKey validates an inline TSIG key supplied with an add/modify
+// request and points every keyless primary (NOKEY/empty) at it, WITHOUT touching
+// the live key store. It returns the staged key to be committed only after the
+// request fully succeeds (commitStagedTsigKey), so a rejected add/modify never
+// installs or rotates a live key. Returns (nil, nil) when no inline key was given.
+func (conf *Config) stageInlineTsigKey(in *DynamicZoneInput) (*TsigDetails, error) {
 	if in.TsigName == "" {
-		return nil
+		return nil, nil
 	}
 	algo := in.TsigAlgo
 	if algo == "" {
 		algo = "hmac-sha256"
 	}
 	if err := validateTsigKeySpec(in.TsigName, algo, in.TsigSecret); err != nil {
-		return err
+		return nil, err
 	}
-	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: in.TsigName, Algorithm: algo, Secret: in.TsigSecret})
 	for i := range in.Primaries {
 		if in.Primaries[i].Key == "" || in.Primaries[i].Key == NOKEY {
 			in.Primaries[i].Key = in.TsigName
 		}
 	}
-	return nil
+	return &TsigDetails{Name: in.TsigName, Algorithm: algo, Secret: in.TsigSecret}, nil
+}
+
+// commitStagedTsigKey adds a staged inline key to the live store just before the
+// dynamic-zone request is registered/persisted, and returns a rollback func. The
+// rollback removes the key only if it was newly added, so rolling back a failed
+// request never deletes a pre-existing config/runtime key. nil staged => no-ops.
+func (conf *Config) commitStagedTsigKey(staged *TsigDetails) (rollback func()) {
+	if staged == nil {
+		return func() {}
+	}
+	existed := conf.Internal.TsigKeyStore.Has(staged.Name)
+	conf.Internal.TsigKeyStore.Add(*staged)
+	if existed {
+		return func() {}
+	}
+	return func() { conf.Internal.TsigKeyStore.Delete(staged.Name) }
 }
 
 // ProvisionDynamicZone is the shared *add* core, called by both the catalog
@@ -665,14 +691,16 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 		return "", fmt.Errorf("zone %s already exists", name)
 	}
 
-	// An inline TSIG key (tsig_name/secret/algo) is upserted into the keys: store
-	// and applied to keyless primaries before we validate the primary keys below.
-	if err := conf.applyInlineTsigKey(&in); err != nil {
-		return "", fmt.Errorf("zone %s: %w", name, err)
+	// Stage an inline TSIG key (tsig_name/secret/algo) and apply it to keyless
+	// primaries. Staging only validates + rewrites; the key is committed to the
+	// live store later (after persistence), so a rejected add installs nothing.
+	staged, serr := conf.stageInlineTsigKey(&in)
+	if serr != nil {
+		return "", fmt.Errorf("zone %s: %w", name, serr)
 	}
 
-	// Validate every primary's key: NOKEY (no TSIG) or a name defined in the
-	// keys: store (config or inline/API). An unknown name is rejected.
+	// Validate every primary's key: NOKEY (no TSIG), a name defined in the keys:
+	// store, or the staged inline key. An unknown name is rejected.
 	if in.Type == Secondary {
 		if len(in.Primaries) == 0 {
 			return "", fmt.Errorf("secondary zone %s requires at least one primary", name)
@@ -686,7 +714,7 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 			if p.Key == "" {
 				return "", fmt.Errorf("secondary zone %s primary %q has no key (use NOKEY for no TSIG)", name, p.Addr)
 			}
-			if !conf.tsigKeyDefined(p.Key) {
+			if !conf.tsigKeyAcceptable(p.Key, staged) {
 				return "", fmt.Errorf("unknown primary key %q (define it in keys.tsig or use NOKEY for no TSIG)", p.Key)
 			}
 		}
@@ -724,11 +752,15 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 		KeyDB:         conf.Internal.KeyDB,
 	}
 
-	// Register, then persist; roll back the live registration if persist fails
-	// (never leave a live-but-unpersisted zone that vanishes on restart).
+	// Commit the staged inline key just before registration/persistence (so the
+	// persisted keys: block includes it), then register and persist. On persist
+	// failure, roll back BOTH the registration and the key so a failed add leaves
+	// no live-but-unpersisted zone and no orphaned live key.
+	rollbackKey := conf.commitStagedTsigKey(staged)
 	Zones.Set(name, zd)
 	if err := conf.AddDynamicZoneToConfig(zd); err != nil {
 		Zones.Remove(name)
+		rollbackKey()
 		return "", fmt.Errorf("failed to persist dynamic zone %s: %w", name, err)
 	}
 
@@ -827,11 +859,13 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	if !oldZd.Options[OptApiManagedZone] {
 		return "", fmt.Errorf("zone %s is not API-managed and cannot be modified here", name)
 	}
-	// An inline TSIG key (tsig_name/secret/algo) is upserted and applied to keyless
-	// primaries first; a same-name upsert rotates the secret for primaries that
-	// already reference it (no primaries needed for a pure key rotation).
-	if err := conf.applyInlineTsigKey(&in); err != nil {
-		return "", fmt.Errorf("zone %s: %w", name, err)
+	// Stage an inline TSIG key (validate + rewrite keyless primaries) without
+	// mutating the live store; a same-name stage rotates the secret for primaries
+	// that already reference it (no primaries needed for a pure rotation). The key
+	// is committed only after the modify succeeds.
+	staged, serr := conf.stageInlineTsigKey(&in)
+	if serr != nil {
+		return "", fmt.Errorf("zone %s: %w", name, serr)
 	}
 	// When primaries are supplied they REPLACE the set, so every entry must be
 	// complete (empty in.Primaries means "keep the old set" and skips this).
@@ -839,7 +873,7 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		if p.Addr == "" {
 			return "", fmt.Errorf("zone %s: a modified primary has no address", name)
 		}
-		if !conf.tsigKeyDefined(p.Key) {
+		if !conf.tsigKeyAcceptable(p.Key, staged) {
 			return "", fmt.Errorf("zone %s primary %q has unknown key %q (define it in keys.tsig or use NOKEY)", name, p.Addr, p.Key)
 		}
 	}
@@ -889,6 +923,9 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		Data:          core.NewCmap[OwnerData](),
 		KeyDB:         conf.Internal.KeyDB,
 	}
+	// Commit the staged inline key just before persistence so the rewritten file
+	// includes it; roll it back if persistence fails.
+	rollbackKey := conf.commitStagedTsigKey(staged)
 	Zones.Set(name, newZd)
 
 	// (4) Overwrite the persisted entry. AddDynamicZoneToConfig rewrites the
@@ -896,6 +933,7 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	// rewrite includes the new params). On failure, surface it — the live zone
 	// now has the new params but they would be lost on restart.
 	if err := conf.AddDynamicZoneToConfig(newZd); err != nil {
+		rollbackKey()
 		return "", fmt.Errorf("zone %s modified in memory but failed to persist (change will be lost on restart): %w", name, err)
 	}
 	// Partial resolution of the new primaries: served from what resolved, with

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -584,8 +584,8 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 			if p.Key == "" {
 				return "", fmt.Errorf("secondary zone %s primary %q has no key (use NOKEY for no TSIG)", name, p.Addr)
 			}
-			if p.Key != NOKEY {
-				return "", fmt.Errorf("unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", p.Key)
+			if !conf.tsigKeyDefined(p.Key) {
+				return "", fmt.Errorf("unknown primary key %q (define it in keys.tsig or use NOKEY for no TSIG)", p.Key)
 			}
 		}
 	}
@@ -731,8 +731,8 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		if p.Addr == "" {
 			return "", fmt.Errorf("zone %s: a modified primary has no address", name)
 		}
-		if p.Key != NOKEY {
-			return "", fmt.Errorf("zone %s primary %q requires key NOKEY (only NOKEY is valid until TSIG keys are configured)", name, p.Addr)
+		if !conf.tsigKeyDefined(p.Key) {
+			return "", fmt.Errorf("zone %s primary %q has unknown key %q (define it in keys.tsig or use NOKEY)", name, p.Addr, p.Key)
 		}
 	}
 

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -166,8 +166,15 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 	// Load dynamic config file
 	cf, err := conf.loadDynamicConfigFile()
 	if err != nil {
-		// Error already logged in loadDynamicConfigFile
-		return nil // Start with empty config rather than failing
+		// The file exists but is unreadable (corrupt). Don't crash — but mark the
+		// config broken so writeDynamicConfigFile refuses to overwrite it, and run
+		// with config zones only until the operator repairs it and restarts.
+		// (Error already logged in loadDynamicConfigFile.)
+		dynamicConfigMutex.Lock()
+		dynamicConfigBroken = true
+		dynamicConfigMutex.Unlock()
+		lg.Error("dynamic config unreadable: blocking dynamic-config writes until repaired and restarted (running with config zones only)", "path", conf.DynamicZones.ConfigFile)
+		return nil
 	}
 
 	// Load the persisted (API-created) TSIG keys into the store BEFORE enqueuing
@@ -306,6 +313,11 @@ var (
 	// Used by both loadDynamicConfigFile() and writeDynamicConfigFile() to prevent
 	// race conditions and ensure consistency between read/write operations
 	dynamicConfigMutex sync.Mutex
+	// dynamicConfigBroken is set (under dynamicConfigMutex) when the dynamic config
+	// file could not be parsed at startup. While set, writeDynamicConfigFile refuses
+	// to write, so an unreadable file is never overwritten with the (incomplete)
+	// in-memory state. Cleared only by a restart with a readable file.
+	dynamicConfigBroken bool
 )
 
 // zoneDataToZoneConf converts a ZoneData to ZoneConf for serialization
@@ -387,12 +399,14 @@ func (conf *Config) loadDynamicConfigFile() (*DynamicConfigFile, error) {
 		return nil, fmt.Errorf("failed to read dynamic config file %s: %v", conf.DynamicZones.ConfigFile, err)
 	}
 
-	// Try to parse YAML
+	// Try to parse YAML. A corrupt file must NOT be treated as empty: doing so
+	// makes startup forget every persisted zone/key, and the next dynamic write
+	// would then overwrite the file with that empty state — permanent data loss.
+	// Surface the error; the caller blocks dynamic-config writes until it's fixed.
 	var configFile DynamicConfigFile
 	if err := yaml.Unmarshal(data, &configFile); err != nil {
-		// File is corrupted - log error and return empty config
-		lg.Error("failed to parse dynamic config file, starting with empty config", "path", conf.DynamicZones.ConfigFile, "err", err)
-		return &DynamicConfigFile{}, nil
+		lg.Error("dynamic config file is corrupt; refusing to treat it as empty", "path", conf.DynamicZones.ConfigFile, "err", err)
+		return nil, fmt.Errorf("dynamic config file %s is corrupt: %w", conf.DynamicZones.ConfigFile, err)
 	}
 
 	lg.Info("loaded zones from dynamic config file", "count", len(configFile.Zones), "path", conf.DynamicZones.ConfigFile)
@@ -407,6 +421,13 @@ func (conf *Config) writeDynamicConfigFile(zones []ZoneConf, keys []TsigDetails)
 
 	dynamicConfigMutex.Lock()
 	defer dynamicConfigMutex.Unlock()
+
+	// Refuse to write if the file was unreadable at startup: the in-memory state is
+	// incomplete (it never loaded the persisted zones/keys), so writing now would
+	// clobber the file. Operator must repair/remove it and restart.
+	if dynamicConfigBroken {
+		return fmt.Errorf("refusing to write dynamic config: %s was corrupt at startup; repair or remove it and restart (avoids clobbering persisted zones/keys)", conf.DynamicZones.ConfigFile)
+	}
 
 	// Create config file structure
 	configFile := DynamicConfigFile{
@@ -655,10 +676,12 @@ func (conf *Config) commitStagedTsigKey(staged *TsigDetails) (rollback func()) {
 	if staged == nil {
 		return func() {}
 	}
-	existed := conf.Internal.TsigKeyStore.Has(staged.Name)
+	// Snapshot any pre-existing key BEFORE overwriting it, so a rollback restores
+	// the previous secret rather than leaving a failed rotation's new secret live.
+	prev, existed := conf.Internal.TsigKeyStore.Get(staged.Name)
 	conf.Internal.TsigKeyStore.Add(*staged)
 	if existed {
-		return func() {}
+		return func() { conf.Internal.TsigKeyStore.Add(prev) }
 	}
 	return func() { conf.Internal.TsigKeyStore.Delete(staged.Name) }
 }
@@ -911,12 +934,25 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	} else {
 		options[OptApiManagedZone] = true
 	}
+	// Carry forward the notify list and the allow-notify / downstreams ACLs from
+	// the old zone (copied under its lock into fresh slices — newZd must not share
+	// mutable state with oldZd). Otherwise a TSIG-only modify, which doesn't supply
+	// these, would erase persisted NOTIFY/transfer authorization policy.
+	oldZd.mu.Lock()
+	notify := append([]PeerConf(nil), oldZd.Notify...)
+	allowNotify := append([]AclEntry(nil), oldZd.AllowNotify...)
+	downstreams := append([]AclEntry(nil), oldZd.Downstreams...)
+	oldZd.mu.Unlock()
+
 	newZd := &ZoneData{
 		ZoneName:      name,
 		ZoneType:      oldZd.ZoneType,
 		ZoneStore:     MapZone,
 		PrimariesConf: primariesConf,
 		Upstreams:     upstreams,
+		Notify:        notify,
+		AllowNotify:   allowNotify,
+		Downstreams:   downstreams,
 		Logger:        log.Default(),
 		Options:       options,
 		Status:        ZoneStatusPending,

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -263,6 +263,21 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 			lg.Warn("dynamic zone: some primaries unavailable, serving from the rest", "zone", zoneName, "unresolved", res.Unresolved, "key_collisions", res.KeyCollisions, "serving", len(res.Resolved))
 		}
 
+		// Validate the persisted ACLs before installing them (ParseZones validates
+		// the config path; this load path must too). A malformed prefix never
+		// matches, so an unvalidated typo in a BLOCKED entry would be silently
+		// skipped while a broader allow still grants access. Quarantine the zone.
+		if err := ValidateACL(zconf.AllowNotify, conf.tsigKeyDefined); err != nil {
+			lg.Error("dynamic zone: invalid allow-notify ACL, skipping zone", "zone", zoneName, "err", err)
+			skippedCount++
+			continue
+		}
+		if err := ValidateACL(zconf.Downstreams, conf.tsigKeyDefined); err != nil {
+			lg.Error("dynamic zone: invalid downstreams ACL, skipping zone", "zone", zoneName, "err", err)
+			skippedCount++
+			continue
+		}
+
 		// Create ZoneRefresher and enqueue to RefreshEngine (same as ParseZones does)
 		zr := ZoneRefresher{
 			Name:          zoneName,
@@ -966,11 +981,13 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 
 	// (4) Overwrite the persisted entry. AddDynamicZoneToConfig rewrites the
 	// whole file from the live Zones map, so it MUST run after Zones.Set (so the
-	// rewrite includes the new params). On failure, surface it — the live zone
-	// now has the new params but they would be lost on restart.
+	// rewrite includes the new params). On failure, fully revert the in-memory
+	// modification: roll back the staged key AND restore the old zone, so the live
+	// zone can't be left referencing a rolled-back key (a partially-applied modify).
 	if err := conf.AddDynamicZoneToConfig(newZd); err != nil {
 		rollbackKey()
-		return "", fmt.Errorf("zone %s modified in memory but failed to persist (change will be lost on restart): %w", name, err)
+		Zones.Set(name, oldZd)
+		return "", fmt.Errorf("zone %s failed to persist; rolled back the in-memory modification: %w", name, err)
 	}
 	// Partial resolution of the new primaries: served from what resolved, with
 	// a visibility-only ConfigWarning naming the rest.

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -164,16 +164,24 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 	lg.Info("loading dynamic zones from config file", "path", conf.DynamicZones.ConfigFile)
 
 	// Load dynamic config file
-	zoneConfs, err := conf.loadDynamicConfigFile()
+	cf, err := conf.loadDynamicConfigFile()
 	if err != nil {
 		// Error already logged in loadDynamicConfigFile
 		return nil // Start with empty config rather than failing
 	}
 
+	// Load the persisted (API-created) TSIG keys into the store BEFORE enqueuing
+	// the zones that reference them, so the refresh engine can sign their SOA
+	// probe / AXFR. Config keys were loaded first (LoadTsigKeys) and win on a name
+	// collision (loadDynamicTsigKeys skips already-defined names).
+	if cf.Keys != nil {
+		conf.loadDynamicTsigKeys(cf.Keys.Tsig)
+	}
+
 	loadedCount := 0
 	skippedCount := 0
 
-	for _, zconf := range zoneConfs {
+	for _, zconf := range cf.Zones {
 		zoneName := zconf.Name
 
 		// Check if zone already exists (from main config or already loaded)
@@ -282,6 +290,12 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 // DynamicConfigFile represents the structure of the dynamic zones config file
 type DynamicConfigFile struct {
 	Zones []ZoneConf `yaml:"zones"`
+	// Keys mirrors the main config's keys: block (keys.tsig[]) so the dynamic file
+	// is self-contained: the TSIG secrets the persisted zones reference (API-created
+	// via `zone add --tsig-*`) are stored alongside them and reloaded on startup,
+	// so an API-provisioned TSIG secondary survives a restart instead of
+	// quarantining on an unknown key. Omitted when empty.
+	Keys *KeyConf `yaml:"keys,omitempty"`
 }
 
 var (
@@ -345,7 +359,7 @@ func zoneDataToZoneConf(zd *ZoneData, zoneDirectory string) ZoneConf {
 
 // loadDynamicConfigFile loads the dynamic config file and returns the zone configs
 // Thread-safe: protected by dynamicConfigMutex to prevent races with writeDynamicConfigFile
-func (conf *Config) loadDynamicConfigFile() ([]ZoneConf, error) {
+func (conf *Config) loadDynamicConfigFile() (*DynamicConfigFile, error) {
 	if conf.DynamicZones.ConfigFile == "" {
 		return nil, fmt.Errorf("dynamic config file path not configured")
 	}
@@ -359,7 +373,7 @@ func (conf *Config) loadDynamicConfigFile() ([]ZoneConf, error) {
 	// Check if file exists
 	if _, err := os.Stat(conf.DynamicZones.ConfigFile); os.IsNotExist(err) {
 		lg.Debug("dynamic config file does not exist, starting with empty config", "path", conf.DynamicZones.ConfigFile)
-		return []ZoneConf{}, nil
+		return &DynamicConfigFile{}, nil
 	}
 
 	// Read file
@@ -373,15 +387,15 @@ func (conf *Config) loadDynamicConfigFile() ([]ZoneConf, error) {
 	if err := yaml.Unmarshal(data, &configFile); err != nil {
 		// File is corrupted - log error and return empty config
 		lg.Error("failed to parse dynamic config file, starting with empty config", "path", conf.DynamicZones.ConfigFile, "err", err)
-		return []ZoneConf{}, nil
+		return &DynamicConfigFile{}, nil
 	}
 
 	lg.Info("loaded zones from dynamic config file", "count", len(configFile.Zones), "path", conf.DynamicZones.ConfigFile)
-	return configFile.Zones, nil
+	return &configFile, nil
 }
 
 // writeDynamicConfigFile writes the dynamic config file with atomic writes
-func (conf *Config) writeDynamicConfigFile(zones []ZoneConf) error {
+func (conf *Config) writeDynamicConfigFile(zones []ZoneConf, keys []TsigDetails) error {
 	if conf.DynamicZones.ConfigFile == "" {
 		return fmt.Errorf("dynamic config file path not configured")
 	}
@@ -392,6 +406,9 @@ func (conf *Config) writeDynamicConfigFile(zones []ZoneConf) error {
 	// Create config file structure
 	configFile := DynamicConfigFile{
 		Zones: zones,
+	}
+	if len(keys) > 0 {
+		configFile.Keys = &KeyConf{Tsig: keys}
 	}
 
 	// Marshal to YAML
@@ -439,8 +456,53 @@ func (conf *Config) writeDynamicConfigFile(zones []ZoneConf) error {
 		return fmt.Errorf("failed to rename temp file to final file: %v", err)
 	}
 
-	lg.Info("wrote dynamic config file", "path", conf.DynamicZones.ConfigFile, "zones", len(zones))
+	lg.Info("wrote dynamic config file", "path", conf.DynamicZones.ConfigFile, "zones", len(zones), "keys", len(keys))
 	return nil
+}
+
+// getDynamicTsigKeysFromZones collects the TSIG key definitions referenced by the
+// persisted dynamic zones' primaries, so the dynamic config file carries the
+// secrets its zones need to sign replication. A config-owned key a dynamic zone
+// happens to reference is included too; on reload it is skipped in favour of the
+// config copy (loadDynamicTsigKeys), so the duplication is harmless.
+func (conf *Config) getDynamicTsigKeysFromZones(zones []ZoneConf) []TsigDetails {
+	seen := map[string]bool{}
+	var out []TsigDetails
+	for _, z := range zones {
+		for _, p := range z.Primaries {
+			if p.Key == "" || p.Key == NOKEY || seen[p.Key] {
+				continue
+			}
+			seen[p.Key] = true
+			if d, ok := conf.Internal.TsigKeyStore.Get(p.Key); ok {
+				out = append(out, d)
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// loadDynamicTsigKeys upserts TSIG keys persisted in the dynamic config file into
+// the live store, but never overrides a key already defined — config keys are
+// loaded first (LoadTsigKeys), so they win. Invalid entries are skipped+logged.
+func (conf *Config) loadDynamicTsigKeys(keys []TsigDetails) {
+	loaded := 0
+	for _, k := range keys {
+		if conf.Internal.TsigKeyStore.Has(k.Name) {
+			lg.Debug("dynamic tsig key already defined (config wins), skipping", "key", k.Name)
+			continue
+		}
+		if err := validateTsigKeySpec(k.Name, k.Algorithm, k.Secret); err != nil {
+			lg.Warn("skipping invalid dynamic tsig key", "key", k.Name, "err", err)
+			continue
+		}
+		conf.Internal.TsigKeyStore.Add(k)
+		loaded++
+	}
+	if loaded > 0 {
+		lg.Info("loaded dynamic TSIG keys from dynamic config file", "count", loaded)
+	}
 }
 
 // getDynamicZonesFromZonesMap collects all dynamic zones from the Zones map
@@ -478,11 +540,13 @@ func (conf *Config) WriteDynamicConfigFile() error {
 		return nil // No config file configured, nothing to write
 	}
 
-	// Collect all dynamic zones
+	// Collect all dynamic zones and the TSIG keys they reference (so the file is
+	// self-contained and an API-created TSIG secondary survives a restart).
 	dynamicZones := conf.getDynamicZonesFromZonesMap()
+	keys := conf.getDynamicTsigKeysFromZones(dynamicZones)
 
 	// Write to file
-	return conf.writeDynamicConfigFile(dynamicZones)
+	return conf.writeDynamicConfigFile(dynamicZones, keys)
 }
 
 // AddDynamicZoneToConfig adds or updates a zone in the dynamic config file
@@ -538,6 +602,39 @@ type DynamicZoneInput struct {
 	Type      ZoneType
 	Primaries []PeerConf
 	Options   map[ZoneOption]bool
+	// Inline TSIG key (API/CLI add/modify). When TsigName is set it is validated
+	// and upserted into the keys: store, then applied to every keyless primary
+	// (NOKEY/empty). The secret is persisted with the zone (the dynamic config
+	// file's keys: block), so an API-created TSIG secondary survives a restart.
+	// TsigAlgo defaults to hmac-sha256 when empty.
+	TsigName   string
+	TsigSecret string
+	TsigAlgo   string
+}
+
+// applyInlineTsigKey upserts an inline TSIG key supplied with an add/modify
+// request into the keys: store and points every keyless primary (NOKEY/empty) at
+// it. It is a no-op when no inline key name was given. Must run before the primary
+// key-validation loop (so the new name validates) and before persistence (so the
+// secret is written out by getDynamicTsigKeysFromZones).
+func (conf *Config) applyInlineTsigKey(in *DynamicZoneInput) error {
+	if in.TsigName == "" {
+		return nil
+	}
+	algo := in.TsigAlgo
+	if algo == "" {
+		algo = "hmac-sha256"
+	}
+	if err := validateTsigKeySpec(in.TsigName, algo, in.TsigSecret); err != nil {
+		return err
+	}
+	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: in.TsigName, Algorithm: algo, Secret: in.TsigSecret})
+	for i := range in.Primaries {
+		if in.Primaries[i].Key == "" || in.Primaries[i].Key == NOKEY {
+			in.Primaries[i].Key = in.TsigName
+		}
+	}
+	return nil
 }
 
 // ProvisionDynamicZone is the shared *add* core, called by both the catalog
@@ -568,9 +665,14 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 		return "", fmt.Errorf("zone %s already exists", name)
 	}
 
-	// Validate the primary's key. Improvement-1 phase: NOKEY is the only
-	// resolvable key name (any other is an unknown-key error until the keys:
-	// block lands).
+	// An inline TSIG key (tsig_name/secret/algo) is upserted into the keys: store
+	// and applied to keyless primaries before we validate the primary keys below.
+	if err := conf.applyInlineTsigKey(&in); err != nil {
+		return "", fmt.Errorf("zone %s: %w", name, err)
+	}
+
+	// Validate every primary's key: NOKEY (no TSIG) or a name defined in the
+	// keys: store (config or inline/API). An unknown name is rejected.
 	if in.Type == Secondary {
 		if len(in.Primaries) == 0 {
 			return "", fmt.Errorf("secondary zone %s requires at least one primary", name)
@@ -724,6 +826,12 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	}
 	if !oldZd.Options[OptApiManagedZone] {
 		return "", fmt.Errorf("zone %s is not API-managed and cannot be modified here", name)
+	}
+	// An inline TSIG key (tsig_name/secret/algo) is upserted and applied to keyless
+	// primaries first; a same-name upsert rotates the secret for primaries that
+	// already reference it (no primaries needed for a pure key rotation).
+	if err := conf.applyInlineTsigKey(&in); err != nil {
+		return "", fmt.Errorf("zone %s: %w", name, err)
 	}
 	// When primaries are supplied they REPLACE the set, so every entry must be
 	// complete (empty in.Primaries means "keep the old set" and skips this).

--- a/v2/edns0/edns0_ede.go
+++ b/v2/edns0/edns0_ede.go
@@ -64,6 +64,7 @@ const (
 	EDENotifyParentNotAuthoritative   // parent zone not authoritative on this server
 	EDENotifyZoneInErrorState         // target zone in error state
 	EDENotifyUnknownType              // unsupported NOTIFY RRtype
+	EDENotifyNotPermitted             // source not permitted by the zone's allow-notify ACL
 )
 
 var EDECodeToString = map[uint16]string{
@@ -96,6 +97,7 @@ var EDECodeToString = map[uint16]string{
 	EDENotifyParentNotAuthoritative:   "this server is not authoritative for the parent zone",
 	EDENotifyZoneInErrorState:         "target zone is in error state",
 	EDENotifyUnknownType:              "unsupported NOTIFY RRtype",
+	EDENotifyNotPermitted:             "source not permitted by allow-notify ACL",
 }
 
 // AttachEDEToResponse attaches an Extended DNS Error (EDE) option to the DNS response

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -116,6 +116,13 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	if err != nil {
 		return fmt.Errorf("error parsing config %q: %w", conf.Internal.CfgFile, err)
 	}
+	// Build the replication TSIG name->secret store from the keys: block before
+	// zones are parsed, so a primary/notify/ACL key name can be validated against
+	// it. A bad key entry is non-fatal (skipped + logged); zones referencing it
+	// are quarantined at parse.
+	if err := conf.LoadTsigKeys(); err != nil {
+		lgConfig.Error("TSIG keys: config error (affected keys skipped; zones referencing them are quarantined)", "err", err)
+	}
 	switch Globals.App.Type {
 	case AppTypeAuth, AppTypeAgent, AppTypeScanner:
 		kdb := conf.Internal.KeyDB

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -264,7 +264,7 @@ func (conf *Config) StartAuth(ctx context.Context, apirouter *mux.Router) error 
 	}
 	kdb := conf.Internal.KeyDB
 	StartEngineNoError(&Globals.App, "RefreshEngine", func() { RefreshEngine(ctx, conf) })
-	StartEngine(&Globals.App, "Notifier", func() error { return Notifier(ctx, conf.Internal.NotifyQ) })
+	StartEngine(&Globals.App, "Notifier", func() error { return Notifier(ctx, conf, conf.Internal.NotifyQ) })
 	StartEngineNoError(&Globals.App, "AuthQueryEngine", func() { AuthQueryEngine(ctx, conf.Internal.AuthQueryQ) })
 	StartEngine(&Globals.App, "ScannerEngine", func() error { return ScannerEngine(ctx, conf) })
 	StartEngine(&Globals.App, "ZoneUpdaterEngine", func() error { return kdb.ZoneUpdaterEngine(ctx) })
@@ -294,7 +294,7 @@ func (conf *Config) StartAgent(ctx context.Context, apirouter *mux.Router) error
 	}
 	kdb := conf.Internal.KeyDB
 	StartEngineNoError(&Globals.App, "RefreshEngine", func() { RefreshEngine(ctx, conf) })
-	StartEngine(&Globals.App, "Notifier", func() error { return Notifier(ctx, conf.Internal.NotifyQ) })
+	StartEngine(&Globals.App, "Notifier", func() error { return Notifier(ctx, conf, conf.Internal.NotifyQ) })
 
 	// MP engines (CHUNK, heartbeats, discovery, SDE, leader election, etc.)
 	// removed — for MP functionality use tdns-mp/v2/start_agent.go.

--- a/v2/notifier.go
+++ b/v2/notifier.go
@@ -141,6 +141,7 @@ func (zd *ZoneData) SendNotify(ctx context.Context, conf *Config, ntype uint16, 
 	var lastFailRcode int
 	var lastFailEDE []dns.EDNS0_EDE
 	haveLastFailRcode := false
+	var lastSetupErr error
 
 	for i, dst := range targets {
 		// Honor cancellation between targets so daemon shutdown
@@ -163,6 +164,7 @@ func (zd *ZoneData) SendNotify(ctx context.Context, conf *Config, ntype uint16, 
 		provider, serr := SignForPeer(m, zd.notifyKeyFor(dst), conf)
 		if serr != nil {
 			lgDns.Error("NOTIFY: TSIG sign setup failed, skipping target", "zone", zd.ZoneName, "target", dst, "err", serr)
+			lastSetupErr = serr
 			continue
 		}
 		c.TsigProvider = provider
@@ -201,6 +203,11 @@ func (zd *ZoneData) SendNotify(ctx context.Context, conf *Config, ntype uint16, 
 			// engine into the transport bucket and lose the EDE
 			// context that's the whole point of Phase 4 plumbing.
 			return lastFailRcode, lastFailEDE, nil
+		}
+		// Every target was skipped because its TSIG sign setup failed (e.g. an
+		// unknown key): surface that real cause rather than a generic "no response".
+		if lastSetupErr != nil {
+			return dns.RcodeServerFailure, nil, fmt.Errorf("TSIG setup failed for NOTIFY target(s): %w", lastSetupErr)
 		}
 		// No response from any target at all → genuine transport
 		// failure. err is non-nil only on this branch.

--- a/v2/notifier.go
+++ b/v2/notifier.go
@@ -142,6 +142,7 @@ func (zd *ZoneData) SendNotify(ctx context.Context, conf *Config, ntype uint16, 
 	var lastFailEDE []dns.EDNS0_EDE
 	haveLastFailRcode := false
 	var lastSetupErr error
+	attemptedTargets := 0
 
 	for i, dst := range targets {
 		// Honor cancellation between targets so daemon shutdown
@@ -167,6 +168,7 @@ func (zd *ZoneData) SendNotify(ctx context.Context, conf *Config, ntype uint16, 
 			lastSetupErr = serr
 			continue
 		}
+		attemptedTargets++
 		c.TsigProvider = provider
 
 		lgDns.Debug("sending NOTIFY message", "msg", m.String())
@@ -204,9 +206,11 @@ func (zd *ZoneData) SendNotify(ctx context.Context, conf *Config, ntype uint16, 
 			// context that's the whole point of Phase 4 plumbing.
 			return lastFailRcode, lastFailEDE, nil
 		}
-		// Every target was skipped because its TSIG sign setup failed (e.g. an
-		// unknown key): surface that real cause rather than a generic "no response".
-		if lastSetupErr != nil {
+		// No target was attempted at all because every one's TSIG sign setup failed
+		// (e.g. an unknown key): surface that real cause rather than a generic "no
+		// response". If at least one target WAS attempted (signed) but failed
+		// transport, fall through to the no-response error below.
+		if attemptedTargets == 0 && lastSetupErr != nil {
 			return dns.RcodeServerFailure, nil, fmt.Errorf("TSIG setup failed for NOTIFY target(s): %w", lastSetupErr)
 		}
 		// No response from any target at all → genuine transport

--- a/v2/notifier.go
+++ b/v2/notifier.go
@@ -37,7 +37,12 @@ type NotifyResponse struct {
 
 // XXX: The whole point with the NotifierEngine is to be able to control the max rate of send notifications per
 // zone. This is not yet implemented, but this is where to do it.
-func Notifier(ctx context.Context, notifyreqQ chan NotifyRequest) error {
+// Notifier drains the NOTIFY queue and sends outbound NOTIFYs, signing each with
+// the matching notify-peer's TSIG key (Improvement 2). conf is threaded for the
+// key store. NOTE: tdns-mp pins a published tdns/v2 and calls Notifier at four
+// sites (start_signer/agent/auditor/combiner) — when it bumps the dependency,
+// pass its conf.Config: Notifier(ctx, conf.Config, conf.Config.Internal.NotifyQ).
+func Notifier(ctx context.Context, conf *Config, notifyreqQ chan NotifyRequest) error {
 
 	lgDns.Info("NotifierEngine: starting")
 	for {
@@ -55,7 +60,7 @@ func Notifier(ctx context.Context, notifyreqQ chan NotifyRequest) error {
 
 			lgDns.Info("NotifierEngine: will notify downstreams", "zone", zd.ZoneName)
 
-			rcode, ede, sendErr := zd.SendNotify(ctx, nr.RRtype, nr.Targets)
+			rcode, ede, sendErr := zd.SendNotify(ctx, conf, nr.RRtype, nr.Targets)
 
 			if nr.Response != nil {
 				resp := NotifyResponse{
@@ -92,7 +97,7 @@ func Notifier(ctx context.Context, notifyreqQ chan NotifyRequest) error {
 // ctx cancels in-flight per-target sends. On daemon shutdown, the
 // caller cancels ctx and the per-target loop exits at the next
 // iteration boundary or via ExchangeContext returning early.
-func (zd *ZoneData) SendNotify(ctx context.Context, ntype uint16, targets []string) (int, []dns.EDNS0_EDE, error) {
+func (zd *ZoneData) SendNotify(ctx context.Context, conf *Config, ntype uint16, targets []string) (int, []dns.EDNS0_EDE, error) {
 	if zd.ZoneName == "." {
 		return dns.RcodeServerFailure, nil, fmt.Errorf("zone %q: error: zone name not specified. Ignoring notify request", zd.ZoneName)
 	}
@@ -151,6 +156,16 @@ func (zd *ZoneData) SendNotify(ctx context.Context, ntype uint16, targets []stri
 
 		// remove SOA, add ntype
 		m.Question = []dns.Question{dns.Question{Name: zd.ZoneName, Qtype: ntype, Qclass: dns.ClassINET}}
+
+		// Sign the NOTIFY with the matching notify-peer's key (NOKEY => unsigned).
+		// c is reused across targets, so the per-target provider (nil for NOKEY)
+		// is reset every iteration.
+		provider, serr := SignForPeer(m, zd.notifyKeyFor(dst), conf)
+		if serr != nil {
+			lgDns.Error("NOTIFY: TSIG sign setup failed, skipping target", "zone", zd.ZoneName, "target", dst, "err", serr)
+			continue
+		}
+		c.TsigProvider = provider
 
 		lgDns.Debug("sending NOTIFY message", "msg", m.String())
 

--- a/v2/notifyresponder.go
+++ b/v2/notifyresponder.go
@@ -131,12 +131,12 @@ func (zd *ZoneData) authorizeInboundNotify(w dns.ResponseWriter, r *dns.Msg) (ok
 	if !parsed {
 		return false, dns.RcodeRefused, edns0.EDENotifyNotPermitted, "unparseable source address"
 	}
-	allowed, requiredKey := zd.allowNotifyDecision(src)
+	allowed, approvedKeys := zd.allowNotifyDecision(src)
 	if !allowed {
 		return false, dns.RcodeRefused, edns0.EDENotifyNotPermitted,
 			fmt.Sprintf("source %s not permitted by allow-notify", src)
 	}
-	if err := checkInboundTSIG(w, r, requiredKey); err != nil {
+	if err := checkInboundTSIG(w, r, approvedKeys); err != nil {
 		ede := edns0.EDETsigValidationFailure
 		if r.IsTsig() == nil {
 			ede = edns0.EDETsigRequired

--- a/v2/notifyresponder.go
+++ b/v2/notifyresponder.go
@@ -146,6 +146,17 @@ func (zd *ZoneData) authorizeInboundNotify(w dns.ResponseWriter, r *dns.Msg) (ok
 	return true, dns.RcodeSuccess, 0, ""
 }
 
+// writeNotifyReply signs the reply to mirror a verified request TSIG (RFC 8945,
+// no-op for unsigned/unverified requests) and writes it. Used for EVERY NOTIFY
+// response — success and refusal — so a TSIG-authenticated NOTIFY never sees its
+// intended rcode/EDE turn into a TSIG-failure on an unsigned reply.
+func writeNotifyReply(dnr *DnsNotifyRequest, m *dns.Msg) {
+	signResponseLikeRequest(dnr.ResponseWriter, dnr.Msg, m)
+	if err := dnr.ResponseWriter.WriteMsg(m); err != nil {
+		lgHandler.Error("NOTIFY: WriteMsg failed", "zone", dnr.Qname, "err", err)
+	}
+}
+
 func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan ZoneRefresher, scannerq chan ScanRequest) error {
 
 	qname := dnr.Qname
@@ -159,9 +170,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		if dnr.Msg != nil {
 			m.MsgHdr.Id = dnr.Msg.MsgHdr.Id
 		}
-		if err := dnr.ResponseWriter.WriteMsg(m); err != nil {
-			lgHandler.Error("WriteMsg error on FormatError", "err", err)
-		}
+		writeNotifyReply(dnr, m)
 		return nil
 	}
 	ntype := dnr.Msg.Question[0].Qtype
@@ -194,7 +203,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
 			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyParentNotAuthoritative,
 				fmt.Sprintf("server is not authoritative for %s", qname), false)
-			dnr.ResponseWriter.WriteMsg(m)
+			writeNotifyReply(dnr, m)
 			return nil
 		}
 		if !strings.EqualFold(dns.Fqdn(zd.ZoneName), dns.Fqdn(qname)) {
@@ -207,14 +216,14 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 				m.SetRcode(dnr.Msg, dns.RcodeRefused)
 				edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
 					fmt.Sprintf("%s is a child delegation, not authoritative on this server", qname), false)
-				dnr.ResponseWriter.WriteMsg(m)
+				writeNotifyReply(dnr, m)
 				return nil
 			}
 			lgHandler.Warn("received NOTIFY for interior name in zone, ignoring", "type", dns.TypeToString[ntype], "qname", qname, "zone", zd.ZoneName)
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
 			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyParentNotAuthoritative,
 				fmt.Sprintf("%s is not a zone apex on this server (containing zone %s)", qname, zd.ZoneName), false)
-			dnr.ResponseWriter.WriteMsg(m)
+			writeNotifyReply(dnr, m)
 			return nil
 		}
 		targetZoneName = zd.ZoneName
@@ -228,7 +237,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
 			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
 				fmt.Sprintf("%s has no parent label", qname), false)
-			dnr.ResponseWriter.WriteMsg(m)
+			writeNotifyReply(dnr, m)
 			return nil
 		}
 		zd, _ = FindZone(labels[1])
@@ -237,7 +246,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 			m.SetRcode(dnr.Msg, dns.RcodeNotAuth)
 			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyParentNotAuthoritative,
 				fmt.Sprintf("server is not authoritative for parent of %s", qname), false)
-			dnr.ResponseWriter.WriteMsg(m)
+			writeNotifyReply(dnr, m)
 			return nil
 		}
 		if !zd.IsChildDelegation(qname) {
@@ -245,7 +254,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 			m.SetRcode(dnr.Msg, dns.RcodeRefused)
 			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyTargetNotChildDelegation,
 				fmt.Sprintf("%s is not a child delegation of %s", qname, zd.ZoneName), false)
-			dnr.ResponseWriter.WriteMsg(m)
+			writeNotifyReply(dnr, m)
 			return nil
 		}
 		// DSYNC scheme gate: refuse NOTIFY for an RRtype the parent
@@ -259,7 +268,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 			edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyDsyncSchemeNotAdvertised,
 				fmt.Sprintf("parent zone %s does not advertise NOTIFY for type %s; ignoring",
 					zd.ZoneName, dns.TypeToString[ntype]), false)
-			dnr.ResponseWriter.WriteMsg(m)
+			writeNotifyReply(dnr, m)
 			return nil
 		}
 		targetZoneName = zd.ZoneName
@@ -269,8 +278,22 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		m.SetRcode(dnr.Msg, dns.RcodeRefused)
 		edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyUnknownType,
 			fmt.Sprintf("NOTIFY for type %s not supported", dns.TypeToString[ntype]), false)
-		dnr.ResponseWriter.WriteMsg(m)
+		writeNotifyReply(dnr, m)
 		return nil
+	}
+
+	// Authorize NOTIFY(SOA) BEFORE exposing any zone state: an unauthorized or
+	// unsigned NOTIFY to an errored zone must get the ACL/TSIG refusal, not the
+	// zone-error response (which would leak zone state). CDS/CSYNC/DNSKEY keep
+	// their own authorization (checked above) and are intentionally not gated here.
+	if ntype == dns.TypeSOA {
+		if ok, rcode, ede, reason := zd.authorizeInboundNotify(dnr.ResponseWriter, dnr.Msg); !ok {
+			lgHandler.Warn("NOTIFY(SOA) refused", "zone", targetZoneName, "from", dnr.ResponseWriter.RemoteAddr(), "reason", reason)
+			m.SetRcode(dnr.Msg, rcode)
+			edns0.AttachEDEToResponseWithText(m, ede, reason, false)
+			writeNotifyReply(dnr, m)
+			return nil
+		}
 	}
 
 	// Refuse NOTIFY only when the zone has a service-impacting error
@@ -282,7 +305,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		m.SetRcode(dnr.Msg, dns.RcodeServerFailure)
 		edns0.AttachEDEToResponseWithText(m, edns0.EDENotifyZoneInErrorState,
 			fmt.Sprintf("zone %s in error state: %s", targetZoneName, zd.ErrorMsg), false)
-		dnr.ResponseWriter.WriteMsg(m)
+		writeNotifyReply(dnr, m)
 		return nil
 	}
 
@@ -290,24 +313,13 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 
 	switch ntype {
 	case dns.TypeSOA:
-		// allow-notify ACL gate (secondary side). CDS/CSYNC/DNSKEY NOTIFYs use
-		// their own authorization (child-delegation / DSYNC / multi-signer) and
-		// are intentionally not gated here.
-		if ok, rcode, ede, reason := zd.authorizeInboundNotify(dnr.ResponseWriter, dnr.Msg); !ok {
-			lgHandler.Warn("NOTIFY(SOA) refused", "zone", targetZoneName, "from", dnr.ResponseWriter.RemoteAddr(), "reason", reason)
-			m.SetRcode(dnr.Msg, rcode)
-			edns0.AttachEDEToResponseWithText(m, ede, reason, false)
-			signResponseLikeRequest(dnr.ResponseWriter, dnr.Msg, m)
-			dnr.ResponseWriter.WriteMsg(m)
-			return nil
-		}
+		// allow-notify ACL + TSIG were already enforced above (before any
+		// zone-state response), so an unauthorized NOTIFY can't observe zone state.
 		select {
 		case <-ctx.Done():
 			// Send immediate failure so NOTIFY sender doesn't block on cancellation
 			m.SetRcode(dnr.Msg, dns.RcodeServerFailure)
-			if err := dnr.ResponseWriter.WriteMsg(m); err != nil {
-				lgHandler.Error("WriteMsg error on cancellation", "notifyType", "SOA", "err", err)
-			}
+			writeNotifyReply(dnr, m)
 			return nil
 		case zonech <- ZoneRefresher{
 			Name:         targetZoneName, // send zone name into RefreshEngine
@@ -324,9 +336,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		case <-ctx.Done():
 			// Send immediate failure so NOTIFY sender doesn't block on cancellation
 			m.SetRcode(dnr.Msg, dns.RcodeServerFailure)
-			if err := dnr.ResponseWriter.WriteMsg(m); err != nil {
-				lgHandler.Error("WriteMsg error on cancellation", "notifyType", "CDS/CSYNC", "err", err)
-			}
+			writeNotifyReply(dnr, m)
 			return nil
 		case scannerq <- ScanRequest{
 			Cmd:          "SCAN",
@@ -344,9 +354,7 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		case <-ctx.Done():
 			// Send immediate failure so NOTIFY sender doesn't block on cancellation
 			m.SetRcode(dnr.Msg, dns.RcodeServerFailure)
-			if err := dnr.ResponseWriter.WriteMsg(m); err != nil {
-				lgHandler.Error("WriteMsg error on cancellation", "notifyType", "DNSKEY", "err", err)
-			}
+			writeNotifyReply(dnr, m)
 			return nil
 		case scannerq <- ScanRequest{
 			Cmd:          "SCAN",
@@ -358,8 +366,6 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		}
 	}
 
-	// Sign the success response when the NOTIFY was itself signed (RFC 8945).
-	signResponseLikeRequest(dnr.ResponseWriter, dnr.Msg, m)
-	dnr.ResponseWriter.WriteMsg(m)
+	writeNotifyReply(dnr, m)
 	return nil
 }

--- a/v2/notifyresponder.go
+++ b/v2/notifyresponder.go
@@ -119,6 +119,33 @@ func NotifyHandler(ctx context.Context, conf *Config) error {
 // TODO: Add per-source rate limiting for NOTIFY messages. An attacker could flood
 // the server with NOTIFY messages to trigger excessive zone refreshes and scanner
 // scans. Consider a token bucket or sliding window rate limiter keyed by source IP.
+// authorizeInboundNotify applies the secondary-side allow-notify ACL and any
+// required TSIG to an inbound NOTIFY(SOA). It returns ok=true to proceed, or
+// ok=false with the refusal rcode, an EDE code, and a human reason to log and
+// return. An empty allow-notify ACL accepts (unsigned) from any resolved primary
+// IP, so operators needn't restate the primary list. The server's TsigProvider
+// (do53.go) has already verified the MAC; this only checks that the source is
+// permitted and that the named key the ACL requires is the one on the wire.
+func (zd *ZoneData) authorizeInboundNotify(w dns.ResponseWriter, r *dns.Msg) (ok bool, rcode int, ede uint16, reason string) {
+	src, parsed := peerIP(w.RemoteAddr().String())
+	if !parsed {
+		return false, dns.RcodeRefused, edns0.EDENotifyNotPermitted, "unparseable source address"
+	}
+	allowed, requiredKey := zd.allowNotifyDecision(src)
+	if !allowed {
+		return false, dns.RcodeRefused, edns0.EDENotifyNotPermitted,
+			fmt.Sprintf("source %s not permitted by allow-notify", src)
+	}
+	if err := checkInboundTSIG(w, r, requiredKey); err != nil {
+		ede := edns0.EDETsigValidationFailure
+		if r.IsTsig() == nil {
+			ede = edns0.EDETsigRequired
+		}
+		return false, dns.RcodeNotAuth, ede, err.Error()
+	}
+	return true, dns.RcodeSuccess, 0, ""
+}
+
 func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan ZoneRefresher, scannerq chan ScanRequest) error {
 
 	qname := dnr.Qname
@@ -263,6 +290,17 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 
 	switch ntype {
 	case dns.TypeSOA:
+		// allow-notify ACL gate (secondary side). CDS/CSYNC/DNSKEY NOTIFYs use
+		// their own authorization (child-delegation / DSYNC / multi-signer) and
+		// are intentionally not gated here.
+		if ok, rcode, ede, reason := zd.authorizeInboundNotify(dnr.ResponseWriter, dnr.Msg); !ok {
+			lgHandler.Warn("NOTIFY(SOA) refused", "zone", targetZoneName, "from", dnr.ResponseWriter.RemoteAddr(), "reason", reason)
+			m.SetRcode(dnr.Msg, rcode)
+			edns0.AttachEDEToResponseWithText(m, ede, reason, false)
+			signResponseLikeRequest(dnr.ResponseWriter, dnr.Msg, m)
+			dnr.ResponseWriter.WriteMsg(m)
+			return nil
+		}
 		select {
 		case <-ctx.Done():
 			// Send immediate failure so NOTIFY sender doesn't block on cancellation
@@ -320,6 +358,8 @@ func NotifyResponder(ctx context.Context, dnr *DnsNotifyRequest, zonech chan Zon
 		}
 	}
 
+	// Sign the success response when the NOTIFY was itself signed (RFC 8945).
+	signResponseLikeRequest(dnr.ResponseWriter, dnr.Msg, m)
 	dnr.ResponseWriter.WriteMsg(m)
 	return nil
 }

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -1087,6 +1087,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				Notify:        zconf.Notify,
 				AllowNotify:   zconf.AllowNotify,
 				Downstreams:   zconf.Downstreams,
+				ConfigUpdate:  true, // config-bearing: lets reload clear removed ACLs
 				Zonefile:      zconf.Zonefile,
 				Options:       options,
 				UpdatePolicy:  policy,

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -669,9 +669,9 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 					secondaryOK = false
 					break
 				}
-				if p.Key != NOKEY {
+				if !conf.tsigKeyDefined(p.Key) {
 					lgConfig.Error("secondary zone primary references unknown key, zone in error state", "zone", zname, "key", p.Key)
-					zd.SetError(ConfigError, "unknown primary key %q (only NOKEY is valid until TSIG keys are configured)", p.Key)
+					zd.SetError(ConfigError, "unknown primary key %q (define it in keys.tsig or use NOKEY for no TSIG)", p.Key)
 					secondaryOK = false
 					break
 				}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -732,6 +732,22 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			continue
 		}
 
+		// allow-notify: / downstreams: ACL validation — every ip-spec must parse
+		// and every key must be NOKEY, BLOCKED, or a defined keys.tsig name.
+		// A bad ACL quarantines just this zone (same rule as the primary check).
+		if err := ValidateACL(zconf.AllowNotify, conf.tsigKeyDefined); err != nil {
+			lgConfig.Error("zone allow-notify ACL invalid, zone in error state", "zone", zname, "err", err)
+			zd.SetError(ConfigError, "allow-notify: %v", err)
+			broken_zones = append(broken_zones, zname)
+			continue
+		}
+		if err := ValidateACL(zconf.Downstreams, conf.tsigKeyDefined); err != nil {
+			lgConfig.Error("zone downstreams ACL invalid, zone in error state", "zone", zname, "err", err)
+			zd.SetError(ConfigError, "downstreams: %v", err)
+			broken_zones = append(broken_zones, zname)
+			continue
+		}
+
 		lgConfig.Debug("checking DNSSEC policy", "zone", zname)
 		// dump.P(zconf)
 
@@ -1069,6 +1085,8 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				Primaries:     resolvedPrimaries,
 				ZoneStore:     zonestore,
 				Notify:        zconf.Notify,
+				AllowNotify:   zconf.AllowNotify,
+				Downstreams:   zconf.Downstreams,
 				Zonefile:      zconf.Zonefile,
 				Options:       options,
 				UpdatePolicy:  policy,

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -311,16 +311,19 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// notify addresses, upstream, zonefile, zone store, options, update policy, DNSSEC policy, etc.
 						// Only update fields that are actually set in ZoneRefresher (non-zero/non-empty values)
 						zd.mu.Lock()
-						// Update notify addresses only if provided
-						if zr.Notify != nil {
+						// Notify + ACLs. For a config-bearing refresher (reload),
+						// assign even when nil/empty so a config that REMOVES a notify
+						// list or an ACL actually clears it (empty downstreams => deny,
+						// empty allow-notify => fall back to primaries) instead of
+						// leaving stale permissions. A NOTIFY/refresh-only trigger
+						// (ConfigUpdate=false) carries none of these and must not touch
+						// them.
+						if zr.ConfigUpdate {
 							zd.Notify = normalizePeerAddrs(zr.Notify)
-						}
-						// Update allow-notify / downstreams ACLs only if provided
-						if zr.AllowNotify != nil {
 							zd.AllowNotify = zr.AllowNotify
-						}
-						if zr.Downstreams != nil {
 							zd.Downstreams = zr.Downstreams
+						} else if zr.Notify != nil {
+							zd.Notify = normalizePeerAddrs(zr.Notify)
 						}
 						// Update primaries only if provided (config-bearing refresher).
 						if len(zr.PrimariesConf) > 0 {

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -245,6 +245,8 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 								zd.Upstreams = clonePeerConfs(zr.Primaries)
 							}
 							zd.Notify = normalizePeerAddrs(zr.Notify)
+							zd.AllowNotify = zr.AllowNotify
+							zd.Downstreams = zr.Downstreams
 							zd.Zonefile = zr.Zonefile
 							zd.ZoneType = zr.ZoneType
 							zd.Options = zr.Options
@@ -312,6 +314,13 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// Update notify addresses only if provided
 						if zr.Notify != nil {
 							zd.Notify = normalizePeerAddrs(zr.Notify)
+						}
+						// Update allow-notify / downstreams ACLs only if provided
+						if zr.AllowNotify != nil {
+							zd.AllowNotify = zr.AllowNotify
+						}
+						if zr.Downstreams != nil {
+							zd.Downstreams = zr.Downstreams
 						}
 						// Update primaries only if provided (config-bearing refresher).
 						if len(zr.PrimariesConf) > 0 {
@@ -577,6 +586,8 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						PrimariesConf:    primariesConf,
 						Upstreams:        upstreams,
 						Notify:           normalizePeerAddrs(zr.Notify),
+						AllowNotify:      zr.AllowNotify,
+						Downstreams:      zr.Downstreams,
 						Zonefile:         zr.Zonefile,
 						ZoneType:         zr.ZoneType,
 						Options:          zr.Options,

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -582,6 +582,13 @@ type ZoneRefresher struct {
 	Notify        []PeerConf
 	AllowNotify   []AclEntry // copied to zd.AllowNotify on merge
 	Downstreams   []AclEntry // copied to zd.Downstreams on merge
+	// ConfigUpdate marks a config-bearing refresher (from ParseZones /
+	// LoadDynamicZoneFiles) as opposed to a NOTIFY/refresh-only trigger. On reload
+	// it lets the merge assign Notify/AllowNotify/Downstreams even when they are
+	// nil/empty, so a config that REMOVES an ACL actually clears it (empty
+	// downstreams => deny, empty allow-notify => primaries) instead of keeping
+	// stale permissions.
+	ConfigUpdate  bool
 	ZoneStore     ZoneStore // 1=xfr, 2=map, 3=slice
 	Zonefile      string
 	Options       map[ZoneOption]bool

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -844,7 +844,7 @@ type KeyBootstrapperRequest struct {
 }
 
 type KeyConf struct {
-	Tsig []TsigDetails
+	Tsig []TsigDetails `yaml:"tsig" mapstructure:"tsig"`
 }
 type TsigDetails struct {
 	Name      string `validate:"required" yaml:"name"`

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -121,6 +121,8 @@ type ZoneData struct {
 	PrimariesConf     []PeerConf // as-written primaries; persisted; re-resolved each load (P3)
 	Upstreams         []PeerConf // resolved addr:port tuples; runtime-only; used for transfer
 	Notify            []PeerConf // downstream secondaries that we notify (addr + key)
+	AllowNotify       []AclEntry // secondary: who may NOTIFY us; empty => accept from resolved primaries
+	Downstreams       []AclEntry // primary: who may AXFR from us (provide-xfr ACL); empty => deny
 	Zonefile          string
 	DelegationSyncQ   chan DelegationSyncRequest
 	Parent            string   // name of parentzone (if filled in)
@@ -217,6 +219,8 @@ type ZoneConf struct {
 	Store             string     // xfr | map | slice | reg (defaults to "map" if not specified)
 	Primaries         []PeerConf `yaml:"primaries" mapstructure:"primaries"` // upstream set, for secondary zones
 	Notify            []PeerConf
+	AllowNotify       []AclEntry   `yaml:"allow-notify" mapstructure:"allow-notify"` // secondary: who may NOTIFY us (ip-spec + key｜NOKEY｜BLOCKED)
+	Downstreams       []AclEntry   `yaml:"downstreams" mapstructure:"downstreams"`   // primary: who may AXFR from us (provide-xfr ACL)
 	OptionsStrs       []string     `yaml:"options" mapstructure:"options"`
 	Options           []ZoneOption `yaml:"-" mapstructure:"-"` // Ignore during both yaml and mapstructure decoding
 	Frozen            bool         // true if zone is frozen; not a config param
@@ -576,6 +580,8 @@ type ZoneRefresher struct {
 	PrimariesConf []PeerConf // as-written; copied to zd.PrimariesConf on merge
 	Primaries     []PeerConf // resolved; copied to zd.Upstreams on merge
 	Notify        []PeerConf
+	AllowNotify   []AclEntry // copied to zd.AllowNotify on merge
+	Downstreams   []AclEntry // copied to zd.Downstreams on merge
 	ZoneStore     ZoneStore // 1=xfr, 2=map, 3=slice
 	Zonefile      string
 	Options       map[ZoneOption]bool

--- a/v2/transfer_fallback_test.go
+++ b/v2/transfer_fallback_test.go
@@ -202,7 +202,7 @@ func TestDoTransfer_AllUnreachableIsError(t *testing.T) {
 
 func TestFetchFromUpstream_NoUpstreams(t *testing.T) {
 	zd := &ZoneData{ZoneName: "example.test."}
-	if _, err := zd.FetchFromUpstream(false, false, nil); err == nil {
+	if _, err := zd.FetchFromUpstream(false, false, nil, &Config{}); err == nil {
 		t.Fatal("expected an error when no upstreams are configured")
 	}
 }

--- a/v2/transfer_fallback_test.go
+++ b/v2/transfer_fallback_test.go
@@ -47,9 +47,88 @@ func startTestSOAServer(t *testing.T, zone string, serial uint32, rcode int) (st
 	return addr, func() { _ = srv.Shutdown() }
 }
 
+// startTestSOAServerTSIG starts a UDP SOA responder that REQUIRES a valid TSIG
+// under keyName and signs its response with the same key.
+func startTestSOAServerTSIG(t *testing.T, zone string, serial uint32, keyName, secret string) (string, func()) {
+	t.Helper()
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := pc.LocalAddr().String()
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		ts := r.IsTsig()
+		if ts == nil || w.TsigStatus() != nil { // require a valid TSIG
+			m.Rcode = dns.RcodeNotAuth
+			_ = w.WriteMsg(m)
+			return
+		}
+		m.Answer = append(m.Answer, &dns.SOA{
+			Hdr:     dns.RR_Header{Name: zone, Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 60},
+			Ns:      "ns." + zone,
+			Mbox:    "hostmaster." + zone,
+			Serial:  serial,
+			Refresh: 3600, Retry: 600, Expire: 86400, Minttl: 60,
+		})
+		// Sign the response with the same key (RFC 8945); the server fills the MAC.
+		m.SetTsig(ts.Hdr.Name, dns.HmacSHA256, 300, time.Now().Unix())
+		_ = w.WriteMsg(m)
+	})
+
+	started := make(chan struct{})
+	srv := &dns.Server{
+		PacketConn:        pc,
+		Handler:           mux,
+		TsigSecret:        map[string]string{dns.CanonicalName(keyName): secret},
+		NotifyStartedFunc: func() { close(started) },
+	}
+	go func() { _ = srv.ActivateAndServe() }()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test DNS server did not start")
+	}
+	return addr, func() { _ = srv.Shutdown() }
+}
+
+// A keyed upstream: the SOA probe must be TSIG-signed (server accepts), and a
+// wrong secret must fail.
+func TestDoTransfer_SignsWithKey(t *testing.T) {
+	zone := "example.test."
+	const secret = "MTIzNDU2Nzg5MDEyMzQ1Ng=="
+	good, stop := startTestSOAServerTSIG(t, zone, 42, "tkey", secret)
+	defer stop()
+
+	conf := &Config{}
+	conf.Keys.Tsig = []TsigDetails{{Name: "tkey", Algorithm: "hmac-sha256", Secret: secret}}
+	if err := conf.LoadTsigKeys(); err != nil {
+		t.Fatalf("LoadTsigKeys: %v", err)
+	}
+	zd := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: good, Key: "tkey"}}}
+	if _, serial, err := zd.DoTransfer(conf); err != nil || serial != 42 {
+		t.Fatalf("signed SOA probe: serial=%d err=%v, want 42/nil", serial, err)
+	}
+
+	bad := &Config{}
+	bad.Keys.Tsig = []TsigDetails{{Name: "tkey", Algorithm: "hmac-sha256", Secret: "YWJjZGVmZ2hpamtsbW5vcA=="}}
+	if err := bad.LoadTsigKeys(); err != nil {
+		t.Fatalf("LoadTsigKeys(bad): %v", err)
+	}
+	zd2 := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: good, Key: "tkey"}}}
+	// Wrong secret -> the server rejects with NOTAUTH, so the probe gets no usable
+	// SOA (quiet back-off) and crucially never reads the upstream's real serial.
+	if _, serial, _ := zd2.DoTransfer(bad); serial == 42 {
+		t.Error("a wrong secret must not yield the upstream's SOA serial")
+	}
+}
+
 func TestDoTransfer_NoUpstreams(t *testing.T) {
 	zd := &ZoneData{ZoneName: "example.test."}
-	if _, _, err := zd.DoTransfer(); err == nil {
+	if _, _, err := zd.DoTransfer(&Config{}); err == nil {
 		t.Fatal("expected an error when no upstreams are configured")
 	}
 }
@@ -64,7 +143,7 @@ func TestDoTransfer_RefusedAdvancesToNextPrimary(t *testing.T) {
 	defer stop2()
 
 	zd := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: refusing}, {Addr: good}}}
-	xfr, serial, err := zd.DoTransfer()
+	xfr, serial, err := zd.DoTransfer(&Config{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,7 +164,7 @@ func TestDoTransfer_TransportErrorAdvancesToNextPrimary(t *testing.T) {
 
 	// 127.0.0.1:1 has no listener -> connection refused / timeout (transport).
 	zd := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: "127.0.0.1:1"}, {Addr: good}}}
-	_, serial, err := zd.DoTransfer()
+	_, serial, err := zd.DoTransfer(&Config{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +183,7 @@ func TestDoTransfer_AllRefusedQuietBackoff(t *testing.T) {
 	defer s2()
 
 	zd := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: r1}, {Addr: r2}}}
-	xfr, _, err := zd.DoTransfer()
+	xfr, _, err := zd.DoTransfer(&Config{})
 	if err != nil {
 		t.Fatalf("all-REFUSED should back off quietly, got error: %v", err)
 	}
@@ -116,7 +195,7 @@ func TestDoTransfer_AllRefusedQuietBackoff(t *testing.T) {
 // When no primary is reachable at all, surface a hard error.
 func TestDoTransfer_AllUnreachableIsError(t *testing.T) {
 	zd := &ZoneData{ZoneName: "example.test.", Upstreams: []PeerConf{{Addr: "127.0.0.1:1"}, {Addr: "127.0.0.1:2"}}}
-	if _, _, err := zd.DoTransfer(); err == nil {
+	if _, _, err := zd.DoTransfer(&Config{}); err == nil {
 		t.Fatal("expected an error when every upstream is unreachable")
 	}
 }

--- a/v2/transfer_fallback_test.go
+++ b/v2/transfer_fallback_test.go
@@ -1,6 +1,7 @@
 package tdns
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -44,7 +45,11 @@ func startTestSOAServer(t *testing.T, zone string, serial uint32, rcode int) (st
 	case <-time.After(2 * time.Second):
 		t.Fatal("test DNS server did not start")
 	}
-	return addr, func() { _ = srv.Shutdown() }
+	return addr, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.ShutdownContext(ctx)
+	}
 }
 
 // startTestSOAServerTSIG starts a UDP SOA responder that REQUIRES a valid TSIG
@@ -92,7 +97,11 @@ func startTestSOAServerTSIG(t *testing.T, zone string, serial uint32, keyName, s
 	case <-time.After(2 * time.Second):
 		t.Fatal("test DNS server did not start")
 	}
-	return addr, func() { _ = srv.Shutdown() }
+	return addr, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.ShutdownContext(ctx)
+	}
 }
 
 // A keyed upstream: the SOA probe must be TSIG-signed (server accepts), and a
@@ -120,9 +129,14 @@ func TestDoTransfer_SignsWithKey(t *testing.T) {
 	}
 	zd2 := &ZoneData{ZoneName: zone, Upstreams: []PeerConf{{Addr: good, Key: "tkey"}}}
 	// Wrong secret -> the server rejects with NOTAUTH, so the probe gets no usable
-	// SOA (quiet back-off) and crucially never reads the upstream's real serial.
-	if _, serial, _ := zd2.DoTransfer(bad); serial == 42 {
-		t.Error("a wrong secret must not yield the upstream's SOA serial")
+	// SOA: it must back off quietly (no error) without warranting a transfer and
+	// crucially without ever reading the upstream's real serial.
+	xfr, serial, err := zd2.DoTransfer(bad)
+	if err != nil {
+		t.Fatalf("wrong secret should back off without accepting data, got err=%v", err)
+	}
+	if xfr || serial == 42 {
+		t.Fatalf("wrong secret must not yield a usable transfer: xfr=%v serial=%d", xfr, serial)
 	}
 }
 

--- a/v2/tsig_dynzone_test.go
+++ b/v2/tsig_dynzone_test.go
@@ -74,12 +74,16 @@ func TestStageInlineTsigKey(t *testing.T) {
 		t.Error("rollback should remove a newly-added key")
 	}
 
-	// Committing a name that already exists must NOT delete it on rollback.
+	// Committing over an existing name (a rotation) must, on rollback, RESTORE the
+	// previous secret — not delete the key and not leave the new (rejected) secret.
 	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: "pre", Algorithm: "hmac-sha256", Secret: b64Secret16})
 	rb := conf.commitStagedTsigKey(&TsigDetails{Name: "pre", Algorithm: "hmac-sha256", Secret: "YWJjZGVmZ2hpamtsbW5vcA=="})
+	if d, _ := conf.Internal.TsigKeyStore.Get("pre"); d.Secret != "YWJjZGVmZ2hpamtsbW5vcA==" {
+		t.Errorf("commit should install the new secret before rollback, got %q", d.Secret)
+	}
 	rb()
-	if !conf.Internal.TsigKeyStore.Has("pre") {
-		t.Error("rollback must not delete a pre-existing key")
+	if d, ok := conf.Internal.TsigKeyStore.Get("pre"); !ok || d.Secret != b64Secret16 {
+		t.Errorf("rollback must restore the previous secret: got %q ok=%v, want %q", d.Secret, ok, b64Secret16)
 	}
 
 	// No inline name -> (nil, nil) no-op.

--- a/v2/tsig_dynzone_test.go
+++ b/v2/tsig_dynzone_test.go
@@ -1,0 +1,118 @@
+package tdns
+
+import "testing"
+
+const b64Secret16 = "MTIzNDU2Nzg5MDEyMzQ1Ng==" // valid std-base64, 16 bytes
+
+func TestKnownTsigAlgo(t *testing.T) {
+	for _, a := range []string{"hmac-sha256", "hmac-sha256.", "HMAC-SHA512", "hmac-sha1", "hmac-sha224", "hmac-sha384"} {
+		if !knownTsigAlgo(a) {
+			t.Errorf("knownTsigAlgo(%q) = false, want true", a)
+		}
+	}
+	for _, a := range []string{"", "md5", "gss-tsig", "sha256"} {
+		if knownTsigAlgo(a) {
+			t.Errorf("knownTsigAlgo(%q) = true, want false", a)
+		}
+	}
+}
+
+func TestValidateTsigKeySpec(t *testing.T) {
+	if err := validateTsigKeySpec("k", "hmac-sha256", b64Secret16); err != nil {
+		t.Errorf("valid spec rejected: %v", err)
+	}
+	bad := []struct{ name, algo, secret string }{
+		{"", "hmac-sha256", b64Secret16},      // no name
+		{"k", "hmac-sha256", ""},              // no secret
+		{"NOKEY", "hmac-sha256", b64Secret16}, // reserved (any case)
+		{"blocked", "hmac-sha256", b64Secret16},
+		{"k", "md5", b64Secret16},        // unsupported algo
+		{"k", "hmac-sha256", "not b64!"}, // bad base64
+	}
+	for _, c := range bad {
+		if err := validateTsigKeySpec(c.name, c.algo, c.secret); err == nil {
+			t.Errorf("validateTsigKeySpec(%q,%q,%q) = nil, want error", c.name, c.algo, c.secret)
+		}
+	}
+}
+
+func TestApplyInlineTsigKey(t *testing.T) {
+	conf := &Config{}
+	conf.Internal.TsigKeyStore = NewTsigKeyStore()
+	in := DynamicZoneInput{
+		Name:       "example.test.",
+		Primaries:  []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}, {Addr: "192.0.2.2:53", Key: "explicit"}},
+		TsigName:   "ikey",
+		TsigSecret: b64Secret16, // no algo -> default hmac-sha256
+	}
+	if err := conf.applyInlineTsigKey(&in); err != nil {
+		t.Fatalf("applyInlineTsigKey: %v", err)
+	}
+	d, ok := conf.Internal.TsigKeyStore.Get("ikey")
+	if !ok || d.Algorithm != "hmac-sha256" {
+		t.Fatalf("key not upserted with default algo: %+v ok=%v", d, ok)
+	}
+	if in.Primaries[0].Key != "ikey" {
+		t.Errorf("keyless primary Key = %q, want ikey", in.Primaries[0].Key)
+	}
+	if in.Primaries[1].Key != "explicit" {
+		t.Errorf("explicit primary Key = %q, want explicit (must be untouched)", in.Primaries[1].Key)
+	}
+
+	// No inline name -> no-op.
+	in2 := DynamicZoneInput{Primaries: []PeerConf{{Addr: "x", Key: NOKEY}}}
+	if err := conf.applyInlineTsigKey(&in2); err != nil || in2.Primaries[0].Key != NOKEY {
+		t.Errorf("no inline name should be a no-op: err=%v key=%q", err, in2.Primaries[0].Key)
+	}
+
+	// Inline name with an invalid secret -> error (and nothing stored).
+	in3 := DynamicZoneInput{TsigName: "bad", TsigSecret: "%%%"}
+	if err := conf.applyInlineTsigKey(&in3); err == nil {
+		t.Error("invalid inline secret should error")
+	}
+	if conf.Internal.TsigKeyStore.Has("bad") {
+		t.Error("a rejected inline key must not be stored")
+	}
+}
+
+func TestGetDynamicTsigKeysFromZones(t *testing.T) {
+	conf := &Config{}
+	conf.Internal.TsigKeyStore = NewTsigKeyStore()
+	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: "k1", Algorithm: "hmac-sha256", Secret: b64Secret16})
+	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: "k2", Algorithm: "hmac-sha256", Secret: b64Secret16})
+	zones := []ZoneConf{
+		{Name: "a.", Primaries: []PeerConf{{Addr: "1", Key: "k1"}, {Addr: "2", Key: NOKEY}}},
+		{Name: "b.", Primaries: []PeerConf{{Addr: "3", Key: "k2"}, {Addr: "4", Key: "k1"}}}, // k1 again
+		{Name: "c.", Primaries: []PeerConf{{Addr: "5", Key: "missing"}}},                    // not in store
+	}
+	keys := conf.getDynamicTsigKeysFromZones(zones)
+	if len(keys) != 2 {
+		t.Fatalf("got %d keys, want 2 (k1,k2 deduped; NOKEY and missing skipped)", len(keys))
+	}
+	if keys[0].Name != "k1" || keys[1].Name != "k2" { // sorted by name
+		t.Errorf("keys = [%s %s], want sorted [k1 k2]", keys[0].Name, keys[1].Name)
+	}
+}
+
+func TestLoadDynamicTsigKeys_ConfigWins(t *testing.T) {
+	conf := &Config{}
+	conf.Internal.TsigKeyStore = NewTsigKeyStore()
+	// Pre-existing config key "shared" (loaded first) with secret A.
+	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: "shared", Algorithm: "hmac-sha256", Secret: b64Secret16})
+
+	conf.loadDynamicTsigKeys([]TsigDetails{
+		{Name: "shared", Algorithm: "hmac-sha256", Secret: "YWJjZGVmZ2hpamtsbW5vcA=="}, // must NOT override
+		{Name: "dyn", Algorithm: "hmac-sha256", Secret: "YWJjZGVmZ2hpamtsbW5vcA=="},    // new -> loaded
+		{Name: "broken", Algorithm: "md5", Secret: "x"},                                // invalid -> skipped
+	})
+
+	if d, _ := conf.Internal.TsigKeyStore.Get("shared"); d.Secret != b64Secret16 {
+		t.Error("config key must win; the dynamic override must be skipped")
+	}
+	if !conf.Internal.TsigKeyStore.Has("dyn") {
+		t.Error("a new dynamic key should be loaded")
+	}
+	if conf.Internal.TsigKeyStore.Has("broken") {
+		t.Error("an invalid dynamic key should be skipped")
+	}
+}

--- a/v2/tsig_dynzone_test.go
+++ b/v2/tsig_dynzone_test.go
@@ -36,7 +36,7 @@ func TestValidateTsigKeySpec(t *testing.T) {
 	}
 }
 
-func TestApplyInlineTsigKey(t *testing.T) {
+func TestStageInlineTsigKey(t *testing.T) {
 	conf := &Config{}
 	conf.Internal.TsigKeyStore = NewTsigKeyStore()
 	in := DynamicZoneInput{
@@ -45,13 +45,18 @@ func TestApplyInlineTsigKey(t *testing.T) {
 		TsigName:   "ikey",
 		TsigSecret: b64Secret16, // no algo -> default hmac-sha256
 	}
-	if err := conf.applyInlineTsigKey(&in); err != nil {
-		t.Fatalf("applyInlineTsigKey: %v", err)
+	staged, err := conf.stageInlineTsigKey(&in)
+	if err != nil {
+		t.Fatalf("stageInlineTsigKey: %v", err)
 	}
-	d, ok := conf.Internal.TsigKeyStore.Get("ikey")
-	if !ok || d.Algorithm != "hmac-sha256" {
-		t.Fatalf("key not upserted with default algo: %+v ok=%v", d, ok)
+	if staged == nil || staged.Algorithm != "hmac-sha256" {
+		t.Fatalf("staged key missing or wrong default algo: %+v", staged)
 	}
+	// Staging must NOT touch the live store.
+	if conf.Internal.TsigKeyStore.Has("ikey") {
+		t.Error("staging must not commit the key to the live store")
+	}
+	// Keyless primary points at the inline key; the explicit one is untouched.
 	if in.Primaries[0].Key != "ikey" {
 		t.Errorf("keyless primary Key = %q, want ikey", in.Primaries[0].Key)
 	}
@@ -59,16 +64,35 @@ func TestApplyInlineTsigKey(t *testing.T) {
 		t.Errorf("explicit primary Key = %q, want explicit (must be untouched)", in.Primaries[1].Key)
 	}
 
-	// No inline name -> no-op.
-	in2 := DynamicZoneInput{Primaries: []PeerConf{{Addr: "x", Key: NOKEY}}}
-	if err := conf.applyInlineTsigKey(&in2); err != nil || in2.Primaries[0].Key != NOKEY {
-		t.Errorf("no inline name should be a no-op: err=%v key=%q", err, in2.Primaries[0].Key)
+	// Commit installs it; the returned rollback removes a newly-added key.
+	rollback := conf.commitStagedTsigKey(staged)
+	if d, ok := conf.Internal.TsigKeyStore.Get("ikey"); !ok || d.Algorithm != "hmac-sha256" {
+		t.Fatalf("commit did not install the key: %+v ok=%v", d, ok)
+	}
+	rollback()
+	if conf.Internal.TsigKeyStore.Has("ikey") {
+		t.Error("rollback should remove a newly-added key")
 	}
 
-	// Inline name with an invalid secret -> error (and nothing stored).
+	// Committing a name that already exists must NOT delete it on rollback.
+	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: "pre", Algorithm: "hmac-sha256", Secret: b64Secret16})
+	rb := conf.commitStagedTsigKey(&TsigDetails{Name: "pre", Algorithm: "hmac-sha256", Secret: "YWJjZGVmZ2hpamtsbW5vcA=="})
+	rb()
+	if !conf.Internal.TsigKeyStore.Has("pre") {
+		t.Error("rollback must not delete a pre-existing key")
+	}
+
+	// No inline name -> (nil, nil) no-op.
+	in2 := DynamicZoneInput{Primaries: []PeerConf{{Addr: "x", Key: NOKEY}}}
+	staged2, err := conf.stageInlineTsigKey(&in2)
+	if err != nil || staged2 != nil || in2.Primaries[0].Key != NOKEY {
+		t.Errorf("no inline name should be a no-op: staged=%v err=%v key=%q", staged2, err, in2.Primaries[0].Key)
+	}
+
+	// Inline name with an invalid secret -> error, nothing staged, nothing stored.
 	in3 := DynamicZoneInput{TsigName: "bad", TsigSecret: "%%%"}
-	if err := conf.applyInlineTsigKey(&in3); err == nil {
-		t.Error("invalid inline secret should error")
+	if staged3, err := conf.stageInlineTsigKey(&in3); err == nil || staged3 != nil {
+		t.Errorf("invalid inline secret should error with no staged key: staged=%v err=%v", staged3, err)
 	}
 	if conf.Internal.TsigKeyStore.Has("bad") {
 		t.Error("a rejected inline key must not be stored")

--- a/v2/tsig_inbound_test.go
+++ b/v2/tsig_inbound_test.go
@@ -73,6 +73,24 @@ func TestCheckInboundTSIG(t *testing.T) {
 	}
 }
 
+// A key provisioned for one algorithm must reject an inbound TSIG that names a
+// different algorithm, even if the secret matches (RFC 8945 keys are algo-bound).
+func TestProviderRejectsAlgorithmMismatch(t *testing.T) {
+	conf := &Config{}
+	conf.Internal.TsigKeyStore = NewTsigKeyStore()
+	conf.Internal.TsigKeyStore.Add(TsigDetails{Name: "k", Algorithm: "hmac-sha256", Secret: "MTIzNDU2Nzg5MDEyMzQ1Ng=="})
+	p := tsigKeyProvider{conf.Internal.TsigKeyStore}
+
+	mismatch := &dns.TSIG{Hdr: dns.RR_Header{Name: "k."}, Algorithm: dns.HmacSHA1}
+	if _, err := p.hmac(mismatch); err != dns.ErrKeyAlg {
+		t.Errorf("algorithm mismatch: got err=%v, want ErrKeyAlg", err)
+	}
+	match := &dns.TSIG{Hdr: dns.RR_Header{Name: "k."}, Algorithm: dns.HmacSHA256}
+	if _, err := p.hmac(match); err != nil {
+		t.Errorf("matching algorithm: unexpected err=%v", err)
+	}
+}
+
 func TestAllowNotifyDecision(t *testing.T) {
 	// Empty allow-notify: accept (unsigned) from a resolved primary IP only.
 	zd := &ZoneData{Upstreams: []PeerConf{{Addr: "192.0.2.1:53"}, {Addr: "192.0.2.2:53"}}}

--- a/v2/tsig_inbound_test.go
+++ b/v2/tsig_inbound_test.go
@@ -43,33 +43,45 @@ func TestCheckInboundTSIG(t *testing.T) {
 	unsigned := new(dns.Msg)
 	unsigned.SetQuestion("example.test.", dns.TypeSOA)
 
-	// NOKEY / empty: always accepted, signed or not.
-	if err := checkInboundTSIG(&fakeRW{}, unsigned, NOKEY); err != nil {
+	// NOKEY / empty approved: always accepted, signed or not (source trusted by addr).
+	if err := checkInboundTSIG(&fakeRW{}, unsigned, []string{NOKEY}); err != nil {
 		t.Errorf("NOKEY unsigned: unexpected error %v", err)
 	}
-	if err := checkInboundTSIG(&fakeRW{}, signedMsg("k"), ""); err != nil {
-		t.Errorf("empty required key: unexpected error %v", err)
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("k"), []string{""}); err != nil {
+		t.Errorf("empty approved key: unexpected error %v", err)
 	}
 
 	// Named key required but request unsigned -> error.
-	if err := checkInboundTSIG(&fakeRW{}, unsigned, "k"); err == nil {
+	if err := checkInboundTSIG(&fakeRW{}, unsigned, []string{"k"}); err == nil {
 		t.Error("named key + unsigned request should error")
 	}
 
 	// Named key, request signed but the server reported a bad MAC -> error.
-	if err := checkInboundTSIG(&fakeRW{tsigStatus: errors.New("bad mac")}, signedMsg("k"), "k"); err == nil {
+	if err := checkInboundTSIG(&fakeRW{tsigStatus: errors.New("bad mac")}, signedMsg("k"), []string{"k"}); err == nil {
 		t.Error("named key + failed TsigStatus should error")
 	}
 
 	// Named key, signed and verified, names match -> ok.
-	if err := checkInboundTSIG(&fakeRW{}, signedMsg("k"), "k"); err != nil {
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("k"), []string{"k"}); err != nil {
 		t.Errorf("named key + valid TSIG: unexpected error %v", err)
 	}
 
-	// Named key, signed and verified, but with a DIFFERENT key than the ACL
-	// requires -> error (a valid MAC under the wrong key must not pass).
-	if err := checkInboundTSIG(&fakeRW{}, signedMsg("other"), "k"); err == nil {
-		t.Error("valid TSIG under the wrong key name should error")
+	// Named key, signed and verified, but with a DIFFERENT key than approved
+	// -> error (a valid MAC under an unapproved key must not pass).
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("other"), []string{"k"}); err == nil {
+		t.Error("valid TSIG under an unapproved key name should error")
+	}
+
+	// Dual-key overlap: two approved keys, signed with either -> ok.
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("oldkey"), []string{"oldkey", "newkey"}); err != nil {
+		t.Errorf("dual-key (oldkey): unexpected error %v", err)
+	}
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("newkey"), []string{"oldkey", "newkey"}); err != nil {
+		t.Errorf("dual-key (newkey): unexpected error %v", err)
+	}
+	// ...but a third, unapproved key is still rejected.
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("evilkey"), []string{"oldkey", "newkey"}); err == nil {
+		t.Error("dual-key: an unapproved third key must still be rejected")
 	}
 }
 
@@ -94,8 +106,8 @@ func TestProviderRejectsAlgorithmMismatch(t *testing.T) {
 func TestAllowNotifyDecision(t *testing.T) {
 	// Empty allow-notify: accept (unsigned) from a resolved primary IP only.
 	zd := &ZoneData{Upstreams: []PeerConf{{Addr: "192.0.2.1:53"}, {Addr: "192.0.2.2:53"}}}
-	if ok, key := zd.allowNotifyDecision(netip.MustParseAddr("192.0.2.1")); !ok || key != NOKEY {
-		t.Errorf("empty ACL, primary src: got (%v,%q), want (true,NOKEY)", ok, key)
+	if ok, keys := zd.allowNotifyDecision(netip.MustParseAddr("192.0.2.1")); !ok || !keysContain(keys, NOKEY) {
+		t.Errorf("empty ACL, primary src: got (%v,%v), want (true,[NOKEY])", ok, keys)
 	}
 	if ok, _ := zd.allowNotifyDecision(netip.MustParseAddr("203.0.113.9")); ok {
 		t.Error("empty ACL, non-primary src should be denied")
@@ -106,8 +118,8 @@ func TestAllowNotifyDecision(t *testing.T) {
 		Upstreams:   []PeerConf{{Addr: "192.0.2.1:53"}},
 		AllowNotify: []AclEntry{{Prefix: "198.51.100.0/24", Key: "nkey"}},
 	}
-	if ok, key := zd2.allowNotifyDecision(netip.MustParseAddr("198.51.100.7")); !ok || key != "nkey" {
-		t.Errorf("ACL match: got (%v,%q), want (true,nkey)", ok, key)
+	if ok, keys := zd2.allowNotifyDecision(netip.MustParseAddr("198.51.100.7")); !ok || !keysContain(keys, "nkey") {
+		t.Errorf("ACL match: got (%v,%v), want (true,[nkey])", ok, keys)
 	}
 	if ok, _ := zd2.allowNotifyDecision(netip.MustParseAddr("192.0.2.1")); ok {
 		t.Error("with a non-empty ACL, a primary not in the ACL must be denied")
@@ -122,8 +134,8 @@ func TestDownstreamsDecision(t *testing.T) {
 	}
 
 	zd2 := &ZoneData{Downstreams: []AclEntry{{Prefix: "0.0.0.0/0", Key: "xkey"}}}
-	if ok, key := zd2.downstreamsDecision(netip.MustParseAddr("192.0.2.1")); !ok || key != "xkey" {
-		t.Errorf("0.0.0.0/0 xkey: got (%v,%q), want (true,xkey)", ok, key)
+	if ok, keys := zd2.downstreamsDecision(netip.MustParseAddr("192.0.2.1")); !ok || !keysContain(keys, "xkey") {
+		t.Errorf("0.0.0.0/0 xkey: got (%v,%v), want (true,[xkey])", ok, keys)
 	}
 }
 

--- a/v2/tsig_inbound_test.go
+++ b/v2/tsig_inbound_test.go
@@ -1,0 +1,140 @@
+package tdns
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// fakeRW is a minimal dns.ResponseWriter for exercising the inbound TSIG/ACL
+// helpers without a live server: RemoteAddr and TsigStatus are settable, the rest
+// are no-ops, and WriteMsg records the last response.
+type fakeRW struct {
+	remote     net.Addr
+	tsigStatus error
+	written    *dns.Msg
+}
+
+func (f *fakeRW) LocalAddr() net.Addr       { return f.remote }
+func (f *fakeRW) RemoteAddr() net.Addr      { return f.remote }
+func (f *fakeRW) WriteMsg(m *dns.Msg) error { f.written = m; return nil }
+func (f *fakeRW) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+func (f *fakeRW) Close() error        { return nil }
+func (f *fakeRW) TsigStatus() error   { return f.tsigStatus }
+func (f *fakeRW) TsigTimersOnly(bool) {}
+func (f *fakeRW) Hijack()             {}
+
+func udpAddr(ip string) net.Addr { return &net.UDPAddr{IP: net.ParseIP(ip), Port: 5353} }
+
+func signedMsg(keyName string) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion("example.test.", dns.TypeSOA)
+	m.SetTsig(dns.CanonicalName(keyName), dns.HmacSHA256, 300, time.Now().Unix())
+	return m
+}
+
+func TestCheckInboundTSIG(t *testing.T) {
+	unsigned := new(dns.Msg)
+	unsigned.SetQuestion("example.test.", dns.TypeSOA)
+
+	// NOKEY / empty: always accepted, signed or not.
+	if err := checkInboundTSIG(&fakeRW{}, unsigned, NOKEY); err != nil {
+		t.Errorf("NOKEY unsigned: unexpected error %v", err)
+	}
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("k"), ""); err != nil {
+		t.Errorf("empty required key: unexpected error %v", err)
+	}
+
+	// Named key required but request unsigned -> error.
+	if err := checkInboundTSIG(&fakeRW{}, unsigned, "k"); err == nil {
+		t.Error("named key + unsigned request should error")
+	}
+
+	// Named key, request signed but the server reported a bad MAC -> error.
+	if err := checkInboundTSIG(&fakeRW{tsigStatus: errors.New("bad mac")}, signedMsg("k"), "k"); err == nil {
+		t.Error("named key + failed TsigStatus should error")
+	}
+
+	// Named key, signed and verified, names match -> ok.
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("k"), "k"); err != nil {
+		t.Errorf("named key + valid TSIG: unexpected error %v", err)
+	}
+
+	// Named key, signed and verified, but with a DIFFERENT key than the ACL
+	// requires -> error (a valid MAC under the wrong key must not pass).
+	if err := checkInboundTSIG(&fakeRW{}, signedMsg("other"), "k"); err == nil {
+		t.Error("valid TSIG under the wrong key name should error")
+	}
+}
+
+func TestAllowNotifyDecision(t *testing.T) {
+	// Empty allow-notify: accept (unsigned) from a resolved primary IP only.
+	zd := &ZoneData{Upstreams: []PeerConf{{Addr: "192.0.2.1:53"}, {Addr: "192.0.2.2:53"}}}
+	if ok, key := zd.allowNotifyDecision(netip.MustParseAddr("192.0.2.1")); !ok || key != NOKEY {
+		t.Errorf("empty ACL, primary src: got (%v,%q), want (true,NOKEY)", ok, key)
+	}
+	if ok, _ := zd.allowNotifyDecision(netip.MustParseAddr("203.0.113.9")); ok {
+		t.Error("empty ACL, non-primary src should be denied")
+	}
+
+	// Non-empty allow-notify: matchACL governs (and the primary list is ignored).
+	zd2 := &ZoneData{
+		Upstreams:   []PeerConf{{Addr: "192.0.2.1:53"}},
+		AllowNotify: []AclEntry{{Prefix: "198.51.100.0/24", Key: "nkey"}},
+	}
+	if ok, key := zd2.allowNotifyDecision(netip.MustParseAddr("198.51.100.7")); !ok || key != "nkey" {
+		t.Errorf("ACL match: got (%v,%q), want (true,nkey)", ok, key)
+	}
+	if ok, _ := zd2.allowNotifyDecision(netip.MustParseAddr("192.0.2.1")); ok {
+		t.Error("with a non-empty ACL, a primary not in the ACL must be denied")
+	}
+}
+
+func TestDownstreamsDecision(t *testing.T) {
+	// Empty downstreams: deny (hard cutover from open AXFR).
+	zd := &ZoneData{}
+	if ok, _ := zd.downstreamsDecision(netip.MustParseAddr("192.0.2.1")); ok {
+		t.Error("empty downstreams must deny")
+	}
+
+	zd2 := &ZoneData{Downstreams: []AclEntry{{Prefix: "0.0.0.0/0", Key: "xkey"}}}
+	if ok, key := zd2.downstreamsDecision(netip.MustParseAddr("192.0.2.1")); !ok || key != "xkey" {
+		t.Errorf("0.0.0.0/0 xkey: got (%v,%q), want (true,xkey)", ok, key)
+	}
+}
+
+func TestSignResponseLikeRequest(t *testing.T) {
+	// Unsigned request -> response stays unsigned.
+	resp := new(dns.Msg)
+	resp.SetQuestion("example.test.", dns.TypeSOA)
+	signResponseLikeRequest(&fakeRW{}, new(dns.Msg), resp)
+	if resp.IsTsig() != nil {
+		t.Error("unsigned request must not produce a signed response")
+	}
+
+	// Signed + verified request -> response carries a TSIG with the same key.
+	resp2 := new(dns.Msg)
+	resp2.SetQuestion("example.test.", dns.TypeSOA)
+	signResponseLikeRequest(&fakeRW{}, signedMsg("k"), resp2)
+	ts := resp2.IsTsig()
+	if ts == nil {
+		t.Fatal("signed+verified request should yield a signed response")
+	}
+	if ts.Hdr.Name != "k." {
+		t.Errorf("response TSIG key = %q, want k.", ts.Hdr.Name)
+	}
+
+	// Signed request that FAILED verification -> response stays unsigned.
+	resp3 := new(dns.Msg)
+	resp3.SetQuestion("example.test.", dns.TypeSOA)
+	signResponseLikeRequest(&fakeRW{tsigStatus: errors.New("bad mac")}, signedMsg("k"), resp3)
+	if resp3.IsTsig() != nil {
+		t.Error("a request that failed TSIG verification must not get a signed response")
+	}
+}

--- a/v2/tsig_keys.go
+++ b/v2/tsig_keys.go
@@ -78,9 +78,9 @@ func (conf *Config) LoadTsigKeys() error {
 	store := NewTsigKeyStore()
 	var firstErr error
 	for _, t := range conf.Keys.Tsig {
-		if strings.EqualFold(t.Name, NOKEY) {
+		if strings.EqualFold(t.Name, NOKEY) || strings.EqualFold(t.Name, BLOCKED) {
 			if firstErr == nil {
-				firstErr = fmt.Errorf("keys.tsig: %q is the reserved no-TSIG sentinel and cannot be a key name", t.Name)
+				firstErr = fmt.Errorf("keys.tsig: %q is a reserved sentinel (NOKEY/BLOCKED) and cannot be a key name", t.Name)
 			}
 			continue
 		}

--- a/v2/tsig_keys.go
+++ b/v2/tsig_keys.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/miekg/dns"
 )
 
 // TsigKeyStore is the auth-server TSIG secret store, keyed by key NAME (the NSD
@@ -33,7 +35,7 @@ func (s *TsigKeyStore) Get(name string) (TsigDetails, bool) {
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	d, ok := s.keys[name]
+	d, ok := s.keys[dns.CanonicalName(name)]
 	return d, ok
 }
 
@@ -50,7 +52,7 @@ func (s *TsigKeyStore) Add(d TsigDetails) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.keys[d.Name] = d
+	s.keys[dns.CanonicalName(d.Name)] = d // canonical (lowercase FQDN) key, matches the wire name
 }
 
 // Names returns the set of defined key names (used to re-point the catalog

--- a/v2/tsig_keys.go
+++ b/v2/tsig_keys.go
@@ -5,6 +5,7 @@
 package tdns
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"sync"
@@ -102,4 +103,33 @@ func (conf *Config) LoadTsigKeys() error {
 // NOKEY (no TSIG) or a name defined in the keys: store.
 func (conf *Config) tsigKeyDefined(name string) bool {
 	return name == NOKEY || conf.Internal.TsigKeyStore.Has(name)
+}
+
+// knownTsigAlgo reports whether algo names a supported HMAC TSIG algorithm
+// (canonical compare, so "hmac-sha256" and "hmac-sha256." both match).
+func knownTsigAlgo(algo string) bool {
+	switch dns.CanonicalName(algo) {
+	case dns.HmacSHA1, dns.HmacSHA224, dns.HmacSHA256, dns.HmacSHA384, dns.HmacSHA512:
+		return true
+	}
+	return false
+}
+
+// validateTsigKeySpec checks an inline (API-supplied) TSIG key before it enters
+// the store: a complete, non-reserved name, a supported algorithm, and a base64
+// secret. Used by the dynamic-zone add/modify path and the dynamic-config reload.
+func validateTsigKeySpec(name, algo, secret string) error {
+	if name == "" || secret == "" {
+		return fmt.Errorf("tsig key requires both a name and a secret")
+	}
+	if strings.EqualFold(name, NOKEY) || strings.EqualFold(name, BLOCKED) {
+		return fmt.Errorf("tsig key name %q is a reserved sentinel (NOKEY/BLOCKED)", name)
+	}
+	if !knownTsigAlgo(algo) {
+		return fmt.Errorf("tsig algorithm %q for key %q is not a supported HMAC algorithm", algo, name)
+	}
+	if _, err := base64.StdEncoding.DecodeString(secret); err != nil {
+		return fmt.Errorf("tsig secret for key %q is not valid base64: %w", name, err)
+	}
+	return nil
 }

--- a/v2/tsig_keys.go
+++ b/v2/tsig_keys.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// TsigKeyStore is the auth-server TSIG secret store, keyed by key NAME (the NSD
+// `key:` model — one secret per name). It is the single secret source for
+// signing outbound and verifying inbound replication messages. Loaded from the
+// keys: config block at startup (LoadTsigKeys) and, later, upserted by the
+// dynamic-zone API. It replaces Globals.TsigKeys on the auth replication path;
+// Globals.TsigKeys remains only for the CLI/reporter client path.
+type TsigKeyStore struct {
+	mu   sync.RWMutex
+	keys map[string]TsigDetails // name -> {Name, Algorithm, Secret}
+}
+
+func NewTsigKeyStore() *TsigKeyStore {
+	return &TsigKeyStore{keys: make(map[string]TsigDetails)}
+}
+
+// Get returns the key for name. NOKEY, the empty string, and unknown names all
+// return (zero, false). Nil-receiver safe.
+func (s *TsigKeyStore) Get(name string) (TsigDetails, bool) {
+	if s == nil || name == "" || name == NOKEY {
+		return TsigDetails{}, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.keys[name]
+	return d, ok
+}
+
+// Has reports whether a (non-NOKEY) key name is defined.
+func (s *TsigKeyStore) Has(name string) bool {
+	_, ok := s.Get(name)
+	return ok
+}
+
+// Add upserts a key by name (used by the dynamic-zone API).
+func (s *TsigKeyStore) Add(d TsigDetails) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys[d.Name] = d
+}
+
+// Names returns the set of defined key names (used to re-point the catalog
+// config-check off Globals.TsigKeys).
+func (s *TsigKeyStore) Names() map[string]bool {
+	out := map[string]bool{}
+	if s == nil {
+		return out
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for n := range s.keys {
+		out[n] = true
+	}
+	return out
+}
+
+// LoadTsigKeys (re)builds conf.Internal.TsigKeyStore from the keys: block. NOKEY
+// is reserved — a keys.tsig[] entry named NOKEY (any case) is an error, because
+// the sentinel must stay unambiguous — and every entry must be complete. Bad
+// entries are skipped (resilient-config rule: a single bad key does not abort
+// startup; zones referencing the skipped name are quarantined at parse), and the
+// first error is returned for loud logging. A missing keys: block is not an error.
+func (conf *Config) LoadTsigKeys() error {
+	store := NewTsigKeyStore()
+	var firstErr error
+	for _, t := range conf.Keys.Tsig {
+		if strings.EqualFold(t.Name, NOKEY) {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("keys.tsig: %q is the reserved no-TSIG sentinel and cannot be a key name", t.Name)
+			}
+			continue
+		}
+		if t.Name == "" || t.Algorithm == "" || t.Secret == "" {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("keys.tsig: entry %q is incomplete (name, algorithm and secret are all required)", t.Name)
+			}
+			continue
+		}
+		store.Add(t)
+	}
+	conf.Internal.TsigKeyStore = store
+	return firstErr
+}
+
+// tsigKeyDefined reports whether a primary/notify/ACL key name is acceptable:
+// NOKEY (no TSIG) or a name defined in the keys: store.
+func (conf *Config) tsigKeyDefined(name string) bool {
+	return name == NOKEY || conf.Internal.TsigKeyStore.Has(name)
+}

--- a/v2/tsig_keys.go
+++ b/v2/tsig_keys.go
@@ -56,6 +56,17 @@ func (s *TsigKeyStore) Add(d TsigDetails) {
 	s.keys[dns.CanonicalName(d.Name)] = d // canonical (lowercase FQDN) key, matches the wire name
 }
 
+// Delete removes a key by name. Used to roll back an inline key that was staged
+// into the store but whose add/modify request then failed. Nil-receiver safe.
+func (s *TsigKeyStore) Delete(name string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.keys, dns.CanonicalName(name))
+}
+
 // Names returns the set of defined key names (used to re-point the catalog
 // config-check off Globals.TsigKeys).
 func (s *TsigKeyStore) Names() map[string]bool {
@@ -87,9 +98,9 @@ func (conf *Config) LoadTsigKeys() error {
 			}
 			continue
 		}
-		if t.Name == "" || t.Algorithm == "" || t.Secret == "" {
+		if err := validateTsigKeySpec(t.Name, t.Algorithm, t.Secret); err != nil {
 			if firstErr == nil {
-				firstErr = fmt.Errorf("keys.tsig: entry %q is incomplete (name, algorithm and secret are all required)", t.Name)
+				firstErr = fmt.Errorf("keys.tsig: %w", err)
 			}
 			continue
 		}
@@ -103,6 +114,16 @@ func (conf *Config) LoadTsigKeys() error {
 // NOKEY (no TSIG) or a name defined in the keys: store.
 func (conf *Config) tsigKeyDefined(name string) bool {
 	return name == NOKEY || conf.Internal.TsigKeyStore.Has(name)
+}
+
+// tsigKeyAcceptable is tsigKeyDefined extended with an optional staged (not yet
+// committed) inline key name, so a dynamic add/modify can validate primaries that
+// reference an inline key before that key is committed to the live store.
+func (conf *Config) tsigKeyAcceptable(name string, staged *TsigDetails) bool {
+	if staged != nil && dns.CanonicalName(name) == dns.CanonicalName(staged.Name) {
+		return true
+	}
+	return conf.tsigKeyDefined(name)
 }
 
 // knownTsigAlgo reports whether algo names a supported HMAC TSIG algorithm

--- a/v2/tsig_keys_test.go
+++ b/v2/tsig_keys_test.go
@@ -1,0 +1,79 @@
+package tdns
+
+import "testing"
+
+func TestTsigKeyStore_GetHasAdd(t *testing.T) {
+	s := NewTsigKeyStore()
+	s.Add(TsigDetails{Name: "k1", Algorithm: "hmac-sha256", Secret: "AAAA"})
+	if d, ok := s.Get("k1"); !ok || d.Secret != "AAAA" || d.Algorithm != "hmac-sha256" {
+		t.Fatalf("Get k1: got %+v ok=%v", d, ok)
+	}
+	if !s.Has("k1") {
+		t.Error("Has(k1) = false")
+	}
+	for _, n := range []string{"", NOKEY, "unknown"} {
+		if _, ok := s.Get(n); ok {
+			t.Errorf("Get(%q) unexpectedly ok", n)
+		}
+		if s.Has(n) {
+			t.Errorf("Has(%q) unexpectedly true", n)
+		}
+	}
+}
+
+func TestTsigKeyStore_NilSafe(t *testing.T) {
+	var s *TsigKeyStore
+	if _, ok := s.Get("k1"); ok {
+		t.Error("nil store Get returned ok")
+	}
+	if s.Has("k1") {
+		t.Error("nil store Has returned true")
+	}
+	s.Add(TsigDetails{Name: "k1"}) // must not panic
+}
+
+func TestLoadTsigKeys_ReservedAndIncompleteSkipped(t *testing.T) {
+	conf := &Config{}
+	conf.Keys.Tsig = []TsigDetails{
+		{Name: "good", Algorithm: "hmac-sha256", Secret: "S"},
+		{Name: "NOKEY", Algorithm: "hmac-sha256", Secret: "S"}, // reserved -> error, skipped
+		{Name: "incomplete", Algorithm: "", Secret: "S"},       // incomplete -> error, skipped
+		{Name: "good2", Algorithm: "hmac-sha512", Secret: "S2"},
+	}
+	if err := conf.LoadTsigKeys(); err == nil {
+		t.Fatal("expected an error for the reserved/incomplete entries")
+	}
+	store := conf.Internal.TsigKeyStore
+	if !store.Has("good") || !store.Has("good2") {
+		t.Error("valid keys were not loaded")
+	}
+	if store.Has("NOKEY") || store.Has("incomplete") {
+		t.Error("reserved/incomplete keys should be skipped")
+	}
+}
+
+func TestLoadTsigKeys_CleanLoad(t *testing.T) {
+	conf := &Config{}
+	conf.Keys.Tsig = []TsigDetails{{Name: "k", Algorithm: "hmac-sha256", Secret: "S"}}
+	if err := conf.LoadTsigKeys(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conf.Internal.TsigKeyStore.Has("k") {
+		t.Error("key k not loaded")
+	}
+}
+
+func TestTsigKeyDefined(t *testing.T) {
+	conf := &Config{}
+	conf.Keys.Tsig = []TsigDetails{{Name: "k", Algorithm: "hmac-sha256", Secret: "S"}}
+	_ = conf.LoadTsigKeys()
+	if !conf.tsigKeyDefined(NOKEY) {
+		t.Error("NOKEY should be accepted (no TSIG)")
+	}
+	if !conf.tsigKeyDefined("k") {
+		t.Error("defined key k should be accepted")
+	}
+	if conf.tsigKeyDefined("nope") {
+		t.Error("unknown key was accepted")
+	}
+}

--- a/v2/tsig_keys_test.go
+++ b/v2/tsig_keys_test.go
@@ -35,10 +35,10 @@ func TestTsigKeyStore_NilSafe(t *testing.T) {
 func TestLoadTsigKeys_ReservedAndIncompleteSkipped(t *testing.T) {
 	conf := &Config{}
 	conf.Keys.Tsig = []TsigDetails{
-		{Name: "good", Algorithm: "hmac-sha256", Secret: "S"},
-		{Name: "NOKEY", Algorithm: "hmac-sha256", Secret: "S"}, // reserved -> error, skipped
-		{Name: "incomplete", Algorithm: "", Secret: "S"},       // incomplete -> error, skipped
-		{Name: "good2", Algorithm: "hmac-sha512", Secret: "S2"},
+		{Name: "good", Algorithm: "hmac-sha256", Secret: b64Secret16},
+		{Name: "NOKEY", Algorithm: "hmac-sha256", Secret: b64Secret16}, // reserved -> error, skipped
+		{Name: "incomplete", Algorithm: "", Secret: b64Secret16},       // no algorithm -> error, skipped
+		{Name: "good2", Algorithm: "hmac-sha512", Secret: b64Secret16},
 	}
 	if err := conf.LoadTsigKeys(); err == nil {
 		t.Fatal("expected an error for the reserved/incomplete entries")
@@ -54,7 +54,7 @@ func TestLoadTsigKeys_ReservedAndIncompleteSkipped(t *testing.T) {
 
 func TestLoadTsigKeys_CleanLoad(t *testing.T) {
 	conf := &Config{}
-	conf.Keys.Tsig = []TsigDetails{{Name: "k", Algorithm: "hmac-sha256", Secret: "S"}}
+	conf.Keys.Tsig = []TsigDetails{{Name: "k", Algorithm: "hmac-sha256", Secret: b64Secret16}}
 	if err := conf.LoadTsigKeys(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestLoadTsigKeys_CleanLoad(t *testing.T) {
 
 func TestTsigKeyDefined(t *testing.T) {
 	conf := &Config{}
-	conf.Keys.Tsig = []TsigDetails{{Name: "k", Algorithm: "hmac-sha256", Secret: "S"}}
+	conf.Keys.Tsig = []TsigDetails{{Name: "k", Algorithm: "hmac-sha256", Secret: b64Secret16}}
 	_ = conf.LoadTsigKeys()
 	if !conf.tsigKeyDefined(NOKEY) {
 		t.Error("NOKEY should be accepted (no TSIG)")

--- a/v2/tsig_peer.go
+++ b/v2/tsig_peer.go
@@ -120,6 +120,66 @@ func (zd *ZoneData) notifyKeyFor(target string) string {
 	return NOKEY
 }
 
+// checkInboundTSIG verifies that an inbound request — already ACL-allowed — carries
+// the TSIG the ACL requires. requiredKey == NOKEY (or "") accepts the request as
+// is, signed or not. For a named key, the request must carry a TSIG RR naming that
+// key (canonical compare) and the server's TsigProvider must have validated the
+// MAC, which the library records in w.TsigStatus(). Returns nil on success, else a
+// reason error for the caller to log. The provider must be set on the dns.Server
+// (conf.tsigProvider()) or w.TsigStatus() is meaningless.
+func checkInboundTSIG(w dns.ResponseWriter, r *dns.Msg, requiredKey string) error {
+	if requiredKey == "" || requiredKey == NOKEY {
+		return nil
+	}
+	ts := r.IsTsig()
+	if ts == nil {
+		return fmt.Errorf("TSIG required (key %q) but request is unsigned", requiredKey)
+	}
+	if status := w.TsigStatus(); status != nil {
+		return fmt.Errorf("TSIG verification failed: %w", status)
+	}
+	if dns.CanonicalName(ts.Hdr.Name) != dns.CanonicalName(requiredKey) {
+		return fmt.Errorf("TSIG signed with key %q but ACL requires %q", ts.Hdr.Name, requiredKey)
+	}
+	return nil
+}
+
+// signResponseLikeRequest mirrors a verified request's TSIG onto a single-message
+// response so the server's WriteMsg fills in the response MAC (RFC 8945: a signed
+// request gets a signed response). It is a no-op when the request was unsigned or
+// its TSIG failed verification (w.TsigStatus() != nil) — matching the library's own
+// Transfer.Out gate. Multi-message AXFR responses are handled by Transfer.Out
+// directly and must NOT call this. The server must have a TsigProvider set for the
+// MAC to actually be written.
+func signResponseLikeRequest(w dns.ResponseWriter, req, resp *dns.Msg) {
+	if ts := req.IsTsig(); ts != nil && w.TsigStatus() == nil {
+		resp.SetTsig(ts.Hdr.Name, ts.Algorithm, ts.Fudge, time.Now().Unix())
+	}
+}
+
+// allowNotifyDecision resolves the allow-notify ACL for an inbound NOTIFY's source
+// IP. An empty ACL accepts (unsigned) from any configured primary's IP — so
+// operators needn't restate the primary list — and ignores everything else. A
+// non-empty ACL is matched verbatim (matchACL: BLOCKED/no-match => deny).
+func (zd *ZoneData) allowNotifyDecision(src netip.Addr) (allowed bool, requiredKey string) {
+	if len(zd.AllowNotify) == 0 {
+		for _, p := range zd.Upstreams { // resolved primaries
+			if pip, ok := peerIP(p.Addr); ok && pip == src {
+				return true, NOKEY
+			}
+		}
+		return false, ""
+	}
+	return matchACL(zd.AllowNotify, src)
+}
+
+// downstreamsDecision resolves the downstreams (provide-xfr) ACL for an inbound
+// AXFR/IXFR's source IP. An empty ACL DENIES — a hard cutover that closes the
+// legacy open-AXFR default (matchACL already returns (false,"") for an empty ACL).
+func (zd *ZoneData) downstreamsDecision(src netip.Addr) (allowed bool, requiredKey string) {
+	return matchACL(zd.Downstreams, src)
+}
+
 // peerIP reduces a "host:port" (or bare "host") address to its IP for ACL
 // matching. The inbound RemoteAddr()'s ephemeral source port is irrelevant, so it
 // is dropped. Returns (zero, false) if no valid IP can be parsed.

--- a/v2/tsig_peer.go
+++ b/v2/tsig_peer.go
@@ -35,11 +35,17 @@ func (p tsigKeyProvider) hmac(t *dns.TSIG) (hash.Hash, error) {
 	if !ok {
 		return nil, dns.ErrSecret
 	}
+	// Bind the algorithm to the configured key (RFC 8945 keys are algorithm-bound):
+	// an inbound TSIG must use the algorithm the key was provisioned with, else a
+	// hmac-sha256 key would also accept a hmac-sha1 MAC whenever the secret matches.
+	if dns.CanonicalName(t.Algorithm) != dns.CanonicalName(d.Algorithm) {
+		return nil, dns.ErrKeyAlg
+	}
 	rawsecret, err := base64.StdEncoding.DecodeString(d.Secret)
 	if err != nil {
 		return nil, err
 	}
-	switch dns.CanonicalName(t.Algorithm) {
+	switch dns.CanonicalName(d.Algorithm) {
 	case dns.HmacSHA1:
 		return hmac.New(sha1.New, rawsecret), nil
 	case dns.HmacSHA224:
@@ -152,6 +158,9 @@ func checkInboundTSIG(w dns.ResponseWriter, r *dns.Msg, requiredKey string) erro
 // directly and must NOT call this. The server must have a TsigProvider set for the
 // MAC to actually be written.
 func signResponseLikeRequest(w dns.ResponseWriter, req, resp *dns.Msg) {
+	if w == nil || req == nil || resp == nil {
+		return
+	}
 	if ts := req.IsTsig(); ts != nil && w.TsigStatus() == nil {
 		resp.SetTsig(ts.Hdr.Name, ts.Algorithm, ts.Fudge, time.Now().Unix())
 	}

--- a/v2/tsig_peer.go
+++ b/v2/tsig_peer.go
@@ -103,6 +103,23 @@ func SignForPeer(msg *dns.Msg, keyName string, conf *Config) (dns.TsigProvider, 
 	return conf.tsigProvider(), nil
 }
 
+// notifyKeyFor returns the TSIG key name to sign an outbound NOTIFY to target,
+// found by matching target's IP against the zone's notify peers (IP-only — the
+// configured and actual ports may differ). NOKEY when no peer matches (e.g. a
+// parent NOTIFY for CSYNC/CDS, which has no notify: entry).
+func (zd *ZoneData) notifyKeyFor(target string) string {
+	tip, ok := peerIP(target)
+	if !ok {
+		return NOKEY
+	}
+	for _, p := range zd.Notify {
+		if pip, ok := peerIP(p.Addr); ok && pip == tip {
+			return p.Key
+		}
+	}
+	return NOKEY
+}
+
 // peerIP reduces a "host:port" (or bare "host") address to its IP for ACL
 // matching. The inbound RemoteAddr()'s ephemeral source port is irrelevant, so it
 // is dropped. Returns (zero, false) if no valid IP can be parsed.

--- a/v2/tsig_peer.go
+++ b/v2/tsig_peer.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"net/netip"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// tsigFudge is the TSIG time-window slack, in seconds (RFC 8945 default 300).
+const tsigFudge = 300
+
+// tsigKeyProvider adapts the live TsigKeyStore to the dns.TsigProvider interface,
+// so signing and verifying always consult the current keystore (including keys
+// upserted by the dynamic-zone API) rather than a static snapshot. It mirrors the
+// vendored library's built-in HMAC provider, parameterised by the secret looked
+// up via the TSIG RR's key name; matching the library byte-for-byte is what makes
+// it interoperate with BIND/NSD peers.
+type tsigKeyProvider struct{ store *TsigKeyStore }
+
+func (p tsigKeyProvider) hmac(t *dns.TSIG) (hash.Hash, error) {
+	d, ok := p.store.Get(t.Hdr.Name) // Get canonicalises the wire name
+	if !ok {
+		return nil, dns.ErrSecret
+	}
+	rawsecret, err := base64.StdEncoding.DecodeString(d.Secret)
+	if err != nil {
+		return nil, err
+	}
+	switch dns.CanonicalName(t.Algorithm) {
+	case dns.HmacSHA1:
+		return hmac.New(sha1.New, rawsecret), nil
+	case dns.HmacSHA224:
+		return hmac.New(sha256.New224, rawsecret), nil
+	case dns.HmacSHA256:
+		return hmac.New(sha256.New, rawsecret), nil
+	case dns.HmacSHA384:
+		return hmac.New(sha512.New384, rawsecret), nil
+	case dns.HmacSHA512:
+		return hmac.New(sha512.New, rawsecret), nil
+	default:
+		return nil, dns.ErrKeyAlg
+	}
+}
+
+func (p tsigKeyProvider) Generate(msg []byte, t *dns.TSIG) ([]byte, error) {
+	h, err := p.hmac(t)
+	if err != nil {
+		return nil, err
+	}
+	h.Write(msg)
+	return h.Sum(nil), nil
+}
+
+func (p tsigKeyProvider) Verify(msg []byte, t *dns.TSIG) error {
+	b, err := p.Generate(msg, t)
+	if err != nil {
+		return err
+	}
+	mac, err := hex.DecodeString(t.MAC)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal(b, mac) {
+		return dns.ErrSig
+	}
+	return nil
+}
+
+// tsigProvider returns a dns.TsigProvider backed by this server's TSIG key store.
+// Set it on dns.Client / dns.Transfer (outbound) and dns.Server (inbound verify).
+func (conf *Config) tsigProvider() dns.TsigProvider {
+	return tsigKeyProvider{conf.Internal.TsigKeyStore}
+}
+
+// SignForPeer prepares msg for TSIG signing under keyName and returns the
+// provider to set on the dns.Client / dns.Transfer. keyName == NOKEY (or the
+// empty string) is a no-op: it returns (nil, nil) and the caller signs nothing.
+// An unknown key name is an error (it should have been caught at config
+// validation). The key's algorithm comes from the keystore; the wire name and
+// algorithm are canonicalised (lowercase FQDN) per RFC 8945.
+func SignForPeer(msg *dns.Msg, keyName string, conf *Config) (dns.TsigProvider, error) {
+	if keyName == "" || keyName == NOKEY {
+		return nil, nil
+	}
+	d, ok := conf.Internal.TsigKeyStore.Get(keyName)
+	if !ok {
+		return nil, fmt.Errorf("TSIG key %q not found in keys store", keyName)
+	}
+	msg.SetTsig(dns.CanonicalName(keyName), dns.CanonicalName(d.Algorithm), tsigFudge, time.Now().Unix())
+	return conf.tsigProvider(), nil
+}
+
+// peerIP reduces a "host:port" (or bare "host") address to its IP for ACL
+// matching. The inbound RemoteAddr()'s ephemeral source port is irrelevant, so it
+// is dropped. Returns (zero, false) if no valid IP can be parsed.
+func peerIP(addr string) (netip.Addr, bool) {
+	if ap, err := netip.ParseAddrPort(addr); err == nil {
+		return ap.Addr().Unmap(), true
+	}
+	if a, err := netip.ParseAddr(addr); err == nil {
+		return a.Unmap(), true
+	}
+	return netip.Addr{}, false
+}

--- a/v2/tsig_peer.go
+++ b/v2/tsig_peer.go
@@ -126,28 +126,44 @@ func (zd *ZoneData) notifyKeyFor(target string) string {
 	return NOKEY
 }
 
-// checkInboundTSIG verifies that an inbound request — already ACL-allowed — carries
-// the TSIG the ACL requires. requiredKey == NOKEY (or "") accepts the request as
-// is, signed or not. For a named key, the request must carry a TSIG RR naming that
-// key (canonical compare) and the server's TsigProvider must have validated the
-// MAC, which the library records in w.TsigStatus(). Returns nil on success, else a
-// reason error for the caller to log. The provider must be set on the dns.Server
-// (conf.tsigProvider()) or w.TsigStatus() is meaningless.
-func checkInboundTSIG(w dns.ResponseWriter, r *dns.Msg, requiredKey string) error {
-	if requiredKey == "" || requiredKey == NOKEY {
-		return nil
+// checkInboundTSIG verifies that an inbound request — already ACL-allowed — is
+// authenticated by ONE OF the keys approved for its source. approvedKeys is the set
+// returned by the ACL match: a NOKEY (or "") member means "unsigned accepted"; a
+// named member means "a TSIG under that key is accepted". The request passes iff:
+//   - it is unsigned AND NOKEY is in the approved set, or
+//   - it is signed, its MAC verified (w.TsigStatus()==nil, set by the server's
+//     TsigProvider), AND its key name matches one of the approved NAMED keys.
+// Accepting ANY approved key (not just one) is what makes the dual-key rotation
+// overlap work. Returns nil on success, else a reason error for the caller to log.
+// The provider must be set on the dns.Server or w.TsigStatus() is meaningless.
+func checkInboundTSIG(w dns.ResponseWriter, r *dns.Msg, approvedKeys []string) error {
+	// NOKEY (or "") in the approved set => the source is trusted by address; TSIG is
+	// not required and a present one is not enforced. Accept — preserving the
+	// empty-allow-notify "accept from primaries" behaviour (a primary that happens to
+	// sign its NOTIFY is still accepted). Checked first, so a NOKEY entry alongside
+	// named keys still means "unsigned is OK too".
+	for _, k := range approvedKeys {
+		if k == "" || k == NOKEY {
+			return nil
+		}
 	}
+	// Named key(s) required: the request must be signed, its MAC must have verified
+	// (w.TsigStatus()==nil, set by the server's TsigProvider), and the key must be
+	// one of the approved names — ANY of them, which is the dual-key overlap.
 	ts := r.IsTsig()
 	if ts == nil {
-		return fmt.Errorf("TSIG required (key %q) but request is unsigned", requiredKey)
+		return fmt.Errorf("TSIG required but request is unsigned (approved keys: %v)", approvedKeys)
 	}
 	if status := w.TsigStatus(); status != nil {
 		return fmt.Errorf("TSIG verification failed: %w", status)
 	}
-	if dns.CanonicalName(ts.Hdr.Name) != dns.CanonicalName(requiredKey) {
-		return fmt.Errorf("TSIG signed with key %q but ACL requires %q", ts.Hdr.Name, requiredKey)
+	wire := dns.CanonicalName(ts.Hdr.Name)
+	for _, k := range approvedKeys {
+		if dns.CanonicalName(k) == wire {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("TSIG signed with key %q, not approved for this source (approved keys: %v)", ts.Hdr.Name, approvedKeys)
 }
 
 // signResponseLikeRequest mirrors a verified request's TSIG onto a single-message
@@ -170,22 +186,22 @@ func signResponseLikeRequest(w dns.ResponseWriter, req, resp *dns.Msg) {
 // IP. An empty ACL accepts (unsigned) from any configured primary's IP — so
 // operators needn't restate the primary list — and ignores everything else. A
 // non-empty ACL is matched verbatim (matchACL: BLOCKED/no-match => deny).
-func (zd *ZoneData) allowNotifyDecision(src netip.Addr) (allowed bool, requiredKey string) {
+func (zd *ZoneData) allowNotifyDecision(src netip.Addr) (allowed bool, approvedKeys []string) {
 	if len(zd.AllowNotify) == 0 {
 		for _, p := range zd.Upstreams { // resolved primaries
 			if pip, ok := peerIP(p.Addr); ok && pip == src {
-				return true, NOKEY
+				return true, []string{NOKEY}
 			}
 		}
-		return false, ""
+		return false, nil
 	}
 	return matchACL(zd.AllowNotify, src)
 }
 
 // downstreamsDecision resolves the downstreams (provide-xfr) ACL for an inbound
 // AXFR/IXFR's source IP. An empty ACL DENIES — a hard cutover that closes the
-// legacy open-AXFR default (matchACL already returns (false,"") for an empty ACL).
-func (zd *ZoneData) downstreamsDecision(src netip.Addr) (allowed bool, requiredKey string) {
+// legacy open-AXFR default (matchACL already returns (false,nil) for an empty ACL).
+func (zd *ZoneData) downstreamsDecision(src netip.Addr) (allowed bool, approvedKeys []string) {
 	return matchACL(zd.Downstreams, src)
 }
 

--- a/v2/tsig_peer_test.go
+++ b/v2/tsig_peer_test.go
@@ -88,6 +88,26 @@ func TestTsigProvider_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestNotifyKeyFor(t *testing.T) {
+	zd := &ZoneData{Notify: []PeerConf{
+		{Addr: "192.0.2.1:53", Key: "k1"},
+		{Addr: "192.0.2.2:5353", Key: "k2"},
+		{Addr: "192.0.2.3:53", Key: NOKEY},
+	}}
+	cases := map[string]string{
+		"192.0.2.1:53":   "k1",
+		"192.0.2.1:9999": "k1", // IP-only match (configured vs actual port differ)
+		"192.0.2.2:5353": "k2",
+		"192.0.2.3:53":   NOKEY,
+		"203.0.113.9:53":  NOKEY, // no matching notify peer
+	}
+	for target, want := range cases {
+		if got := zd.notifyKeyFor(target); got != want {
+			t.Errorf("notifyKeyFor(%q) = %q, want %q", target, got, want)
+		}
+	}
+}
+
 func TestPeerIP(t *testing.T) {
 	cases := map[string]string{
 		"192.0.2.1:53":     "192.0.2.1",

--- a/v2/tsig_peer_test.go
+++ b/v2/tsig_peer_test.go
@@ -1,0 +1,107 @@
+package tdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func tsigTestConf(t *testing.T) *Config {
+	t.Helper()
+	conf := &Config{}
+	// "MTIzNDU2Nzg5MDEyMzQ1Ng==" is valid std-base64 (decodes to 16 bytes).
+	conf.Keys.Tsig = []TsigDetails{{Name: "tkey", Algorithm: "hmac-sha256", Secret: "MTIzNDU2Nzg5MDEyMzQ1Ng=="}}
+	if err := conf.LoadTsigKeys(); err != nil {
+		t.Fatalf("LoadTsigKeys: %v", err)
+	}
+	return conf
+}
+
+func TestSignForPeer_NOKEY(t *testing.T) {
+	conf := tsigTestConf(t)
+	m := new(dns.Msg)
+	m.SetQuestion("example.", dns.TypeSOA)
+	p, err := SignForPeer(m, NOKEY, conf)
+	if err != nil || p != nil {
+		t.Fatalf("NOKEY should be a no-op: p=%v err=%v", p, err)
+	}
+	if m.IsTsig() != nil {
+		t.Error("NOKEY must not add a TSIG RR")
+	}
+}
+
+func TestSignForPeer_SetsTsig(t *testing.T) {
+	conf := tsigTestConf(t)
+	m := new(dns.Msg)
+	m.SetQuestion("example.", dns.TypeSOA)
+	p, err := SignForPeer(m, "tkey", conf)
+	if err != nil || p == nil {
+		t.Fatalf("keyed sign: p=%v err=%v", p, err)
+	}
+	ts := m.IsTsig()
+	if ts == nil {
+		t.Fatal("no TSIG RR set")
+	}
+	if ts.Hdr.Name != "tkey." {
+		t.Errorf("TSIG key name = %q, want tkey.", ts.Hdr.Name)
+	}
+	if ts.Algorithm != dns.HmacSHA256 {
+		t.Errorf("TSIG algorithm = %q, want %q", ts.Algorithm, dns.HmacSHA256)
+	}
+}
+
+func TestSignForPeer_UnknownKey(t *testing.T) {
+	conf := tsigTestConf(t)
+	m := new(dns.Msg)
+	m.SetQuestion("example.", dns.TypeSOA)
+	if _, err := SignForPeer(m, "nope", conf); err == nil {
+		t.Error("unknown key should error")
+	}
+}
+
+// Sign a message with the provider and verify it back, via the vendored library's
+// own generate/verify — proving the provider matches the wire format (and so
+// interoperates with BIND/NSD), and that a wrong secret fails.
+func TestTsigProvider_RoundTrip(t *testing.T) {
+	conf := tsigTestConf(t)
+	provider := conf.tsigProvider()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.", dns.TypeSOA)
+	m.SetTsig(dns.CanonicalName("tkey"), dns.HmacSHA256, tsigFudge, time.Now().Unix())
+	signed, _, err := dns.TsigGenerateWithProvider(m, provider, "", false)
+	if err != nil {
+		t.Fatalf("TsigGenerate: %v", err)
+	}
+	if err := dns.TsigVerifyWithProvider(signed, provider, "", false); err != nil {
+		t.Fatalf("TsigVerify (good secret): %v", err)
+	}
+
+	other := &Config{}
+	other.Keys.Tsig = []TsigDetails{{Name: "tkey", Algorithm: "hmac-sha256", Secret: "YWJjZGVmZ2hpamtsbW5vcA=="}}
+	if err := other.LoadTsigKeys(); err != nil {
+		t.Fatalf("LoadTsigKeys(other): %v", err)
+	}
+	if err := dns.TsigVerifyWithProvider(signed, other.tsigProvider(), "", false); err == nil {
+		t.Error("verification with a wrong secret should fail")
+	}
+}
+
+func TestPeerIP(t *testing.T) {
+	cases := map[string]string{
+		"192.0.2.1:53":     "192.0.2.1",
+		"192.0.2.1":        "192.0.2.1",
+		"[2001:db8::1]:53": "2001:db8::1",
+		"2001:db8::1":      "2001:db8::1",
+	}
+	for in, want := range cases {
+		got, ok := peerIP(in)
+		if !ok || got.String() != want {
+			t.Errorf("peerIP(%q) = %v ok=%v, want %v", in, got, ok, want)
+		}
+	}
+	if _, ok := peerIP("garbage"); ok {
+		t.Error("garbage should not parse to an IP")
+	}
+}

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -63,7 +63,7 @@ func (zd *ZoneData) Refresh(verbose, debug, force bool, conf *Config) (bool, err
 			} else if force {
 				lg.Debug("forced retransfer regardless of SOA serial", "zone", zd.ZoneName)
 			}
-			updated, err = zd.FetchFromUpstream(verbose, debug, dynamicRRs)
+			updated, err = zd.FetchFromUpstream(verbose, debug, dynamicRRs, conf)
 			if err != nil {
 				lg.Error("FetchZone failed", "zone", zd.ZoneName, "upstream", firstUpstreamAddr(zd.Upstreams), "err", err)
 				return false, err
@@ -258,7 +258,7 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 }
 
 // Return updated, err
-func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RRset) (bool, error) {
+func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RRset, conf *Config) (bool, error) {
 
 	if len(zd.Upstreams) == 0 {
 		return false, fmt.Errorf("FetchFromUpstream: zone %s has no upstreams configured", zd.ZoneName)
@@ -295,7 +295,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 			Ready:          true, // this is only used by the checks for changes to DNSKEYs, HSYNC, etc.
 			// FoldCase:       zd.FoldCase, // Must be here, as this is an instruction to the zone reader
 		}
-		if _, err := new_zd.ZoneTransferIn(upstream, zd.IncomingSerial, "axfr"); err != nil {
+		if _, err := new_zd.ZoneTransferIn(upstream, zd.IncomingSerial, "axfr", up.Key, conf); err != nil {
 			lg.Warn("FetchFromUpstream: AXFR from upstream failed, trying next", "zone", zd.ZoneName, "upstream", upstream, "err", err)
 			lastErr = err
 			continue

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -52,7 +52,7 @@ func (zd *ZoneData) Refresh(verbose, debug, force bool, conf *Config) (bool, err
 		return updated, err
 
 	case Secondary:
-		do_transfer, upstream_serial, err := zd.DoTransfer()
+		do_transfer, upstream_serial, err := zd.DoTransfer(conf)
 		if err != nil {
 			return false, err
 		}
@@ -98,7 +98,7 @@ func firstUpstreamAddr(upstreams []PeerConf) string {
 // A usable NOERROR+SOA from any primary is honoured (transfer decided on
 // serial). If every primary answered but none gave a usable SOA, we back off
 // quietly (no transfer, no error); only all-unreachable is a hard error.
-func (zd *ZoneData) DoTransfer() (bool, uint32, error) {
+func (zd *ZoneData) DoTransfer(conf *Config) (bool, uint32, error) {
 	if zd == nil {
 		panic("DoTransfer: zd == nil")
 	}
@@ -106,10 +106,6 @@ func (zd *ZoneData) DoTransfer() (bool, uint32, error) {
 	if len(zd.Upstreams) == 0 {
 		return false, 0, fmt.Errorf("DoTransfer: zone %s has no upstreams configured", zd.ZoneName)
 	}
-
-	// log.Printf("%s: known zone, current incoming serial %d", zd.ZoneName, zd.IncomingSerial)
-	m := new(dns.Msg)
-	m.SetQuestion(zd.ZoneName, dns.TypeSOA)
 
 	sawResponse := false
 	var lastErr error
@@ -120,10 +116,22 @@ func (zd *ZoneData) DoTransfer() (bool, uint32, error) {
 			upstream = net.JoinHostPort(upstream, "53")
 			lg.Debug("DoTransfer: no port specified for upstream, using default port 53", "zone", zd.ZoneName, "upstream", upstream)
 		}
-		r, err := dns.Exchange(m, upstream)
+		// Fresh message per attempt: TSIG signing adds an RR with a per-attempt
+		// timestamp and this upstream's key.
+		m := new(dns.Msg)
+		m.SetQuestion(zd.ZoneName, dns.TypeSOA)
+		c := new(dns.Client)
+		provider, serr := SignForPeer(m, up.Key, conf)
+		if serr != nil {
+			lg.Error("DoTransfer: TSIG sign setup failed, trying next upstream", "zone", zd.ZoneName, "upstream", upstream, "key", up.Key, "err", serr)
+			lastErr = serr
+			continue
+		}
+		c.TsigProvider = provider // nil for NOKEY => plain exchange (no MAC)
+		r, _, err := c.Exchange(m, upstream)
 		if err != nil {
-			// Transport failure for this address — try the next sibling.
-			lg.Warn("DoTransfer: SOA probe transport error, trying next upstream", "zone", zd.ZoneName, "upstream", upstream, "err", err)
+			// Transport failure (or a TSIG response-verify failure) — try the next sibling.
+			lg.Warn("DoTransfer: SOA probe failed, trying next upstream", "zone", zd.ZoneName, "upstream", upstream, "err", err)
 			lastErr = err
 			continue
 		}


### PR DESCRIPTION
Implements **Improvement 2 — TSIG on zone-replication peer transactions** from `docs/2026-06-23-dynamic-zones-interface-and-tsig-transfers.md` (§6, NSD-aligned model). All nine plan steps land as one commit each; every commit builds, passes `go test -race ./...`, and is `go vet`-clean.

## Model (NSD-aligned)
- **`keys:` block** — a single name→secret store (`TsigKeyStore`); both sign (outbound) and verify (inbound) look the secret up **by name** (the name is on the wire). `NOKEY`/`BLOCKED` are reserved sentinels.
- **Secondary:** `primaries: [{addr, key}]` (key signs our SOA/AXFR to that primary) + `allow-notify: []AclEntry` (who may NOTIFY us).
- **Primary:** `notify: [{addr, key}]` (key signs our NOTIFY) + `downstreams: []AclEntry` (who may AXFR from us — the provide-xfr ACL).
- **`AclEntry{prefix, key}`** — `prefix` is an ip-spec (bare IP, CIDR, `a&mask`, `a-b` range, `0.0.0.0/0`/`::/0`); `key ∈ {<name>, NOKEY, BLOCKED}`. Ordered matcher on `net/netip`: a matching `BLOCKED` supersedes; else first prefix match wins.

## Steps
| Step | Commit | What |
|------|--------|------|
| 1 | `ce5edcd` | `keys:` name→secret store + key-name validation |
| 2 | `a11b0fb`, `05ca2a8` | ip-spec address ACL engine (net/netip) |
| — | `946486d` | keystore-backed `TsigProvider`, `SignForPeer`, `peerIP` |
| 3 | `0437828` | sign the SOA probe (`DoTransfer`) |
| 4 | `f58c205` | sign AXFR/IXFR (`ZoneTransferIn`) |
| 6 | `7890be5` | sign outbound NOTIFY (`SendNotify`) |
| **5+7** | `d68acff` | **verify inbound** NOTIFY + AXFR (`allow-notify` / `downstreams`) |
| 8 | `1a92b0d` | catalog `tsig_key` → `primaries[].key` |
| 9 | `5c9f771` | inline `tsig_name/secret/algo` on `zone add`/`modify` + persistence |
| docs | `9ddd689` | mark Improvement 2 complete in the plan |

## Inbound verification (steps 5+7)
A single keystore-backed `TsigProvider` on the auth `dns.Server` (`do53.go`) does both inbound MAC verification (`w.TsigStatus()`) and RFC 8945 response signing. Verified against the vendored library that `Transfer.Out` auto-signs each AXFR envelope (rolling MACs) when the request carried a verified TSIG, so no per-transfer wiring was needed. Steps 5 and 7 are **combined** in one commit because they share all the wiring (provider, struct fields, refresh-merge, config validation). tdns UPDATEs are SIG(0)-signed (a SIG RR, not a TSIG RR), so the provider never touches them.

## ⚠️ Operator-visible behaviour change (hard cutover, step 7)
An empty `downstreams:` ACL now **denies all AXFR/IXFR** — tdns previously served transfers to anyone. After deploy, every zone that should serve transfers needs an explicit `downstreams:` (e.g. `- prefix: 0.0.0.0/0` + a key, or `key: NOKEY`). See the plan's §11 migration.

## Step 9 persistence
API-created TSIG keys (`zone add --tsig-name/--tsig-secret/--tsig-algo`) are upserted into the store, applied to keyless primaries, and **persisted** into the dynamic config file's new `keys:` block. On startup they load before their zones (config keys win on name collision), so an API-provisioned TSIG secondary survives a restart instead of quarantining on an unknown key.

## Deferred (per the plan, not gaps)
- API ACL flags (`--allow-notify` / `--downstreams`) are static-config-only in v1.
- TSIG key auto-drop is not implemented (a never-dropped name store is acceptable).
- **tdns-mp** pins the published `tdns/v2`, so the signature changes (`Notifier`, `DoTransfer`, `FetchFromUpstream`, `ZoneTransferIn` now take `conf`) are deferred breaks — its call sites need updating when it bumps the dependency.

## Tests
New: `tsig_keys_test.go`, `tsig_peer_test.go`, `tsig_inbound_test.go`, `tsig_dynzone_test.go`; extended `transfer_fallback_test.go` (a TSIG-requiring upstream proving a wrong secret never yields the real serial). Covers the ACL matcher, the provider round-trip through the library's own generate/verify (wire-format / BIND-NSD interop), inbound accept/deny + key-name enforcement, and the dynamic-zone inline-key apply / persistence / config-wins reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline TSIG support for dynamic zone provisioning via API and CLI (TSIG name/secret/algorithm).
  * Added ordered ACL-based authorization for downstream transfers and inbound NOTIFY(SOA), including explicit EDNS EDE for “NOTIFY not permitted”.

* **Bug Fixes**
  * Improved IP-spec and ACL validation, including correct handling of blocked entries and safer malformed range/mask rejection.
  * Replication and NOTIFY flows now consistently refuse unauthorized/failed TSIG requests and sign responses to match verified requests.

* **Improvements**
  * Config and dynamic TSIG keys are rebuilt/reloaded so updates take effect without restarting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->