### PR TITLE
docs: KSK/ZSK algorithm-rollover design; E12 resolved; ZSK cleanup punch-list

### DIFF
--- a/docs/2026-05-02-rollover-timing-report-rollover-notify-scheme.md
+++ b/docs/2026-05-02-rollover-timing-report-rollover-notify-scheme.md
@@ -19,6 +19,18 @@ an "extract orchestrator-agnostic push engine" refactor.
 
 ---
 
+> **RESOLVED (2026-07-01).** This audit re-confirmed the E3/E12/E13
+> divergence on the `rollover-notify-scheme` branch; it is now **fixed** in
+> current `main` / `feat/tsig-first-class`. `T_publish` subtracts the DNSKEY
+> TTL: `tPublish := tRoll.Add(-(deps.PropagationDelay + dnskeyTTL))`
+> (`ksk_rollover_automated.go:1162`), `dnskeyTTL = min(TTLS.DNSKEY,
+> TTLS.MaxServed)` (or observed served TTL) via `effectiveServedDnskeyTTL`
+> (`:1400`). Landed as **W1** (`e120dc4`) + tests **W8** (`ed47876`),
+> merged via **PR #212** (`rollover-timing-fixes-1`). The NOTIFY-specific
+> `parent_prop` caveat (the E6 note below) is operator guidance, not a code
+> bug — it remains open as a documentation item. Verdicts below retained as
+> the historical audit record.
+
 ## E1 — DS-side cache-flush invariant: `T_DS_pub_n + parent_prop + DS_TTL ≤ T_roll_n`
 
 **Verdict:** UNCLEAR (structurally implied iff E10 holds; E10 is *not*

--- a/docs/2026-05-02-rollover-timing-report.md
+++ b/docs/2026-05-02-rollover-timing-report.md
@@ -8,6 +8,23 @@ timing equations")
 
 ---
 
+> **RESOLVED (2026-07-01).** The E3/E12/E13 divergence this audit found is
+> **fixed** in current `main` / `feat/tsig-first-class`. `T_publish` now
+> subtracts the DNSKEY TTL:
+> `tPublish := tRoll.Add(-(deps.PropagationDelay + dnskeyTTL))`
+> (`ksk_rollover_automated.go:1162`), with
+> `dnskeyTTL = effectiveServedDnskeyTTL(...)` = `min(TTLS.DNSKEY,
+> TTLS.MaxServed)` (or the observed served TTL, deferring the transition
+> when still unknowable) (`:1400`). Landed as **W1** (`e120dc4`) with
+> regression tests **W8** (`ed47876`), merged via **PR #212**
+> (`rollover-timing-fixes-1`); **W7** (`01c2c4b`) reshaped it into the
+> deps-helper `transitionDsPublishedToPublishedForZone` (`:1059`; public
+> entry `TransitionRolloverKskDsPublishedToPublished`, `:1004`). The
+> transition is now `ds-published → published` after the C18
+> published/standby split. E5/E10/E11 config-load validation (**W2**) is
+> also present. The per-equation verdicts below (E3/E12/E13 DIVERGES) are
+> retained as the historical audit record.
+
 ## E1 — DS-side cache-flush invariant: `T_DS_pub_n + parent_prop + DS_TTL ≤ T_roll_n`
 
 **Verdict:** UNCLEAR (structurally satisfied iff E10 holds; E10 is *not*

--- a/docs/2026-05-03-rollover-timing-fixes-plan.md
+++ b/docs/2026-05-03-rollover-timing-fixes-plan.md
@@ -8,6 +8,21 @@
 
 ---
 
+> **LANDED (2026-07-01).** The core of this plan shipped. **W1** (E12/E13 —
+> the `− DNSKEY_TTL` term) landed as `e120dc4` and **W8** (tests) as
+> `ed47876`, merged via **PR #212** (`rollover-timing-fixes-1`); **W2**
+> (E5/E10/E11 config-load validation via `EvaluateRolloverPolicyInvariants`)
+> is present and wired at config load. Current code:
+> `tPublish := tRoll.Add(-(deps.PropagationDelay + dnskeyTTL))` in the
+> deps-shaped helper `transitionDsPublishedToPublishedForZone`
+> (`ksk_rollover_automated.go:1162`; public entry
+> `TransitionRolloverKskDsPublishedToPublished`, `:1004`). Note the
+> transition is now `ds-published → published` (C18 published/standby
+> split), not `…ToStandby` as named in W1 below. `effectiveServedDnskeyTTL`
+> (`:1400`) implements the E13 clamp with the deferral branch W1 specified.
+> The remaining operator-signalling / multi-error workstreams (W4–W9) were
+> not separately re-verified in this pass.
+
 ## Recommendation: where to fix
 
 Fix on `rollover-notify-scheme` directly.

--- a/docs/2026-06-21-ksk-algorithm-rollover-plan.md
+++ b/docs/2026-06-21-ksk-algorithm-rollover-plan.md
@@ -1,5 +1,14 @@
 # KSK algorithm rollover via the auto-rollover engine
 
+> **Superseded on method (2026-07-01)** by
+> `2026-07-01-ksk-alg-rollover-parallel-fifo-design.md`. This plan assumed
+> a KSK algorithm rollover "rides the multi-DS engine unchanged"; that is
+> wrong — multi-DS cannot do an algorithm rollover (orphan-DS / downgrade
+> signature), so the design moved to **double-signature via parallel
+> per-(role,algorithm) FIFOs**. The build-step scaffolding below (entry
+> dispatch, safety refusals, trigger UX, test matrix) still applies; see
+> §9 of the 2026-07-01 doc for how each K-step is re-rated.
+
 Status: PLANNING. This is the build plan for a **KSK algorithm
 rollover** — changing a zone's KSK signing algorithm (e.g. ED25519 →
 MAYO5 for a post-quantum transition) with correct parent-DS coordination.

--- a/docs/2026-07-01-ksk-alg-rollover-parallel-fifo-design.md
+++ b/docs/2026-07-01-ksk-alg-rollover-parallel-fifo-design.md
@@ -1,0 +1,417 @@
+# KSK algorithm rollover: the parallel-FIFO / double-signature design
+
+Status: DESIGN (concluded 2026-07-01). This supersedes the **method** of
+`2026-06-21-ksk-algorithm-rollover-plan.md` — its premise that a KSK
+algorithm rollover "rides the existing multi-DS engine unchanged" is
+retired here. The 2026-06-21 doc's build-step *scaffolding* (entry-layer
+dispatch, safety refusals, trigger UX, test matrix) still applies; §9
+re-rates each step against this model.
+
+Code references are `file:line` into `v2/` on branch `feat/tsig-first-class`
+(contains all merged rollover work). Cross-references of the form
+"(eval §N)" point at `2026-06-17-algorithm-rollover-evaluation.md`.
+
+This work is EXPERIMENTAL, consistent with the alg-split / PQ-transition
+goal (draft-johani-dnsop-dnssec-alg-split). The parent is under our
+control in the testbed, so a mixed-algorithm CDS/DS at the parent is a
+requirement to satisfy, not an external constraint.
+
+
+## 0. One-paragraph summary
+
+A KSK algorithm rollover cannot use multi-DS (§1). It must use
+**double-signature**: the new-algorithm KSK signs the apex DNSKEY RRset
+*before* its DS is pushed to the parent. We model this as **parallel
+FIFOs**: a zone already runs one KSK FIFO and one ZSK FIFO in parallel,
+jointly emitting the DNSKEY RRset (§2); a KSK algorithm rollover
+transiently **spawns a second, new-algorithm KSK FIFO** alongside the
+old one. The old-algorithm FIFO keeps its key **active** (still the
+load-bearing chain) until the new-algorithm DS is confirmed at the
+parent, then drains and is dropped. The governing invariant becomes
+**one active key per (role, algorithm)** (§4), which also closes the ZSK
+single-active gap (cleanup punch-list P0-2). Double-signature is promoted
+to a first-class, general KSK rollover method (§3) — likely the KSK
+*default*, since its only cost is one extra RRSIG on an already-large,
+already-TCP RRset.
+
+
+## 1. Why multi-DS does not work for algorithm rollovers
+
+Multi-DS pre-positions the **DS at the parent while the key is a
+non-signing standby** — the DS goes up (a hash, PQ-opaque) while the
+DNSKEY stays out of the zone (`loadTargetKSKsForRollover` selects
+`state IN ('created','ds-published',…)`, `ksk_rollover_ds_push.go:85`;
+rationale spelled out at `ksk_rollover_automated.go:991-997`: "DS hashes
+are post-quantum-opaque, but DNSKEYs reveal the public key").
+
+For a **same-algorithm** rollover this is safe: the algorithm is already
+signing the DNSKEY RRset via the active key, so the pre-positioned DS
+points into a chain that already works.
+
+For an **algorithm** rollover it is not. During the pre-positioning
+window the parent advertises:
+
+```
+parent DS RRset   = { DS(oldK, algA), DS(newK, algB) }
+child DNSKEY RRset = { oldK(A), newK(B), ZSK(A) }, signed by A only
+```
+
+The parent asserts "this zone uses algorithm B," but **nothing in the
+child signs with B** — not even the DNSKEY RRset. `DS(newK, B)` is an
+orphan: it points to a key that signs nothing. And because B is a whole
+new *algorithm*, that state is indistinguishable from an
+algorithm-stripping downgrade attack — exactly what the completeness
+requirement (RFC 4035 §2.2; the DS→DNSKEY chain rule) exists to detect.
+
+The underlying rule: *a DS is only useful if the key it points to is in
+the DNSKEY RRset **and signs it**.* Multi-DS deliberately publishes the DS
+before that second half is true. A same-algorithm rollover forgives it; a
+new algorithm does not.
+
+**Conclusion:** for an algorithm rollover the new-algorithm KSK must be
+**signing the apex DNSKEY RRset before its DS is trusted at the parent.**
+That is the double-signature invariant.
+
+(The relaxed/alg-split assumption — validators accept one valid chain and
+do not require algorithm B to sign the *whole zone*, RFC 6840 §5.11 — is
+what makes an *independent* KSK-only algorithm rollover legal at all. But
+even alg-split does not bless a DS for algorithm B with *zero* B
+signatures; the DS→DNSKEY chain for B must be complete the instant B's DS
+is visible. That is a stronger, more fundamental requirement than the
+whole-zone completeness alg-split relaxes.)
+
+### Why the ZSK gets away with a single relaxed FIFO and the KSK does not
+
+The ZSK has **no DS**. Its algorithm is only signalled by the DNSKEY RRset
+and its own RRSIGs, so a ZSK algorithm rollover can use a single relaxed
+FIFO (PR #263): the new-algorithm ZSK becomes the single active, the
+old-algorithm RRSIGs drain out of caches, one active at all times. There
+is nothing at the parent that must stay consistent with a second live
+algorithm.
+
+The KSK's DS is exactly that constraint. It forces both algorithms to be
+simultaneously live and self-consistent during the overlap — old-algorithm
+chain still validating, new-algorithm chain already complete — which is
+double-signature, which needs two simultaneously-signing KSKs, which is
+two parallel FIFOs. The parent DS is the single variable that decides
+parallel-vs-in-queue. (Double-signing the KSK is cheap — one RRset; this
+is precisely why the dual-model doc *rejected* conservative double-signing
+for the whole-zone ZSK but it is fine for the KSK.)
+
+
+## 2. The N-FIFO model
+
+The engine already runs **two FIFOs in parallel** — the KSK FIFO and the
+ZSK FIFO — that **jointly** manage the shared apex DNSKEY RRset. Each owns
+its slice; `PublishDnskeyRRs` unions across them (`published ∪ standby ∪
+retired`, `ops_dnskey.go:23-24`, with active fetched separately and
+merged), and the signer is additive (below). So the real abstraction is:
+
+> A zone holds a **set of FIFOs**, each keyed by **(role, algorithm)**,
+> each managing its own keys within the shared DNSKEY RRset; they compose.
+
+Steady state: **N = 2** (one KSK-algA FIFO, one ZSK-algA FIFO). A KSK
+algorithm rollover transiently makes **N = 3** (KSK-algA + KSK-algB +
+ZSK-algA) and returns to 2 when the old KSK FIFO drains. This is a
+generalization of an existing pattern, not a new mechanism — we are going
+from 2 to 3, not from 1 to 2.
+
+A "FIFO" is the ordered succession of same-(role,algorithm) keys
+(`published_at ASC, keyid ASC`), with at most one active head, keys
+retiring in order. Same-algorithm rollover advances *within* a FIFO. An
+algorithm rollover *spawns a new* FIFO.
+
+
+## 3. Two methods: multi-DS and double-signature
+
+Both are RFC 7583 KSK rollover methods; they differ only in the **order of
+the DS push relative to the swap**:
+
+| | Multi-DS (DS-first) | Double-signature (sign-first) |
+|---|---|---|
+| Order | pre-position DS → confirm → swap | swap/activate → sign → push DS → confirm → drain old |
+| New DNSKEY | hidden until activation (PQ-opaque) | published + signing during the overlap |
+| Rollover latency | instant (DS already at parent) | one DS round-trip |
+| FIFO shape | single FIFO, in-place succession | new key's activation is a **bootstrap** (§5, corner a) |
+| Algorithm rollover | **impossible** (§1) | **required** |
+
+DECISION D1 — **double-signature becomes a first-class, general KSK
+rollover method**, not an algorithm-rollover-only special case. For a
+same-algorithm KSK rollover it is a valid alternative to multi-DS
+(swap-early — §4); for an algorithm rollover it is the only option.
+
+DECISION D2 — **double-signature is likely the KSK default.** Its only
+cost is one extra RRSIG on the apex DNSKEY RRset, which is already large
+and already TCP-transported. Multi-DS's advantages — hidden DNSKEY (PQ
+opacity), instant rollover, no early key exposure — earn their keep on the
+ZSK and on large standby pipelines, far less on a single KSK RRset. The
+existing scaffolded-but-unimplemented `double-signature` method (enum +
+`num-ds==2` validation at `ksk_rollover_policy.go:53,225-233`, engine
+early-return at `ksk_rollover_automated.go:79-81`, `AtomicRollover`
+deferral "4E" at `ksk_rollover_atomic.go:18`) is the natural home for this.
+
+
+## 4. The invariant: one active per (role, algorithm)
+
+Today `pickActiveSEPTx` (`ksk_rollover_atomic.go:152-178`) hard-errors on
+**> 1 active SEP KSK**. Under parallel FIFOs the correct scoping is:
+
+DECISION D3 — the invariant becomes **at most one active key per
+(role, algorithm)**. This is not a weakening — it is the same
+"one active head" rule, scoped to the FIFO. It permits exactly the states
+the model needs:
+
+- **Same-algorithm rollover** (multi-DS or double-signature): one FIFO,
+  one active KSK of that algorithm. Unchanged from today.
+- **Algorithm rollover overlap**: two active KSKs, one per algorithm
+  (KSK-algA active + KSK-algB active). Permitted; this *is* the
+  double-signature state.
+
+**Unification with the ZSK cleanup.** The ZSK punch-list (P0-2) wants a
+single-active guard added to `RolloverKey` (which today retires "the first
+active" with no guard). "One active per (role, algorithm)" *is* that
+guard: it catches a same-algorithm ZSK double-active bug and permits the
+KSK alg-roll overlap. One rule, both jobs. The ZSK never uses its "second
+algorithm slot" (its relaxed FIFO does an atomic swap, always one active).
+
+Same-algorithm double-signature stays within one FIFO via **swap-early**:
+the old key goes `active → retired` (honestly superseded — a same-algorithm
+successor now exists) but keeps signing through the drain (§5, FACT 3).
+Only the *algorithm* rollover keeps the old key active in a *separate*
+FIFO, because the old-algorithm key is genuinely still the load-bearing
+chain until the new-algorithm DS confirms.
+
+
+## 5. The algorithm rollover, end to end
+
+Three code facts ground the sequence (verified 2026-07-01):
+
+- **FACT 1 — only active KSKs sign the DNSKEY RRset.**
+  `signingkeys = dak.KSKs` where `dak.KSKs = GetDnssecKeys(zone, Active)`,
+  purely state-driven, no algorithm predicate (`sign.go:171-175`,
+  `keystore.go:942-943`). Standby keys are *in* the RRset but do not sign.
+- **FACT 2 — the DS is pushed while the pipeline key is a non-signing
+  `created`/`ds-published` key** (`loadTargetKSKsForRollover`,
+  `ds_push.go:85`). This is the ordering the algorithm case must invert.
+- **FACT 3 — a retiring KSK keeps its RRSIG until `retired → removed`.**
+  The signer is additive — `SignZone` never strips other keys' RRSIGs
+  (`sign.go:180-185`); the strip happens only at `removed`, gated on
+  `effective_margin = max(clamping.margin, max_observed_ttl)`
+  (`ksk_rollover_automated.go:1637`; withdraw loop `:565-612`). At
+  `removed`, the key's DNSKEY, its DS (the DS target query excludes
+  `removed`), and its RRSIG all drop together. **The engine already
+  maintains a drain-window double-signature for the same-algorithm case;
+  the algorithm case inherits it.**
+
+The sequence (waits italicised):
+
+1. **Trigger.** `change-policy` binds the new KSK algorithm. Refuse if:
+   a same-role roll is already in flight (re-entrancy), both roles' algorithms
+   differ (one role per roll, eval §4.1), or it is a CSK (eval §4.5).
+2. **Spawn the new-algorithm FIFO; bootstrap its head.** Mint new-alg KSK
+   B, publish its DNSKEY, make it **active** so it signs the DNSKEY RRset
+   (double-signing alongside old-alg active A). Because both A and B are
+   active-and-different-algorithm, D3 permits it and the additive signer
+   double-signs with **zero signer change**. Meanwhile the old-alg FIFO
+   **freezes**: A stays active, and A's orphaned standby keys are
+   **deleted and their DSes withdrawn** (we are rolling away from algA).
+3. *Wait for B's DNSKEY + its RRSIG to propagate* (child propagation +
+   effective DNSKEY_TTL). This is the invert-FACT-2 gate: **B's DS is not
+   pushed until B is signing and propagated.**
+4. **Push DS(B).** Parent DS RRset becomes the mixed set
+   `{ DS(A), DS(B) }`.
+5. **Observe** the parent until the mixed set is confirmed. Throughout
+   1–5 the zone validates via `DS(A) → A → A's RRSIG`; B is signing but not
+   yet a relied-upon chain. No gap.
+6. **Retire the old-alg FIFO's head.** Only now (new-alg DS confirmed)
+   `A: active → retired`. A keeps signing (FACT 3). B is now the sole
+   active KSK. The old-alg FIFO has one draining key left.
+7. *Hold A for `effective_margin`* (existing withdraw phase). During this
+   window `DS(A)` is still at the parent and A still signs — resolvers with
+   cached `DS(A)` keep validating.
+8. **`A: retired → removed`** — DNSKEY(A), DS(A) and RRSIG(A) drop
+   together. The old-alg FIFO is now empty → **drop it**. N returns to 2.
+
+**On the DS-drain wait we discussed earlier.** In a hand-written
+double-signature sequence one is tempted to *remove DS(A), then* unsign A —
+which leaves A **present-but-unsigned** while `DS(A)` may still be cached,
+a SERVFAIL for any resolver holding only `DS(A)`. The engine's
+decomposition **avoids this entirely**: A stays fully in force (active →
+retired, *signing*, DS at parent) through the margin, then DNSKEY+DS+RRSIG
+drop **together** at `removed`. A is never present-but-unsigned; and since
+`DS(A)` and `DS(B)` were co-published in one RRset from step 4, no resolver
+holds `DS(A)` without `DS(B)`, so the instant A vanishes the orphaned
+`DS(A)` is simply skipped and `DS(B) → B` carries the chain. So the
+separate DS-drain wait is **subsumed by the existing `retired → removed`
+margin**, not a new step. (Verify: `effective_margin` need not cover the
+parent DS_TTL here, because the co-published `DS(B)` is the fallback — but
+confirm this holds for the same-algorithm multi-DS case too, which relies
+on the same property.)
+
+
+## 6. What is reused vs. what is new
+
+**Reused, unchanged:**
+- The **additive signer** — two active KSKs of different algorithms both
+  sign the DNSKEY RRset automatically (`sign.go:180-226`). No signer change.
+- **`AtomicRollover`** — stays the same-algorithm in-FIFO swap.
+- **FACT-3 retired-signing drain** — the old-alg FIFO's tail
+  (`retired → removed` over `effective_margin`) is the existing withdraw
+  machinery.
+- **Bootstrap-activation** — the new FIFO's head is a bootstrap (corner a).
+  Reuse the shape of `RegisterBootstrapActiveKSK` / `healBootstrapActiveAt`
+  (which already do activate-then-DS for a zone's first key).
+
+**New:**
+- **The invariant change** — `pickActiveSEPTx` → "one active per
+  (role, algorithm)" (D3). Small but load-bearing; every "the active SEP
+  key" caller must tolerate one-per-algorithm during a roll.
+- **FIFO instantiation** (corner c) — allocate/spawn a parallel FIFO,
+  bootstrap its head alongside the existing FIFOs, freeze + drain + drop
+  the old one.
+- **Per-FIFO rollover state** (§7) — the one genuinely new modelling piece.
+- **The DS-push gate** — hold the new-alg DS until its key is signing +
+  propagated. In this model it falls out of the bootstrap ordering (B is
+  active-and-signing *before* step 4), but the DS-target query still needs
+  to not select B while it is pre-active.
+- **Generalizing double-signature** to same-algorithm rollovers (D1/D2):
+  filling in the scaffolded method so it is not algorithm-roll-only.
+
+**Caution — the signer's strip behaviour must become role/mode-aware.**
+The KSK alg roll *keeps* both algorithms' RRSIGs over the DNSKEY RRset
+(additive, FACT 3 — no KSK-side signer change; the double-signature is
+required). But the **ZSK relaxed alg roll must do the opposite** — *replace*
+old-alg RRSIGs rather than accumulate them (ZSK cleanups P0-6; the
+accidental double-sign there is the conservative whole-zone double-sign the
+dual-model doc rejected). Both flow through the same uniformly-additive
+signer today, so the strip/resign logic must distinguish: **keep** for a
+KSK alg roll and same-alg drains, **strip** for a relaxed ZSK alg roll.
+Co-design this with ZSK cleanups P0-6 and P0-2 (the D3 invariant) as one
+coordinated change — see `2026-07-01-zsk-alg-rollover-cleanups.md` P0-6.
+
+
+## 7. The open design question: per-FIFO state vs. the shared DS range
+
+Today `RolloverZoneState` is per-**zone**: one `rollover_phase`, one
+submitted/confirmed DS index range. Parallel FIFOs want **per-FIFO
+phase/progress** (old = "draining", new = "establishing"), naturally keyed
+**(zone, role, algorithm)** — one row in steady state, two during a roll.
+
+But there is exactly **one physical DS RRset at the parent**, holding every
+FIFO's DSes. So the submitted/confirmed DS range is most naturally
+**per-zone** (an aggregate), while each FIFO tracks its own key's DS
+status. Reconciling per-FIFO phase with the shared per-zone DS range is
+the main thing to design; everything else in §6 is wiring over existing
+primitives. Options to weigh when we spec this:
+
+- per-(zone, role, algorithm) rollover-state rows + a shared per-zone DS
+  range row; or
+- keep the DS range per-key (each FIFO's head/members carry their own
+  submitted/confirmed markers) and derive the parent DS set as their union.
+
+This is the first thing to settle before build.
+
+
+## 8. Corner cases (the four that motivated this design)
+
+- **(a) The new FIFO's first key is different — it is a bootstrap.** Every
+  FIFO's first key is inherently sign-first (no same-FIFO predecessor to
+  pre-position a DS against). This is identical to bootstrapping a zone's
+  initial chain, run alongside an existing one — reuse that machinery
+  rather than inventing an algorithm-roll special case. Multi-DS's
+  "DS-first" is a steady-state optimization that only works once a FIFO
+  already has an active key.
+- **(b) Double-signature must be general, not algorithm-roll-only.**
+  Handled by D1/D2 — it becomes a first-class method and the likely KSK
+  default. The algorithm rollover is then "double-signature where the new
+  FIFO's key differs in algorithm."
+- **(c) FIFO instantiation is the new machinery.** Spawn (allocate
+  identity, bootstrap head), run in parallel, freeze + drain + drop.
+  Freezing means **deleting the old FIFO's orphaned standbys and
+  withdrawing their DSes**, not letting them sit.
+- **(d) We already have two parallel FIFOs.** KSK + ZSK. This design
+  generalizes N from 2 to 3, jointly managing the DNSKEY RRset — extending
+  the existing pattern.
+
+**Re-entrancy.** An algorithm roll must be refused while a same-algorithm
+roll is in flight on that FIFO, so the old FIFO is always in a clean
+one-active state when it freezes (2026-06-21 §5.3 / K3 predicate; measure
+against the bound algorithm, per `3c6f7d3`).
+
+
+## 9. Re-rating the 2026-06-21 build steps
+
+The 2026-06-21 plan assumed the engine carries the roll unchanged and the
+only real change was a pipeline-counting bump (its K-3). Under this model:
+
+- **K-1 (entry-layer dispatch + refusals)** — unchanged and still valid.
+  Reuses the ZSK `change-policy` guards; adds the KSK role branch.
+- **K-2 (reconcile hand-off)** — **changes meaning.** It is no longer
+  "turn the refusal into a no-op and let the multi-DS engine carry it"
+  (multi-DS cannot — §1). It becomes "route the KSK-algorithm mismatch into
+  the **double-signature / FIFO-spawn** path." The two refusals to flip are
+  still `apihandler_zone.go:517` (entry) and `sign.go:314` (reconcile
+  backstop). Risk profile from the earlier re-grounding still holds: the
+  synchronous retire is *deleted*, so a wrong branch yields a stuck/refused
+  roll, not a bogus zone.
+- **K-3 (pipeline-fill bump)** — **replaced** by **FIFO instantiation**
+  (§6, corner c). This is larger than a counting bump: spawning a parallel
+  FIFO, bootstrapping its head, and the per-FIFO state (§7). Still the
+  highest-risk engine change; still a separate, testbed-checkpointed commit.
+- **New steps** not in the 2026-06-21 plan:
+  - the **invariant change** (D3, `pickActiveSEPTx`) — pairs with the ZSK
+    single-active guard (clean-then-generalize prerequisite);
+  - **generalizing the double-signature method** (D1/D2) — the same-algorithm
+    double-signature path, which the algorithm roll builds on;
+  - **per-FIFO rollover state** (§7).
+- **K-4 (trigger UX + status)** — unchanged in spirit; status must now show
+  two KSK FIFOs during a roll (old draining, new establishing).
+- **K-5 (full-sequence + timing tests)** — unchanged in spirit; the
+  full-sequence test now drives the spawn → double-sign → confirm → drain →
+  drop lifecycle, and asserts the invariant (one active per (role,algorithm))
+  and no-zero-chain at every step.
+
+**Effort:** materially larger than the 2026-06-21 estimate (~17–29 h),
+which assumed "rides multi-DS unchanged." A real breakdown belongs in a
+follow-up once §7 is settled; the new weight is the double-signature method
+generalization + FIFO instantiation + per-FIFO state.
+
+
+## 10. Sequencing (clean-then-generalize)
+
+Per the ZSK cleanup punch-list
+(`2026-07-01-zsk-alg-rollover-cleanups.md` §0), land the
+generalization-enabling cleanups **first**, so this work builds on shared
+primitives instead of duplicating KSK-shaped code:
+
+1. The **single-active guard** (punch-list P0-2) — implement it directly as
+   the **"one active per (role, algorithm)"** invariant (D3), so the ZSK fix
+   and the KSK enabler are the same commit.
+2. A **role-generalized in-flight / `FromAlg` predicate** (P0-4 +
+   generalizing `zskAlgRollInFlight`) — the re-entrancy guard both roles need.
+3. The `256/257` **flag constants** (P2-1) and a **`firstKeyOfRole` helper**
+   (P2-4) — touched heavily by the FIFO work.
+
+Then: generalize the double-signature method (same-algorithm) → build FIFO
+instantiation → wire the algorithm rollover on top.
+
+
+## 11. Summary
+
+- Multi-DS cannot do a KSK algorithm rollover: pre-positioning a
+  new-algorithm DS with nothing signing that algorithm is an orphan DS /
+  downgrade signature (§1). The parent DS is what forces double-signature.
+- Model it as **parallel FIFOs keyed (role, algorithm)**, generalizing the
+  KSK+ZSK pair already present (§2). A KSK algorithm rollover spawns a
+  parallel new-algorithm FIFO; the old-algorithm FIFO keeps its key active
+  until the new-algorithm DS confirms, then drains and is dropped.
+- **Double-signature** becomes a first-class, general method — likely the
+  KSK default (§3).
+- Invariant: **one active per (role, algorithm)** (§4), which also closes
+  the ZSK single-active gap.
+- Most primitives are reused (additive signer, `AtomicRollover`, FACT-3
+  drain, bootstrap-activation); the new work is the invariant change, FIFO
+  instantiation, per-FIFO state, and generalizing the double-signature
+  method (§6).
+- The one genuinely open modelling question is per-FIFO rollover state vs.
+  the shared per-zone DS range (§7); settle it before build.

--- a/docs/2026-07-01-zsk-alg-rollover-cleanups.md
+++ b/docs/2026-07-01-zsk-alg-rollover-cleanups.md
@@ -1,0 +1,275 @@
+# ZSK algorithm rollover — cleanup punch-list
+
+Status: PLANNING / punch-list (2026-07-01). Prioritized cleanups for the
+as-merged relaxed-mode ZSK algorithm rollover (FIFO model, PR #263) and
+its follow-ups. Grounded in a read of the current tree on branch
+`feat/tsig-first-class` (contains all merged rollover work). Code
+references are `file:line` into `v2/`.
+
+Several of these are **prerequisites for the KSK algorithm rollover work**
+(`2026-07-01-ksk-alg-rollover-parallel-fifo-design.md`) under the
+clean-then-generalize sequencing — see §0.
+
+Feature commits + follow-ups this covers: `5f95388` (automate ZSK rollover
+from lifetime), `64dc39b` (completeness knob), `db693db` (step 2 —
+relaxed-mode ZSK alg rollover), `3c6f7d3` (change-policy re-entrancy fix),
+`5581bf6` (flagged the unordered-standby FIFO bug), `5ba805c` (CodeRabbit
+review), `6e6c4aa`/`81dcb2d`/`a817dfa` (status header), `7ef4cef` (`when`
+schedule).
+
+
+## What is confirmed sound (no action)
+
+The merged feature is fundamentally correct; the cleanups below are
+hardening, not rescue.
+
+- **FIFO ordering is fixed.** `GetDnssecKeysByState` orders
+  `published_at ASC, keyid ASC` on both the all-zones and per-zone query
+  (`keystore.go:1201,1204`); every FIFO consumer relies on it (promotion,
+  the cap tail-delete, the next-to-promote pick). The `5581bf6`
+  "unordered-standby FIFO bug" is resolved and pinned by
+  `TestT4cFifoOrderingByPublishedAt` (`zsk_alg_rollover_test.go:298`).
+- **Role-only counting + total cap is correct** and algorithm-agnostic
+  (`key_state_worker.go:290-402`); the total-count cap replaces
+  algorithm-based deletion for relaxed same-role ZSK keys
+  (`sign.go:365-368`). No off-by-one found.
+- **Reconcile relaxed branch is correct**: relaxed does NOT retire the
+  wrong-alg active ZSK (no-op, `sign.go:329-336`); strict REFUSES
+  (`:329-332`); KSK REFUSES in both modes (`:312-317`); CSK early-returns
+  (`:296`).
+- **The re-entrancy fix (`3c6f7d3`) is clean**: measuring against the
+  *bound* `curZSKAlg` (not the target) is the right predicate, tested by
+  `TestReentrancyFreshZoneNotInFlight` /
+  `TestChangePolicyFreshZonePassesReentrancyGuard`.
+
+
+## 0. Clean-then-generalize prerequisites (do these first)
+
+These four are the shared primitives the KSK parallel-FIFO work
+generalizes; landing them first means the KSK work builds on them instead
+of duplicating ZSK-shaped code. Ordered:
+
+1. **P0-2 → implement as the D3 invariant.** The single-active guard the
+   punch-list wants is exactly the KSK design's **"one active per
+   (role, algorithm)"** invariant. Implement it once, for both roles, in
+   the same commit — it closes the ZSK gap and enables the KSK alg-roll
+   overlap. (See KSK design §4.)
+2. **P0-4 + generalize `zskAlgRollInFlight`** into a **role-generalized
+   in-flight / `FromAlg` predicate** — the re-entrancy guard both roles
+   need (KSK design §8, corner "re-entrancy").
+3. **P2-1** — the `256`/`257` **flag constants** (touched heavily by the
+   FIFO work).
+4. **P2-4** — a **`firstKeyOfRole` helper** (collapses the repeated
+   role-scan idiom the FIFO work would otherwise duplicate).
+
+**P0-6 is a fifth member of this sensitive cluster** — not a prerequisite
+(it does not *unblock* the KSK work), but it must be **co-designed** with
+P0-2 and the KSK double-sign, because all three change how the old-alg
+key's RRSIGs are handled during an alg roll and share the signer's
+strip/resign path. Land it in the same coordinated change.
+
+The remaining items (P0-1, P0-3, P0-5, all P1, P2-2/3/5) are independent
+ZSK hygiene and can land whenever.
+
+
+## P0 — correctness / latent bugs
+
+**P0-1 — no invariant enforces non-NULL `published_at` on a standby key.**
+FIFO promotion sorts `published_at ASC`; a standby that somehow lands with
+NULL `published_at` sorts *first* and would be promoted out of order. The
+ordering fix (`keystore.go:1201/1204`) assumes standbys always have a
+`published_at`, but nothing enforces it.
+→ *Fix direction:* a cheap guard in `RolloverKey`'s standby selection —
+skip/warn when `PublishedAt == nil` — or a NOT-NULL story at the
+published→standby transition.
+
+**P0-2 — `RolloverKey` retires the first role-matching active key with no
+single-active guard** (`keystore.go:1358`). The loop `break`s on the first
+active of the role; if two actives ever exist (e.g. a double promotion),
+it silently retires one and keeps the other, masking the invariant
+violation instead of failing loud. The whole "atomic swap, never two
+active" model is unchecked at the one place it is assumed.
+→ *Fix direction:* implement as the **D3 invariant** (§0.1): collect
+role-matching actives and, if `> 1` for the same `(role, algorithm)`,
+return an error. (For the KSK this permits one active *per algorithm*
+during an alg-roll overlap; for the ZSK it means one active, full stop.)
+
+**P0-3 — TOCTOU in `changeZonePolicy`** (`apihandler_zone.go:487-554`).
+The source algorithm / re-entrancy / mode guards run against a snapshot
+read under `zd.mu`, which is released before the rebind re-acquires
+`zd.mu`. A concurrent policy change in that window can move
+`zd.DnssecPolicy`, so the guards validate one source algorithm while the
+rollback captures a different `oldPol`. `5ba805c` fixed the narrower
+`oldName`/`oldPol` pairing but not this wider window.
+→ *Fix direction:* hold one lock (or a per-zone change-policy lock) across
+guard + rebind, matching the pattern the rollover `asap` handlers use with
+`AcquireRolloverLock`.
+
+**P0-4 — `zskAlgRollInFlight` collapses multiple in-flight algorithms to
+one `FromAlg`** (`zsk_rollover.go:240`, `if fromAlg == 0 { fromAlg =
+k.Algorithm }` captures only the first-seen non-target algorithm). The
+boolean guard stays safe, but the operator-facing error and the status
+header (`AlgTransitionInfo.FromAlg`) can name the wrong source algorithm
+during a multi-algorithm state.
+→ *Fix direction:* collect the distinct set of non-target algorithms;
+render joined, or explicitly report ">1 old algorithm present." Fold into
+the role-generalized predicate (§0.2).
+
+**P0-5 (watch, not a bug today) — generate/cap non-oscillation rests on an
+unstated invariant.** The tick order (`key_state_worker.go:110-124`)
+`rolloverZsksForAllZones → transitionRetiredToRemoved → maintainStandbyKeys`
+never oscillates *only because* `maintainStandbyKeysForType` mints into
+`published` (via `GenerateAndStageKey`) while `capStandbyZsksByCount`
+counts `standby` only (`:296-297`, `:360-361`). If a future change staged
+generated keys directly into `standby`, generate-then-cap would churn every
+tick.
+→ *Fix direction:* a one-line assertion/comment at the generate call
+("must stage to published, not standby, or the relaxed cap oscillates"),
+or make cap+generate share a single counting pass over both states.
+
+**P0-6 — a relaxed ZSK alg roll must REPLACE old-alg RRSIGs, not
+accumulate them (remove the accidental double-signature).** During a
+relaxed-mode ZSK algorithm roll the uniformly-additive signer generates
+new-alg RRSIGs over each RRset but does **not** strip the old-alg RRSIGs —
+they linger until the old-alg key is removed (the signer never strips
+others' RRSIGs, `sign.go:180-185`; the strip happens only at
+`retired → removed`, `key_state_worker.go:239-241`). The result is a
+whole-zone double-signature across the entire drain window — but an
+*accidental, partial, unguaranteed* one (an RRset carries both only if it
+happened to be re-signed while both keys existed), so it delivers no real
+double-sign guarantee, only the cost. This is a remnant of the earlier
+assumption that ZSK alg rolls need double-signature; the dual-model design
+(`2026-06-27-zsk-alg-rollover-dual-model-design.md`) explicitly **rejected**
+conservative whole-zone double-signing for the ZSK in favour of relaxed
+FIFO / alg-split — one valid RRSIG per RRset suffices (RFC 6840 §5.11).
+→ *Fix direction:* during a relaxed ZSK alg roll, the new-alg key's RRSIG
+should **replace** the old-alg key's RRSIG per RRset — strip old-alg ZSK
+RRSIGs as the zone is re-signed, not at key removal. The old-alg ZSK
+**DNSKEY stays published** until *cached* old-alg RRSIGs drain (the existing
+removal margin `propagationDelay + max_ttl` still governs the DNSKEY); only
+the *served* RRSIGs are replaced immediately. Net: one new-alg RRSIG per
+RRset, no whole-zone double-sign, drain via the retained DNSKEY.
+
+> **⚠ Sensitive — this is the exact opposite of the KSK decision; co-design
+> with P0-2.** Keeping both old- and new-alg RRSIGs is precisely what we
+> decided is *correct* for the **KSK** alg roll (the deliberate
+> double-signature over the DNSKEY RRset —
+> `2026-07-01-ksk-alg-rollover-parallel-fifo-design.md` §5, FACT 3). The
+> signer is uniformly additive today; the KSK design *relies* on
+> additive-keep (FACT 3) while this item wants the ZSK alg roll to strip.
+> So the strip/resign behaviour must become **role/mode-aware**: **strip**
+> old-alg RRSIGs for a *relaxed ZSK alg roll*, **keep** them for a *KSK alg
+> roll* (double-sign) and for *same-alg drains*. Implement P0-6, P0-2 (the
+> D3 invariant), and the KSK double-sign as **one coordinated change** — a
+> naive edit to the strip/active logic for either role will break the other.
+
+
+## P1 — test gaps
+
+**P1-1 — no test asserts the no-double-active invariant across an alg
+roll.** T5 (`zsk_alg_rollover_test.go:403-406`) only checks
+`len(active) != 0` at the end. The core "never two active" property (P0-2)
+is untested.
+→ Assert exactly one active ZSK after each `RolloverKey` step.
+
+**P1-2 — removal margin (sum `propagationDelay + max_ttl`) is only
+unit-tested on the helper**, not on the worker path.
+`TestZskRemovalMargin` (`zsk_rollover_test.go:29-38`) checks
+`zskRemovalMargin` arithmetic; nothing tests that
+`transitionRetiredToRemoved` (`key_state_worker.go:216-229`) actually
+holds a retired ZSK for that margin. The sum-vs-max distinction is the
+whole safety margin; a regression to `propagationDelay`-only would strip
+still-cached RRSIGs unnoticed.
+→ Table test: retired ZSK at `now-(margin-ε)` stays, `now-(margin+ε)`
+removed; assert `LoadZoneSigningMaxTTL` participates.
+
+**P1-3 — T5 bypasses the real worker path** (`zsk_alg_rollover_test.go:325-407`
+drives `kdb.RolloverKey` directly and hand-simulates published→standby),
+so `rolloverZskForZone`'s gating (`zskRollDue`, `haveStandby` wait, the
+manual-request clear-on-commit, lock acquisition) is never exercised in
+the FIFO alg-roll scenario.
+→ One end-to-end test driving `rolloverZskForZone` + `maintainStandbyKeys`
++ `transitionPublishedToStandby` across a full old→new drain.
+
+**P1-4 — no test for `asap --zsk` mid-drain, and the intentional KSK
+asymmetry is undocumented.** The ZSK `asap` handler has no
+`RolloverInProgress` guard (`apihandler_rollover.go:106-119`), unlike the
+KSK path (`:128-137`) — by design (asap *is* the throttle), but untested
+and unspecified.
+→ Test that asap mid-drain promotes the next FIFO standby without
+skip/duplicate; document that ZSK asap has no in-progress refusal
+(asymmetry with KSK is intentional).
+
+**P1-5 — no direct over-mint-prevention assertion during the drain
+window.** T3/T3b cover the endpoints (role-only count generates nothing;
+generate-on-drain uses the new alg) but not the middle — with N old
+standbys and asap firing faster than propagation, does anything over-mint?
+(Reading says no: generate is gated on `standbyCount < standbyKeyCount`
+AND `publishedCount == 0`.)
+→ A direct assertion of the middle case.
+
+
+## P2 — hygiene / naming / dead code
+
+**P2-1 — magic `256`/`257` flag literals vs `dns.SEP`, mixed within the
+same function.** `reconcileActiveKeyAlgorithms` uses `Flags != 256`
+(`sign.go:323`) and `Flags&dns.SEP != 0` (`:357`) side by side; bare
+literals also at `key_state_worker.go:290,306,370`;
+`zsk_rollover.go:232,292,310,408,429,455`; `sign.go:426,436,514`;
+`keystore.go:1345,1347`. One typo away from a role confusion in
+security-critical key selection.
+→ Introduce `flagsZSK uint16 = 256` / `flagsKSK uint16 = 257` (or
+standardize on `Flags&dns.SEP` role tests) and use consistently.
+**Prerequisite for the FIFO work (§0.3).**
+
+**P2-2 — `resolveCompletenessMode` is misfiled** in `large_ksk.go:91-102`;
+the `CompletenessStrict/Relaxed` constants are in `config.go:112-113`. The
+completeness feature is scattered across `config.go`, `large_ksk.go`,
+`parseconfig.go`.
+→ Move `resolveCompletenessMode` (and its test) into a small
+`completeness.go` next to the constants.
+
+**P2-3 — `AlgTransitionInfo.Done/Total` progress is misleading during the
+drain window** (`zsk_rollover.go:235-237`). `Total` counts standby ∪ active
+∪ retired (any alg); `Done` counts target-alg. Retired old-alg keys inflate
+`Total` while draining, so `Done/Total` can appear to regress. Cosmetic
+(status header only).
+→ Exclude `retired` from the denominator, or relabel to make the
+drain-window semantics explicit.
+
+**P2-4 — KSK vs ZSK rollover duplication.** The
+role-matching-scan-then-break idiom
+(`for i := range keys { if Flags==… { … break } }`) is repeated ~8× across
+`zsk_rollover.go`, `keystore.go`, `sign.go`, mirroring the KSK equivalents
+in `ksk_rollover_automated.go`.
+→ Extract `firstKeyOfRole(keys, flags)` / `filterByRole` in `keystore.go`;
+migrate call sites. **Prerequisite for the FIFO work (§0.4)** — the
+parallel-FIFO code would otherwise add more copies.
+
+**P2-5 — `retiredAny` naming residue.** `5ba805c` renamed the
+reconcile's `retired`→`removed` semantics and fixed the stale comment
+(`sign.go:271-294`), but the `retiredAny` return variable
+(`sign.go:338,380,384`) still reads "retired" though it now means "removed
+a non-active leftover."
+→ Rename `retiredAny`→`removedAny`.
+
+**P2-6 — pre-existing `XXX/FIXME` in the blast-radius files** (not from
+#263): `keystore.go:92` ("add should also add to TrustStore"),
+`keystore.go:946` ("use this once we've found all the bugs in the sqlite
+code"), `sign.go:232/746/859`. Flagged only; out of scope for this
+cleanup unless bundled.
+
+
+## Sequencing
+
+1. **§0 prerequisites** (P0-2 as the D3 invariant, P0-4 + generalized
+   predicate, P2-1 flag constants, P2-4 role helper) — these unblock the
+   KSK parallel-FIFO work. **P0-6 (ZSK RRSIG replacement) is co-designed
+   here** — same signer strip/resign path as P0-2 and the KSK double-sign,
+   opposite direction; one coordinated change.
+2. **Independent ZSK hardening** (P0-1, P0-3, P0-5) — any time.
+3. **Test gaps** (P1-1…P1-5) — ideally alongside the correctness items
+   they cover (P1-1 with P0-2, P1-2 with the margin path); add a P0-6 test
+   asserting the served zone carries exactly one (new-alg) RRSIG per RRset
+   mid-roll, with the old-alg DNSKEY still published.
+4. **Remaining hygiene** (P2-2/3/5) — low priority, opportunistic.


### PR DESCRIPTION
Planning-only documentation for the DNSSEC key-rollover work. **No code changes** — docs only, based on `main`.

## New docs

- **`2026-07-01-ksk-alg-rollover-parallel-fifo-design.md`** — the KSK *algorithm* rollover design. Multi-DS cannot do an algorithm rollover (pre-positioning a new-algorithm DS while nothing signs that algorithm is an orphan-DS / downgrade signature), so it must use **double-signature**, modelled as **parallel per-(role, algorithm) FIFOs** — a generalization of the KSK+ZSK FIFO pair already present. The old-algorithm FIFO keeps its key active until the new-algorithm DS is confirmed, then drains and is dropped. Invariant: **one active key per (role, algorithm)** (which also closes the ZSK single-active gap). Supersedes the *method* of the 2026-06-21 plan.
- **`2026-07-01-zsk-alg-rollover-cleanups.md`** — prioritized cleanup punch-list (**6 P0 / 5 P1 / 6 P2**) for the merged relaxed-mode ZSK algorithm rollover, including **P0-6** (RRSIG replacement — the mirror image of the KSK double-signature decision) and the clean-then-generalize prerequisites for the KSK work.

## Updated docs

- **`2026-06-21-ksk-algorithm-rollover-plan.md`** — superseded-on-method banner (build-step scaffolding still applies).
- **`2026-05-02` / `2026-05-03` rollover timing docs** — mark the E12/E13 timing divergence **resolved**, verified in current code (`ksk_rollover_automated.go:1162`, W1 + W8 tests, merged via #212). Historical audit verdicts retained.
