### PR TITLE
Retire SliceZone and harden outbound zone transfers

### DIFF
--- a/docs/2026-07-02-outbound-transfer-hardening.md
+++ b/docs/2026-07-02-outbound-transfer-hardening.md
@@ -1,0 +1,245 @@
+# Project A — Retire SliceZone + Outbound Zone Transfer Hardening
+
+**Status:** implementation-ready (final — SliceZone retirement + transfer fixes;
+all review rounds folded in)
+**Date:** 2026-07-02
+**Scope:** (0) retire the SliceZone store entirely, then (1) fix `ZoneTransferOut`
++ the envelope batcher in `v2/dnsutils.go`. **Independent** of Projects B and C.
+Do **first** — it fixes live bugs (PQ-apex envelope overflow + a goroutine hang on
+client disconnect) and hands B a single-store (MapZone-only) codebase.
+**Siblings:** `…-zone-mutation-snapshot-correctness.md` (B), `…-ixfr-support.md`
+(C). **Review folded in:** `…-outbound-transfer-hardening-review.md`.
+Anchors are as of 2026-07-02; verify before editing.
+
+---
+
+## Step 0 — Retire SliceZone (behavior-neutral simplification)
+
+**Why:** `OwnerData` is a 24-byte handle (`Name string` + `RRtypes *RRTypeStore`;
+structs.go:518) — the real RR data is behind the shared pointer. So SliceZone
+(`[]OwnerData` **plus** a `map[string]int` `OwnerIndex`) buys nothing: its lookup
+is a map lookup **+** an array deref (strictly slower than MapZone's single map
+lookup), and its memory is marginally *higher* (a slice *and* an index map). The
+map-overhead it was meant to dodge doesn't exist because the value is a thin
+handle. At 1M owners the store-choice difference is ~4 MB inside a multi-hundred-
+MB-to-GB zone. It's a dead hedge — remove it so A and B only ever handle one
+representation.
+
+**Full retirement checklist (verified; DNS responses identical before/after):**
+- **Enum / type / fields:** delete the `SliceZone` `ZoneStore` value + names
+  (structs.go:24/30/41), the `Owners` type (structs.go:516), and the `zd.Owners`
+  / `zd.OwnerIndex` fields (structs.go:119-120).
+- **The `"slice"` string parser → MapZone:** `parseZoneStore` (catalog.go:492-512,
+  the branch at :506) and config parsing (parseconfig.go:629-630) map `"slice"`.
+  Make both a **deprecated alias returning MapZone** so existing configs don't
+  error. (Correction: catalog *member* zones are already created as MapZone —
+  catalog.go:406 — there is no "catalog defaults to slice.")
+- **Cross-module + tests (else the build breaks when the enum value is removed):**
+  `tdns-mp/v2/hsync_utils.go:1187-1197` (`PrintOwnerNames` `case tdns.SliceZone` —
+  delete the branch) and `zonestore_test.go` (:10/:22/:38 enumerate `SliceZone` —
+  expect `"slice"`→MapZone, drop the const).
+- **dnsutils.go:** delete `ComputeIndices()` (796-820) + the `Owners` sort methods
+  `Len`/`Swap`/`Less` (822-830); drop the `ComputeIndices()` calls (113, 549);
+  collapse the store checks/branches at 68, 340-374 (→ the MapZone loop 376-411),
+  479, 677; in `SortFunc` remove the `case SliceZone: fallthrough` at 574 (keep
+  the MapZone path only — inbound transfer already stores into `Data`).
+- **zone_utils.go:** delete the `Owners`/`OwnerIndex` copies in the two hard flips
+  (237-238, 341-342); collapse the `case SliceZone` branches in `nameExists`
+  (440), `GetOwner` (464-469 → `Data.Get`), `AddOwner` (500-502, the FIXME'd
+  broken path), `GetOwnerNames` (536-550 → `Data.Keys()`), and `PrintOwners` (608-628);
+  update stale error strings that mention “SliceZone and MapZone” (e.g. `GetOwner`
+  :489, `GetOwnerNames` :550) to MapZone-only (or MapZone + XfrZone where relevant).
+- api_structs.go:315 `OwnerIndex map[string]int` is an unrelated API-response
+  field — leave it.
+- **NSEC scoping check — RESOLVED, safe:** `GenerateNsecChain` (sign.go:948-952)
+  and `SignZone` (sign.go:804-808) collect names via `GetOwnerNames()` then
+  **`sort.Strings()`** — they do **not** rely on SliceZone's pre-sorted `Owners`.
+  Retiring the slice does not break NSEC(3) generation (MapZone's unordered
+  `Data` + the existing sort is already the universal path).
+- **Bonus:** zone_utils.go:455 `XXX: FIXME: SliceZones do not yet support adding
+  new owner names` — retirement eliminates that latent limitation.
+
+**Effect on the rest of A:** `ZoneTransferOut` now has a **single** owner loop, so
+the batcher fixes below apply once, not twice.
+
+**Risk: low** (behavior-neutral). No `ZoneTransferOut`/query integration tests exist
+today, so add a smoke AXFR round-trip (via the §4 harness) to cover Step 0 rather
+than leaning on existing coverage.
+**~150–300 LOC** (mostly deletions).
+
+---
+
+## 1. The transfer defects (verified against code)
+
+`ZoneTransferOut` at dnsutils.go:229; dispatched from queryresponder.go:813-816.
+Batcher `maybeFlushBatch` (132-192), `estimateRRSize` (196-210),
+`estimateEnvelopeSize` (214-227); `safeMessageSize = 59000` (duplicated 134 & 285).
+
+1. **Mismatched flush gate** (141-164): gates on `estimated+newRRSize` but flushes
+   only if the *current* batch alone `>= safe` → `current=55k, new=12k` → 67k
+   envelope.
+2. **Apex bypasses the batcher** (290-326): apex SOA + apex RRtypes + RRSIGs
+   accumulate raw with no `maybeFlushBatch` (owner loop starts at 339). A PQ apex
+   can exceed 64K alone → first envelope overflows.
+3. **Final send not size-gated** (426-437): `finalSize` logged only; unconditional
+   send.
+4. **Producer hangs on consumer failure**: `outbound_xfr` unbuffered (252);
+   `tr.Out` consumer in a goroutine (257-263) returns on write error without
+   draining (miekg `for x := range ch`); producer then blocks forever on the next
+   send → leaked goroutine; `wg.Wait()`/`w.Close()` (440-441) never run.
+5. **Panic on missing apex/SOA** (265-266): `apex, _ := GetOwner(...)` discards the
+   error; `...RRs[0]` nil-derefs / index-panics; the already-spawned goroutine
+   leaks.
+6. **Unsupported `ZoneStore` streams partial apex** (413-416 → 437) — but after
+   step 0 the only stores are MapZone (+ the pure-`xfr` store); keep a REFUSE
+   default anyway.
+7. **No `Ready`/`Status` gate** — serves during refresh.
+8. **`safeMessageSize` duplicated** (134, 285).
+9. **Stale TODO** dnsutils.go:29 (TSIG transfers are implemented).
+
+TSIG-out signing is **correct** (miekg `Transfer.Out` `SetTsig`s each envelope;
+provider MACs via `w.WriteMsg`; wrapper idempotent). Do not touch.
+
+---
+
+## 2. The fixes
+
+### (f) Guard apex/SOA before spawning the goroutine — 265-266
+Fetch the apex **before** the `tr.Out` spawn (257). Handle **all three** failure
+modes: `err != nil` (incl. `ErrZoneNotReady`), `err == nil && apex == nil`
+(missing apex), and an **empty SOA RRset** (`RRs[0]` would panic). On any → REFUSE
+(no goroutine spawned).
+
+### (g) Serve without writing shared state — delete the transfer-time re-sign — 267-276
+Interim (pre-B): capture `CurrentSerial` + the `Data` pointer at entry, deep-copy
+the SOA, stamp `Serial=CurrentSerial` on the **copy**, and **delete the
+transfer-time SOA re-sign block (270-276)** — no write to `apex.RRtypes`.
+**Acceptance criterion: `ZoneTransferOut` performs zero writes to shared zone
+state.** (Not full read-isolation — reads still traverse shared `RRtypes` until B;
+torn logical views remain possible until B's snapshot. That residual is accepted
+for A.) After B, (g) collapses to `snap := zd.snapshot.Load()`.
+
+### (a) Flush gate — 141-164
+Flush the current batch when `estimateEnvelopeSize(current) + newRRSize >= safe`
+(measure current accurately, add the candidate's estimate), then start the next
+batch with the new RRset — do **not** reuse the "measure current alone" branch at
+144. Edge case: if a **single** RRset's own packed size approaches `safe`, the
+append is valid but the send may exceed cap once the trailing SOA is added — (d)
++ (e) must catch it.
+
+### (b) Apex through the batcher — 290-326
+Feed apex SOA + apex RRtypes + RRSIGs through the same `maybeFlushBatch` path as
+the (now single) owner loop.
+
+### (d) Size-gate the final send — 426-437
+Size-check the final batch (remaining + trailing SOA). If it exceeds cap because
+it holds multiple RRsets → flush earlier batches via the same gate. If it exceeds
+cap as a **single** RRset → **abort via (e) + log owner+type** (no splitting, per
+§3). Do **not** "split."
+
+### (e) Producer + consumer abort — both directions — 252-263, 154/179/437
+Two abort directions must both be handled:
+- **Consumer fails first** (client disconnect / write error): `tr.Out` returns an
+  error → the **wrapper goroutine** around it closes `done` (`go func(){ defer
+  wg.Done(); if err := tr.Out(...); err != nil { close(done) } }()` — `tr.Out`
+  itself has no `done` param). Producer sends `select { case outbound_xfr <- env:
+  case <-done: return }`.
+- **Producer aborts first** (oversize final batch / local fatal): the producer
+  must **`close(outbound_xfr)`** so `tr.Out`'s `for x := range ch` exits, then
+  `wg.Wait()`. Returning on `<-done` alone would leave `tr.Out` blocked → the
+  original hang.
+Use one `sync.Once` for the channel close so no path double-closes.
+
+### Unified cleanup on every exit — new
+After the `tr.Out` spawn — **immediately, before any batcher work that could return
+early** — arm one teardown:
+`defer func(){ closeOnce.Do(func(){ close(outbound_xfr) }); wg.Wait(); w.Close() }()`.
+Pre-spawn guards (f, Ready gate, unsupported store) return **before** the spawn,
+so they never reach it. Every post-spawn exit runs the same teardown.
+
+### safe 59000 → 64000, one constant — 134, 285
+Single `const safeMessageSize = 64000` (remove the duplicate). Comment: ~1.5 KB
+headroom reserves the per-envelope **question** (`SetReply`, ≤259 B) + **TSIG**
+(miekg appends after our measurement, ≤~360 B) that `estimateEnvelopeSize` omits.
+
+### Ready/Status gate — entry
+Refuse/SERVFAIL when `zd.GetStatus() != ZoneStatusReady`. Note: `GetOwner` gates
+on the weaker `zd.Ready` bool, which is set `true` mid-refresh ("this is a lie",
+zone_utils.go:223-225) while `Status` stays `loading` until the flip — so
+**`GetStatus()` is the correct transfer gate**, not `zd.Ready`.
+
+### Unsupported `ZoneStore` → REFUSE — 413-416
+Replace the fall-through with a REFUSE before streaming (defensive; step 0 already
+removed SliceZone).
+
+### Remove stale TODO — 29
+
+### (optional) IXFR → REFUSE until Project C
+Dispatch still sends `TypeIXFR` to `ZoneTransferOut` (queryresponder.go:813-816),
+which serves full AXFR. Optionally REFUSE `TypeIXFR` (or document "IXFR yields
+AXFR") until C. Not a blocker.
+
+---
+
+## 3. Won't do
+- **(c) Intra-RRset splitting** — an RRset >64K is unanswerable to any ordinary
+  query anyway (TCP is also capped at 65535; RFC 5936 keeps RRsets whole), so the
+  zone is unserveable regardless. Handle via (e)'s clean abort + a **loud log
+  naming the owner+type**.
+- **Shelf / bin-packing** — over-engineering; `safe`→64000 captures the win.
+
+---
+
+## 4. Test plan
+No `ZoneTransferOut` tests exist (only `transfer_fallback_test.go`, SOA probe,
+TSIG server :55-105). Build the harness (**reused by Project C**):
+- **TCP-AXFR-over-TSIG harness** — model on `startTestSOAServerTSIG`
+  (transfer_fallback_test.go:57-105): a `dns.Server{Net:"tcp",
+  TsigSecret:{key:secret}, Handler:mux}` whose mux installs
+  `TsigSigningHandler(func(w,r){ zd.ZoneTransferOut(w,r) })` for the zone (it's a
+  method — needs the closure; `TsigSigningHandler` @ tsig_peer.go:126, installed on
+  Do53 @ do53.go:51); client `tr :=
+  &dns.Transfer{TsigSecret:{key:secret}}` with `msg.SetAxfr(zone)` +
+  `msg.SetTsig(...)` then `tr.In(msg, addr)`. Minimal (one MapZone, one
+  HMAC-SHA256 key, loopback TCP). For the **explicit per-envelope size check**,
+  wrap the server's `dns.ResponseWriter` to record `len(packed)` per `WriteMsg`
+  and assert every envelope ≤ 65535 (and ≤ 64000). (Over TCP a >65535 message
+  can't be framed — 2-byte length prefix — so an oversize envelope fails the
+  *server-side* Pack and aborts the transfer; the round-trip-success test already
+  catches overflow, the recorder just makes it explicit.)
+- **Oversized PQ apex** — apex alone spans envelopes; assert **every** emitted
+  envelope packs < 65536 on a **TSIG-signed** transfer (exercises question+TSIG
+  headroom; a pack-only test without `SetReply`+TSIG gives false confidence).
+- **Single RRset > cap** — clean abort + log; no hang.
+- **Producer-initiated oversize abort** (no client disconnect) — the abort fires
+  on the producer before any send; assert channel closed, `tr.Out` exits, no leak.
+- **Client disconnect mid-transfer** — producer aborts, no goroutine leak.
+- **Round-trip** — normal zone, correct RR count/content.
+
+---
+
+## 5. Implementation order
+1. **Step 0 — retire SliceZone** (behavior-neutral; unblocks single-loop batcher).
+2. **(f)** guard + **Ready/Status gate** + **unsupported-store REFUSE** + remove
+   TODO (cheap; all pre-spawn, no goroutine on REFUSE paths).
+3. **(g)** transfer-local SOA, delete write-back (zero shared writes).
+4. **Extract `safeMessageSize`** (dedupe) → **(a)+(b)+(d)** batcher rework +
+   `safe`→64000.
+5. **(e) + unified cleanup** — `done` channel, `sync.Once` close, teardown defer;
+   route all producer sends through the `select`.
+6. **Harness + tests** — a Project-A deliverable (incl. the producer-oversize
+   abort test).
+
+## 6. Risk / effort / LOC
+**Risk: medium** — step 0 is low-risk but broad; the batcher rework + abort
+lifecycle carry the medium risk (covered by the pack-<65536 + abort tests).
+**Effort: ~3–4 h agent** (step 0 ~1–2 h + transfer fixes ~1.5–2 h).
+**LOC: ~200 (retire) + ~130 (fixes) + ~300 (tests+harness) ≈ 630.**
+
+## 7. Interaction with B/C
+- After **B**, (g) collapses to `snapshot.Load()` — the immutable snapshot removes
+  the residual torn-read and the SOA-copy dance. A's interim (g) is written so
+  that is a simplification, not a rewrite.
+- Step 0 hands B a **MapZone-only** codebase → B's snapshot is map-only, no
+  store normalization.
+- The harness is reused by **C** for IXFR-out tests.

--- a/docs/2026-07-02-zone-mutation-snapshot-correctness.md
+++ b/docs/2026-07-02-zone-mutation-snapshot-correctness.md
@@ -192,6 +192,7 @@ func (zd *ZoneData) requestPublish(urgent bool)                  // enqueue to t
 
 ## 3. Current state to convert
 ### 3.1 Mutators
+
 | Mutator / path | file:line | writer | note |
 |---|---|---|---|
 | `SignZone`/`ResignZone`/`GenerateNsecChain`/`StripZoneRRSIGs` | sign.go:749/580/918/702 | **ResignerEngine** | whole pass → one publish |

--- a/docs/2026-07-02-zone-mutation-snapshot-correctness.md
+++ b/docs/2026-07-02-zone-mutation-snapshot-correctness.md
@@ -1,0 +1,312 @@
+# Project B — Zone-Mutation Correctness via an Immutable Snapshot
+
+**Status:** implementation-ready (final — all review rounds folded in; milestoned
+B1→B2→B3; SliceZone retired by Project A step 0)
+**Date:** 2026-07-02
+**Scope:** replace direct-write-then-bump-serial mutation with an **immutable
+snapshot published atomically**, across `v2/` **and** `tdns-mp/v2/`. A **standalone
+correctness fix** (repairs a serial-invariant violation that bites *queries*
+today), independent of A and C. Project C (IXFR) is scheduled **after** B.
+**Prerequisite:** Project A **step 0 retires SliceZone**, so the whole store is
+MapZone (`zd.Data`) — B's snapshot is **map-only, no store normalization**.
+**Reference:** the sibling POP component solved the same problem the same way —
+`tapir/docs/2026-06-02-pop-149-snapshot-concurrency-design.md` (*POP §n*).
+**Review folded in:** `…-zone-mutation-snapshot-correctness-review.md`.
+Anchors as of 2026-07-02; verify before editing.
+
+---
+
+## 0. The bug and the fix
+**Bug.** Every mutating site writes **directly into published zone data**
+(`OwnerData.RRtypes.Set(...)`) and bumps the SOA serial **later**, separately —
+violating "a zone's serial uniquely identifies its content." Verified:
+`signApexRRsets` writes RRSIGs back to the apex on **every DO query**
+(queryresponder.go:103-108, called from 638, 212-213, 277); positive answers
+persist signed RRsets (771-776); query SOA stamps (339-340, 403, 747, 791); RFC2136
+mutates then bumps in defer (zone_updater.go:562-567); signing passes Set per-RRset
+then bump once (sign.go:874-898). Two secondaries can serve **different content for
+the same serial**. (tdns's `zd.Data` is a `core.ConcurrentMap`, so the symptom is a
+logical inconsistency, not POP's uncatchable `fatal error: concurrent map read/
+write` — same disease, quieter symptom.)
+
+**Fix (POP-proven).** Mutators never touch the served view. A writer builds a
+**fresh** `ZoneSnapshot` and swaps it behind an `atomic.Pointer`; readers `Load()`
+lock-free. Content changes only at a serial boundary, atomically. IXFR (C) later
+retains the delta publish already computes.
+
+---
+
+## 1. Design
+
+### 1.1 The snapshot type (map-only; bundle everything consistent)
+```go
+type ZoneSnapshot struct {
+    Serial          uint32
+    SOA             *dns.SOA     // single source of truth; Serial == CurrentSerial
+    Apex            *OwnerData   // apex incl. NS / DNSKEY
+    Data            map[string]*OwnerData // read-only after publish (map-only; SliceZone gone)
+    TransportSignal *core.RRset  // parallel field the query path reads (see §1.5)
+    IxfrChain       []Ixfr       // read-only; empty in B, populated by C
+}
+```
+On `ZoneData` (structs.go:108): add `snapshot atomic.Pointer[ZoneSnapshot]`.
+Reuse the dead `Ixfr` (structs.go:509) / `IxfrChain` (structs.go:140) scaffolding.
+
+### 1.2 Stage vs publish
+- **Stage** — immediate; a mutator applies its change into a per-zone **working
+  set** (the *next* zone) so the next mutator reads current-including-pending
+  state. Readers never see the working set.
+- **Publish** — a **request** to a per-zone publisher which, under the **per-zone
+  publish mutex** (`zd.mu`), runs:
+  1. `old := zd.snapshot.Load()`
+  2. build a **fresh** `ZoneSnapshot` from the working set (fresh `Data` map; one
+     fresh `*dns.SOA` with `Serial=CurrentSerial`; fresh `IxfrChain` slice — copy,
+     don't append onto `old`'s backing array); compute the delta
+  3. **generation guard** — verify `zoneStillLive(zd, gen)` (refreshengine.go:18-28)
+     before `Store`, so a publish racing a zone-delete doesn't resurrect it
+  4. `zd.snapshot.Store(new)`
+  5. persist serial if configured (`SaveOutgoingSerial`, db_outgoing_serial.go:5)
+  6. **NOTIFY downstreams once** (subsumes the `BumpSerial`→`NotifyDownstreams`
+     path, zone_utils.go:823-829)
+
+### 1.3 The publisher: rate-limited, coalescing
+- **idle ⇒ publish immediately** (zero latency for a lone change);
+- **under load ⇒ ≤ 1 publish per configurable per-zone cadence** (default **5 s**;
+  10 s fine), folding all pending changes into one snapshot (a 50/s trickle ⇒ one
+  publish/cadence, one serial bump, one delta). **urgent** flag lets an RFC 2136
+  update bypass. Mechanism: publish now if `now-lastPublish >= cadence`, else
+  schedule at `lastPublish+cadence` and absorb further requests.
+- **NOTIFY fires once per *completed publish*, not per stage.** Under coalescing,
+  downstreams see serial lag up to the cadence — intentional; document in the
+  config knob. The `ResignerEngine` whole-zone resign (a whole pass) is **one**
+  publish, not per-RRset.
+
+### 1.4 Copy strategy A + the immutability invariant
+**Full-copy-on-publish**, cost **O(number of names)** (copy `name→*OwnerData`
+slots; unchanged owners share pointers; PQ signature bytes live in the shared
+`*RRTypeStore`, never copied). `ZoneSnapshot` is the reader-facing boundary, so a
+persistent map (B, e.g. HAMT) can replace A later with no reader changes; not
+building it. **Critical invariant this depends on:**
+
+> Staging **never** mutates any `OwnerData`/`*RRTypeStore` reachable from the
+> currently published snapshot. A staged change always **allocates fresh**
+> RRset/owner structures; publish copies the map shell and swaps pointers.
+
+Without this, "unchanged owners share pointers" (§1.4) would let a stage mutate a
+live snapshot in place (`GetOwner` returns a struct copy sharing the same
+`*RRTypeStore`, zone_utils.go:475-485).
+
+### 1.5 Multi-writer — per-zone publish mutex (option i)
+POP had a single writer goroutine (POP §1.1); tdns has several — `RefreshEngine`,
+**`ResignerEngine`** (resigner.go:14, main_initfuncs.go:280; `SignZone(..,true)` on
+`triggerResign` resigner.go:58), update handlers, and today query goroutines. So
+`atomic.Pointer` makes **readers** lock-free, but the `load→build→guard→swap→notify`
+sequence runs under the **per-zone publish mutex** or two writers clobber each
+other (lost update). `TransportSignal` (query path reads `zd.TransportSignal`,
+queryresponder.go:370-371; set by `RepopulateDynamicRRs` zone_utils.go:1228-1230
+and `CreateTransportSignalRRs` tsignal.go:307) is **part of the snapshot bundle**
+so it flips atomically with `Data`.
+
+### 1.6 Staging API + working-set structure (concrete)
+Data-structure facts (verified): `RRTypeStore` (rrtypestore.go:7-50) =
+`struct{ data ConcurrentMap[uint16, core.RRset] }`, methods
+`Get/GetOnlyRRSet/Set/Delete/Keys/Count`, **no Copy/Clone**; `core.RRset`
+(core/core_structs.go:10-23) = `{Name,Class,RRtype,RRs []dns.RR,RRSIGs []dns.RR,
+UnclampedTTL}` (slices are references, no Copy); `GetOwner` returns an `OwnerData`
+copy **sharing the same `*RRTypeStore`** (zone_utils.go:469/475) — so a stage must
+never write through such a handle. No zone/owner clone helper exists.
+
+Working set on `ZoneData`: `workingSet map[string]*OwnerData` (nil between
+publishes) + `wsTransportSignal *core.RRset`, guarded by **the same `zd.mu` as
+publish** (one lock for stage + publish avoids a stage-lock↔publish-mutex deadlock
+when `requestPublish` flushes mid-stage; writers already serialize on it per §1.5):
+```go
+func (zd *ZoneData) ensureWorkingSet() {              // O(names) shallow clone, once per publish cycle
+    if zd.workingSet == nil {
+        snap := zd.snapshot.Load()
+        zd.workingSet = make(map[string]*OwnerData, len(snap.Data))
+        for k, v := range snap.Data { zd.workingSet[k] = v }   // share *OwnerData for unchanged owners
+    }
+}
+func (zd *ZoneData) cloneOwner(name string) *OwnerData {       // fresh-alloc (no Copy helper exists)
+    src := zd.workingSet[name]
+    nod := &OwnerData{Name: name, RRtypes: NewRRTypeStore()}
+    if src != nil { for _, t := range src.RRtypes.Keys() { rs, _ := src.RRtypes.Get(t); nod.RRtypes.Set(t, rs) } }
+    zd.workingSet[name] = nod; return nod                       // COW: replace shared pointer with a fresh owner
+}
+func (zd *ZoneData) stageRRset(name string, rs core.RRset)       { zd.ensureWorkingSet(); zd.cloneOwner(name).RRtypes.Set(rs.RRtype, cloneRRset(rs)) }
+func (zd *ZoneData) stageDelete(name string, t uint16)          { zd.ensureWorkingSet(); zd.cloneOwner(name).RRtypes.Delete(t) }
+func (zd *ZoneData) stageOwnerReplace(name string, od *OwnerData){ zd.ensureWorkingSet(); zd.workingSet[name] = od }
+func (zd *ZoneData) requestPublish(urgent bool)                  // enqueue to the coalescing publisher
+```
+- `publish()` hands the working-set map to the new snapshot (`Data: zd.workingSet`)
+  and sets `zd.workingSet = nil` — the published map is never mutated again (next
+  stage re-clones). This **is** copy-strategy-A: the O(names) cost is the one
+  `ensureWorkingSet` shallow clone per publish cycle.
+- **Fresh-alloc rule + `cloneRRset` helper:** `stageRRset` always passes
+  `cloneRRset(rs)` — fresh `RRs`/`RRSIGs` slices with `dns.Copy` per RR. But
+  `cloneOwner` copies RRset *headers* for unchanged types — those slices stay
+  aliased to the published snapshot — so **append paths (RFC2136 add) must clone
+  before appending** onto an existing RRset. **Whole-RRset replace** must also use
+  `cloneRRset` when `rs` was built from a handle obtained via `GetOwner` (in-place
+  signing mutates shared slices). Never append onto or reuse slice backing arrays
+  reachable from the published snapshot.
+- **Whole-zone passes** (SignZone/GenerateNsecChain/combiner) stage many owners,
+  then **one** `requestPublish` — one delta, one serial bump.
+
+### 1.7 Serial semantics
+- **`ZoneSnapshot.Serial == CurrentSerial`** at publish (via `nextOutboundSerial`,
+  zone_utils.go:736-748). `IncomingSerial` (structs.go:135) stays on `ZoneData` as
+  **upstream-sync metadata only — never served** in a SOA.
+- Refresh flip (today `IncomingSerial ← upstream`, `CurrentSerial++`,
+  zone_utils.go:343-348; post-flip `setApexSOASerial` without lock,
+  refreshengine.go:150,709) becomes **`publish(fullReplacement)`** — the serial
+  logic moves inside publish.
+- **`CurrentSerial` migration (enumerated — smaller than "dozens"):** keep
+  `zd.CurrentSerial` as a **cached mirror written only inside `publish()`** and the
+  refresh serial-init (refreshengine.go:132-145/694-704). The ~15 *write* sites
+  collapse into publish()/refresh. The served SOA comes from `snapshot.SOA`, not
+  the field, so the query/transfer stamps (queryresponder.go:339/403/747/791;
+  dnsutils.go:267) are **deleted, not migrated**. Only ~4 *genuine* readers remain
+  and just read the mirror (consistent because publish is the sole writer): CSYNC
+  serial (ops_csync.go:17), `WriteZoneToFile` stamp (dnsutils.go:670), ParentSerial
+  (zone_utils.go:844), a log line (zone_utils.go:160). A transitional
+  `zd.CurrentSerial == snapshot.Load().Serial` assertion catches drift during B1's
+  dual-write.
+
+---
+
+## 2. Invariants
+- **Serial ⇒ content**; published content changes only at a serial boundary via one
+  atomic swap.
+- **A published snapshot is never mutated**; staging never touches memory aliased
+  by it (§1.4); publish builds fresh `Data`/`IxfrChain`.
+- **Readers lock-free** — queries, AXFR, SOA all `snapshot.Load()`.
+- **Writers serialize per zone** via the publish mutex.
+- **Responses never write back** — inline RRSIGs from the snapshot; online/compact
+  RRSIGs signed into the response and discarded.
+- **NOTIFY once per publish**; **`Serial == CurrentSerial`**; **served store
+  writable only via `publish()`** (enforced, §4).
+
+---
+
+## 3. Current state to convert
+### 3.1 Mutators
+| Mutator / path | file:line | writer | note |
+|---|---|---|---|
+| `SignZone`/`ResignZone`/`GenerateNsecChain`/`StripZoneRRSIGs` | sign.go:749/580/918/702 | **ResignerEngine** | whole pass → one publish |
+| RFC2136 `ApplyZoneUpdate`/`ApplyChildUpdate` | zone_updater.go:540/386 | update | delta-shaped already; convert first |
+| `PublishDnskeyRRs`/`PublishCsyncRR` | ops_dnskey.go:26 / ops_csync.go:13 | engine | |
+| `RepopulateDynamicRRs` (+ `TransportSignal`) | zone_utils.go:1170-1230 | post-flip, **no lock** | fold into the post-refresh publish; ordering vs `SetupZoneSigning` (refreshengine.go:713-716) must be fixed |
+| `CreateTransportSignalRRs` | tsignal.go:307,420 | engine | into `snapshot.TransportSignal` |
+| Catalog | apihandler_catalog.go:167,524,565 | API | |
+| Refresh flips + `OnZonePreRefresh` | zone_utils.go:236-260/340-364; :231-233/335-337 | RefreshEngine | flip → `publish(fullReplacement)`; PreRefresh callbacks mutate a **draft snapshot** |
+| `BumpSerialOnly`/`BumpSerial` | zone_utils.go:782-830 | engine | generalised by `publish()` |
+| **Query-path signing** — `signApexRRsets` (def 92-115; calls 638, 212-213, 277); positive 771-776; CNAME 449/514/534; `signRRsetForZone` 134-183 | queryresponder.go | **query goroutines** | **B2:** delete all `Set`-after-sign write-backs (not only 771-776). **B3:** read inline RRSIGs from snapshot; online/compact stays ephemeral |
+| Query SOA stamps | queryresponder.go:339,403,747,791 | query | **B2:** delete (with other query write-backs) |
+| `WriteZoneToFile` stamp | dnsutils.go:669-670 | API | export reads snapshot |
+| **`tdns-mp`** signing/combiner | mp_signer.go:142,356 (+`BumpSerial` :151); combiner_utils.go:163,165,170 (`mpzd.Data.Set`) | MP | **CONFIRMED no forked store:** `MPZoneData` **embeds** `tdns.ZoneData` (imports the v2 module, go.mod:16) → same `Data` field, all v2 receivers (incl. future `stage*`/`publish()`) promoted for free. Route these Set-sites through `stage*`/`requestPublish` like any mutator (combiner = one publish at end); the CI grep gate catches any missed |
+
+`addCDEResponse` (queryresponder.go:940-944) already signs NSEC into the **response
+only** — matches the ephemeral-online split; leave it.
+
+### 3.2 Reuse: `nextOutboundSerial`, `setApexSOASerial`, `Save/LoadOutgoingSerial`,
+`zoneStillLive` (B5b guard), `Zones` registry (global.go:55), `ModifyDynamicZone`
+pointer-swap + `generation.Add(1)` (dynamic_zones.go:934,981 — epoch reset in C).
+
+---
+
+### 3.3 Refresh-flip recipe (H4) + PreRefresh callbacks (H5)
+Today: hard flip copies `zd.Data` under mutex (zone_utils.go:257) →
+`RepopulateDynamicRRs` (no lock) → post-refresh callbacks → RefreshEngine
+`SetupZoneSigning`→`SignZone`→`BumpSerial` (refreshengine.go:713-716). Under the
+publish model this becomes one ordered, single-writer sequence:
+1. Build a **working set** from `new_zd` (the freshly loaded/transferred zone) —
+   replaces the hard-flip field copy.
+2. Stage the dynamic RRs + `TransportSignal` (`RepopulateDynamicRRs`'s content).
+3. If the zone signs: stage the signing pass (`SignZone`/NSEC) into the **same**
+   working set.
+4. **One** `publish()` (full replacement) — one snapshot, one serial bump, one
+   NOTIFY (chain epoch reset for Project C happens here).
+
+**`OnZonePreRefresh` callbacks** (zone_utils.go:231-233/335-337) today receive
+`(zd, new_zd)` and mutate `new_zd` before the flip. Migration: **`new_zd` becomes
+the working-set build target** — callbacks stage into it (combiner contributions,
+MP pre-refresh hooks, delsync-proxy analysis parseconfig.go:1043-1049), and the
+single `publish()` in step 4 makes it live. No callback writes served data
+directly.
+
+## 4. Implementation — milestoned (NOT one PR), **writers before readers**
+At ~2000+ LOC across `v2` + `tdns-mp` + QueryResponder, one PR is too risky. Use a
+**dual-write / strangler** transition, `-race`-gated at each milestone. **Order is
+load-bearing: writers cut over before readers.** If readers moved to the snapshot
+while legacy mutators still bypassed `publish()`, the snapshot would freeze while
+served data changed underneath — worse than today. So:
+
+- **B1 — engine (dormant, dual-write ready).** Add `ZoneSnapshot`, `snapshot
+  atomic.Pointer`, `publish()` (§1.2, incl. generation guard), the coalescing
+  publisher (§1.3, 5 s), the staging API (§1.6). **Dual-write definition:** each
+  `publish()`, under `zd.mu`, (1) stores the new snapshot AND (2) replaces
+  `zd.Data`'s content to match it — converting the snapshot's
+  `map[string]*OwnerData` back into the legacy `ConcurrentMap[string, OwnerData]`
+  (values). Both stores stay byte-identical. Build the initial snapshot **before**
+  the zone serves (closes the `Ready=true` "lie", zone_utils.go:223-225; POP §5).
+  Nothing reads the snapshot yet; legacy writers unchanged. `-race` gate: publisher
+  + immutability tests.
+- **B2 — writers cut over (dual-write keeps legacy current for readers).** Route
+  every §3.1 mutator — refresh flips, RFC2136, signing passes, the **ResignerEngine**,
+  DNSKEY/CSYNC/transport/catalog, and **`tdns-mp`** — through `stage*` +
+  `requestPublish`. **Also at the start of B2:** delete all query-path write-backs
+  (`signApexRRsets`, positive/CNAME `Set`-after-sign, query SOA stamps) — readers
+  still use legacy `GetOwner`, but legacy must only change via `publish()` so
+  dual-write stays consistent. `publish()` still dual-writes, so legacy `zd.Data`
+  stays current AND the snapshot advances. After B2 both stores are always current;
+  **no path may mutate served data except via `publish()`**. `-race` gate:
+  `TestConcurrentServeAndUpdate` (see §5 — B2 variant). Online-signing: the
+  resigner must produce signed snapshots via publish before DO queries rely on them.
+- **B3 — readers cut over + drop legacy + enforce.** Switch QueryResponder
+  (`GetOwner`/`GetRRset` → `snap.Data`), `ZoneTransferOut`, and the SOA responder
+  to `snapshot.Load()`. Query-path signing split: inline RRSIGs **read** from the
+  snapshot; online/compact signed into the response and discarded (write-backs
+  already removed in B2). **Remove the dual-write** (publish stores the snapshot
+  only). **Enforce structurally:** an unexported published type (no exported
+  mutators) + a CI grep gate rejecting `RRtypes.Set`/`Data.Set` outside an
+  allowlist (`zone_mutation.go`, the staging file). `-race` gate: full
+  serving+update path (see §5 — B3 variant); the serial-invariant guarantee holds
+  here.
+
+---
+
+## 5. Test plan (acceptance gate)
+- **`TestConcurrentServeAndUpdate` (`-race`)** — would fail today. Two variants:
+  - **B2:** N reader goroutines iterate via legacy `GetOwner`/`Data` while writers
+    publish a delta stream; assert legacy ≡ snapshot after each publish (dual-write
+    consistency). Query write-backs must be gone before this runs.
+  - **B3:** same load under `snapshot.Load()`; full serial-invariant gate.
+- **`TestSnapshotImmutability`** — publish, mutate the working set, assert the
+  published snapshot unchanged (catches the §1.4 aliasing trap and the `IxfrChain`
+  slice-header trap).
+- **`TestPublishCoalescing`** — burst ⇒ ≤1 publish/cadence (one serial bump); idle
+  stage ⇒ immediate publish; urgent ⇒ bypass.
+- **Per-writer** — each mutator class (incl. `tdns-mp`) produces the right served
+  zone.
+- **CI grep gate** — no `Set` outside the allowlist.
+
+## 6. Risk / effort / LOC (revised)
+**Risk: high** — multi-writer serialization, QueryResponder surgery, ~15 mutator
+classes, `tdns-mp`, structural enforcement. Mitigated by dual-write milestones +
+`-race` gates + the CI enforcement. **Effort: multi-day (~20–40 h agent), not 6–9
+h** — the earlier estimate undercounted MP + QueryResponder + enforcement by ~3–5×.
+**LOC: ~1400–1800 impl + ~600 test ≈ 2000–2400.** Parallelizable by mutator class
+within B2 (writer routing) and B3 (enforcement cleanup).
+
+## 7. Decisions (settled)
+map-only snapshot (SliceZone retired by A) · copy strategy **A** · **5 s** coalescing
+cadence (per-zone, urgent bypass, NOTIFY once/publish) · transfer-time signing
+deleted (serve verbatim) · **`tdns-mp` in scope** · **`Serial == CurrentSerial`**,
+`IncomingSerial` = metadata · **milestoned B1→B2→B3 (dual-write), `-race` gate each**.
+
+## 8. What B hands to Project C
+`publish()` already **computes** the per-publish delta; C **retains** it in the
+byte-bounded `IxfrChain`, adds the serial-space chain spec, the downstream tracker,
+and inbound/outbound IXFR. See `…-ixfr-support.md`.

--- a/v2/catalog.go
+++ b/v2/catalog.go
@@ -503,7 +503,8 @@ func parseZoneStore(storeStr string) ZoneStore {
 	case "map", "mapzone":
 		return MapZone
 	case "slice", "slicezone":
-		return SliceZone
+		lg.Warn("zone store type slice is deprecated, using map", "store", storeStr)
+		return MapZone
 	case "":
 		// Default to map when not specified
 		return MapZone

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -634,48 +634,40 @@ func (zd *ZoneData) WriteZoneToFile(f *os.File) error {
 	count := 0
 	//	var total_sent int
 
-	switch zd.ZoneStore {
-	case MapZone:
-		// SOA
-		soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-		zonedata += RRsetToString(&soa)
-		count += len(soa.RRs) + len(soa.RRSIGs)
+	// SOA
+	zonedata += RRsetToString(&soa)
+	count += len(soa.RRs) + len(soa.RRSIGs)
 
-		// Rest of apex
-		for _, rrt := range apex.RRtypes.Keys() {
-			if rrt != dns.TypeSOA {
-				rrset := apex.RRtypes.GetOnlyRRSet(rrt)
-				zonedata += RRsetToString(&rrset)
-				count += len(rrset.RRs) + len(rrset.RRSIGs)
-			}
+	// Rest of apex
+	for _, rrt := range apex.RRtypes.Keys() {
+		if rrt != dns.TypeSOA {
+			rrset := apex.RRtypes.GetOnlyRRSet(rrt)
+			zonedata += RRsetToString(&rrset)
+			count += len(rrset.RRs) + len(rrset.RRSIGs)
 		}
+	}
 
-		// Rest of zone
-		for _, owner := range zd.Data.Keys() {
-			omap, _ := zd.Data.Get(owner)
-			if owner == zd.ZoneName {
-				continue
-			}
-			for _, rrt := range omap.RRtypes.Keys() {
-				rrl := omap.RRtypes.GetOnlyRRSet(rrt)
-				zonedata += RRsetToString(&rrl)
-				count += len(rrl.RRs) + len(rrl.RRSIGs)
+	// Rest of zone
+	for _, owner := range zd.Data.Keys() {
+		omap, _ := zd.Data.Get(owner)
+		if owner == zd.ZoneName {
+			continue
+		}
+		for _, rrt := range omap.RRtypes.Keys() {
+			rrl := omap.RRtypes.GetOnlyRRSet(rrt)
+			zonedata += RRsetToString(&rrl)
+			count += len(rrl.RRs) + len(rrl.RRSIGs)
 
-				if count >= 1000 {
-					bytes, err = writer.WriteString(zonedata)
-					if err != nil {
-						return err
-					}
-					totalbytes += bytes
-					bytes = 0
-					count = 0
+			if count >= 1000 {
+				bytes, err = writer.WriteString(zonedata)
+				if err != nil {
+					return err
 				}
+				totalbytes += bytes
+				bytes = 0
+				count = 0
 			}
 		}
-
-	default:
-		zd.Logger.Printf("Zone %s: zone store %d: no outbound zone transfer. Sorry.",
-			zd.ZoneName, zd.ZoneStore)
 	}
 
 	// 	for _, rr := range zd.RRs {

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,16 +16,15 @@ import (
 	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
 	"github.com/spf13/viper"
-	"github.com/twotwotwo/sorts"
 	// "github.com/gookit/goutil/dump"
 )
 
 const (
-	year68     = 1 << 31 // For RFC1982 (Serial Arithmetic) calculations in 32 bits
-	TimeLayout = "2006-01-02 15:04:05"
+	year68            = 1 << 31 // For RFC1982 (Serial Arithmetic) calculations in 32 bits
+	TimeLayout        = "2006-01-02 15:04:05"
+	safeMessageSize   = 64000 // ~1.5 KB headroom for per-envelope question + TSIG
+	dnsMaxMessageSize = 65535
 )
-
-// TODO: Add support for TSIG zone transfers.
 
 // clarifyXfrError turns the opaque miekg/dns "bad xfr rcode: N" transfer
 // error into a human-readable failure that names the rcode, e.g.
@@ -65,8 +63,7 @@ func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype, keyNam
 		msg.SetAxfr(zd.ZoneName)
 	}
 
-	if zd.ZoneStore == MapZone || zd.ZoneStore == SliceZone {
-		// zd.Data = make(map[string]OwnerData, 30)
+	if zd.ZoneStore == MapZone {
 		zd.Data = core.NewCmap[OwnerData]()
 	}
 	lgDns.Info("ZoneTransferIn", "zone", zd.ZoneName, "store", ZoneStoreToString[zd.ZoneStore])
@@ -110,8 +107,6 @@ func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype, keyNam
 		return 0, nil
 	}
 
-	zd.ComputeIndices() // if zd.ZoneStore == SliceZone, otherwise no-op
-
 	return soa.Serial, nil
 }
 
@@ -123,72 +118,84 @@ type batchState struct {
 	batchNum      *int
 	totalSent     *int
 	outbound      chan<- *dns.Envelope
+	done          <-chan struct{}
 	zd            *ZoneData
 }
 
-// maybeFlushBatch checks if the current batch should be sent based on size estimates.
-// It handles both pre-add checks (when newRRSize > 0) and periodic checks (when newRRSize == 0).
-// Returns true if a batch was sent, false otherwise.
+func (bs *batchState) sendEnvelope(rrs []dns.RR) bool {
+	select {
+	case bs.outbound <- &dns.Envelope{RR: rrs}:
+		return true
+	case <-bs.done:
+		return false
+	}
+}
+
+func (bs *batchState) flushBatch() bool {
+	if len(*bs.rrs) == 0 {
+		return true
+	}
+	actualSize := estimateEnvelopeSize(*bs.rrs)
+	*bs.totalSent += *bs.count
+	if bs.zd.Verbose || Globals.Debug {
+		bs.zd.Logger.Printf("XfrOut: Zone %s: Sending batch #%d: %d RRs, %d bytes (estimated: %d)",
+			bs.zd.ZoneName, *bs.batchNum, *bs.count, actualSize, *bs.estimatedSize)
+	}
+	if !bs.sendEnvelope(*bs.rrs) {
+		return false
+	}
+	*bs.rrs = []dns.RR{}
+	*bs.count = 0
+	*bs.estimatedSize = 0
+	(*bs.batchNum)++
+	return true
+}
+
+// maybeFlushBatch flushes the current batch when adding newRRSize would exceed
+// safeMessageSize, or on periodic accurate checks near the limit.
 func maybeFlushBatch(bs *batchState, newRRSize int, isPeriodicCheck bool) bool {
-	const maxMessageSize = 60000
-	const safeMessageSize = 59000
-	const theoreticalMaxSize = 65536
-	const checkSizeInterval = 50
-	const accurateCheckThreshold = 55000
-
-	// Pre-add check: if adding newRRSize would exceed limit, do accurate check
-	if newRRSize > 0 {
-		if *bs.estimatedSize+newRRSize >= safeMessageSize ||
-			(*bs.estimatedSize >= accurateCheckThreshold && len(*bs.rrs)%checkSizeInterval == 0) {
-			actualSize := estimateEnvelopeSize(*bs.rrs)
-			if actualSize >= safeMessageSize {
-				// Send current batch before adding more
-				*bs.totalSent += *bs.count
-				if bs.zd.Verbose || Globals.Debug {
-					efficiency := float64(actualSize) / float64(safeMessageSize) * 100.0
-					maxEfficiency := float64(actualSize) / float64(maxMessageSize) * 100.0
-					theoreticalEfficiency := float64(actualSize) / float64(theoreticalMaxSize) * 100.0
-					bs.zd.Logger.Printf("XfrOut: Zone %s: Sending batch #%d: %d RRs, %d bytes (estimated: %d, efficiency: %.1f%% of %d safe / %.1f%% of %d target / %.1f%% of %d theoretical max)",
-						bs.zd.ZoneName, *bs.batchNum, *bs.count, actualSize, *bs.estimatedSize, efficiency, safeMessageSize, maxEfficiency, maxMessageSize, theoreticalEfficiency, theoreticalMaxSize)
-				}
-				bs.outbound <- &dns.Envelope{RR: *bs.rrs}
-				*bs.rrs = []dns.RR{}
-				*bs.count = 0
-				*bs.estimatedSize = 0
-				(*bs.batchNum)++
-				return true
-			} else {
-				// Update estimate with accurate measurement
-				*bs.estimatedSize = actualSize
-			}
-		}
+	if len(*bs.rrs) == 0 {
+		return true
 	}
-
-	// Periodic accurate check to verify estimate accuracy
-	if isPeriodicCheck && len(*bs.rrs)%checkSizeInterval == 0 && *bs.estimatedSize >= accurateCheckThreshold {
-		actualSize := estimateEnvelopeSize(*bs.rrs)
-		if actualSize >= safeMessageSize {
-			*bs.totalSent += *bs.count
-			if bs.zd.Verbose || Globals.Debug {
-				efficiency := float64(actualSize) / float64(safeMessageSize) * 100.0
-				maxEfficiency := float64(actualSize) / float64(maxMessageSize) * 100.0
-				theoreticalEfficiency := float64(actualSize) / float64(theoreticalMaxSize) * 100.0
-				bs.zd.Logger.Printf("XfrOut: Zone %s: Sending batch #%d: %d RRs, %d bytes (estimated: %d, efficiency: %.1f%% of %d safe / %.1f%% of %d target / %.1f%% of %d theoretical max)",
-					bs.zd.ZoneName, *bs.batchNum, *bs.count, actualSize, *bs.estimatedSize, efficiency, safeMessageSize, maxEfficiency, maxMessageSize, theoreticalEfficiency, theoreticalMaxSize)
-			}
-			bs.outbound <- &dns.Envelope{RR: *bs.rrs}
-			*bs.rrs = []dns.RR{}
-			*bs.count = 0
-			*bs.estimatedSize = 0
-			(*bs.batchNum)++
-			return true
-		} else {
-			// Adjust estimate based on actual measurement
-			*bs.estimatedSize = actualSize
-		}
+	currentSize := estimateEnvelopeSize(*bs.rrs)
+	if newRRSize > 0 && currentSize+newRRSize >= safeMessageSize {
+		return bs.flushBatch()
 	}
+	if isPeriodicCheck && currentSize >= safeMessageSize {
+		return bs.flushBatch()
+	}
+	if isPeriodicCheck && currentSize > 0 {
+		*bs.estimatedSize = currentSize
+	}
+	return true
+}
 
-	return false
+func appendRRset(bs *batchState, rrset core.RRset) bool {
+	newRRSize := 0
+	for _, rr := range rrset.RRs {
+		newRRSize += estimateRRSize(rr)
+	}
+	for _, sig := range rrset.RRSIGs {
+		newRRSize += estimateRRSize(sig)
+	}
+	if newRRSize >= safeMessageSize {
+		owner, rrtype := oversizeRRsetOwner(append([]dns.RR(nil), rrset.RRs...))
+		if owner == "" && len(rrset.RRs) > 0 {
+			owner = rrset.RRs[0].Header().Name
+			rrtype = dns.TypeToString[rrset.RRs[0].Header().Rrtype]
+		}
+		bs.zd.Logger.Printf("ZoneTransferOut: %s: aborting transfer, oversize RRset owner=%s type=%s size~=%d",
+			bs.zd.ZoneName, owner, rrtype, newRRSize)
+		return false
+	}
+	if !maybeFlushBatch(bs, newRRSize, false) {
+		return false
+	}
+	*bs.rrs = append(*bs.rrs, rrset.RRs...)
+	*bs.rrs = append(*bs.rrs, rrset.RRSIGs...)
+	*bs.count += len(rrset.RRs) + len(rrset.RRSIGs)
+	*bs.estimatedSize += newRRSize
+	return maybeFlushBatch(bs, 0, len(*bs.rrs)%50 == 0 && *bs.estimatedSize >= 55000)
 }
 
 // estimateRRSize estimates the size of a single RR by packing it individually
@@ -229,11 +236,6 @@ func estimateEnvelopeSize(rrs []dns.RR) int {
 func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	zone := dns.Fqdn(zd.ZoneName)
 
-	// downstreams (provide-xfr) ACL: who may AXFR/IXFR from us. An empty ACL
-	// DENIES — a hard cutover that closes the legacy open-AXFR default. On a
-	// denied or unverifiable requester, REFUSE and serve no zone data. The
-	// server's TsigProvider (do53.go) has verified any TSIG MAC already; here
-	// we enforce the source ACL and that the required key is the one on the wire.
 	if src, ok := peerIP(w.RemoteAddr().String()); !ok {
 		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, unparseable source %q", zone, w.RemoteAddr())
 		return zd.refuseTransfer(w, r)
@@ -245,204 +247,169 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 		return zd.refuseTransfer(w, r)
 	}
 
+	if zd.GetStatus() != ZoneStatusReady {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, zone status %s", zone, ZoneStatusToString[zd.GetStatus()])
+		return zd.refuseTransfer(w, r)
+	}
+
+	if zd.ZoneStore != MapZone {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, zone store %s not supported",
+			zone, ZoneStoreToString[zd.ZoneStore])
+		return zd.refuseTransfer(w, r)
+	}
+
+	apex, err := zd.GetOwner(zd.ZoneName)
+	if err != nil {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, apex lookup failed: %v", zone, err)
+		return zd.refuseTransfer(w, r)
+	}
+	if apex == nil {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, missing apex", zone)
+		return zd.refuseTransfer(w, r)
+	}
+	soaRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	if len(soaRRset.RRs) == 0 {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, empty SOA RRset", zone)
+		return zd.refuseTransfer(w, r)
+	}
+	soaOrig, ok := soaRRset.RRs[0].(*dns.SOA)
+	if !ok {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, invalid SOA RR", zone)
+		return zd.refuseTransfer(w, r)
+	}
+
+	soaCopy := dns.Copy(soaOrig).(*dns.SOA)
+	soaCopy.Serial = zd.CurrentSerial
+	transferSOA := core.RRset{
+		Name:   zd.ZoneName,
+		Class:  dns.ClassINET,
+		RRtype: dns.TypeSOA,
+		RRs:    []dns.RR{soaCopy},
+		RRSIGs: soaRRset.RRSIGs,
+	}
+
 	if zd.Verbose {
 		zd.Logger.Printf("ZoneTransferOut: Will try to serve zone %s", zone)
 	}
 
 	outbound_xfr := make(chan *dns.Envelope)
+	done := make(chan struct{})
+	var closeOnce sync.Once
+	closeOutbound := func() { closeOnce.Do(func() { close(outbound_xfr) }) }
+
 	tr := new(dns.Transfer)
 	var wg sync.WaitGroup
 	wg.Add(1)
-
 	go func() {
-		err := tr.Out(w, r, outbound_xfr)
-		if err != nil {
+		defer wg.Done()
+		if err := tr.Out(w, r, outbound_xfr); err != nil {
 			zd.Logger.Printf("Error from transfer.Out(): %v", err)
+			close(done)
 		}
-		wg.Done()
 	}()
 
-	apex, _ := zd.GetOwner(zd.ZoneName)
-	soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs[0].(*dns.SOA)
-	soa.Serial = zd.CurrentSerial
+	defer func() {
+		closeOutbound()
+		wg.Wait()
+		w.Close()
+	}()
 
-	// Re-sign SOA after serial update (the RRSIG covers the serial)
-	if zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning] {
-		soaRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-		if signed, err := zd.SignRRset(&soaRRset, zd.ZoneName, nil, true, nil); err != nil {
-			zd.Logger.Printf("ZoneTransferOut: failed to re-sign SOA: %v", err)
-		} else if signed {
-			apex.RRtypes.Set(dns.TypeSOA, soaRRset)
-		}
-	}
-
-	total_sent := 0
+	totalSent := 0
 	count := 0
-	batchNum := 1                // Track batch number for debug output
-	estimatedSize := 0           // Running estimate of message size
-	const maxMessageSize = 60000 // Practical limit we target (theoretical DNS max is 65536 bytes / 64K)
-	// We may overshoot maxMessageSize by up to ~1000 bytes in practice, but that's still safely below 65536
-	const safeMessageSize = 59000        // Conservative threshold to avoid "message too large" errors (leaves headroom for DNS header/overhead and compression variations)
-	const theoreticalMaxSize = 65536     // True theoretical maximum DNS message size (64K)
-	const checkSizeInterval = 50         // Check actual size every N RRs to verify estimate accuracy
-	const accurateCheckThreshold = 55000 // When estimated size exceeds this, do accurate checks more frequently
-	// env := dns.Envelope{}
-	rrs := []dns.RR{soa}
-	// Estimate size of initial SOA
-	estimatedSize += estimateRRSize(soa)
+	batchNum := 1
+	estimatedSize := 0
+	rrs := []dns.RR{}
 
-	// SOA
-	// env.RR = append(env.RR, soa)
-	// XXX: If we change the SOA serial we must also recompute the RRSIG.
-	// env.RR = append(env.RR, apex.RRtypes[dns.TypeSOA].RRSIGs...)
-	soaRRSIGs := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRSIGs
-	rrs = append(rrs, soaRRSIGs...)
-	for _, sig := range soaRRSIGs {
-		estimatedSize += estimateRRSize(sig)
-	}
-	if Globals.Debug {
-		// zd.Logger.Printf("XfrOut[%s]: %v\n", zd.ZoneName, soa.String())
-	}
-
-	// Rest of apex
-	for _, rrt := range apex.RRtypes.Keys() {
-		if rrt != dns.TypeSOA {
-			// env.RR = append(env.RR, apex.RRtypes[rrt].RRs...)
-			rrset := apex.RRtypes.GetOnlyRRSet(rrt)
-			rrs = append(rrs, rrset.RRs...)
-			for _, rr := range rrset.RRs {
-				estimatedSize += estimateRRSize(rr)
-			}
-			if Globals.Debug {
-				// zd.Logger.Printf("XfrOut[%s]: %v\n", zd.ZoneName, apex.RRtypes.GetOnlyRRSet(rrt).RRs)
-			}
-			// env.RR = append(env.RR, apex.RRtypes[rrt].RRSIGs...)
-			rrs = append(rrs, rrset.RRSIGs...)
-			for _, sig := range rrset.RRSIGs {
-				estimatedSize += estimateRRSize(sig)
-			}
-		}
-	}
-	count = len(rrs)
-
-	// Initialize batch state for helper function
 	bs := &batchState{
 		rrs:           &rrs,
 		count:         &count,
 		estimatedSize: &estimatedSize,
 		batchNum:      &batchNum,
-		totalSent:     &total_sent,
+		totalSent:     &totalSent,
 		outbound:      outbound_xfr,
+		done:          done,
 		zd:            zd,
 	}
 
-	switch zd.ZoneStore {
-	case SliceZone:
-		// Rest of zone
-		for _, owner := range zd.Owners {
-			if owner.Name == zd.ZoneName {
-				continue
-			}
-			for _, rrt := range owner.RRtypes.Keys() {
-				rrl := owner.RRtypes.GetOnlyRRSet(rrt)
-
-				// Estimate size of new RRs before adding
-				newRRSize := 0
-				for _, rr := range rrl.RRs {
-					newRRSize += estimateRRSize(rr)
-				}
-				for _, sig := range rrl.RRSIGs {
-					newRRSize += estimateRRSize(sig)
-				}
-
-				// Check if batch should be flushed before adding new RRs
-				maybeFlushBatch(bs, newRRSize, false)
-
-				// Now add the RRset
-				rrs = append(rrs, rrl.RRs...)
-				if Globals.Debug {
-					// zd.Logger.Printf("XfrOut[%s]: %v\n", zd.ZoneName, rrl.RRs)
-				}
-				count += len(rrl.RRs)
-				rrs = append(rrs, rrl.RRSIGs...)
-				count += len(rrl.RRSIGs)
-				estimatedSize += newRRSize
-
-				// Periodic accurate check to verify estimate accuracy
-				maybeFlushBatch(bs, 0, true)
-			}
+	if !appendRRset(bs, transferSOA) {
+		return 0, nil
+	}
+	for _, rrt := range apex.RRtypes.Keys() {
+		if rrt == dns.TypeSOA {
+			continue
 		}
-
-	case MapZone:
-		// Rest of zone
-		for _, owner := range zd.Data.Keys() {
-			omap, _ := zd.Data.Get(owner)
-			if owner == zd.ZoneName {
-				continue
-			}
-			for _, rrt := range omap.RRtypes.Keys() {
-				rrl := omap.RRtypes.GetOnlyRRSet(uint16(rrt))
-
-				// Estimate size of new RRs before adding
-				newRRSize := 0
-				for _, rr := range rrl.RRs {
-					newRRSize += estimateRRSize(rr)
-				}
-				for _, sig := range rrl.RRSIGs {
-					newRRSize += estimateRRSize(sig)
-				}
-
-				// Check if batch should be flushed before adding new RRs
-				maybeFlushBatch(bs, newRRSize, false)
-
-				// Now add the RRset
-				rrs = append(rrs, rrl.RRs...)
-				if Globals.Debug {
-					// zd.Logger.Printf("XfrOut[%s]: %v\n", zd.ZoneName, rrl.RRs)
-				}
-				count += len(rrl.RRs)
-				rrs = append(rrs, rrl.RRSIGs...)
-				count += len(rrl.RRSIGs)
-				estimatedSize += newRRSize
-
-				// Periodic accurate check to verify estimate accuracy
-				maybeFlushBatch(bs, 0, true)
-			}
+		if !appendRRset(bs, apex.RRtypes.GetOnlyRRSet(rrt)) {
+			return 0, nil
 		}
-
-	default:
-		zd.Logger.Printf("Zone %s: zone store %d: outbound zone transfer not supported. Sorry.",
-			zd.ZoneName, zd.ZoneStore)
 	}
 
-	// env.RR = append(env.RR, soa) // trailing SOA
-	rrs = append(rrs, soa)
-	if Globals.Debug {
-		// zd.Logger.Printf("XfrOut[%s]: %v\n", zd.ZoneName, soa)
+	for _, owner := range zd.Data.Keys() {
+		if owner == zd.ZoneName {
+			continue
+		}
+		omap, _ := zd.Data.Get(owner)
+		for _, rrt := range omap.RRtypes.Keys() {
+			rrset := omap.RRtypes.GetOnlyRRSet(uint16(rrt))
+			if !appendRRset(bs, rrset) {
+				return 0, nil
+			}
+		}
 	}
 
-	total_sent += len(rrs)
-	// Get actual size of final message
-	finalSize := estimateEnvelopeSize(rrs)
+	trailingSOA := dns.Copy(soaCopy).(*dns.SOA)
+	trailingSize := estimateRRSize(trailingSOA)
+	if !maybeFlushBatch(bs, trailingSize, false) {
+		return 0, nil
+	}
+	*bs.rrs = append(*bs.rrs, trailingSOA)
+	*bs.count++
+	*bs.estimatedSize += trailingSize
+
+	finalSize := estimateEnvelopeSize(*bs.rrs)
+	if finalSize >= safeMessageSize {
+		if len(*bs.rrs) > 1 {
+			withoutTrailing := (*bs.rrs)[:len(*bs.rrs)-1]
+			savedCount := *bs.count - 1
+			*bs.rrs = withoutTrailing
+			*bs.count = savedCount
+			if !bs.flushBatch() {
+				return 0, nil
+			}
+			*bs.rrs = []dns.RR{trailingSOA}
+			*bs.count = 1
+			*bs.estimatedSize = trailingSize
+			finalSize = estimateEnvelopeSize(*bs.rrs)
+		}
+	}
+	if finalSize >= safeMessageSize {
+		owner, rrtype := oversizeRRsetOwner(*bs.rrs)
+		zd.Logger.Printf("ZoneTransferOut: %s: aborting transfer, oversize RRset owner=%s type=%s size=%d",
+			zone, owner, rrtype, finalSize)
+		return 0, fmt.Errorf("ZoneTransferOut: %s: oversize transfer envelope (%d bytes)", zone, finalSize)
+	}
+
+	totalSent += *bs.count
 	if zd.Verbose || Globals.Debug {
-		efficiency := float64(finalSize) / float64(safeMessageSize) * 100.0
-		maxEfficiency := float64(finalSize) / float64(maxMessageSize) * 100.0
-		theoreticalEfficiency := float64(finalSize) / float64(theoreticalMaxSize) * 100.0
-		zd.Logger.Printf("XfrOut: Zone %s: Sending final batch #%d: %d RRs, %d bytes (efficiency: %.1f%% of %d safe / %.1f%% of %d target / %.1f%% of %d theoretical max, total sent: %d RRs)\n",
-			zd.ZoneName, batchNum, len(rrs), finalSize, efficiency, safeMessageSize, maxEfficiency, maxMessageSize, theoreticalEfficiency, theoreticalMaxSize, total_sent)
+		zd.Logger.Printf("XfrOut: Zone %s: Sending final batch #%d: %d RRs, %d bytes (total sent: %d RRs)",
+			zd.ZoneName, batchNum, len(*bs.rrs), finalSize, totalSent)
 	} else {
-		zd.Logger.Printf("XfrOut: Zone %s: Sending final %d RRs (including trailing SOA, total sent %d)\n",
-			zd.ZoneName, len(rrs), total_sent)
+		zd.Logger.Printf("XfrOut: Zone %s: Sending final %d RRs (including trailing SOA, total sent %d)",
+			zd.ZoneName, len(*bs.rrs), totalSent)
 	}
-	outbound_xfr <- &dns.Envelope{RR: rrs}
+	if !bs.sendEnvelope(*bs.rrs) {
+		return 0, nil
+	}
 
-	close(outbound_xfr)
-	wg.Wait() // wait until everything is written out
-	w.Close() // close connection
+	zd.Logger.Printf("ZoneTransferOut: %s: Sent %d RRs.", zone, totalSent)
+	return totalSent, nil
+}
 
-	zd.Logger.Printf("ZoneTransferOut: %s: Sent %d RRs.", zone, total_sent)
-
-	return total_sent, nil
+func oversizeRRsetOwner(rrs []dns.RR) (owner, rrtype string) {
+	if len(rrs) == 0 {
+		return "", ""
+	}
+	rr := rrs[0]
+	return rr.Header().Name, dns.TypeToString[rr.Header().Rrtype]
 }
 
 // refuseTransfer writes a REFUSED reply to an AXFR/IXFR request (signed when the
@@ -476,7 +443,7 @@ func (zd *ZoneData) ParseZoneFromReader(r io.Reader, force bool, filename string
 	zd.Logger.Printf("ParseZoneFromReader: zone: %s", zd.ZoneName)
 
 	switch zd.ZoneStore {
-	case MapZone, SliceZone:
+	case MapZone:
 		zd.Data = core.NewCmap[OwnerData]()
 	default:
 		return false, 0, fmt.Errorf("ParseZoneFromReader: zone store %d not supported", zd.ZoneStore)
@@ -546,7 +513,6 @@ func (zd *ZoneData) ParseZoneFromReader(r io.Reader, force bool, filename string
 	zd.CurrentSerial = soa.Serial
 	zd.IncomingSerial = soa.Serial
 
-	zd.ComputeIndices()
 	zd.XfrType = "axfr"
 	// Return true only if serial changed (indicates actual update)
 	// If force=true but serial unchanged, return false (validated but no update)
@@ -571,13 +537,8 @@ func (zd *ZoneData) SortFunc(rr dns.RR, firstSoaSeen bool) bool {
 	switch zd.ZoneStore {
 	case XfrZone:
 		ztype = XfrZone
-	case SliceZone:
-		fallthrough // store slicezones as mapzones during inbound transfer, sort afterwards into slice
 	case MapZone:
-		// omap = zd.Data[owner]
 		if omap, ok = zd.Data.Get(owner); !ok {
-
-			// if omap.RRtypes == nil {
 			omap.Name = owner
 			omap.RRtypes = NewRRTypeStore()
 		}
@@ -674,44 +635,6 @@ func (zd *ZoneData) WriteZoneToFile(f *os.File) error {
 	//	var total_sent int
 
 	switch zd.ZoneStore {
-	case SliceZone:
-		// SOA
-		soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-		zonedata += RRsetToString(&soa)
-		count += len(soa.RRs) + len(soa.RRSIGs)
-
-		// Rest of apex
-		for _, rrt := range apex.RRtypes.Keys() {
-			if rrt != dns.TypeSOA {
-				rrset := apex.RRtypes.GetOnlyRRSet(rrt)
-				zonedata += RRsetToString(&rrset)
-				count += len(rrset.RRs) + len(rrset.RRSIGs)
-			}
-		}
-
-		// Rest of zone
-		for _, owner := range zd.Owners {
-			if owner.Name == zd.ZoneName {
-				continue
-			}
-			for _, rrt := range owner.RRtypes.Keys() {
-				rrl := owner.RRtypes.GetOnlyRRSet(rrt)
-				zonedata += RRsetToString(&rrl)
-				count += len(rrl.RRs) + len(rrl.RRSIGs)
-
-				if count >= 1000 {
-					//				   	total_sent += count
-					bytes, err = writer.WriteString(zonedata)
-					if err != nil {
-						return err
-					}
-					totalbytes += bytes
-					bytes = 0
-					count = 0
-				}
-			}
-		}
-
 	case MapZone:
 		// SOA
 		soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
@@ -739,7 +662,6 @@ func (zd *ZoneData) WriteZoneToFile(f *os.File) error {
 				count += len(rrl.RRs) + len(rrl.RRSIGs)
 
 				if count >= 1000 {
-					//					total_sent += count
 					bytes, err = writer.WriteString(zonedata)
 					if err != nil {
 						return err
@@ -791,48 +713,6 @@ func RRsetToString(rrset *core.RRset) string {
 
 func InBailiwick(zone string, ns *dns.NS) bool {
 	return strings.HasSuffix(ns.Ns, zone)
-}
-
-func (zd *ZoneData) ComputeIndices() {
-	if zd.ZoneStore == SliceZone {
-		// for _, v := range zd.Data {
-		for _, key := range zd.Data.Keys() {
-			v, _ := zd.Data.Get(key)
-			zd.Owners = append(zd.Owners, v)
-		}
-		quickSort(zd.Owners)
-		// zd.Data = nil
-		zd.Data.Clear()
-		// zd.OwnerIndex = map[string]int{}
-		zd.OwnerIndex = core.NewCmap[int]()
-		for i, od := range zd.Owners {
-			// zd.OwnerIndex[od.Name] = i
-			zd.OwnerIndex.Set(od.Name, i)
-		}
-		idx, _ := zd.OwnerIndex.Get(zd.ZoneName)
-		soas := zd.Owners[idx].RRtypes.GetOnlyRRSet(dns.TypeSOA)
-		soas.RRs = soas.RRs[:1]
-		zd.Owners[idx].RRtypes.Set(dns.TypeSOA, soas)
-	}
-	if zd.Verbose {
-		zd.PrintOwners()
-	}
-}
-
-func (owners Owners) Len() int {
-	return len(owners)
-}
-
-func (owners Owners) Swap(i, j int) {
-	owners[i], owners[j] = owners[j], owners[i]
-}
-
-func (owners Owners) Less(i, j int) bool {
-	return owners[i].Name < owners[j].Name
-}
-
-func quickSort(sortable sort.Interface) {
-	sorts.Quicksort(sortable)
 }
 
 // formatZoneParseError extracts the line number from the parse error string

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -222,7 +222,8 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 		}
 
 		// Parse zone store (tolerant: parseZoneStore also accepts the legacy
-		// display tokens MapZone/SliceZone/XfrZone the daemon used to persist).
+		// display tokens MapZone/XfrZone (and the deprecated "slice" alias) the
+		// daemon used to persist).
 		// If the on-disk token isn't already canonical, normalize it in the
 		// parsed config and flag a one-shot re-persist after the load.
 		zoneStore := parseZoneStore(zconf.Store)

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -627,7 +627,8 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		case "map":
 			zonestore = MapZone
 		case "slice":
-			zonestore = SliceZone
+			lgConfig.Warn("zone store type slice is deprecated, using map", "zone", zname)
+			zonestore = MapZone
 		default:
 			lgConfig.Warn("unknown zone store type, using map store", "zone", zname, "store", zconf.Store)
 			zonestore = MapZone

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -618,21 +618,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			}
 		}
 
-		zconf.Store = strings.ToLower(zconf.Store)
-		// fmt.Printf("Zone %s uses \"%s\" storage\n", zconf.Name, zconf.Store)
-		var zonestore ZoneStore
-		switch zconf.Store {
-		case "xfr":
-			zonestore = XfrZone
-		case "map":
-			zonestore = MapZone
-		case "slice":
-			lgConfig.Warn("zone store type slice is deprecated, using map", "zone", zname)
-			zonestore = MapZone
-		default:
-			lgConfig.Warn("unknown zone store type, using map store", "zone", zname, "store", zconf.Store)
-			zonestore = MapZone
-		}
+		zonestore := parseZoneStore(zconf.Store)
 
 		var zonetype ZoneType
 		// resolvedPrimaries holds the addr:port tuples for a secondary zone's

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -606,7 +606,7 @@ type ZoneRefresher struct {
 	// downstreams => deny, empty allow-notify => primaries) instead of keeping
 	// stale permissions.
 	ConfigUpdate bool
-	ZoneStore    ZoneStore // 1=xfr, 2=map, 3=slice
+	ZoneStore    ZoneStore // 1=xfr, 2=map
 	Zonefile     string
 	Options      map[ZoneOption]bool
 	Edns0Options *edns0.MsgOptions

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -21,13 +21,11 @@ type ZoneStore uint8
 const (
 	XfrZone ZoneStore = iota + 1
 	MapZone
-	SliceZone
 )
 
 var ZoneStoreToString = map[ZoneStore]string{
-	XfrZone:   "XfrZone",
-	MapZone:   "MapZone",
-	SliceZone: "SliceZone",
+	XfrZone: "XfrZone",
+	MapZone: "MapZone",
 }
 
 // zoneStoreToConfigToken maps a ZoneStore to its CANONICAL config-file token
@@ -36,9 +34,8 @@ var ZoneStoreToString = map[ZoneStore]string{
 // used in API responses and logs. Persisting config must use the token, not the
 // display string, or the daemon writes a value its own reader rejects.
 var zoneStoreToConfigToken = map[ZoneStore]string{
-	XfrZone:   "xfr",
-	MapZone:   "map",
-	SliceZone: "slice",
+	XfrZone: "xfr",
+	MapZone: "map",
 }
 
 // zoneStoreConfigToken returns the canonical config token for s, defaulting to
@@ -114,10 +111,8 @@ type ZoneData struct {
 	// resurrection race where a mid-flight refresh re-writes a deleted zone.
 	generation atomic.Uint64
 	ZoneName   string
-	ZoneStore  ZoneStore // 1 = "xfr", 2 = "map", 3 = "slice". An xfr zone only supports xfr related ops
+	ZoneStore  ZoneStore // 1 = "xfr", 2 = "map". An xfr zone only supports xfr related ops
 	ZoneType   ZoneType
-	Owners     Owners
-	OwnerIndex *core.ConcurrentMap[string, int]
 	ApexLen    int
 	//	RRs            RRArray
 	Data *core.ConcurrentMap[string, OwnerData]
@@ -513,8 +508,6 @@ type Ixfr struct {
 	Added      []core.RRset
 }
 
-type Owners []OwnerData
-
 type OwnerData struct {
 	Name    string
 	RRtypes *RRTypeStore
@@ -612,17 +605,17 @@ type ZoneRefresher struct {
 	// nil/empty, so a config that REMOVES an ACL actually clears it (empty
 	// downstreams => deny, empty allow-notify => primaries) instead of keeping
 	// stale permissions.
-	ConfigUpdate  bool
-	ZoneStore     ZoneStore // 1=xfr, 2=map, 3=slice
-	Zonefile      string
-	Options       map[ZoneOption]bool
-	Edns0Options  *edns0.MsgOptions
-	UpdatePolicy  UpdatePolicy
-	DnssecPolicy  string
-	MultiSigner   string
-	Force         bool // force refresh, ignoring SOA serial
-	Wait          bool // wait for refresh to complete before responding
-	Response      chan RefresherResponse
+	ConfigUpdate bool
+	ZoneStore    ZoneStore // 1=xfr, 2=map, 3=slice
+	Zonefile     string
+	Options      map[ZoneOption]bool
+	Edns0Options *edns0.MsgOptions
+	UpdatePolicy UpdatePolicy
+	DnssecPolicy string
+	MultiSigner  string
+	Force        bool // force refresh, ignoring SOA serial
+	Wait         bool // wait for refresh to complete before responding
+	Response     chan RefresherResponse
 }
 
 type RefresherResponse struct {

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -2,6 +2,7 @@ package tdns
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
@@ -25,6 +26,48 @@ func (s *axfrTestServer) recordSize(m *dns.Msg) {
 	if packed, err := m.Pack(); err == nil {
 		s.sizes = append(s.sizes, len(packed))
 	}
+}
+
+func startTestAXFRServerTSIG(t *testing.T, zd *ZoneData, conf *Config) *axfrTestServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := &axfrTestServer{addr: ln.Addr().String()}
+	zone := dns.Fqdn(zd.ZoneName)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
+		rec := &recordingResponseWriter{
+			ResponseWriter: w,
+			record:         srv.recordSize,
+		}
+		handler := TsigSigningHandler(func(w2 dns.ResponseWriter, req *dns.Msg) {
+			_, _ = zd.ZoneTransferOut(w2, req)
+		})
+		handler(rec, r)
+	})
+
+	started := make(chan struct{})
+	dnsSrv := &dns.Server{
+		Listener:          ln,
+		Handler:           mux,
+		TsigProvider:      conf.tsigProvider(),
+		NotifyStartedFunc: func() { close(started) },
+	}
+	go func() { _ = dnsSrv.ActivateAndServe() }()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test AXFR server did not start")
+	}
+	srv.shutdown = func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = dnsSrv.ShutdownContext(ctx)
+	}
+	return srv
 }
 
 func startTestAXFRServer(t *testing.T, zd *ZoneData) *axfrTestServer {
@@ -98,6 +141,77 @@ func loadTestTransferZone(t *testing.T, zoneData string) *ZoneData {
 	zd.Ready = true
 	zd.Status = ZoneStatusReady
 	return zd
+}
+
+func testXfrConf(t *testing.T) *Config {
+	t.Helper()
+	conf := &Config{}
+	conf.Keys.Tsig = []TsigDetails{{Name: "tkey", Algorithm: "hmac-sha256", Secret: testXfrSecret}}
+	if err := conf.LoadTsigKeys(); err != nil {
+		t.Fatalf("LoadTsigKeys: %v", err)
+	}
+	return conf
+}
+
+func axfrClientTSIG(t *testing.T, conf *Config, addr, zone, keyName string) ([]dns.RR, error) {
+	t.Helper()
+	msg := new(dns.Msg)
+	msg.SetAxfr(zone)
+	provider, err := SignForPeer(msg, keyName, conf)
+	if err != nil {
+		t.Fatalf("SignForPeer: %v", err)
+	}
+	tr := &dns.Transfer{TsigProvider: provider}
+	ch, err := tr.In(msg, addr)
+	if err != nil {
+		return nil, err
+	}
+	var rrs []dns.RR
+	for env := range ch {
+		if env.Error != nil {
+			return rrs, env.Error
+		}
+		rrs = append(rrs, env.RR...)
+	}
+	return rrs, nil
+}
+
+func assertTransferEnvelopeSizes(t *testing.T, sizes []int) {
+	t.Helper()
+	if len(sizes) < 2 {
+		t.Fatalf("expected multiple envelopes, got %d", len(sizes))
+	}
+	for i, sz := range sizes {
+		if sz > dnsMaxMessageSize {
+			t.Fatalf("envelope %d size %d exceeds DNS max %d", i, sz, dnsMaxMessageSize)
+		}
+		if sz > safeMessageSize {
+			t.Fatalf("envelope %d size %d exceeds safe limit %d", i, sz, safeMessageSize)
+		}
+	}
+}
+
+func largeApexZone(typeCount, byteLen int) string {
+	var b strings.Builder
+	b.WriteString(`
+$ORIGIN example.test.
+@ IN SOA ns.example.test. hostmaster.example.test. (
+	1 ; serial
+	3600 ; refresh
+	600 ; retry
+	86400 ; expire
+	60 ; minimum
+)
+@ IN NS ns.example.test.
+ns IN A 192.0.2.1
+`)
+	payload := hex.EncodeToString(make([]byte, byteLen))
+	const apexSynthBase = 65350 // unassigned private-use types (avoid tdns core RR types)
+	for i := 0; i < typeCount; i++ {
+		fmt.Fprintf(&b, "@ 60 TYPE%d \\# %d %s\n", apexSynthBase+i, byteLen, payload)
+	}
+	b.WriteString("www IN A 192.0.2.2\n")
+	return b.String()
 }
 
 func axfrClient(t *testing.T, addr, zone string) ([]dns.RR, error) {
@@ -191,13 +305,51 @@ $ORIGIN example.test.
 		t.Fatalf("expected many RRs, got %d", len(rrs))
 	}
 	if len(srv.sizes) < 2 {
-		t.Fatalf("expected multiple envelopes for large apex, got %d", len(srv.sizes))
+		t.Fatalf("expected multiple envelopes, got %d", len(srv.sizes))
 	}
-	for i, sz := range srv.sizes {
-		if sz > dnsMaxMessageSize {
-			t.Fatalf("envelope %d size %d exceeds DNS max", i, sz)
-		}
+	assertTransferEnvelopeSizes(t, srv.sizes)
+}
+
+// TestZoneTransferOut_LargeApexSpansEnvelopes is the regression for fix (b): many
+// large RRsets at the zone apex must batch through maybeFlushBatch instead of
+// accumulating in the first envelope (the old PQ-apex overflow).
+func TestZoneTransferOut_LargeApexSpansEnvelopes(t *testing.T) {
+	zd := loadTestTransferZone(t, largeApexZone(10, 9000))
+
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := axfrClient(t, srv.addr, zd.ZoneName)
+	if err != nil {
+		t.Fatalf("AXFR: %v", err)
 	}
+	if len(rrs) < 12 {
+		t.Fatalf("expected apex SOA bookends plus apex RRsets, got %d RRs", len(rrs))
+	}
+	if _, ok := rrs[0].(*dns.SOA); !ok {
+		t.Fatalf("first RR should be SOA, got %T", rrs[0])
+	}
+	assertTransferEnvelopeSizes(t, srv.sizes)
+}
+
+// TestZoneTransferOut_TSIGLargeApexEnvelopeSizes checks every TSIG-signed envelope
+// on a multi-envelope apex transfer stays under cap (question + TSIG headroom).
+func TestZoneTransferOut_TSIGLargeApexEnvelopeSizes(t *testing.T) {
+	conf := testXfrConf(t)
+	zd := loadTestTransferZone(t, largeApexZone(10, 9000))
+	zd.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+
+	srv := startTestAXFRServerTSIG(t, zd, conf)
+	defer srv.shutdown()
+
+	rrs, err := axfrClientTSIG(t, conf, srv.addr, zd.ZoneName, "tkey")
+	if err != nil {
+		t.Fatalf("AXFR: %v", err)
+	}
+	if len(rrs) < 12 {
+		t.Fatalf("expected many RRs, got %d", len(rrs))
+	}
+	assertTransferEnvelopeSizes(t, srv.sizes)
 }
 
 func hugeTXT(name string, total int) *dns.TXT {
@@ -331,63 +483,18 @@ func TestZoneTransferOut_RefusesWhenNotReady(t *testing.T) {
 // TestZoneTransferOut_TSIGRoundTrip exercises AXFR over TCP with TSIG on both
 // request and response envelopes (production uses TsigSigningHandler + TsigProvider).
 func TestZoneTransferOut_TSIGRoundTrip(t *testing.T) {
-	conf := &Config{}
-	conf.Keys.Tsig = []TsigDetails{{Name: "tkey", Algorithm: "hmac-sha256", Secret: testXfrSecret}}
-	if err := conf.LoadTsigKeys(); err != nil {
-		t.Fatalf("LoadTsigKeys: %v", err)
-	}
+	conf := testXfrConf(t)
 	zd := loadTestTransferZone(t, basicZone)
 	zd.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	zone := dns.Fqdn(zd.ZoneName)
-	mux := dns.NewServeMux()
-	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
-		TsigSigningHandler(func(w2 dns.ResponseWriter, req *dns.Msg) {
-			_, _ = zd.ZoneTransferOut(w2, req)
-		})(w, r)
-	})
-	started := make(chan struct{})
-	dnsSrv := &dns.Server{
-		Listener:          ln,
-		Handler:           mux,
-		TsigProvider:      conf.tsigProvider(),
-		NotifyStartedFunc: func() { close(started) },
-	}
-	go func() { _ = dnsSrv.ActivateAndServe() }()
-	select {
-	case <-started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("test AXFR server did not start")
-	}
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = dnsSrv.ShutdownContext(ctx)
-	}()
+	srv := startTestAXFRServerTSIG(t, zd, conf)
+	defer srv.shutdown()
 
-	msg := new(dns.Msg)
-	msg.SetAxfr(zd.ZoneName)
-	provider, err := SignForPeer(msg, "tkey", conf)
-	if err != nil {
-		t.Fatalf("SignForPeer: %v", err)
-	}
-	tr := &dns.Transfer{TsigProvider: provider}
-	ch, err := tr.In(msg, ln.Addr().String())
+	rrs, err := axfrClientTSIG(t, conf, srv.addr, zd.ZoneName, "tkey")
 	if err != nil {
 		t.Fatalf("Transfer.In: %v", err)
 	}
-	var count int
-	for env := range ch {
-		if env.Error != nil {
-			t.Fatalf("envelope error: %v", env.Error)
-		}
-		count += len(env.RR)
-	}
-	if count < 4 {
-		t.Fatalf("expected at least 4 RRs, got %d", count)
+	if len(rrs) < 4 {
+		t.Fatalf("expected at least 4 RRs, got %d", len(rrs))
 	}
 }

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -1,0 +1,393 @@
+package tdns
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+const testXfrSecret = "MTIzNDU2Nzg5MDEyMzQ1Ng=="
+
+type axfrTestServer struct {
+	addr     string
+	sizes    []int
+	shutdown func()
+}
+
+func (s *axfrTestServer) recordSize(m *dns.Msg) {
+	if packed, err := m.Pack(); err == nil {
+		s.sizes = append(s.sizes, len(packed))
+	}
+}
+
+func startTestAXFRServer(t *testing.T, zd *ZoneData) *axfrTestServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := &axfrTestServer{addr: ln.Addr().String()}
+	zone := dns.Fqdn(zd.ZoneName)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
+		rec := &recordingResponseWriter{
+			ResponseWriter: w,
+			record:         srv.recordSize,
+		}
+		_, _ = zd.ZoneTransferOut(rec, r)
+	})
+
+	started := make(chan struct{})
+	dnsSrv := &dns.Server{
+		Listener:          ln,
+		Handler:           mux,
+		NotifyStartedFunc: func() { close(started) },
+	}
+	go func() { _ = dnsSrv.ActivateAndServe() }()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test AXFR server did not start")
+	}
+	srv.shutdown = func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = dnsSrv.ShutdownContext(ctx)
+	}
+	return srv
+}
+
+type recordingResponseWriter struct {
+	dns.ResponseWriter
+	record func(*dns.Msg)
+}
+
+func (w *recordingResponseWriter) WriteMsg(m *dns.Msg) error {
+	if w.record != nil {
+		w.record(m)
+	}
+	return w.ResponseWriter.WriteMsg(m)
+}
+
+func loadTestTransferZone(t *testing.T, zoneData string) *ZoneData {
+	t.Helper()
+	const zone = "example.test."
+	zd := &ZoneData{
+		ZoneName:  zone,
+		ZoneStore: MapZone,
+		ZoneType:  Primary,
+		Logger:    log.Default(),
+		Ready:     true,
+		Status:    ZoneStatusReady,
+		Downstreams: []AclEntry{{
+			Prefix: "127.0.0.0/8",
+			Key:    NOKEY,
+		}},
+	}
+	if _, _, err := zd.ReadZoneData(zoneData, true); err != nil {
+		t.Fatalf("ReadZoneData: %v", err)
+	}
+	zd.Ready = true
+	zd.Status = ZoneStatusReady
+	return zd
+}
+
+func axfrClient(t *testing.T, addr, zone string) ([]dns.RR, error) {
+	t.Helper()
+	msg := new(dns.Msg)
+	msg.SetAxfr(zone)
+	tr := new(dns.Transfer)
+	ch, err := tr.In(msg, addr)
+	if err != nil {
+		return nil, err
+	}
+	var rrs []dns.RR
+	for env := range ch {
+		if env.Error != nil {
+			return rrs, env.Error
+		}
+		rrs = append(rrs, env.RR...)
+	}
+	return rrs, nil
+}
+
+const basicZone = `
+$ORIGIN example.test.
+@ IN SOA ns.example.test. hostmaster.example.test. (
+	1 ; serial
+	3600 ; refresh
+	600 ; retry
+	86400 ; expire
+	60 ; minimum
+)
+@ IN NS ns.example.test.
+ns IN A 192.0.2.1
+www IN A 192.0.2.2
+`
+
+func TestZoneTransferOut_RoundTrip(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := axfrClient(t, srv.addr, zd.ZoneName)
+	if err != nil {
+		t.Fatalf("AXFR: %v", err)
+	}
+	if len(rrs) < 4 {
+		t.Fatalf("expected at least 4 RRs (SOA bookends + data), got %d", len(rrs))
+	}
+	if _, ok := rrs[0].(*dns.SOA); !ok {
+		t.Fatalf("first RR should be SOA, got %T", rrs[0])
+	}
+	if _, ok := rrs[len(rrs)-1].(*dns.SOA); !ok {
+		t.Fatalf("last RR should be SOA, got %T", rrs[len(rrs)-1])
+	}
+	for i, sz := range srv.sizes {
+		if sz > dnsMaxMessageSize {
+			t.Fatalf("envelope %d size %d exceeds DNS max %d", i, sz, dnsMaxMessageSize)
+		}
+		if sz > safeMessageSize {
+			t.Fatalf("envelope %d size %d exceeds safe limit %d", i, sz, safeMessageSize)
+		}
+	}
+}
+
+func TestZoneTransferOut_LargeZoneSpansEnvelopes(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`
+$ORIGIN example.test.
+@ IN SOA ns.example.test. hostmaster.example.test. (
+	1 ; serial
+	3600 ; refresh
+	600 ; retry
+	86400 ; expire
+	60 ; minimum
+)
+@ IN NS ns.example.test.
+`)
+	for i := 0; i < 80; i++ {
+		fmt.Fprintf(&b, "pad%d IN TXT \"%s\"\n", i, strings.Repeat("x", 900))
+	}
+	b.WriteString("www IN A 192.0.2.2\n")
+
+	zd := loadTestTransferZone(t, b.String())
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := axfrClient(t, srv.addr, zd.ZoneName)
+	if err != nil {
+		t.Fatalf("AXFR: %v", err)
+	}
+	if len(rrs) < 82 {
+		t.Fatalf("expected many RRs, got %d", len(rrs))
+	}
+	if len(srv.sizes) < 2 {
+		t.Fatalf("expected multiple envelopes for large apex, got %d", len(srv.sizes))
+	}
+	for i, sz := range srv.sizes {
+		if sz > dnsMaxMessageSize {
+			t.Fatalf("envelope %d size %d exceeds DNS max", i, sz)
+		}
+	}
+}
+
+func hugeTXT(name string, total int) *dns.TXT {
+	var chunks []string
+	for remaining := total; remaining > 0; {
+		n := 255
+		if remaining < n {
+			n = remaining
+		}
+		chunks = append(chunks, strings.Repeat("x", n))
+		remaining -= n
+	}
+	return &dns.TXT{
+		Hdr: dns.RR_Header{
+			Name:   name,
+			Rrtype: dns.TypeTXT,
+			Class:  dns.ClassINET,
+			Ttl:    60,
+		},
+		Txt: chunks,
+	}
+}
+
+func TestZoneTransferOut_OversizeRRsetAborts(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	txt := hugeTXT("big.example.test.", 65000)
+	od := OwnerData{
+		Name:    "big.example.test.",
+		RRtypes: NewRRTypeStore(),
+	}
+	od.RRtypes.Set(dns.TypeTXT, core.RRset{
+		Name:   "big.example.test.",
+		Class:  dns.ClassINET,
+		RRtype: dns.TypeTXT,
+		RRs:    []dns.RR{txt},
+	})
+	zd.Data.Set("big.example.test.", od)
+
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	_, err := axfrClient(t, srv.addr, zd.ZoneName)
+	if err == nil {
+		t.Fatal("expected transfer to fail on oversize RRset")
+	}
+}
+
+func TestZoneTransferOut_ClientDisconnect(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`
+$ORIGIN example.test.
+@ IN SOA ns.example.test. hostmaster.example.test. (
+	1 ; serial
+	3600 ; refresh
+	600 ; retry
+	86400 ; expire
+	60 ; minimum
+)
+@ IN NS ns.example.test.
+`)
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&b, "host%d IN A 192.0.2.1\n", i)
+	}
+	zd := loadTestTransferZone(t, b.String())
+
+	handlerDone := make(chan struct{})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	zone := dns.Fqdn(zd.ZoneName)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
+		defer close(handlerDone)
+		_, _ = zd.ZoneTransferOut(w, r)
+	})
+	started := make(chan struct{})
+	dnsSrv := &dns.Server{
+		Listener:          ln,
+		Handler:           mux,
+		NotifyStartedFunc: func() { close(started) },
+	}
+	go func() { _ = dnsSrv.ActivateAndServe() }()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test AXFR server did not start")
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = dnsSrv.ShutdownContext(ctx)
+	}()
+
+	msg := new(dns.Msg)
+	msg.SetAxfr(zd.ZoneName)
+	tr := new(dns.Transfer)
+	ch, err := tr.In(msg, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Transfer.In: %v", err)
+	}
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected at least one envelope before disconnect")
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not finish after client stopped reading")
+	}
+}
+
+func TestZoneTransferOut_RefusesWhenNotReady(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	zd.Status = ZoneStatusLoading
+	w := &fakeRW{remote: udpAddr("127.0.0.1")}
+	r := new(dns.Msg)
+	r.SetAxfr(zd.ZoneName)
+	sent, err := zd.ZoneTransferOut(w, r)
+	if err != nil {
+		t.Fatalf("ZoneTransferOut: %v", err)
+	}
+	if sent != 0 {
+		t.Fatalf("expected 0 RRs sent, got %d", sent)
+	}
+	if w.written == nil || w.written.Rcode != dns.RcodeRefused {
+		t.Fatalf("expected REFUSED, got %v", w.written)
+	}
+}
+
+// TestZoneTransferOut_TSIGRoundTrip exercises AXFR over TCP with TSIG on both
+// request and response envelopes (production uses TsigSigningHandler + TsigProvider).
+func TestZoneTransferOut_TSIGRoundTrip(t *testing.T) {
+	conf := &Config{}
+	conf.Keys.Tsig = []TsigDetails{{Name: "tkey", Algorithm: "hmac-sha256", Secret: testXfrSecret}}
+	if err := conf.LoadTsigKeys(); err != nil {
+		t.Fatalf("LoadTsigKeys: %v", err)
+	}
+	zd := loadTestTransferZone(t, basicZone)
+	zd.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	zone := dns.Fqdn(zd.ZoneName)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
+		TsigSigningHandler(func(w2 dns.ResponseWriter, req *dns.Msg) {
+			_, _ = zd.ZoneTransferOut(w2, req)
+		})(w, r)
+	})
+	started := make(chan struct{})
+	dnsSrv := &dns.Server{
+		Listener:          ln,
+		Handler:           mux,
+		TsigProvider:      conf.tsigProvider(),
+		NotifyStartedFunc: func() { close(started) },
+	}
+	go func() { _ = dnsSrv.ActivateAndServe() }()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test AXFR server did not start")
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = dnsSrv.ShutdownContext(ctx)
+	}()
+
+	msg := new(dns.Msg)
+	msg.SetAxfr(zd.ZoneName)
+	provider, err := SignForPeer(msg, "tkey", conf)
+	if err != nil {
+		t.Fatalf("SignForPeer: %v", err)
+	}
+	tr := &dns.Transfer{TsigProvider: provider}
+	ch, err := tr.In(msg, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Transfer.In: %v", err)
+	}
+	var count int
+	for env := range ch {
+		if env.Error != nil {
+			t.Fatalf("envelope error: %v", env.Error)
+		}
+		count += len(env.RR)
+	}
+	if count < 4 {
+		t.Fatalf("expected at least 4 RRs, got %d", count)
+	}
+}

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -28,7 +28,7 @@ func (s *axfrTestServer) recordSize(m *dns.Msg) {
 	}
 }
 
-func startTestAXFRServerTSIG(t *testing.T, zd *ZoneData, conf *Config) *axfrTestServer {
+func startTestAXFRServerCore(t *testing.T, zd *ZoneData, tsigProvider dns.TsigProvider) *axfrTestServer {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -43,17 +43,21 @@ func startTestAXFRServerTSIG(t *testing.T, zd *ZoneData, conf *Config) *axfrTest
 			ResponseWriter: w,
 			record:         srv.recordSize,
 		}
-		handler := TsigSigningHandler(func(w2 dns.ResponseWriter, req *dns.Msg) {
+		serve := func(w2 dns.ResponseWriter, req *dns.Msg) {
 			_, _ = zd.ZoneTransferOut(w2, req)
-		})
-		handler(rec, r)
+		}
+		if tsigProvider != nil {
+			TsigSigningHandler(serve)(rec, r)
+		} else {
+			serve(rec, r)
+		}
 	})
 
 	started := make(chan struct{})
 	dnsSrv := &dns.Server{
 		Listener:          ln,
 		Handler:           mux,
-		TsigProvider:      conf.tsigProvider(),
+		TsigProvider:      tsigProvider,
 		NotifyStartedFunc: func() { close(started) },
 	}
 	go func() { _ = dnsSrv.ActivateAndServe() }()
@@ -72,40 +76,12 @@ func startTestAXFRServerTSIG(t *testing.T, zd *ZoneData, conf *Config) *axfrTest
 
 func startTestAXFRServer(t *testing.T, zd *ZoneData) *axfrTestServer {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	return startTestAXFRServerCore(t, zd, nil)
+}
 
-	srv := &axfrTestServer{addr: ln.Addr().String()}
-	zone := dns.Fqdn(zd.ZoneName)
-	mux := dns.NewServeMux()
-	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
-		rec := &recordingResponseWriter{
-			ResponseWriter: w,
-			record:         srv.recordSize,
-		}
-		_, _ = zd.ZoneTransferOut(rec, r)
-	})
-
-	started := make(chan struct{})
-	dnsSrv := &dns.Server{
-		Listener:          ln,
-		Handler:           mux,
-		NotifyStartedFunc: func() { close(started) },
-	}
-	go func() { _ = dnsSrv.ActivateAndServe() }()
-	select {
-	case <-started:
-	case <-time.After(2 * time.Second):
-		t.Fatal("test AXFR server did not start")
-	}
-	srv.shutdown = func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = dnsSrv.ShutdownContext(ctx)
-	}
-	return srv
+func startTestAXFRServerTSIG(t *testing.T, zd *ZoneData, conf *Config) *axfrTestServer {
+	t.Helper()
+	return startTestAXFRServerCore(t, zd, conf.tsigProvider())
 }
 
 type recordingResponseWriter struct {

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -431,6 +431,9 @@ func (zd *ZoneData) SetOption(option ZoneOption, value bool) {
 }
 
 func (zd *ZoneData) NameExists(qname string) bool {
+	if zd.ZoneStore != MapZone || zd.Data == nil || zd.Data.IsEmpty() {
+		return false
+	}
 	_, ok := zd.Data.Get(qname)
 	lg.Debug("NameExists result", "qname", qname, "exists", ok)
 	return ok

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -234,8 +234,6 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 
 	// Hard flip: update served zone data atomically.
 	zd.mu.Lock()
-	zd.Owners = new_zd.Owners
-	zd.OwnerIndex = new_zd.OwnerIndex
 	zd.IncomingSerial = new_zd.IncomingSerial
 	if zd.FirstZoneLoad {
 		zd.CurrentSerial = new_zd.CurrentSerial
@@ -338,8 +336,6 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 
 	// Hard flip: update served zone data atomically.
 	zd.mu.Lock()
-	zd.Owners = new_zd.Owners
-	zd.OwnerIndex = new_zd.OwnerIndex
 	zd.IncomingSerial = new_zd.IncomingSerial
 	if zd.FirstZoneLoad {
 		zd.CurrentSerial = new_zd.CurrentSerial
@@ -435,76 +431,31 @@ func (zd *ZoneData) SetOption(option ZoneOption, value bool) {
 }
 
 func (zd *ZoneData) NameExists(qname string) bool {
-	var ok bool
-	switch zd.ZoneStore {
-	case SliceZone:
-		_, ok = zd.OwnerIndex.Get(qname)
-
-	case MapZone:
-		_, ok = zd.Data.Get(qname)
-
-	default:
-		lg.Error("NameExists: unexpected zone storage type", "zoneStore", ZoneStoreToString[zd.ZoneStore])
-		return false
-	}
-
+	_, ok := zd.Data.Get(qname)
 	lg.Debug("NameExists result", "qname", qname, "exists", ok)
 	return ok
 }
-
-// XXX: FIXME: SliceZones do not yet have support for adding new owner names.
 
 func (zd *ZoneData) GetOwner(qname string) (*OwnerData, error) {
 	if !zd.Ready {
 		return nil, fmt.Errorf("getOwner: zone %s: %w", zd.ZoneName, ErrZoneNotReady)
 	}
-	var owner OwnerData
-	var ok bool
-	switch zd.ZoneStore {
-	case SliceZone:
-		if len(zd.Owners) == 0 {
-			return nil, nil
-		}
-		idx, _ := zd.OwnerIndex.Get(qname)
-		owner = zd.Owners[idx]
-
-	case MapZone:
-		if zd.Data.IsEmpty() {
-			return nil, nil
-		}
-		if owner, ok = zd.Data.Get(qname); !ok {
-			owner = OwnerData{
-				Name:    qname,
-				RRtypes: NewRRTypeStore(),
-			}
-			// XXX: Hmm. This seems wrong. We create an ownername where there wasn't one
-			//      based on a request for it?
-			// zd.Data.Set(qname, owner)
-			return nil, nil // Seems better
-		}
-		return &owner, nil
-
-	default:
-		lg.Error("GetOwner: zone storage not supported", "zoneStore", zd.ZoneStore)
-		return &owner, fmt.Errorf("getOwner: only supported for SliceZone and MapZone, not %s",
+	if zd.ZoneStore != MapZone {
+		return nil, fmt.Errorf("getOwner: only supported for MapZone, not %s",
 			ZoneStoreToString[zd.ZoneStore])
 	}
-	// dump.P(owner)
-	return &owner, nil
+	if zd.Data.IsEmpty() {
+		return nil, nil
+	}
+	if owner, ok := zd.Data.Get(qname); ok {
+		return &owner, nil
+	}
+	return nil, nil
 }
 
 // XXX: This MUST ONLY be called from the ZoneUpdater, due to locking issues
 func (zd *ZoneData) AddOwner(owner *OwnerData) {
-	//	zd.mu.Lock()
-	switch zd.ZoneStore {
-	case SliceZone:
-		zd.Owners = append(zd.Owners, *owner)
-		zd.OwnerIndex.Set(owner.Name, len(zd.Owners)-1)
-
-	case MapZone:
-		zd.Data.Set(owner.Name, *owner)
-	}
-	// zd.mu.Unlock()
+	zd.Data.Set(owner.Name, *owner)
 }
 
 func (zd *ZoneData) GetRRset(qname string, rrtype uint16) (*core.RRset, error) {
@@ -531,26 +482,14 @@ func (zd *ZoneData) GetRRset(qname string, rrtype uint16) (*core.RRset, error) {
 }
 
 func (zd *ZoneData) GetOwnerNames() ([]string, error) {
-	var names []string
-	switch zd.ZoneStore {
-	case SliceZone:
-		if len(zd.Owners) == 0 {
-			return names, nil
-		}
-		names = zd.OwnerIndex.Keys()
-
-	case MapZone:
-		if zd.Data.IsEmpty() {
-			return names, nil
-		}
-		names = zd.Data.Keys()
-
-	default:
-		lg.Error("GetOwnerNames: zone storage not supported", "zoneStore", zd.ZoneStore)
-		return names, fmt.Errorf("getOwnerNames: only supported for SliceZone and MapZone, not %s",
+	if zd.ZoneStore != MapZone {
+		return nil, fmt.Errorf("getOwnerNames: only supported for MapZone, not %s",
 			ZoneStoreToString[zd.ZoneStore])
 	}
-	return names, nil
+	if zd.Data.IsEmpty() {
+		return nil, nil
+	}
+	return zd.Data.Keys(), nil
 }
 
 // XXX: Is qname the name of a zone cut for a child zone?
@@ -606,26 +545,8 @@ func (zd *ZoneData) GetSOA() (*dns.SOA, error) {
 }
 
 func (zd *ZoneData) PrintOwners() {
-	switch zd.ZoneStore {
-	case SliceZone:
-		fmt.Printf("owner name\tindex\n")
-		for i, v := range zd.Owners {
-			rrtypes := []string{}
-			for _, t := range v.RRtypes.Keys() {
-				rrtypes = append(rrtypes, dns.TypeToString[t])
-			}
-			fmt.Printf("%d\t%s\t%s\n", i, v.Name, strings.Join(rrtypes, ", "))
-		}
-		for _, k := range zd.OwnerIndex.Keys() {
-			v, _ := zd.OwnerIndex.Get(k)
-			fmt.Printf("%s\t%d\n", k, v)
-		}
-	case MapZone:
-		for _, key := range zd.Data.Keys() {
-			fmt.Printf("%s\n", key)
-		}
-	default:
-		lg.Debug("PrintOwners: unsupported zone storage type", "zoneStore", ZoneStoreToString[zd.ZoneStore])
+	for _, key := range zd.Data.Keys() {
+		fmt.Printf("%s\n", key)
 	}
 }
 

--- a/v2/zonestore_test.go
+++ b/v2/zonestore_test.go
@@ -7,7 +7,7 @@ import "testing"
 // that shipped — the write side used the display form ("MapZone") which the
 // reader rejected.
 func TestZoneStoreRoundTrip(t *testing.T) {
-	for _, s := range []ZoneStore{MapZone, SliceZone, XfrZone} {
+	for _, s := range []ZoneStore{MapZone, XfrZone} {
 		tok := zoneStoreConfigToken(s)
 		if got := parseZoneStore(tok); got != s {
 			t.Errorf("round-trip failed: %v -> %q -> %v", s, tok, got)
@@ -19,7 +19,7 @@ func TestZoneStoreRoundTrip(t *testing.T) {
 // what parseZoneStore considers canonical (lowercase), or the dirty-detection
 // in LoadDynamicZoneFiles would re-flag and re-persist on every load.
 func TestZoneStoreCanonicalToken(t *testing.T) {
-	want := map[ZoneStore]string{MapZone: "map", SliceZone: "slice", XfrZone: "xfr"}
+	want := map[ZoneStore]string{MapZone: "map", XfrZone: "xfr"}
 	for s, tok := range want {
 		if got := zoneStoreConfigToken(s); got != tok {
 			t.Errorf("zoneStoreConfigToken(%v) = %q, want %q", s, got, tok)
@@ -35,8 +35,8 @@ func TestParseZoneStoreTolerant(t *testing.T) {
 		"map":       MapZone,
 		"MapZone":   MapZone, // legacy display form (the shipped bug)
 		"mapzone":   MapZone,
-		"slice":     SliceZone,
-		"SliceZone": SliceZone,
+		"slice":     MapZone, // deprecated alias
+		"SliceZone": MapZone, // deprecated display form
 		"xfr":       XfrZone,
 		"XfrZone":   XfrZone,
 		"  Map  ":   MapZone, // trimmed + case-insensitive


### PR DESCRIPTION
## Summary

- Retire `SliceZone` in v2 (MapZone-only outbound transfers) and harden `ZoneTransferOut`: readiness/MapZone guards, transfer-local SOA copy, apex batching through `maybeFlushBatch` with `safeMessageSize` (64000), producer/consumer abort on oversize RRsets or client disconnect, and no transfer-time re-signing.
- Add planning docs for outbound transfer hardening and zone-mutation snapshot correctness (Projects B/C follow-ups).
- Add regression tests for the large-apex overflow case (fix b) and TSIG-signed multi-envelope size caps; fix stale `ZoneStore` comments after SliceZone removal.

## Test plan

- [x] `go test -run TestZoneTransferOut ./v2/...`
- [x] `cd cmdv2 && make` (build)
- [ ] Manual AXFR of a large signed zone against a secondary (optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardened AXFR outbound transfers with clearer error messages, stricter readiness/store checks, and enforced per-envelope size caps (including large-zone and TSIG-signed scenarios).
  * Deprecated `slice` zone-store aliases now automatically resolve to the modern zone format with a warning.
* **Bug Fixes**
  * Prevented abort/hang edge cases, improved client-disconnect handling, and tightened outbound transfer SOA/apex handling for safer batching.
  * Improved refresh/load consistency by ensuring owner/zone inspection is MapZone-only.
* **Documentation**
  * Added detailed design docs for outbound transfer hardening and immutable zone-mutation snapshot correctness.
* **Tests**
  * Added TCP AXFR transfer test coverage validating envelope sizing, abort behavior, and disconnect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->