### PR TITLE
Project B: zone-mutation snapshot correctness (immutable snapshot + atomic.Pointer)

### DIFF
--- a/docs/2026-07-02-zone-mutation-snapshot-correctness.md
+++ b/docs/2026-07-02-zone-mutation-snapshot-correctness.md
@@ -1,7 +1,7 @@
 # Project B — Zone-Mutation Correctness via an Immutable Snapshot
 
-**Status:** **B3 enforcement pending** — B1 **done** (`98e50fa`); B2 **done** (`c76dfc4`);
-B3 reader cut-over **done** (uncommitted); unexported published type **remaining**.
+**Status:** **done (tdns-core)** — B1 (`98e50fa`), B2 (`c76dfc4`), B3 complete on branch
+`feature/zone-snapshot-correctness`. B-MP (tdns-mp) deferred per §9.
 **Date:** 2026-07-02 (plan); **implementation log:** 2026-07-08
 **Scope:** replace direct-write-then-bump-serial mutation with an **immutable
 snapshot published atomically**, in **tdns core (`v2/` + `cmdv2/`) only**. A
@@ -65,7 +65,7 @@ Branch: `feature/zone-snapshot-correctness` (off `main`).
 
 **B2 gate:** all B1 tests + `TestPendingChanges` + `TestConcurrentServeAndUpdate` (B2 variant) pass `-race`.
 
-### B3 — reader cut-over done; enforcement remaining
+### B3 — done
 
 | Deliverable | Status | Notes |
 |---|---|---|
@@ -76,11 +76,11 @@ Branch: `feature/zone-snapshot-correctness` (off `main`).
 | Drop dual-write | **done** | `syncLegacyFromSnapshot` removed; publish stores snapshot only |
 | Dead code cleanup | **done** | `setApexSOASerial`, `AddOwner` removed |
 | `check-no-mutators` grep gate | **done** | `utils/Makefile.common`; wired into `lint` |
-| B3 tests | **done** | `TestPublishedSnapshotAfterPublish`; B3 `TestConcurrentServeAndUpdate` — pass `-race` |
-| Unexported published type | **remaining** | `ZoneSnapshot` still exported; rename → `zoneSnapshot` |
-| `PrintOwners` | **remaining** | still walks draft `zd.Data`; should use `GetOwnerNames` |
+| Unexported published type | **done** | `zoneSnapshot` (unexported) |
+| `PrintOwners` | **done** | reads via `GetOwnerNames` |
+| B3 tests | **done** | `TestPublishedSnapshotAfterPublish`, `TestCurrentSerialMatchesSnapshot`, B3 `TestConcurrentServeAndUpdate` — pass `-race` |
 
-**B3 gate (partial):** B1 + B2 + B3 snapshot tests pass `-race`. Full sign-off blocked on unexported type.
+**B3 gate:** all §5 acceptance tests pass `-race`; `make -C v2 check-no-mutators` clean.
 
 ---
 

--- a/docs/2026-07-02-zone-mutation-snapshot-correctness.md
+++ b/docs/2026-07-02-zone-mutation-snapshot-correctness.md
@@ -1,8 +1,8 @@
 # Project B — Zone-Mutation Correctness via an Immutable Snapshot
 
-**Status:** implementation-ready (final — all review rounds folded in; milestoned
-B1→B2→B3; SliceZone retired by Project A step 0)
-**Date:** 2026-07-02
+**Status:** **in progress** — B1 **done** (`98e50fa`); B2 **feature-complete, sign-off pending** on branch
+`feature/zone-snapshot-correctness`; B3 not started.
+**Date:** 2026-07-02 (plan); **implementation log:** 2026-07-08
 **Scope:** replace direct-write-then-bump-serial mutation with an **immutable
 snapshot published atomically**, in **tdns core (`v2/` + `cmdv2/`) only**. A
 **standalone correctness fix** (repairs a serial-invariant violation that bites
@@ -26,6 +26,51 @@ MapZone (`zd.Data`) — B's snapshot is **map-only, no store normalization**.
 `tapir/docs/2026-06-02-pop-149-snapshot-concurrency-design.md` (*POP §n*).
 **Review folded in:** `…-zone-mutation-snapshot-correctness-review.md`.
 Anchors as of 2026-07-02; verify before editing.
+
+---
+
+## Implementation status (2026-07-08)
+
+Branch: `feature/zone-snapshot-correctness` (off `main`).
+
+### B1 — done (`98e50fa`)
+
+| Deliverable | Status |
+|---|---|
+| `ZoneSnapshot`, `atomic.Pointer`, `PendingChanges` | `v2/zone_snapshot.go` |
+| Staging API, coalescing publisher, dual-write `syncLegacyFromSnapshot` | `v2/zone_mutation.go` |
+| `publish-cadence` on `ZoneConf` / `TemplateConf` | `v2/structs.go`, `v2/parseconfig.go` |
+| `InstallInitialSnapshot()` after first load / `SetupZoneSigning` | `v2/refreshengine.go`, `v2/zone_utils.go` |
+| B1 tests (`TestSnapshotImmutability`, dual-write, coalescing, generation guard) | `v2/zone_snapshot_test.go` — pass `-race` |
+
+### B2 — in progress (commits `6f0b3a3` … pending)
+
+| Mutator / deliverable | Status | Notes |
+|---|---|---|
+| Query-path write-backs removed | **done** | `signedApexRRsets`, `soaForResponse`; no `Set`-after-sign |
+| `SignZone` / `ResignZone` / `GenerateNsecChain` / `StripZoneRRSIGs` | **done** | stage + `publishLocked` under `zd.mu` |
+| `PublishDnskeyRRs` | **done** | `publishDnskeyRRsLocked` |
+| `BumpSerial` / `BumpSerialOnly` | **done** | `publishSync()` |
+| RFC2136 `ApplyZoneUpdate` / `ApplyChildUpdate` | **done** | `stagedOwner`, sync `publishLocked` on commit |
+| Refresh flips (`FetchFromFile` / `FetchFromUpstream`) | **done** | `applyRefreshReplacementLocked` — no hard `Data` flip |
+| `RepopulateDynamicRRs` | **done** | `repopulateWorkingSetLocked`; folded into refresh publish |
+| `CreateTransportSignalRRs` | **done** | `commitTransportSignalLocked` |
+| Catalog (`regenerateCatalogZone`, create version TXT) | **done** | working-set rebuild + publish |
+| Post-refresh serial override (`outbound_soa_serial`) | **done** | republish instead of `setApexSOASerial` on served data |
+| `PublishCsyncRR` | **unchanged** | already routes via internal `ZONE-UPDATE` → staged RFC2136 |
+| `dnsutils.SortFunc` (zone file load into `new_zd`) | **intentionally unchanged** | draft build target; consumed by refresh publish |
+| `setApexSOASerial` / `AddOwner` | **dead / unused** | remove in B3 cleanup |
+| `tdns-cli debug zone-txlog` + `/debug` handler | **done** | `pendingChanges()` → `zone-txlog` command + JSON view |
+| `TestConcurrentServeAndUpdate` (B2 variant) | **done** | readers via `GetOwner`; dual-write checked under `zd.mu` after publish |
+| `pendingChanges` test | **done** | `TestPendingChanges` |
+
+**B2 gate:** all B1 tests + `TestPendingChanges` + `TestConcurrentServeAndUpdate` pass `-race`.
+
+**Remaining before B2 sign-off:** dead-code cleanup (`setApexSOASerial`, `AddOwner`); optional smoke of `debug zone-txlog` against a live auth.
+
+### B3 — not started
+
+Reader cut-over (`GetOwner` → snapshot), drop dual-write, grep gate, unexported published type.
 
 ---
 

--- a/docs/2026-07-02-zone-mutation-snapshot-correctness.md
+++ b/docs/2026-07-02-zone-mutation-snapshot-correctness.md
@@ -1,7 +1,7 @@
 # Project B — Zone-Mutation Correctness via an Immutable Snapshot
 
-**Status:** **in progress** — B1 **done** (`98e50fa`); B2 **feature-complete, sign-off pending** on branch
-`feature/zone-snapshot-correctness`; B3 not started.
+**Status:** **B3 enforcement pending** — B1 **done** (`98e50fa`); B2 **done** (`c76dfc4`);
+B3 reader cut-over **done** (uncommitted); unexported published type **remaining**.
 **Date:** 2026-07-02 (plan); **implementation log:** 2026-07-08
 **Scope:** replace direct-write-then-bump-serial mutation with an **immutable
 snapshot published atomically**, in **tdns core (`v2/` + `cmdv2/`) only**. A
@@ -38,12 +38,12 @@ Branch: `feature/zone-snapshot-correctness` (off `main`).
 | Deliverable | Status |
 |---|---|
 | `ZoneSnapshot`, `atomic.Pointer`, `PendingChanges` | `v2/zone_snapshot.go` |
-| Staging API, coalescing publisher, dual-write `syncLegacyFromSnapshot` | `v2/zone_mutation.go` |
+| Staging API, coalescing publisher | `v2/zone_mutation.go` (dual-write removed in B3) |
 | `publish-cadence` on `ZoneConf` / `TemplateConf` | `v2/structs.go`, `v2/parseconfig.go` |
 | `InstallInitialSnapshot()` after first load / `SetupZoneSigning` | `v2/refreshengine.go`, `v2/zone_utils.go` |
 | B1 tests (`TestSnapshotImmutability`, dual-write, coalescing, generation guard) | `v2/zone_snapshot_test.go` — pass `-race` |
 
-### B2 — in progress (commits `6f0b3a3` … pending)
+### B2 — done (`c76dfc4`)
 
 | Mutator / deliverable | Status | Notes |
 |---|---|---|
@@ -59,18 +59,28 @@ Branch: `feature/zone-snapshot-correctness` (off `main`).
 | Post-refresh serial override (`outbound_soa_serial`) | **done** | republish instead of `setApexSOASerial` on served data |
 | `PublishCsyncRR` | **unchanged** | already routes via internal `ZONE-UPDATE` → staged RFC2136 |
 | `dnsutils.SortFunc` (zone file load into `new_zd`) | **intentionally unchanged** | draft build target; consumed by refresh publish |
-| `setApexSOASerial` / `AddOwner` | **dead / unused** | remove in B3 cleanup |
 | `tdns-cli debug zone-txlog` + `/debug` handler | **done** | `pendingChanges()` → `zone-txlog` command + JSON view |
-| `TestConcurrentServeAndUpdate` (B2 variant) | **done** | readers via `GetOwner`; dual-write checked under `zd.mu` after publish |
+| `TestConcurrentServeAndUpdate` (B2 variant) | **done** | superseded by B3 variant in same commit |
 | `pendingChanges` test | **done** | `TestPendingChanges` |
 
-**B2 gate:** all B1 tests + `TestPendingChanges` + `TestConcurrentServeAndUpdate` pass `-race`.
+**B2 gate:** all B1 tests + `TestPendingChanges` + `TestConcurrentServeAndUpdate` (B2 variant) pass `-race`.
 
-**Remaining before B2 sign-off:** dead-code cleanup (`setApexSOASerial`, `AddOwner`); optional smoke of `debug zone-txlog` against a live auth.
+### B3 — reader cut-over done; enforcement remaining
 
-### B3 — not started
+| Deliverable | Status | Notes |
+|---|---|---|
+| Readers via `publishedSnapshot()` | **done** | `GetOwner`, `GetOwnerNames`, `NameExists`, `GetSOA`, `soaForResponse` |
+| Query transport signal | **done** | `queryresponder.go` → `publishedTransportSignal()` |
+| `ZoneTransferOut` / `WriteZoneToFile` | **done** | `GetOwnerNames`/`GetOwner`; no transfer-time SOA serial override |
+| Mutators use working set | **done** | `stagedOwner`, `workingOwnerNamesLocked` in sign/tsignal/ops_dnskey |
+| Drop dual-write | **done** | `syncLegacyFromSnapshot` removed; publish stores snapshot only |
+| Dead code cleanup | **done** | `setApexSOASerial`, `AddOwner` removed |
+| `check-no-mutators` grep gate | **done** | `utils/Makefile.common`; wired into `lint` |
+| B3 tests | **done** | `TestPublishedSnapshotAfterPublish`; B3 `TestConcurrentServeAndUpdate` — pass `-race` |
+| Unexported published type | **remaining** | `ZoneSnapshot` still exported; rename → `zoneSnapshot` |
+| `PrintOwners` | **remaining** | still walks draft `zd.Data`; should use `GetOwnerNames` |
 
-Reader cut-over (`GetOwner` → snapshot), drop dual-write, grep gate, unexported published type.
+**B3 gate (partial):** B1 + B2 + B3 snapshot tests pass `-race`. Full sign-off blocked on unexported type.
 
 ---
 

--- a/docs/2026-07-08-pipeline-projects-review-and-execution-order.md
+++ b/docs/2026-07-08-pipeline-projects-review-and-execution-order.md
@@ -1,0 +1,302 @@
+# Pipeline projects — alignment review & recommended execution order
+
+**Date:** 2026-07-08
+**Status:** review for discussion — no code or docs changed
+**Scope:** three in-pipeline projects, reviewed for (1) doc↔code alignment and
+(2) the best order to execute them, relative to the in-flight #275/#257 PRs.
+
+Projects reviewed (scope as confirmed with the author):
+- **(a)** Zone-mutation **snapshot correctness** — immutable snapshot + transaction
+  log + `atomic.Pointer` version switch. *(IXFR = separate later project;
+  outbound-transfer hardening = already done — both out of scope here.)*
+- **(b)** **KSK algorithm rollover** via two parallel FIFOs. *(ZSK dual-model = out
+  of scope.)*
+- **(c)** **tdns-mp ↔ tdns-transport registry consolidation** — collapse the
+  duplicated per-peer registries down to one `transport.Peer` registry in
+  tdns-transport, and clean the interface between the two.
+
+Baseline: tdns working tree on `feature/alg-registry-generator` (#275); each plan
+cross-checked against actual code (not doc-trusted). File:line anchors below were
+code-verified.
+
+---
+
+## TL;DR
+
+- **All three plans are still in line with the code.** Drift is cosmetic
+  (shifted line anchors, a couple of stale status lines) — no structural rot.
+- **Readiness differs sharply:**
+  - **(a)** is *implementation-ready* (review signed off, prerequisite already
+    met, ~0% built) — and fixes a **real, reproducible correctness bug**.
+  - **(c)** is *~70–80% done* by hard-effort; the inventive half is finished and
+    testbed-verified, the rest is largely mechanical deletion.
+  - **(b)** is *design-strong but not build-ready*: one open modelling question
+    (§7) must be settled, and it sits behind **#275 + the ZSK cleanups**.
+- **Recommended order:** **land #275 → finish (c) → land (a) → do (b).**
+  (a)'s tdns-*core* work can run in parallel with (c); (a)'s tdns-mp leg must land
+  *after* (c). The DNSSEC track (ZSK cleanups → (b)) is independent and can run
+  concurrently once #275 is in.
+- **(a)/(c) coordination (not a hard constraint):** both are significant tdns-mp
+  efforts, so avoid running them at once — and don't interrupt (c)'s risky Phase 1.
+  *(The `tdns.SliceZone` reference in tdns-mp is NOT a real forcing function — the
+  author confirms tdns-mp doesn't need SliceZone, it merely references it; the
+  cleanup is trivial and already known. Earlier draft over-weighted it.)*
+
+---
+
+## Per-project findings
+
+### (a) Zone-mutation snapshot correctness
+
+**The bug is real.** `GetOwner` returns a copy of the map *value*, but `RRtypes`
+is a pointer, so the copy shares the live `*RRTypeStore`
+(`v2/zone_utils.go:442-457`). Query-path write-backs (apex re-sign, SOA serial
+stamps, positive-answer `Set`-after-sign) mutate *published* data while the SOA
+serial is bumped separately — so two secondaries can serve different content
+under the same serial. Confirmed at `v2/queryresponder.go:108/115/339-340/775`
+and the ~15 mutator sites the plan enumerates.
+
+**Status: ~0% built.** No `ZoneSnapshot`, `atomic.Pointer[ZoneSnapshot]`,
+`workingSet`, `publish()` anywhere in `v2/` or `tdns-mp/v2/`. The only partial
+convergence is per-RRset atomicity in `ResignZone`/`StripZoneRRSIGs`
+(`v2/sign.go:560-580`) — narrower than the plan's zone-level, serial-boundary
+guarantee.
+
+**Alignment: sound, light anchor-refresh needed.** All named structs/funcs exist;
+`structs.go` line anchors have shifted ~5-6 lines (`ZoneData` now :105, `IxfrChain`
+:135, `Ixfr` :504). The plan's headline prerequisite — "Project A step 0 retires
+SliceZone; store becomes map-only" — is **already satisfied** (`ZoneStore` is only
+`XfrZone`+`MapZone`; `SliceZone` survives only in a test). The adversarial review
+(`…-review.md`) is signed off "no blockers"; open items are doc nits (N1-N3 stale
+milestone labels) foldable at implementation time.
+
+**Dependencies & blast radius.** No conflict with #275 or #257 (zone-data layer is
+untouched by both). Blast radius **large and correctly self-assessed**: it reshapes
+the core served type on the hottest path (~2000-2400 LOC), and **it ripples into
+tdns-mp**, which embeds `*tdns.ZoneData` and mutates zone data directly in
+`mp_signer.go`/`combiner_utils.go` (9+ `Set` sites) — those must route through the
+new staging API, cross-repo, landing compatibly.
+
+**Readiness: implementation-ready** (after a ~30-min anchor-refresh pass).
+
+### (b) KSK algorithm rollover — parallel FIFO
+
+**Mechanism.** Multi-DS *cannot* do an algorithm rollover (a pre-positioned
+`DS(newalg)` with nothing yet signing under that algorithm is an orphan DS,
+indistinguishable from a downgrade). The design does a double-signature roll: the
+engine already runs a KSK FIFO and a ZSK FIFO in parallel that jointly emit the
+apex DNSKEY RRset; an alg roll transiently **spawns a second, new-algorithm KSK
+FIFO** (N:2→3), keeps the old-alg KSK active until the new-alg DS confirms, then
+drains and drops it.
+
+**Status: engine is single-track today.** Nothing multi-FIFO exists; the
+`double-signature` method is **scaffolded but unimplemented**
+(`v2/ksk_rollover_policy.go:53/231/407`). The single-active-SEP guard the design
+must rescope (to *one active per (role, algorithm)*) is present and hard-errors
+today (`v2/ksk_rollover_atomic.go:152-178`). Per-zone rollover state
+(`v2/ksk_rollover_zone_state.go:19`) exists and is exactly what §7 must extend to
+per-FIFO.
+
+**Alignment: sound; registry-agnostic.** Minor drift (filename shorthand
+`ds_push.go`→`ksk_rollover_ds_push.go`; doc cites `feat/tsig-first-class` line
+numbers, resolve anyway). Crucially, the FIFO engine keys everything on `uint8`
+codepoints and does **not** import `v2/algorithms`, so #275's registry rework does
+*not* invalidate it. The one real touch-point is policy validation:
+`validateRoleCapabilities` (`v2/large_ksk.go:130-153`, new on #275) now gates a
+target algorithm's role via `CapsReal`/`ForKSK`/`ForZSK` — which is precisely the
+correct substrate for minting a `ForKSK && !ForZSK` PQ KSK. The design predates
+that function; it doesn't conflict, but should adopt it.
+
+**Not build-ready — one open design question.** §7 (per-FIFO rollover state keyed
+`(zone, role, algorithm)` vs. the single physical per-zone DS RRset at the parent)
+is explicitly "settle before build." Plus a self-flagged margin-correctness check
+(§5) and a role/mode-aware signer-strip change that must be co-designed with ZSK
+cleanup P0-6 (§6).
+
+**Dependencies (firm, and they drive ordering):**
+1. **#275 must land first** — the role-capability model (`ForKSK`/`ForZSK`) is the
+   substrate for alg-split policies.
+2. **ZSK cleanups first** (`docs/2026-07-01-zsk-alg-rollover-cleanups.md`): the D3
+   invariant unifies with **P0-2**, the signer-strip logic co-designs with **P0-6**,
+   the in-flight predicate generalizes via **P0-4**. Starting (b) before these
+   duplicates KSK-shaped code the cleanups are meant to share.
+3. Then: generalize double-signature (same-alg) → FIFO instantiation → alg roll.
+
+**Readiness: needs one focused design pass (§7)**, then it's the most-gated of the three.
+
+### (c) tdns-mp ↔ tdns-transport registry consolidation
+
+**End state.** Two peer-state stores joined only by `PeerID`:
+`transport.PeerRegistry` (identity/address/per-mechanism state/liveness/crypto/stats)
+as the sole source of truth, and one nearly-empty MP `AgentRegistry` view. Transport
+speaks an opaque `{Scope, TypeToken, Payload}` vocabulary; no MP body types in
+transport. (Collapsing to a single Go map is provably impossible across the package
+boundary — the real target is "one allocation, two typed views, no bridge.")
+
+**Status: ~70–80% done by hard-effort; at end of A3d-END.1 (E1.a).** The inventive
+half — making `transport.Peer` canonical without breaking the live beat/hello state
+machine — is **done and testbed-verified**: `AgentDetails.State` has **zero**
+functional writers, the hsync engine reads `transport.Peer`
+(`hsync/hello.go:24/98`), decay-on-read lives on transport (`peer.go:269`), and
+`Agent` embeds `*hsync.Peer` (`agent_structs.go:84-97`). What remains (E1.b bridge
+teardown → delete `AgentDetails` → crypto rehome → discovery relocate → inbound
+collapse) is largely **compiler-checkable deletion**. Est. ~3.5–6.5 sessions to the
+single-registry end state. *(Stage C — the reusable-library "opaque seam" — is a
+separate ~5-7 sessions at 0%, and is downstream of the consolidation.)*
+
+**Open issues: both already resolved in code.** The a3d-end0 testbed regression was
+properly retired by D2.5 (engine repointed at `transport.Peer`; `hsync/d25_test.go`
+guards it). The peer-state/discovery "truth-fix" (4 bugs) landed and has operator
+sign-off. The doc status lines that still say "regression found" are stale history.
+
+**Alignment: no structural drift.** `2026-06-14-road-to-stage-C-plan.md` is the doc
+that best matches reality (it supersedes v3 for the END/A5/discovery work); **v3
+remains authoritative for Stage C and D/E/F**. Only cosmetic nits (a stale
+`peer.go:85` "legacy fields canonical" comment; the stale status line above).
+
+**Dependencies: self-contained — with one latent collision.** Phases 1–3 need **no
+tdns core changes** and #275 is already absorbed (Gate-2 pinned the shared
+`johanix/dns` fork). Project (a) does **not** collide with the transport/peer work
+(orthogonal). **But:** `tdns-mp/v2/hsync_utils.go:1189-1190` still references
+`tdns.SliceZone` / `mpzd.Owners`, both **deleted by the already-merged Project A**.
+tdns-mp is insulated *today* only because it pins tdns/v2 at 2026-06-11 (pre-Project-A).
+The moment tdns-mp advances that pin, the build breaks there (one-line fix).
+
+**Readiness: executable as-is** on the road-to-C plan. Biggest risk: Phase 1 (E1.b)
+— universal pointer-sharing + collapsing to one mutex per peer + bridge teardown, all
+at once on the live state machine ("riskiest commit of the stage"). **Do not interrupt
+it mid-flight.**
+
+---
+
+## Cross-project dependency & collision map
+
+```
+#275 (alg registry, lands soon) ──┬─► (b) role-capability substrate  [HARD PREREQ]
+                                  └─► already absorbed by (c) (Gate-2) [settled]
+
+ZSK cleanups (P0-2/4/6) ─────────────► (b)  [HARD PREREQ — shared invariant/strip]
+
+(b) §7 design pass ──────────────────► (b) build  [must settle first]
+
+Project A (SliceZone deleted, MERGED) ─► latent break in (c)'s repo (tdns-mp:1189)
+                                          triggered by any tdns-dep bump
+
+(a) staging API (tdns core) ─────────► forces tdns-mp dep bump ─► trips the
+                                          SliceZone break + needs Set-site routing
+                                          ⇒ (a)'s tdns-mp leg must land on a STABLE
+                                            tdns-mp ⇒ after (c) consolidates
+
+(a) ⟂ (b): different subsystem, no interaction.
+(c) ⟂ (b): different subsystem, no interaction.
+#257 (imr transport): independent of all three; own schedule; gates nothing here.
+```
+
+The only genuine entanglement is **(a) ↔ (c) via tdns-mp**: both are significant
+tdns-mp efforts, and (a)'s dep bump trips (c)'s dormant SliceZone break. They don't
+share files, but running two large tdns-mp refactors at once (one near a delicate
+concurrency commit) is the thing to avoid.
+
+---
+
+## Rough effort estimates (LOC)
+
+LOC is a **misleading cross-project unit here** — (a) is additive new machinery on
+the hottest path, (b) is an additive state-machine, **(c) is mostly deletion**
+(net-negative). Read the "net" column, not the total.
+
+| Project | Impl | Test | Total (gross) | Net | Confidence |
+|---|---|---|---|---|---|
+| **(a)** snapshot correctness | ~1400–1800 | ~600 | **~2000–2400** | additive | **high** — author's revised §6 |
+| **(b)** KSK parallel-FIFO *proper* | — | — | **~1200–2200** | additive | **low** — design defers it (§7) |
+| **(b)** prereq: ZSK cleanups (P0-2/4/6 + P2-1/4 helpers) | — | — | **~300–600** | additive | med-low |
+| **(c)** → one registry (Phases 1–3) | deletion-dominant | | **~800–1500 gross, NET negative** | removes code | med; already ~70–80% done |
+| **(c)** Stage C seam (separate, downstream, 0%) | — | | ~1500–3000 gross (reorg) | moves code | low |
+
+- **(a) ~2000–2400 LOC** (~20–40 h): firmest figure — the plan's own revised §6
+  estimate; reviewer judged it "credible, if anything on the low side."
+- **(b) ~1500–2800 LOC end-to-end** incl. the ZSK-cleanup prerequisite — the
+  **softest** number: the design doc explicitly defers a real breakdown until §7 is
+  settled. Anchored on the older "rides multi-DS unchanged" estimate (~630–1000 LOC /
+  17–29 h), scaled up for the "materially larger" parallel-FIFO machinery.
+- **(c)** don't read its low/negative net LOC as "small effort." It's ~70–80% done;
+  the tail is deletion (strip `AgentDetails` fields from a 427-line file, tear down
+  the 148-line copy-bridge, slim the 331-line bridge wiring) + one risky rewrite
+  (Phase 1 E1.b concurrency) + a net-zero discovery move. Plan measures it as
+  **~3.5–6.5 sessions** to the single-registry end state; LOC understates progress and
+  overstates remaining effort.
+
+**Remaining-effort ranking:** (a) ≳ (b) > (c-remaining). **Risk ranking:** (a)'s
+hot-path rewrite and (c)'s Phase 1 concurrency are the spiky ones; (b)'s risk is the
+§7 model + DS-coordination correctness.
+
+## Recommended execution order
+
+**Primary spine:**
+
+1. **Land #275** (imminent; already decided). Unblocks (b)'s prerequisites and the
+   already-built `large-alg-prefix` follow-on.
+
+2. **Finish (c) to its single-registry end state** (Phases 1–3), keeping tdns-mp's
+   tdns/v2 dep **pinned** throughout. *Why first:* it's furthest along, fully
+   self-contained, momentum-sensitive (don't interrupt the risky Phase 1), and
+   finishing it lands tdns-mp in a clean, consolidated state that makes (a)'s
+   cross-repo leg far easier.
+
+3. **Land (a) snapshot correctness.** Start the **tdns-core** work (B1→B2→B3) now —
+   it's independent and can run *in parallel with (c)* since it's a different repo
+   area. Prefer to land the **tdns-mp leg** (dep bump + route the 9+ `Set` sites
+   through the staging API) **after (c) consolidates**, so tdns-mp isn't carrying
+   two big refactors at once — but this is a soft preference, not a hard gate.
+   *(The `tdns.SliceZone` reference tripped by the dep bump is a trivial known
+   one-liner, not a blocker.)*
+
+4. **Do (b) KSK parallel-FIFO** — naturally last. After #275: run the **ZSK
+   cleanups**, then the **§7 design pass**, then build (generalize double-signature →
+   FIFO instantiation → alg roll). This whole DNSSEC track is independent of (a)/(c)
+   and can proceed on its own thread whenever attention allows.
+
+**If you parallelize** (two independent threads):
+- *Thread α — zone-data / tdns-mp:* (c) → (a). (a)'s tdns-core work overlaps (c).
+- *Thread β — DNSSEC:* [#275] → ZSK cleanups → (b) §7 design → (b).
+
+**If you serialize** (strictly one thing at a time):
+`#275 → (c) → (a) → ZSK cleanups → (b) §7 design → (b)`.
+
+**Judgment call to flag:** (a) fixes a *live correctness bug* (cross-secondary serial
+divergence), whereas (c) is consolidation/quality. If that bug is actually biting in
+production, (a)'s **tdns-core** portion can jump the queue immediately (it needs
+nothing from (c)); only its tdns-mp leg should still wait for (c). Momentum otherwise
+favors finishing (c) first.
+
+**#257 note:** it's on its own track (phase2 already prepped), slower, and gates
+nothing here — merge it whenever it's ready, independent of this sequence.
+
+---
+
+## Coordination checkpoints & watch-items
+
+1. **No reason to bump tdns-mp's tdns/v2 dep mid-(c).** Keeping it pinned avoids
+   dragging unrelated tdns churn into the refactor. When (a)'s tdns-mp leg does bump
+   it, the `tdns.SliceZone` reference (`tdns-mp/v2/hsync_utils.go:1189`) needs a
+   trivial one-line cleanup — known and expected, not a blocker.
+2. **Don't interrupt (c) Phase 1 (E1.b).** It's the highest-risk single commit
+   (one-mutex-per-peer + bridge teardown on the live state machine); it wants a clean
+   run with `-race` + a testbed checkpoint, not a context switch.
+3. **(b) is not "start now."** It needs #275 landed, the ZSK cleanups done, and the
+   §7 design settled — in that order. Doing the §7 pass early (it's cheap, ~1 session)
+   is the highest-leverage prep.
+4. **Doc hygiene (cheap, do opportunistically):** re-pin (a)'s `structs.go` anchors
+   and fold review nits N1-N3; clear (c)'s two stale status lines
+   (`a3d-end0` "regression found", `peer.go:85` "legacy fields canonical"); note in
+   (b)'s doc that `validateRoleCapabilities` (post-#275) is now the role-capability gate.
+
+---
+
+## One-line verdict per project
+
+| Project | Doc↔code | Built | Ready to start? | Gated by |
+|---|---|---|---|---|
+| **(a)** snapshot correctness | in line (anchor drift) | ~0% | **yes** (core now; tdns-mp leg after (c)) | — |
+| **(b)** KSK parallel FIFO | in line; registry-agnostic | ~0% (scaffold only) | **no** — needs §7 design | #275 + ZSK cleanups |
+| **(c)** registry consolidation | in line (road-to-C is live) | ~70–80% | **in progress — finish it** | — (keep dep pinned) |

--- a/docs/2026-07-08-post-snapshot-simplification-options.md
+++ b/docs/2026-07-08-post-snapshot-simplification-options.md
@@ -1,0 +1,189 @@
+# Post-snapshot simplification options
+
+**Date:** 2026-07-08
+**Scope:** Active tree only (`v2/`, `cmdv2/`). Legacy trees (`cmd/`, `tdns/`,
+`music/`, `obe/`) explicitly excluded.
+**Nature:** Read-only evaluation. No code was changed. This document records
+simplification *options*, not decisions.
+**Context:** Evaluation performed on branch `feature/zone-snapshot-correctness`
+(tip `a093592`), i.e. after the immutable-snapshot publication model landed.
+
+---
+
+## Summary
+
+| # | Question | Verdict | Confidence |
+|---|----------|---------|------------|
+| a | Is anything using `ValidatorEngine`? | Dead code. Removable. | High |
+| b | Is `RRTypeStore`'s concurrency still needed? | Not for served data — strong case for a plain map. | High (design), Medium (full write-audit) |
+| c | Are all `ZoneData` fields needed? | A few write-only/vestigial fields; one documented redundant cluster. | High for the named fields |
+| d | Locks removable in query / transfer hot path? | Partial — the win is the per-RRset shard locks, same change as (b). | High |
+
+The through-line: **(b) and (d) are the same fix**, and it is the
+highest-value simplification available. (a) is the easiest clean win. (c) is
+minor.
+
+---
+
+## (a) ValidatorEngine — dead code
+
+`ValidatorEngine` (`v2/validatorengine.go:23`) is a goroutine that blocks
+reading `conf.Internal.ValidatorCh`, started three times in
+`v2/main_initfuncs.go:250,259,267`. The channel is **created**
+(`v2/main_initfuncs.go:190`) and **read** (`v2/validatorengine.go:24`) — but
+there is **not a single send site** anywhere in `v2/` or `cmdv2/`. Every
+reference to `ValidatorCh`, `ValidatorRequest`, and `ValidatorResponse` was
+grepped: they appear only in the engine, the struct definitions, the config
+field, and the channel init. No caller ever submits a `ValidatorRequest`.
+
+So the goroutine parks forever on an empty channel. It is also gated behind
+`viper.GetBool("validator.active")` (`v2/validatorengine.go:28`), but even when
+"active" nothing feeds it. Real validation happens elsewhere via direct calls
+to `ValidateChildDnskeys` / `ValidateRRset` — exactly what the engine would
+have called.
+
+**Removable:**
+
+- `v2/validatorengine.go` (171 lines)
+- `ValidatorRequest` / `ValidatorResponse` (`v2/structs.go:644-651`)
+- `ValidatorCh` field (`v2/config.go:454`)
+- its `make()` (`v2/main_initfuncs.go:190`)
+- the 3 `StartEngineNoError` calls (`v2/main_initfuncs.go:250,259,267`)
+
+~200 lines net, zero behavior change. The only risk is an out-of-tree consumer
+importing the exported structs — worth a quick check before deleting them.
+
+---
+
+## (b) RRTypeStore vs. plain maps — strong case to simplify
+
+`RRTypeStore` (`v2/rrtypestore.go:7`) wraps a
+`core.ConcurrentMap[uint16, core.RRset]` — a 16-shard `RWMutex` map. Under the
+snapshot model its concurrency is **redundant for served data**, for two
+verified reasons:
+
+1. **Writes are single-writer.** Every `RRtypes.Set`/`Delete` is either
+   construction of a *fresh, not-yet-published* `OwnerData` during zone load
+   (`v2/dnsutils.go:575-593`) or staging into `workingSet` under `zd.mu`
+   (`v2/zone_mutation.go:36,45,50,205,223,228`). No writer mutates a
+   *published* store — the documented copy-strategy-A invariant
+   (`v2/zone_snapshot.go:170-179`), CI-grep-enforced.
+
+2. **Reads are post-freeze.** Served reads come off the immutable snapshot,
+   whose owner map `snap.Data` is *already* a plain `map[string]*OwnerData`
+   (`v2/zone_snapshot.go:17-24`). The snapshot de-concurrent-ified the owner
+   map but left each owner's `RRtypes` as a `ConcurrentMap` — an asymmetry
+   with no justification once the freeze invariant is accepted.
+
+**The case:** back `RRTypeStore` with a plain `map[uint16]core.RRset` (keeping
+the same `Get/Set/Keys/Count` API so no call sites change), relying on `zd.mu`
+for staging writes and snapshot immutability for reads. Not used in any
+genuinely-concurrent context — the IMR/resolver path (`v2/dnslookup.go`) builds
+per-operation `OwnerData` locally, not shared.
+
+**What would break** only if the invariant is violated (a future direct writer
+to a published store) — the same failure mode the design already warns about.
+
+---
+
+## (c) ZoneData fields — a few removable, one redundant cluster
+
+Verified write-only / vestigial fields (evidence = exact reference list):
+
+- **`LatestRefresh`** — written once (`v2/refreshengine.go:120`), **never
+  read**. Dead.
+- **`LatestError`** — written in 8 places (all `= time.Now()`), **never read**.
+  Dead bookkeeping.
+- **`ApexLen`** — incremented on load (`v2/dnsutils.go:571`) and copied on flip
+  (`v2/zone_mutation.go:312`), but **no logic ever reads it**. Write-only
+  leftover from older name-handling.
+- **`IxfrChain`** (on `ZoneData`) — copied into the snapshot
+  (`v2/zone_mutation.go:341`) but **never populated anywhere**, so it is always
+  empty. Vestigial, tied to the not-yet-implemented IXFR project — either wire
+  it up there (see `docs/2026-07-02-ixfr-support.md`) or drop it now.
+
+**Documented redundant-by-design cluster:** `Error`, `ErrorType`, `ErrorMsg`,
+`LatestError` are all derived from `Errors map[ErrorType]ZoneError` and kept in
+sync by `SetError`/`ClearError` (`v2/structs.go:155-165`). Deliberately
+duplicated for legacy call sites — a consolidation opportunity (migrate readers
+to `ErrorList()`), not dead code. `LatestError` is the one member of the
+cluster that is pure dead weight.
+
+**Suspicious but load-bearing — leave them:**
+
+- `XfrType` — surfaced to API (`v2/zone_utils.go:200,279`).
+- `RefreshCount` — gates responses when a zone never refreshed
+  (`v2/defaultqueryhandlers.go:103,164`, `v2/updateresponder.go:135`).
+- `PrimariesConf`/`Upstreams` and `ParentNS`/`ParentServers` — as-written vs.
+  resolved variants, both read.
+
+---
+
+## (d) Hot-path locks — partial, and the same change as (b)
+
+The snapshot refactor already did the big structural win: **neither the query
+responder nor the transfer path takes `zd.mu` while building a response.**
+`zd.snapshot` is an `atomic.Pointer` (`v2/structs.go:178`), both paths pin one
+snapshot at entry (`v2/queryresponder.go:623`, `v2/dnsutils.go:264`), and
+`snap.Data` is a lock-free plain map.
+
+The **remaining** hot-path locks are the shard `RWMutex` RLocks *inside*
+`RRtypes.Get/GetOnlyRRSet/Keys/Count`, hit on immutable snapshot data:
+
+- **Highest value — AXFR out loop** (`v2/dnsutils.go:362-363`): calls
+  `RRtypes.Keys()` (16-shard RLock + goroutine fan-out) plus `GetOnlyRRSet`
+  **for every owner in the zone** while streaming a transfer. All against
+  frozen data.
+- **Query path**: repeated `RRtypes.Get/Count/Keys` RLocks per query
+  (`v2/queryresponder.go:94-95,417,462,515,697,792`, `v2/auth_utils.go:35-164`).
+  `Count()` RLocks all 16 shards; `Keys()` also spawns goroutines — heavy for
+  reading a handful of RR types.
+
+**These vanish for free if (b) is done** — a plain-map-backed snapshot RRset
+store makes every one of these a lock-free map read. It is a data-type change,
+not a mechanical "delete `Lock()`"; no lock statement is safe to just remove on
+its own.
+
+**Keep (genuinely mutable):**
+
+- the global `Zones` registry lookup (`v2/zone_utils.go:612,623`)
+- `zd.Status` via `GetStatus()` (`v2/enums.go:436`)
+- per-connection TSIG state (`v2/dnsutils.go:246`)
+- the KeyDB signing path
+- the publisher-side `zd.mu` that serializes working-set build + atomic swap
+
+---
+
+## Ranked recommendation
+
+1. **Lock-free snapshot RRset store** (b + d together) — retire
+   `RRTypeStore`'s concurrent map for the *served* path; biggest
+   correctness-neutral perf/simplicity win, removes all hot-path RLocks.
+   Requires holding the freeze invariant, which the design already asserts.
+2. **Delete `ValidatorEngine`** (a) — ~200 lines, trivially safe, no behavior
+   change.
+3. **Drop `LatestRefresh`, `LatestError`, `ApexLen`** (c) — verified write-only.
+4. **Decide `IxfrChain`'s fate** with the IXFR project — vestigial until then.
+5. **Housekeeping:** 8 stray `.go~` editor-backup files are in the tree (e.g.
+   `v2/imrengine.go~`, `v2/delegation_utils.go~`, `cmdv2/cli/root.go~`). Not
+   compiled, but clutter that shows up in greps.
+
+---
+
+## Deeper thread not fully resolved
+
+There are now *three* owner-map representations — `zd.Data` (`ConcurrentMap`),
+`workingSet` (plain map), and `snap.Data` (plain map). It is plausible
+`zd.Data`'s concurrent type is now redundant too, but confirming whether
+`zd.Data` can be retired needs a dedicated trace of every remaining live-store
+reader. Worth its own read-only pass before touching it.
+
+---
+
+## Method note
+
+Evaluation ran four parallel read-only investigations (one per question) plus
+direct grep/read verification of the `ValidatorCh` send sites, the
+`RRtypes.Set/Delete` writer discipline, and per-field reference counts on
+`ZoneData`. All `file:line` citations above were checked against the working
+tree at branch tip `a093592`.

--- a/docs/2026-07-08-snapshot-corrections-eval.md
+++ b/docs/2026-07-08-snapshot-corrections-eval.md
@@ -1,0 +1,142 @@
+# Project B Review — Zone-Mutation Snapshot Correctness
+
+**Date:** 2026-07-08
+**Source:** evaluation summary from an external review agent, of the snapshot-correctness (Project B) implementation.
+
+**Verdict: Do not merge.** Two critical defects + one confirmed regression must be
+fixed first. The writer side (B1/B2 staging, publish, dual-write, locking) is
+genuinely solid and well-tested. The reader cutover (B3) is incomplete in exactly
+the way that matters: the serial-tearing bug this project was chartered to
+eliminate is **moved, not fixed**.
+
+## Objective gates
+
+- ✅ Builds clean, `go vet` clean, 7 GPG-signed commits, correctly milestoned
+  B1→B2→B3, tdns-mp untouched (scope respected).
+- ❌ **`-race` acceptance gate FAILS** — 2 tests regress (`TestRepublishPubkey…`,
+  `TestRepublishPubcds…`), confirmed passing on `origin/main`. (Not a data race —
+  assertion failures.)
+
+## CRITICAL (block merge)
+
+### C1 — Intra-response snapshot tearing: the core bug is not actually fixed.
+
+QueryResponder and ZoneTransferOut make many independent `snapshot.Load()` calls
+per response (verified: `queryresponder.go` lines 274, 340, 370, 624, 631, 654,
+670, 680, 688, 737, 777…; no single threaded snap). If a `publish()` lands
+mid-query, the Answer RRset and the authority SOA come from different snapshot
+generations → different content under a mismatched serial. This is precisely plan
+§0's "two secondaries serve different content for the same serial." The
+immutable-snapshot machinery is correct; it's just not being used atomically per
+response.
+
+**Fix:** load the snapshot once at the top of QueryResponder (and ZoneTransferOut)
+and thread that one `*zoneSnapshot` through all readers. This is the central
+deliverable of B3 and is currently unmet. `TestConcurrentServeAndUpdate` misses it
+because it loads once per iteration and never drives the real multi-load query
+path.
+
+### C2 — Catalog membership parsing left on live `zd.Data`, now broken.
+
+`v2/catalog.go` (untouched by B) still reads `zd.Data.IsEmpty()`/`IterBuffered()`
+(lines 56, 81). B3 removed the dual-write, so live `zd.Data` is now empty/stale →
+`ParseCatalogZone` returns "catalog zone data is empty" on every load, silently
+breaking catalog auto-configuration.
+
+**Fix:** read `zd.publishedSnapshot().Data`.
+
+## MAJOR
+
+### M1 — ZoneTransferOut can emit a torn AXFR
+
+Same root cause as C1, distinct path: `dnsutils.go` 261/345/354. Load once, iterate
+that snapshot.
+
+### M2 — Reachable nil-snapshot panic in `soaForResponse` (`zone_snapshot.go:251`)
+
+The fallback dereferences apex with no nil-check, and
+`applyRefreshReplacementLocked` sets `Ready=true` even when the publish was dropped
+via the `!zoneStillLive` early-return, leaving `Ready && snapshot==nil`. Query
+dispatch doesn't gate on `Ready`.
+
+**Fix:** nil-guard the fallback and/or SERVFAIL when `publishedSnapshot()==nil`.
+
+## Regression
+
+### R1 — the 2 failing tests are a TEST-HARNESS gap, not a production bug
+
+(Verified by the trace agent, and it's sound.) `newMapZone` populates `zd.Data` but
+never installs a snapshot, so post-cutover `GetOwner` returns nil. Real zones always
+publish before `OnZonePostRefresh` runs, so republish works in production.
+
+**Fix:** `newMapZone` must call `InstallInitialSnapshot()`. But note: this is also a
+warning sign — several tests now pass **vacuously** (they expect empty and get empty
+for the wrong reason), which is why C1/C2 slipped through.
+
+## MINOR / hardening
+
+- **m1** — dead reader `XXfindServerTSYNCRRset` (`queryresponder.go:942`) still
+  iterates live `zd.Data`; delete it.
+- **m2** (reviewer's own finding) — `snapshotMapFromData` shares the `*RRTypeStore`
+  pointer with live `zd.Data` (`zone_snapshot.go:176`, `odCopy := od` copies the
+  pointer, not the store). Latent, not currently exploitable — B removed the
+  in-place writers, so nothing mutates the shared store post-publish. But it's a
+  fragile invariant the grep gate doesn't fully protect; a future direct `zd.Data`
+  writer silently reintroduces the immutability bug. Consider deep-copying in
+  `snapshotMapFromData`, or documenting the invariant loudly.
+- **m3** — the CI grep gate only catches mutation regressions (`RRtypes.Set`/
+  `Data.Set`), not reader regressions — which is exactly what C1/C2 are.
+  Scope-correct per the plan, but it gives zero protection against the two worst
+  findings.
+
+## What's genuinely good (credit where due)
+
+The writer side is well-executed: staging via `cloneOwner`/`cloneRRset` correctly
+fresh-allocates, publish is properly locked under `zd.mu`, the coalescing publisher
++ generation guard are sound, the `pendingChanges`/debug zone-txlog observability is
+clean, and the immutability discipline on the write path holds. The B1→B2→B3
+strangler structure was followed faithfully.
+
+## Recommendation
+
+Send back with **C1, C2, M1, M2, R1** as required fixes (C1 is the headline — the
+project doesn't achieve its own goal without it). **m1–m3** as follow-ups. After
+C1's "load once per response" fix, the acceptance test should be strengthened to
+drive QueryResponder under concurrent publishes (not just the raw snapshot), or
+C1-class tearing will regress silently.
+
+## Addendum (2026-07-08) — pre-existing harness failures + a real StripZoneRRSIGs bug
+
+When the eight fixes above were applied, `go test -race .` in `v2/` had **14
+further failures** beyond the two R1 named — all the *same* root cause R1
+identified (a test builds/loads a zone but never installs a published snapshot,
+so after the B3 reader cutover every read returns empty). The original eval
+undercounted this. None were introduced by the eight fixes.
+
+Failing tests, by file:
+- `delsync_proxy_p2_test.go` — TestProxyPreRefresh{NoChange,CDSChange,CSYNCChange,NSChange}, TestProxySelfDebounceOnRepeatedTransfer
+- `delsync_proxy_update_test.go` — TestProxyApexKEYs, TestProxyCurrentDelegationRRs, TestProxyCurrentDelegationRRsUnsigned
+- `zone_transfer_out_test.go` — TestZoneTransferOut_{RoundTrip,LargeZoneSpansEnvelopes,LargeApexSpansEnvelopes,TSIGLargeApexEnvelopeSizes,TSIGRoundTrip}
+- `sign_reconcile_test.go` — TestStripZoneRRSIGs
+
+**Harness fix:** the shared helpers `testZone` and `loadTestTransferZone` now call
+`InstallInitialSnapshot()` after loading (mirroring `testSnapshotZone`/`newMapZone`),
+and `testZone`-based tests register the zone so `publishLocked`'s `zoneStillLive`
+(registry + generation) guard does not silently drop the publish. Two tests that
+mutated zone data *after* the snapshot was built — `TestStripZoneRRSIGs` and
+`TestZoneTransferOut_OversizeRRsetAborts` (which had been passing **vacuously**
+because the empty transfer "failed" for the wrong reason) — were made
+B3-compatible (mutate the live store, then re-publish).
+
+**Real bug found — not just harness — `StripZoneRRSIGs` mis-keyed every stripped
+RRset.** Once `TestStripZoneRRSIGs` could actually run, it showed
+`StripZoneRRSIGs` (`sign.go`) staging each stripped RRset under `rrset.RRtype` —
+but `GetOnlyRRSet` returns RRsets whose `RRtype` field is unset (0); the store
+keys by type separately. So every strip landed under type **0**, leaving the real
+RRSIGs untouched (the function returned the correct removal *count* but published
+unstripped data). Fixed by keying the stage on the authoritative loop type
+(`rrset.RRtype = rrt` before staging). This was a **B3 regression** — B3 rewrote
+`StripZoneRRSIGs` onto the working-set/stage path — that the harness gap had been
+hiding; exactly the "tests now pass vacuously" risk flagged in R1.
+
+Result: `go test -race .` in `v2/` is fully green.

--- a/docs/2026-07-08-snapshot-corrections-eval.md
+++ b/docs/2026-07-08-snapshot-corrections-eval.md
@@ -180,3 +180,58 @@ C1/M1 read-path refactor and (2) a testbed smoke test of query + AXFR under a
 concurrent publish.
 
 Branch state: three signed commits on top of the B3 work; **not yet pushed**.
+
+## Transport-signal redesign — option (b) (2026-07-09)
+
+Follow-up beyond the eval defects, addressing the CodeRabbit finding that the
+TSYNC transport signal was **signed after commit** (the snapshot froze an
+unsigned copy) and the broader smell that a separate pre-signed `TransportSignal`
+field duplicated data the resigner already maintains on the stored owner RRset.
+
+**Decision (agreed with maintainer): option (b) — retire the separate field;
+inject from the stored, resigner-maintained owner RRset.** Rationale: pre-sign
+and store everything known beforehand and let the resigner refresh it; reserve
+online signing for genuinely-ephemeral data (CDE). The transport signal must stay
+a stored, directly-queryable RRset (unlike CDE's ephemeral NSEC) so a resolver
+can explicitly fetch it and middleboxes/adversaries cannot strip it.
+
+What changed:
+
+- **Retired** `zd.TransportSignal`, `snap.TransportSignal`, `zd.wsTransportSignal`,
+  `zd.AddTransportSignal`, and helpers `cloneTransportSignal` /
+  `publishedTransportSignal` / `rrMatchesTransportSignal`, plus the
+  `transportSignalInAnswer` plumbing through the query path. The snapshot keeps
+  only `signalSynth map[string]*core.RRset` — the synthesized fallback for the
+  one case with no authoritative home (Case A, below).
+- **Stored under `_dns.<ns>`, signed before publish.** In-bailiwick signals are
+  synthesized, signed, and staged as real `_dns.<ns>` owner RRsets; the resigner
+  keeps their signatures fresh. This fixes the TSYNC sign-after-commit ordering
+  (no late-signed copy exists) and a **latent bug**: the old code stored the synth
+  under the *bare* NS owner (`ns.example.com`) while the RR was named
+  `_dns.ns.example.com`, so it was never directly queryable and was missed by the
+  `_dns.*` refresh carryover.
+- **Injection resolves at query time.** `collectSignalRRsets(snap)` derives the
+  signal owners from the apex NS RRset (the authoritative "which nameservers"
+  source — no parallel name list to keep in sync), and for each reads the stored
+  signed owner RRset from its authoritative home: the pinned snapshot when
+  in-bailiwick, another co-hosted zone's snapshot via `FindZone` when the
+  nameserver's own zone is co-hosted (Case A), or `signalSynth` otherwise. SVCB
+  `Target` / TSYNC `Alias` bridges (Case B) are chased the same way, depth-guarded
+  and deduped. **An alias whose target cannot be resolved is still returned** —
+  the alias is authoritative and SVCB fails safe (the resolver chases it or may
+  already hold the target); dropping it would diverge the injected and
+  direct-query paths.
+- `addTransportSignal` now dedups against the Answer section (so a direct query
+  for the signal is not duplicated into Additional), replacing the removed
+  in-answer flag.
+
+Behavior shifts (intentional): a co-hosted identity nameserver now serves
+provider.com's *authoritative signed* copy rather than an example.com-synthesized
+one (requires the signal enabled on the nameserver's own zone); `_dns.<ns>` is now
+a real owner and thus appears in AXFR; the `ValidateExplicitServerSVCB` gate is no
+longer applied (function retained, now unused).
+
+**Verified:** `go build ./...`, `go vet ./...`, `go test -race -count=1 .` in
+`v2/` — all green. Added `transport_signal_inject_test.go` (5 tests: in-bailiwick
+pickup, cross-zone alias chase, unresolvable-target-still-returns-alias,
+disabled-option, Answer-dedup); the signal path previously had no unit coverage.

--- a/docs/2026-07-08-snapshot-corrections-eval.md
+++ b/docs/2026-07-08-snapshot-corrections-eval.md
@@ -3,7 +3,9 @@
 **Date:** 2026-07-08
 **Source:** evaluation summary from an external review agent, of the snapshot-correctness (Project B) implementation.
 
-**Verdict: Do not merge.** Two critical defects + one confirmed regression must be
+**Original verdict: Do not merge** (now DISCHARGED — every defect below is fixed;
+see "Resolution & updated verdict" at the end for the commit mapping and the
+conditional merge recommendation). Two critical defects + one confirmed regression must be
 fixed first. The writer side (B1/B2 staging, publish, dual-write, locking) is
 genuinely solid and well-tested. The reader cutover (B3) is incomplete in exactly
 the way that matters: the serial-tearing bug this project was chartered to
@@ -140,3 +142,41 @@ unstripped data). Fixed by keying the stage on the authoritative loop type
 hiding; exactly the "tests now pass vacuously" risk flagged in R1.
 
 Result: `go test -race .` in `v2/` is fully green.
+
+## Resolution & updated verdict (2026-07-08)
+
+Every defect in this review has been fixed on branch
+`feature/zone-snapshot-correctness` in three GPG-signed commits:
+
+| Item | Fix | Commit |
+|---|---|---|
+| **C1** intra-response tearing | pin one snapshot per response; thread it through all readers via `…From(snap,…)` variants | `a093592` |
+| **M1** torn AXFR / file dump | pin one snapshot per `ZoneTransferOut` / `WriteZoneToFile` | `a093592` |
+| **m3** weak acceptance test | added `TestQueryResponderNoIntraResponseTearing` (concurrent-publish tearing check) | `a093592` |
+| **C2** catalog reads live `zd.Data` | read `publishedSnapshot().Data` | `bdfd444` |
+| **M2** nil-snapshot panic / `Ready` lie | nil-guard `soaForResponse`; gate `Ready` on a real published snapshot | `bdfd444` |
+| **R1** republish test-harness gap | `newMapZone` installs the initial snapshot | `bdfd444` |
+| **m1** dead reader on live `zd.Data` | delete `XXfindServerTSYNCRRset` | `bdfd444` |
+| **m2** shared `*RRTypeStore` | documented the copy-strategy-A invariant (NOT deep-copied — that would defeat the PQ-signature perf goal) | `bdfd444` |
+| +14 pre-existing harness failures | `InstallInitialSnapshot()` in the shared test helpers | `5209efa` |
+| + `StripZoneRRSIGs` mis-keying (**real bug found**) | key the stage on the loop type, not the unset `rrset.RRtype` | `5209efa` |
+
+**Verified:** `go build ./...`, `go vet ./...`, and `go test -race .` in `v2/` —
+all clean; suite fully green (0 failures).
+
+**NOT verified (merge caveats):**
+- Only the `v2` package's unit tests were run — no testbed/integration pass, no
+  real binary build, no live query/AXFR smoke test. C1/M1 is a substantial
+  refactor of the auth server's hot query + transfer path.
+- The "tests pass vacuously" risk (R1/m3) is only half-retired: the tests that
+  were *failing* vacuously are fixed, but tests that *pass* for the wrong reason
+  were not audited — and a real `StripZoneRRSIGs` bug was hiding behind one.
+- m2 is enforced by the CI grep gate + discipline, not by deep-copy.
+
+**Updated verdict: CONDITIONALLY MERGEABLE.** The original "do not merge"
+blockers are discharged and the suite is green, so it clears the review's bar.
+But do not merge on green unit tests alone — gate on (1) human review of the
+C1/M1 read-path refactor and (2) a testbed smoke test of query + AXFR under a
+concurrent publish.
+
+Branch state: three signed commits on top of the B3 work; **not yet pushed**.

--- a/docs/2026-07-13-unsigned-publish-window.md
+++ b/docs/2026-07-13-unsigned-publish-window.md
@@ -1,0 +1,387 @@
+# Unsigned-publish window on reload/refresh: analysis, fix, and the tdns-debug reload test
+
+**Date:** 2026-07-13
+**Branch context:** analysis/fix target `feature/zone-snapshot-correctness`;
+test target `feature/tdns-debug`.
+**Status:** planning only — no code written. Read-only investigation of the
+snapshot branch. Intended sequencing (Johan's lean): **build the tdns-debug
+reload test first, use it to observe the window on the current build, then land
+the fix and A/B it** — same rigor as the tearing A/B that validated the
+snapshot branch.
+
+This document grew out of the `.Ready`-gate discussion. The short version: the
+readiness gate today does not mean "has content", it means "has *complete*
+(i.e. signed) content". That is load-bearing, and replacing the stored `Ready`
+boolean with a derived method is correct **only** if we also stop publishing
+incomplete (unsigned) snapshots. Investigating that turned up a real,
+pre-existing latent bug: a window on reload/refresh where a signed zone
+transiently serves and transfers **unsigned** content while marked Ready.
+
+---
+
+## (a) The defect: an unsigned-publish window on reload / refresh
+
+### The chain
+
+1. `config reload-zones` -> `ReloadZones` -> `ParseZones(reload=true)`
+   (`config.go:622`) queues a **forced** refresh:
+   `ZoneRefresher{Force:true}` onto `RefreshZoneCh`
+   ("force refresh, ignoring SOA serial, when reloading from file",
+   `parseconfig.go:1084`).
+2. The refresh engine runs `zd.Refresh` ->
+   `applyRefreshReplacementLocked(firstLoad=false)` (`zone_utils.go:235`).
+   Because `firstLoad == false`, it:
+   - publishes the freshly-parsed **unsigned** snapshot (`zone_mutation.go:349`), and
+   - sets `Ready = true` / `Status = ZoneStatusReady` (`zone_mutation.go:355-357`)
+     — the first-load guard does **not** hold it back on a reload.
+3. *Then* the engine re-signs: `SetupZoneSigning` at `refreshengine.go:467`
+   (comment: *"Re-sign zone after refresh (upstream data has no RRSIGs)"*) ->
+   `SignZone` -> publishes the signed snapshot (`sign.go:127`).
+
+**Between step 2 and step 3, `Ready`/`Status` are true over unsigned content,
+and it is not masked** (unlike first load, where the flip is deferred to
+`InstallInitialSnapshot`). For an online-signing primary the on-disk zone file
+carries no DNSKEY and no RRSIGs (keys live in the keystore, signatures are
+generated online), so during the window the zone momentarily serves as if
+completely **unsigned** — no apex DNSKEY, no RRSIGs anywhere.
+
+### Two exposure points, both open during the window
+
+- `GetOwner` gates on `!zd.Ready` (`zone_utils.go:434`) -> true -> **serves
+  unsigned answers** to validating resolvers -> SERVFAIL.
+- `ZoneTransferOut` gates on `Status == ZoneStatusReady` (`dnsutils.go:251`) ->
+  passes -> **hands an unsigned zone to a secondary**, which then serves
+  unsigned until its *next* transfer — more durable damage than a transient
+  query miss.
+
+### Scope
+
+- **Reload** (`config reload-zones`, `Force:true`) of an online-signing primary:
+  window on every reload.
+- **Any forced/file-changed refresh** of an online-signing primary follows the
+  same path.
+- **Inline-signing secondary:** every inbound AXFR/IXFR that updates the zone
+  (`updated == true`) re-publishes unsigned then re-signs at the same
+  `refreshengine.go:467`, so the window recurs on **every** refresh there, not
+  just on config reload.
+
+### Severity / window length
+
+Window length == `SignZone` duration. On a large zone signed with an expensive
+post-quantum algorithm that is **not** a nanosecond race — tens of ms to
+seconds (see the test setup in (c), which deliberately maximises it). Easy to
+hit under load.
+
+### Pre-existing, not a snapshot-branch regression
+
+The publish-then-sign *ordering* on refresh predates the snapshot work (that
+work changed tearing behaviour, not the signedness ordering), so `main` almost
+certainly has this too. Implication: this is **not** a snapshot-merge blocker
+on its own — but the fix in (b) closes it for free, and the test in (c) is
+exactly what surfaces it.
+
+---
+
+## (b) The fix: publish only a complete snapshot
+
+**Principle:** Store a snapshot only when it is a complete, servable state —
+signed, if we sign the zone. Then "has a published snapshot" *is* "ready", and
+readiness derives from the snapshot pointer (one source of truth). `SignZone`
+already performs a signed publish (`sign.go:127`); that is the "complete"
+publish we keep. The only offending publish is the unsigned one at
+`zone_mutation.go:349`.
+
+### Change 1 — defer the unsigned publish for to-be-signed zones
+
+In `applyRefreshReplacementLocked`, gate the *Store* (not the staging):
+
+```go
+// working set is already staged above (workingSet, wsSignalSynth, repopulate)
+willSign := (zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning])
+            // && app != agent && zone eligible — mirror SetupZoneSigning's condition exactly
+if !willSign {
+    zd.publishWorkingSetLocked(zd.generation.Load(), false) // unsigned zone: working set IS complete
+}
+// signed zone: publish nothing here; SignZone's signed publish is the authoritative first Store
+```
+
+Effect:
+- **Reload, signed zone:** the *old signed snapshot keeps serving* until
+  `SignZone` atomically swaps in the new signed one — the unsigned window is
+  gone, and we get the "serve old until the atomic swap" behaviour we want.
+- **First load, signed zone:** no snapshot until signed — same masking as
+  today, but now *truthful* (no phantom unsigned snapshot behind `Ready=false`).
+- **Unsigned zone:** unchanged.
+
+### Change 2 — derive `Ready`, delete the boolean
+
+```go
+func (zd *ZoneData) Ready() bool {
+    snap := zd.snapshot.Load()
+    return snap != nil && snap.SOA != nil
+}
+```
+
+- `GetOwner` -> `if !zd.Ready()`.
+- Secondary synthetic-SOA gate (`zone_utils.go:506`): `!zd.Ready` ->
+  `zd.snapshot.Load() == nil`.
+- Delete the five `zd.Ready = true` writes (`zone_mutation.go:356/422/431`,
+  `zone_utils.go:224/309`) and the `Ready bool` field.
+
+"Ready => valid published snapshot" then holds **by construction** — which is
+the invariant we repeatedly failed to maintain by hand (several of the
+2026-07-13 live-bring-up bugs were `Ready`/snapshot desyncs).
+
+### Change 3 — Status
+
+`Status` is a richer lifecycle enum (Pending/Loading/Ready/Error) used as the
+transfer gate at `dnsutils.go:251`. The nil-snapshot check right below it
+(`dnsutils.go:264`) already covers "not servable" once a snapshot means
+"complete". Cleanest: make servability derive from the snapshot everywhere, and
+keep `Status` as a pure display/telemetry projection (so `auth zone list` still
+shows Pending/Loading/Ready/Error) rather than a second source of truth.
+
+### `InstallInitialSnapshot` mostly collapses
+
+Its job was "flip Ready after first-load signing". With `Ready` derived and
+`SignZone` doing the first signed publish, it is a no-op for signed zones and
+redundant for unsigned ones (they publish at `:349`). It likely reduces to
+"start publisher + assert a snapshot exists", or goes away — pending a check of
+its other callers (`refreshengine.go:293`, `CreateAutoZone` at
+`zone_utils.go:1321`).
+
+### Three things to nail before writing code
+
+1. **Confirm every to-be-signed path re-signs after the deferred publish** —
+   first load (OnFirstLoad -> SetupZoneSigning), reload/refresh
+   (`refreshengine.go:467`), dynamic (`refreshengine.go:628`). If any signed
+   path does *not* call `SignZone` afterward, deferring its publish would leave
+   it unpublished. (First glance: all three do; needs a positive check.)
+2. **Decide the sign-failure policy.** With the deferral, a failed re-sign on
+   reload keeps the *old signed* snapshot serving (good — beats today's "serve
+   unsigned"), but silently. That wants a `DnssecError` + surfacing, which
+   dovetails with the deferred loud-config / `config status` work.
+3. **Decide Status's role** (Change 3): display-only vs. still a gate.
+
+---
+
+## (c) The tdns-debug reload test
+
+### Goal
+
+Observe the (a) window empirically on the current (pre-fix) build, then use the
+same run to prove the (b) fix closes it — the tearing-A/B method applied to
+signedness. The test targets a **different invariant class** from `churn`
+(completeness/signedness, not tearing) but reuses the same actor/ledger/checker
+engine.
+
+**Decision: a new, separate `test reload` family — do NOT fold the reload actor
+into `churn`.** `churn` is deliberately **mgmt-API-free**: it stresses the
+server using only standard DNS (SIG(0) UPDATE, AXFR, queries), which is exactly
+why it is portable to BIND/NSD/Knot and any other authoritative implementation.
+The reload test is inherently mgmt-API-dependent (it must *trigger* reloads via
+the management API), so it belongs in its own family rather than contaminating
+`churn`'s portability. This keeps a clean split: `churn` = the reference
+portable stress test; `reload` = a tdns-oriented test that drives the server's
+own reload machinery.
+
+### The new invariant
+
+**I10 — no unsigned window (signedness/completeness).** If the zone is
+DNSSEC-signed, then every observation must be consistent with a signed zone:
+the apex DNSKEY is present, and every authoritative RRset the tool tracks (the
+SOA, and the `_churn` TXT set) carries a covering RRSIG. An observation missing
+the DNSKEY/RRSIGs is an **unsigned-window violation** — the server transiently
+served or transferred incomplete (unsigned) content.
+
+How the tool decides the zone is "signed":
+- **Declared** at provision time (the test provisions online-signing), and/or
+- **Latched**: once the tool has observed an apex DNSKEY (or any RRSIG) for the
+  zone, it latches "signed", and any later observation lacking them is a
+  violation. Latching keeps I10 portable to non-tdns signed servers.
+
+**Presence, not cryptographic validity.** I10 checks that an RRSIG exists and
+covers the right owner/type (miekg/dns parses RRSIG RRs regardless of
+algorithm) — it does **not** verify the signature. That is sufficient to catch
+the window and keeps tdns-debug free of C-backed algorithm linkage (no
+`algs.list`), consistent with its "pure client" build. The tool can therefore
+test a SQISIGN-signed zone without itself supporting SQISIGN.
+
+The crispest observable is the SOA/AXFR: in a signed zone the SOA RRset always
+carries an RRSIG, and an AXFR always contains RRSIGs. During the window the
+freshly-parsed snapshot has neither -> stark, false-positive-free signal.
+
+### The new actor
+
+**Reload actor** (mgmt-API, capability-gated, optional). Periodically triggers
+the reload endpoint (`config reload-zones`, `apihandler_funcs.go:324`) to force
+the refresh -> republish-unsigned -> re-sign cycle. Cadence tuned so reloads
+overlap the AXFR/query sampling.
+
+- Capability-gated per the tool's design: if the target does not expose the
+  reload endpoint (non-tdns server, API not configured), the reload actor is
+  reported **SKIPPED** — the test then cannot *force* the window (it can still
+  passively watch during operator-triggered reloads, but forcing is what makes
+  it a controlled experiment).
+- I10 itself is pure-DNS and runs regardless (portable).
+
+The existing update-sender / AXFR poller / query hammer keep running; the AXFR
+poller and query hammer feed I10 in addition to the tearing checkers. Note the
+window opens on **reload**, not on update, so the reload actor is the essential
+new stimulus; the churn updates are an orthogonal (realistic) co-stress.
+
+### Widening the window: large zone + expensive algorithm
+
+Window length == `SignZone` duration == (RRset count) x (per-signature cost).
+To make the window large and reliably sampled:
+
+- **Large zone: >= 10,000 signable RRsets.** Provisioning emits N filler owner
+  names (e.g. `hostNNNNN.<zone>` each with a single A record) plus the `_churn`
+  subtree. A records only — no delegations/glue, which would complicate
+  coverage checks.
+- **Expensive algorithm: SQISIGN** (Johan's suggestion). Very slow per
+  signature; 10K RRsets x SQISIGN -> a window of seconds (possibly much more).
+  Ideal for both the positive control (catch) and the fix-validation (a large
+  window that the fixed build must still show **zero** unsigned observations
+  across).
+  - Trade-off: SQISIGN makes each reload cycle slow, so reload cadence is
+    coarse (e.g. one reload every 20-60 s) — but each window is huge, so even a
+    modest AXFR/query cadence lands many observations inside it.
+  - Faster fallbacks if SQISIGN iteration is impractical: FALCON1024 or a MAYO
+    variant — still slow enough to expose a multi-hundred-ms window on 10K
+    RRsets, much quicker to iterate on.
+
+### Provisioning changes (`--generate-config`)
+
+- New knob **`--zone-size N`** (alias `--rrsets N`): emit a zone with N filler
+  RRsets. Default large (e.g. 10000) for this family.
+- Emitted config enables **online-signing** with a DNSSEC policy referencing
+  **SQISIGN1** (algorithm number 65).
+- Emitted operator to-do must spell out the server-side prerequisites:
+  - a DNSSEC policy referencing **SQISIGN1**. **No rebuild is required** — the
+    running `tdns-auth` already includes SQISIGN1 (verify with
+    `tdns-cli auth keystore dnssec algorithms | grep -i sqisign`). The old
+    `WITH_*` build flags are dead; algorithm inclusion is driven by `algs.list`
+    + the genalgs generator, and SQISIGN1 is already in the current binary.
+  - the reload endpoint must be reachable by the tool's mgmt-API identity;
+  - trust the churn SIG(0) key (`sig0 add` + `sig0 trust`), as with `churn`;
+  - AXFR permitted to the tool.
+
+### Command shape (proposed)
+
+`tdns-debug test reload` — the reload/refresh completeness test. Reuses the
+churn engine; adds the reload actor and I10.
+
+```
+# provision a large SQISIGN-signed zone (server untouched)
+tdns-debug test reload --generate-config --base-zone test.axfr.net. \
+    --zone-size 10000 --algorithm SQISIGN1
+
+# run it: force reloads while transferring/querying, check I10 (+ churn invariants)
+tdns-debug test reload --test test002 --dns 127.0.0.1:5354 \
+    --reloadcadence 30s --axfrcadence 400ms --qps 100 --duration 5m
+```
+
+Knobs: `--reloadcadence`, plus the existing `--axfrcadence`, `--qps`,
+`--updatecadence`, `--duration`, `--json`. (`--updatecadence` optional here —
+the window is reload-driven, not update-driven — but running churn concurrently
+is a fine combined stress.)
+
+### The A/B plan
+
+1. **Positive control (current build).** Run `test reload` against today's
+   snapshot-branch (pre-fix) `tdns-auth`. Expect I10 violations: AXFRs and/or
+   queries landing in the re-sign window return the zone with no DNSKEY/RRSIGs.
+2. **Fix validation.** Apply the (b) fix, rebuild, run the identical command +
+   load. Expect **zero** I10 violations: the old signed snapshot serves
+   continuously until the atomic signed swap.
+
+This mirrors the tearing A/B (main tears / snapshot clean) that established the
+snapshot branch fixes C1: here the pre-fix build shows the unsigned window and
+the fixed build is clean under identical load.
+
+---
+
+## Sequencing / task list (for tomorrow)
+
+Test-first, then fix (Johan's lean). Rationale: proving the tool catches the
+defect on the pre-fix build first is what makes the post-fix "clean" result
+evidence rather than assertion — the same discipline that made the tearing
+result convincing.
+
+### Phase 1 — Build the `test reload` family *(tdns-debug, `feature/tdns-debug`)*
+
+- [ ] **Reload actor** — mgmt-API call to the reload endpoint (`config
+      reload-zones`, `apihandler_funcs.go:324`); capability-gated (SKIPPED if
+      absent); `--reloadcadence` knob.
+- [ ] **I10 checker** — signedness/completeness. RRSIG *presence* + coverage
+      (owner/type-covered/labels), NOT crypto validity. Zone is "signed" if
+      declared at provision AND/OR latched on first observed apex DNSKEY/RRSIG.
+      Crispest observable: SOA/AXFR carries no RRSIG during the window.
+- [ ] **Provisioning** — `--zone-size N` filler-RRset generator (N distinct
+      `hostNNNNN.<zone>` A records, no delegations/glue); `--algorithm` knob;
+      emit online-signing config with a **SQISIGN1** policy + operator to-do
+      (no rebuild; reachable reload endpoint; trust SIG(0) key; AXFR permitted).
+- [ ] **`test reload` command** — reuse the churn engine; AXFR poller + query
+      hammer feed I10 alongside the existing observation streams.
+- [ ] **Unit tests for I10** — false-positive-free: a signed zone trips
+      nothing; an unsigned observation is flagged.
+
+### Phase 2 — Positive control (observe the window on the CURRENT build)
+
+- [ ] Provision the large (≈10K) SQISIGN1 zone; install config + DNSSEC policy;
+      trust the key; reload. *(No server rebuild — SQISIGN1 already supported;
+      just a policy that uses it.)*
+- [ ] Run `test reload` against the current snapshot-branch `tdns-auth`; **expect
+      I10 violations** (AXFRs/queries landing in the re-sign window come back
+      unsigned).
+- [ ] Capture the run output as the worked example (mirrors the tearing
+      example in `guide/testing.md`).
+
+### Phase 3 — Land the fix *(`feature/zone-snapshot-correctness`)*
+
+- [ ] Verify the three prerequisites: every to-be-signed path re-signs after the
+      deferred publish (first load / `refreshengine.go:467` / `:628`);
+      sign-failure policy; Status's role.
+- [ ] **Change 1** — defer the unsigned publish for to-be-signed zones
+      (`zone_mutation.go:349`).
+- [ ] **Change 2** — derive `Ready()`; delete the boolean + its 5 writes; fix
+      the secondary synthetic-SOA gate (`zone_utils.go:506`).
+- [ ] **Change 3** — Status as display-only projection.
+- [ ] Collapse/retire `InstallInitialSnapshot` (check callers
+      `refreshengine.go:293`, `zone_utils.go:1321`).
+- [ ] Full `v2 -race` suite green.
+
+### Phase 4 — Fix-validation A/B
+
+- [ ] Rebuild; run the **identical** `test reload` command + load; **expect zero
+      I10 violations** (old signed snapshot serves until the atomic signed swap).
+- [ ] Add the A/B pair to `guide/testing.md` as the reload worked example.
+
+### Phase 5 — Follow-up
+
+- [ ] Fold the sign-failure surfacing into the loud-config / `config status`
+      work.
+- [ ] Document `test reload` in `cmdv2/debug/README.md` + `guide/testing.md`.
+
+## Decisions made
+
+- **New, separate `test reload` family** (not folded into `churn`) — to keep
+  `churn` mgmt-API-free and therefore portable. See the rationale in (c).
+- **SQISIGN1 needs no server rebuild** — already supported by the running
+  binary; only a DNSSEC policy referencing it is required.
+
+## Open questions
+
+- **`--algorithm` default for the emitted config:** SQISIGN1 (maximises the
+  window, slow to iterate) vs. a faster PQ fallback (FALCON1024 / MAYO — still
+  exposes a multi-hundred-ms window on 10K RRsets). Lean: SQISIGN1 for the
+  headline positive-control run, a faster alg for quick iteration.
+- **Sign-failure policy** (b, item 2): keep-old-and-flag is the proposed
+  behaviour; confirm and decide how loudly to surface it (ties into the
+  deferred loud-config / `config status` work).
+- **Status's role** (b, Change 3): display-only vs. gate.
+- **Passive I10 in `churn`?** I10 is pure-DNS, so running it under `churn` would
+  *not* break `churn`'s portability — but `churn` never triggers reloads, so
+  I10 would rarely fire there. Low value; leaving it out unless a reason
+  appears. (The mgmt-API split is about the reload *actor*, not I10.)

--- a/docs/2026-07-13-unsigned-publish-window.md
+++ b/docs/2026-07-13-unsigned-publish-window.md
@@ -322,13 +322,15 @@ currently exercises** (0 log mentions), must be proven before we build a 10K
 reload test on it — else we get `unknown algorithm` spam instead of slow
 signing.
 
-- [ ] Provision a **tiny** SQISIGN1 zone (a handful of RRsets) and confirm it
-      signs cleanly: apex DNSKEY + RRSIGs appear, **no** `unknown algorithm:
-      SQISIGN*` / `bad private key` in `/var/log/tdns/tdns-auth.log`.
-- [ ] If SQISIGN1 is broken (qruov-style or falcon-style), fall back to a
-      **verified** algorithm. `MLDSA` signs cleanly on this server today (0
-      errors) — the safe default; we trade some window width for a valid test.
-      (Chase the SQISIGN break separately — same class as the qruov chip.)
+- [x] **VERIFIED 2026-07-14: SQISIGN1 signs.** `sqisign.pq.axfr.net.` serves a
+      SQISIGN1 ZSK (keyid 56474) whose RRSIG covers the SOA (alg 212); DNSKEY +
+      RRSIGs present, no `unknown algorithm` / `bad private key`. Phase 0 gate
+      cleared — no MLDSA fallback needed.
+- [ ] For the reload test, provision a **single-algorithm** SQISIGN1 zone
+      (KSK+ZSK both SQISIGN1), not a mixed set, to keep the I10 presence/coverage
+      check simple. (The existing `sqisign.pq.axfr.net.` uses a mixed
+      MAYO5-KSK / SQISIGN1-ZSK apex — fine for the verification above, but a
+      clean single-alg zone is the better test fixture.)
 
 ### Phase 1 — Build the `test reload` family *(tdns-debug, `feature/tdns-debug`)*
 

--- a/docs/2026-07-13-unsigned-publish-window.md
+++ b/docs/2026-07-13-unsigned-publish-window.md
@@ -309,6 +309,27 @@ defect on the pre-fix build first is what makes the post-fix "clean" result
 evidence rather than assertion — the same discipline that made the tearing
 result convincing.
 
+### Phase 0 — Verify the signing algorithm actually SIGNS (gates Phase 2, not Phase 1)
+
+**"Listed in `keystore dnssec algorithms`" does NOT mean "actually signs."**
+Proven on the running server 2026-07-13: `QRUOV1` is advertised by the registry
+but the signer's key-parse path rejects it — `ParsePrivateKeyFromDB failed:
+unknown algorithm: QRUOV1` (`keystore.go:983/1225`), 525 recurring errors, zone
+`qruov1.pq.axfr.net.` effectively unsignable. A registry-vs-implementation
+seam. (`falcon.pq.axfr.net.` fails differently — `dns: bad private key`: the
+algorithm is known but the key won't parse.) So SQISIGN1, which **no zone
+currently exercises** (0 log mentions), must be proven before we build a 10K
+reload test on it — else we get `unknown algorithm` spam instead of slow
+signing.
+
+- [ ] Provision a **tiny** SQISIGN1 zone (a handful of RRsets) and confirm it
+      signs cleanly: apex DNSKEY + RRSIGs appear, **no** `unknown algorithm:
+      SQISIGN*` / `bad private key` in `/var/log/tdns/tdns-auth.log`.
+- [ ] If SQISIGN1 is broken (qruov-style or falcon-style), fall back to a
+      **verified** algorithm. `MLDSA` signs cleanly on this server today (0
+      errors) — the safe default; we trade some window width for a valid test.
+      (Chase the SQISIGN break separately — same class as the qruov chip.)
+
 ### Phase 1 — Build the `test reload` family *(tdns-debug, `feature/tdns-debug`)*
 
 - [ ] **Reload actor** — mgmt-API call to the reload endpoint (`config

--- a/docs/2026-07-14-dnssec-error-single-bucket.md
+++ b/docs/2026-07-14-dnssec-error-single-bucket.md
@@ -1,0 +1,344 @@
+# `DnssecError` is a single bucket: cross-owner clobber, stuck errors, and a self-block
+
+**Date:** 2026-07-14
+**Branch context:** analysis of `feature/zone-snapshot-correctness` (the running
+tdns-auth tree). Applies equally to `main` — this is pre-existing structural
+debt, not snapshot-specific.
+**Status:** design only — **no code written**. Implementation deferred until the
+snapshot branch merges (see *Deferral & branch strategy*). Read-only
+investigation.
+
+This doc grew out of the `falcon.pq.axfr.net` "dns: bad private key" diagnosis
+(a FALCON1024 codepoint renumber orphaned the stored KSK). The operational fix
+there was a key regen. But that investigation surfaced a deeper, separate
+problem: **when a zone silently fails to sign, the operator gets no signal** —
+`tdns-cli auth zone list` reports the zone as healthy while it serves unsigned.
+Wiring a `zd.SetError()` into the signing-failure path looks like a one-liner,
+but it isn't, because of how the `DnssecError` category is structured today.
+
+---
+
+## TL;DR
+
+`DnssecError` is one flat entry in the per-zone error registry, but it is
+**written by three unrelated concerns** and **cleared unconditionally by one of
+them**:
+
+1. **Policy resolution** — missing/unusable DNSSEC policy (`SetError`, never
+   cleared).
+2. **Sig-validity floor** — `UpdateSigValidityFloor()` (`SetError` on violation,
+   `ClearError` when the floor is fine).
+3. **Signing execution** (proposed, not yet wired) — the zone can't actually
+   sign (bad key, keystore/codepoint mismatch).
+
+Because they share one bucket:
+
+- **(P1) Clobber.** `UpdateSigValidityFloor()` calls `ClearError(DnssecError)`
+  whenever *its* floor check passes — erasing an unrelated policy or signing
+  error. parseconfig runs the floor check on every parse pass, right after
+  signing setup, so on reload a signing error would be cleared the instant it's
+  set.
+- **(P2) Stuck error.** The policy-missing `DnssecError` is **never cleared** by
+  anyone (there is no `ClearError(DnssecError)` on the "policy became usable"
+  path). A zone that recovers keeps showing the error until UpdateSigValidityFloor
+  happens to run and blanket-clears it — i.e. it's cleared by accident, by the
+  wrong owner.
+- **(P3) Self-block.** `SignZone`/`ResignZone` refuse to run if
+  `HasError(DnssecError)`. So a signing-execution error, once set, would block
+  the *next* signing attempt — including the operator's fix. The only thing that
+  clears it is the same floor check from (P1). Circular.
+
+The fix is to give each concern an independent lifecycle. This doc lays out the
+alternatives and recommends one, but **defers the implementation**.
+
+---
+
+## Background: the zone error registry today
+
+`ZoneData` carries a small error registry (`v2/enums.go`):
+
+```go
+type ZoneError struct { Type ErrorType; Msg string }
+
+// zd.Errors is keyed by ErrorType — at most ONE entry per category.
+func (zd *ZoneData) setErrorLocked(errtype ErrorType, errmsg string, ...) {
+    zd.Errors[errtype] = ZoneError{Type: errtype, Msg: ...}
+    zd.recomputeDerivedErrorFieldsLocked() // -> zd.Error, zd.ErrorType, zd.ErrorMsg
+    Zones.Set(zd.ZoneName, zd)
+}
+```
+
+The `ErrorType` enum (`v2/enums.go:248`) has: `ConfigError`, `RefreshError`,
+`AgentError`, **`DnssecError`**, plus warnings (`DnssecPolicyWarning`,
+`ConfigWarning`, rollover categories, …).
+
+Classification is by slice + helper, so **call sites don't grow** when the set
+of categories changes:
+
+- `serviceImpactingErrors = {ConfigError, AgentError, DnssecError}`
+  (`enums.go:348`) → `HasServiceImpactingError()`; the query/NOTIFY/UPDATE
+  handlers `SERVFAIL` when true.
+- CLI already renders it: `ListZones` collapses a service-impacting row to
+  `ERROR` (`v2/cli/zone_cmds.go:636`); `VerboseListZone` prints
+  `State: ERROR ErrorType: DnssecError ErrorMsg: …` (`:689`).
+
+So the **surfacing chain is complete** — an unsigned/broken zone would render as
+`ERROR` the moment a `DnssecError` is set. The problem is purely that the
+signing-failure path never sets one, and that the `DnssecError` bucket is
+overloaded so we can't just add a set/clear without collateral damage.
+
+### Who writes `DnssecError` today
+
+| Concern | Site | Sets? | Clears? |
+|---|---|---|---|
+| Policy unusable | `parseconfig.go:765`, `refreshengine.go:237`, `:614` | yes | **never** |
+| Sig-validity floor | `UpdateSigValidityFloor()` (`ksk_rollover_validation.go` ~448/497) | on violation | **on any pass — unconditionally** |
+| Signing execution | — (proposed) | — | — |
+
+### Where signing failures go today (nowhere)
+
+The falcon failure is logged three times and recorded **nowhere**:
+
+- `SignZone` → logs, returns err (`sign.go:766`)
+- `SetupZoneSigning` → logs "SignZone failed", returns err (`zone_utils.go:1104`)
+- the `OnFirstLoad` closure → logs "SetupZoneSigning failed", **returns void —
+  error dropped** (`parseconfig.go:960-969`)
+
+---
+
+## The core defect in detail
+
+### (P1) Cross-owner clobber
+
+`UpdateSigValidityFloor()` ends with, in effect:
+
+```go
+if len(hardMsgs) == 0 {
+    clearErr(DnssecError)          // <-- clears the WHOLE category
+} else {
+    setErr(DnssecError, "sig-validity floor: %s", ...)
+}
+```
+
+It treats `DnssecError` as *its* private flag. But parseconfig invokes it on
+**every parse pass**, immediately after registering/executing signing setup
+(`parseconfig.go:974-977`). So the reload ordering is:
+
+```
+SetupZoneSigning(...)          // (proposed) would setErr(DnssecError, "signing failed")
+UpdateSigValidityFloor(...)    // floor is fine -> clearErr(DnssecError) -> ERROR ERASED
+```
+
+Any naive `SetError(DnssecError, "signing failed")` is wiped out on the next
+reload — and at runtime the floor check's `maxObservedTTL == 0` early path clears
+it outright.
+
+### (P2) Stuck policy error
+
+There is **no** `ClearError(DnssecError)` on the policy-resolution success path.
+Grep confirms the only clears live in `UpdateSigValidityFloor`. So a zone whose
+policy was fixed on reload keeps its `DnssecError` until — again — the floor
+check happens to run and blanket-clears it. The error's lifecycle is owned by
+the *wrong* concern.
+
+### (P3) Self-block / precondition-vs-outcome
+
+`SignZone` and `ResignZone` both start with (`sign.go:758`, `:584`):
+
+```go
+if zd.HasError(DnssecError) {
+    return 0, fmt.Errorf("...has DNSSEC error: %s", zd.ErrorMsg)
+}
+```
+
+This guard conflates two fundamentally different kinds of DNSSEC error:
+
+- **Precondition errors** — *don't even attempt to sign.* Missing policy; a
+  sig-validity floor that would produce dangerous RRSIG lifetimes. Gating
+  `SignZone` entry on these is **correct**.
+- **Outcome errors** — *an attempt just failed.* Bad key material, keystore /
+  codepoint mismatch. These are the **result** of signing, not a precondition.
+  Gating the next attempt on them is **wrong**: the error you set to *report* the
+  failure prevents the operator's fix from ever running (deadlock, since the only
+  clearer is the floor check from P1).
+
+So the guard was never really "any `DnssecError`" — it is "any *precondition*
+`DnssecError`." Expressing that requires distinguishing the two, which is the
+crux of every option below.
+
+---
+
+## Requirements for a correct design
+
+1. A signing-execution failure must be **recorded on the zone** (so `zone list` /
+   `zone status` shows `ERROR`), not just logged.
+2. Independent set/clear per concern: the floor check must not clear a signing
+   or policy error, and vice versa. (Fixes P1.)
+3. Each concern clears its **own** error on its **own** recovery. (Fixes P2.)
+4. The `SignZone`/`ResignZone` entry guard must gate on **preconditions only**,
+   so an outcome error doesn't self-block recovery. (Fixes P3.)
+5. Serving is **fail-closed**: a zone that is supposed to be signed but can't sign
+   should `SERVFAIL`, not serve unsigned. (Decided — see below.)
+6. Don't let the classifier logic sprawl into `||`-chains at call sites.
+
+---
+
+## Design alternatives
+
+### Option A — flat new categories
+
+Add `DnssecSigningError`, `DnssecValidityFloorError`, `DnssecPolicyError` as
+peer `ErrorType`s; retire the umbrella `DnssecError`.
+
+- **Pros:** No change to the registry shape — the existing
+  `map[ErrorType]ZoneError` already gives each its own slot, so independent
+  set/clear falls out for free (fixes P1/P2). Classification stays slice-based
+  (`serviceImpactingErrors` gains the three; a new `signingPreconditionErrors`
+  slice backs the guard) so **call sites don't grow** — P3's guard becomes
+  `HasSigningPreconditionError()`, one call.
+- **Cons:** Enum proliferation; three names where one concept ("this zone's
+  DNSSEC is unhealthy") lived. Report-order (`errorTypeReportOrder`), the
+  string map, and every classification slice must list all three. If more DNSSEC
+  sub-failures appear (DS-push, keygen, rollover-precondition) the enum keeps
+  growing. Loses the natural "all DNSSEC problems" category for serving
+  semantics (must be reconstructed as a slice).
+
+### Option B — subtype under `DnssecError`
+
+Keep the umbrella `DnssecError` category; add a `DnssecErrorSubtype`
+(`SubPolicy`, `SubValidityFloor`, `SubSigning`). Multiple subtypes can coexist
+and are cleared independently.
+
+- **Pros:** One category for serving semantics — `HasServiceImpactingError()`
+  stays "any DNSSEC subtype → fail closed" with no change (satisfies req 5
+  trivially). Independent set/clear per subtype fixes P1/P2. The guard becomes
+  `HasBlockingDnssecPrecondition()` = subtype ∈ {policy, validityfloor} — one
+  call site, backed by a subtype set, so no `||` sprawl (req 6). Matches the
+  operator's mental model ("DnssecError, subtype signing: bad private key").
+  Extensible — new sub-failures are new subtype constants, not new categories.
+- **Cons:** The registry key must become `(Type, Subtype)` so two `DnssecError`
+  subtypes can coexist; today it's keyed by `Type` alone. That's an API change to
+  `SetError`/`ClearError`/`HasError`. Two ways to absorb it:
+  - **B1 (uniform):** change the key to `(Type, Subtype)` everywhere.
+    Future-proof (subtypes will recur — per-scheme `RolloverParentBlocker`,
+    per-primary `ConfigWarning`), but touches ~79 call sites (60 `SetError`, 12
+    `ClearError`, 7 `HasError`), almost all mechanically passing `SubNone`.
+  - **B2 (minimal):** leave the flat `map[ErrorType]ZoneError` for the other 11
+    categories; give `DnssecError` a subtype dimension only (nested map, or a
+    composite `DnssecError:<subtype>` key handled inside the DNSSEC paths).
+    Touches only the ~5 existing `DnssecError` sites + the new signing site.
+    Slightly asymmetric, but contained and low-risk.
+
+### Option C — keep the single bucket, make the floor clear surgical
+
+Leave `DnssecError` flat; change `UpdateSigValidityFloor()` to clear the error
+**only if it owns it** (e.g. tag the stored `Msg`/a source field and clear only
+when `source == validityfloor`).
+
+- **Pros:** Smallest diff; no enum or key change.
+- **Cons:** A hack — encodes ownership in the message string or a side field
+  rather than the type system. Still can't represent a floor error **and** a
+  signing error at once (they'd overwrite in the single slot), so it fails req 2
+  for coexistence. Doesn't address P3 (guard still gates on the whole bucket).
+  Effectively a worse B2 with the same touch points. **Not recommended.**
+
+### Cross-cutting (all options): the precondition/outcome guard
+
+Independent of A/B/C, req 4 needs the `SignZone`/`ResignZone` entry guard changed
+from "any `DnssecError`" to "precondition only." Under A that's a
+`signingPreconditionErrors` slice; under B a subtype predicate. Without this,
+recovery self-blocks (P3) no matter how the error is categorised.
+
+---
+
+## Serving policy (decided): fail-closed
+
+A zone configured for online/inline signing that cannot sign should return
+`SERVFAIL`, not serve unsigned data. `DnssecError` is already in
+`serviceImpactingErrors`, so any option that records the signing failure under
+`DnssecError` (B) — or lists the new signing category as service-impacting (A) —
+gets this for free. Concretely, `falcon.pq.axfr.net` would `SERVFAIL` until it
+can sign again, instead of serving an unsigned SOA with zero DNSKEY/RRSIG.
+
+Rationale: a resolver holding the zone's DS `SERVFAIL`s anyway once the RRSIGs
+are missing; serving unsigned NOERROR to non-validators is actively misleading
+about the zone's health. Fail-closed also makes the outage loud, which is the
+whole point of this exercise.
+
+---
+
+## Recommendation
+
+**Option B, variant B2 (minimal-footprint subtype under `DnssecError`)**, plus
+the precondition/outcome guard split, plus fail-closed serving.
+
+- B keeps one operator-facing category with clean serving semantics and models
+  "several DNSSEC sub-failures, cleared independently" directly — which is
+  exactly the shape of this problem and the next ones (DS-push, keygen).
+- B2 over B1 because this lands on a must-not-destabilise tree; the surgical
+  version fixes this bug **and** the two latent ones (P1 clobber, P2 stuck
+  policy error) with ~6 touched sites instead of ~79. Generalise to B1 later if
+  a second category genuinely grows subtypes.
+
+Sketch of the end state (illustrative, not final):
+
+```go
+// set at the SignZone failure return; covers load, reload, resigner uniformly
+zd.SetDnssecError(SubSigning, "bad private key: %v", err)
+// cleared at the SignZone success return
+zd.ClearDnssecError(SubSigning)
+
+// entry guard: preconditions only, so an outcome error doesn't self-block
+if zd.HasBlockingDnssecPrecondition() { return ... }   // {SubPolicy, SubValidityFloor}
+
+// floor check clears only its own subtype
+clearErr(DnssecError, SubValidityFloor)
+
+// policy-usable branch finally clears its own subtype (fixes P2)
+zd.ClearDnssecError(SubPolicy)
+```
+
+Open sub-question to settle at implementation time: whether the signing set/clear
+belongs in `SignZone` (covers whole-zone re-sign) alone, or also in the
+per-query RRset signing path — needs a check of `SignRRset` vs `SignZone` call
+sites so we don't set the error at the wrong granularity or thrash it per query.
+
+---
+
+## Deferral & branch strategy
+
+**Implementation is deferred until the snapshot branch merges.** The snapshot
+branch already reworked `SetError` (locked variants `setErrorLocked` /
+`clearErrorLocked`, added for the SignZone self-deadlock fix). Doing a competing
+`SetError`/subtype redesign off `main`-now would collide badly with that rework.
+
+The pivotal question, to answer post-merge: does snapshot's already-reworked
+error API suffice to layer subtypes on cleanly (→ do it on the snapshot branch /
+post-merge main), or does the subtype key change warrant its own pass (→
+sequence it after)? Either way, do **not** open a parallel `SetError` redesign
+on `main` before the merge.
+
+A small, low-coupling **Part 1** can proceed independently of this doc's
+redesign — and, revised 2026-07-14, **entirely tdns-side, with NO fork change**
+(the maintainer does not want to diverge the `johanix/dns` fork further):
+
+- The failure the operator actually hit (`falcon` "dns: bad private key") comes
+  from tdns's own decode call `rr.NewPrivateKey(privkey)` in
+  `v2/readkey.go:285` (`PrepareKeyCache`), which fails *first* with a vague
+  error. tdns already HAS the right check — the algorithm-mismatch guard at
+  `v2/keystore.go:894` (`pkc.Algorithm != alg` → "algorithm mismatch: stored=%d
+  parsed=%d") — but it runs *after* `PrepareKeyCache` has already returned the
+  vague error, so it never fires.
+- **Fix:** run the algorithm-consistency check *before* the decode (compare the
+  stored DNSKEY's algorithm against the expected one up front), so tdns emits a
+  clear "stored key is algorithm X but the zone wants Y — codepoint renumber;
+  regenerate" itself. Uses the *current* `SetError`; no subtype work needed; no
+  fork change. The fork's `PrivateKeyString` "" swallow is a harmless latent
+  wart we can push upstream to miek later — we simply stop depending on it.
+
+So the next codepoint renumber can't fail silently even before the full
+propagation redesign lands, and it costs zero fork divergence.
+
+See also: `docs/2026-07-13-unsigned-publish-window.md`, the falcon
+codepoint-renumber diagnosis, and the SignZone self-deadlock fix (why
+`setErrorLocked` exists).

--- a/docs/2026-07-14-snapshot-branch-signing-findings.md
+++ b/docs/2026-07-14-snapshot-branch-signing-findings.md
@@ -137,6 +137,87 @@ landing the snapshot branch — there may be a #3.
 
 ---
 
+## Finding 4 — `confMu` is held across zone signing on reload (contention/serialization; NOT a deadlock)
+
+Distinct from Finding 3 (the deadlock, now fixed): even with no deadlock, the
+config mutex `confMu` is held across potentially long-lived signing on every
+`config reload-zones`, so slow PQ signing serialises **all** config operations.
+
+**Lock scope.** Both reload entry points hold `confMu` for their entire body:
+- `config reload` → `ReloadConfig` (config.go:562): `confMu.Lock()` +
+  **`defer confMu.Unlock()`** wrapping `ParseConfig(true)`.
+- `config reload-zones` → `ReloadZoneConfig` (config.go:600): `confMu.Lock()` at
+  entry, `confMu.Unlock()` only at config.go:662 — *after* `ParseZones` + the
+  zone-removal loop.
+
+**Who signs.** `config reload` (`ParseConfig`) re-parses the config *sections*
+(dnssec, keys, apiservers) — it does **not** re-parse or sign zones — but it
+shares `confMu`, so a `config reload` **blocks behind** any concurrent
+`reload-zones` that is signing. `config reload-zones` (`ParseZones`) is the
+signer: for every existing signed zone it synchronously calls
+`SetupZoneSigning` → **`SignZone(kdb, false)`** (parseconfig.go:966 →
+zone_utils.go:1102), all under `confMu`.
+
+**Two ways `confMu` ends up spanning signing:**
+**Queries are NOT in scope — the DNS answer path is lock-free.** The read path
+takes **no `zd.mu`**: `GetOwner` (zone_utils.go:441) reads
+`getOwnerFrom(zd.publishedSnapshot(), qname)`, and `publishedSnapshot()`
+(zone_snapshot.go:247) is a bare `zd.snapshot.Load()` over
+`atomic.Pointer[zoneSnapshot]` (structs.go:176) — an atomic load of an immutable
+snapshot, then a map read. So `zd.mu` here is a **writer-side lock only** (guards
+the mutable working set + the publish pointer-swap at sign.go:817); nothing the
+signer does to `zd.mu` can stall a query. This whole finding is about the
+**config plane**, not the query plane.
+
+1. **Directly.** `SignZone`'s RRSIG-generation loop (`SignRRset` per RRset,
+   sign.go:807) runs *before* it takes `zd.mu` (only grabbed at sign.go:817 for
+   the publish), and **it is under `confMu`.** Steady-state `force=false` is
+   additive (skips already-signed RRsets → O(zone-size) checks, cheap-ish); any
+   zone actually needing signatures (fresh/expired/key-change, esp. PQ) generates
+   RRSIGs **under `confMu`**.
+2. **Indirectly (the source of the long holds) — writer-vs-writer.** `SignZone`
+   grabs `zd.mu` at :817 to publish. That contends with the **async refresh
+   engine**, which does the re-read + full re-sign off `RefreshZoneCh` and holds
+   the same `zd.mu` across *its* work. Under rapid/concurrent reloads, a prior
+   reload's slow async re-sign still holds `zd.mu` when the next reload's
+   synchronous `SetupZoneSigning` reaches :817 → it **blocks on `zd.mu` while
+   holding `confMu`**, for the full PQ-sign duration. This is exactly the dump
+   picture: `ParseZones` holding `confMu`, parked on a `zd.mu` held by the
+   refresh-engine goroutine. Note this is writer-vs-writer (config path vs
+   refresh path); a query would sail past on the current snapshot regardless.
+
+**Consequence.** `confMu` serialises **all config ops** — every `reload`,
+`reload-zones`, `reload-tsig`, `config status` — behind zone signing. Under a
+reload storm they pile up on `confMu` (the ~200 blocked handlers we saw); slow
+PQ signing stretches each hold to seconds-minutes. Separate from the deadlock:
+it would make config ops sluggish under PQ load even with the deadlock fixed.
+**DNS queries are unaffected** — they read the immutable snapshot lock-free.
+
+**Fix direction (post-merge, non-gating) — it's mostly a deletion.** The async
+path already runs on every reload: `ParseZones` unconditionally queues a
+`ZoneRefresher{Force: true}` to `RefreshZoneCh` (parseconfig.go:1099), and the
+refresh engine re-reads the file and re-signs off `confMu` (refreshengine.go:512
+→ `SetupZoneSigning`), then `resignq` → `ResignerEngine.resignNow` force-resigns.
+So the synchronous `SetupZoneSigning` at parseconfig.go:966 is largely
+**redundant** — it signs the *old* data with the *old* policy (the policy rebind
+happens in the refresh engine, not at :966) while holding `confMu`. **Fix: delete
+the :966 synchronous call; the already-queued ZoneRefresher covers the signing
+off-lock.** `confMu` then covers only fast config work.
+
+Safety: :966 runs only for *already-loaded* zones (new zones take the
+`FirstZoneLoad`/`OnFirstLoad` branch), which already hold a signed snapshot behind
+the atomic pointer — they keep serving it until the async re-sign atomically
+swaps in the new one, so **no unsigned blip**. Fail-closed (A3 SERVFAIL +
+AXFR-refuse) covers any genuinely-unsigned transient.
+
+Homework before doing it: (a) confirm no caller banks on "signed by the time
+reload returns" (reload response text, tests that reload then assert RRSIGs);
+(b) leave the `FirstZoneLoad`/`OnFirstLoad` branch alone (restart-time, separate
+path); (c) note the async path still double-signs (`force=false` at :512 then
+resigner `force=true`) — pre-existing, a separate cleanup.
+
+---
+
 ## Status & branch/defer contract (2026-07-14)
 
 **Principle (agreed):** the `SetError` / `DnssecError`-subtype restructuring is
@@ -196,6 +277,63 @@ cross-check `e117121` (tdns-debug).
   optimisation once fail-closed is in; not a safety gate).
 - **falcon Part 1** — tdns-side clear error at load (`keystore.go:894` check
   before the `readkey.go:285` decode); Easy, no fork, anytime.
+- **Finding 4** — `confMu` held across zone signing on reload (contention, not a
+  deadlock). Defer the synchronous `SignZone` in `SetupZoneSigning` to the async
+  refresh/`resignq` so `confMu` covers only fast config work. Latency/scalability
+  under PQ signing; not a safety gate.
+
+## Signing pipeline — post-merge redesign (companion to Finding 4)
+
+Design agreed in discussion 2026-07-14. All post-merge, non-gating; independent
+of but complementary to the Finding 4 `confMu` deletion. Target scale: ~100k
+signed zones, mixed algs (MLDSA fast … SQISIGN very slow).
+
+**State of play discovered:**
+- Refresh is **already** parallel — refreshengine.go:481 spawns `go func` per
+  zone (with an explicit `// XXX: Should do refresh in parallel`). But it is
+  **unbounded** and has **no same-zone guard**. The resigner (resigner.go) is
+  **serial** (single goroutine draining `resignq`).
+- `EnsureActiveDnssecKeys` hits the DB on **every** sign (sign.go:406
+  `kdb.GetDnssecKeys`). `KeyDB` is shared SQLite + `kdb.mu` + `Tx`.
+- `zd.generation` already exists (atomic, bumped on zone replacement,
+  config.go:653) and already backs the B5b stale-publish guard.
+
+**1. Bounded worker pool (replaces the unbounded fan-out).** At 100k zones a
+bounded pool (~NumCPU) completes *some zones fully, sooner*, with no CPU/memory
+thrash — strictly better than launching all signs at once to finish together
+much later. Replace the raw `go func` at refreshengine.go:481; feed the resigner
+into the same pool.
+
+**2. Per-`zd` active-key cache (takes the DB out of the hot path).** Cache the
+active `DnssecKeys` behind `atomic.Pointer[DnssecKeys]` on `zd` — the exact
+pattern already used for `snapshot` (structs.go:176) and `options` (:819).
+Lock-free read while signing; skip `GetDnssecKeys` when set. Invalidate at the
+one choke point where the key *set* changes: `DnssecKeyMgmt` add/setstate/delete
++ the key-state/rollover worker. Result: steady-state signing is pure in-memory
+(no DB, no `kdb.mu`); the DB only bites on infrequent key-gen/rollover.
+Correctness rests entirely on invalidating on **every** key-state transition
+(the active set shifts mid-rollover). Supersedes the shared
+`KeystoreDnskeyCache` map (structs.go:811) with a per-zd, lock-free field.
+
+**3. Same-zone ordering (the real hazard) — coalescing dirty-bit + generation
+CAS, NOT per-zone locks or hash-sharding.** `zd.mu` serializes critical sections,
+not whole logical ops, so two `SignZone` on one zone can interleave SOA-serial
+bumps / IXFR appends, or a stale one can publish over a newer one. Hash-sharding
+the pool by zone would serialize same-zone for free but load-imbalances badly
+(one SQISIGN zone stalls its shard) and can't coalesce. Instead:
+- **Single entry point per zone** for *all* triggers (config-reload, refresh,
+  resigner, key-state, dynamic update) with a per-zone state
+  `idle → running → running+pending`. Request: idle→submit one job; running→set
+  `pending` (do **not** submit a second). Worker done: `pending`→re-run once;
+  else idle. Guarantees never-two-concurrent per zone, and a burst of N requests
+  collapses to ≤2 signs — decisive under a reload storm (enqueue O(in-flight),
+  not `zones × reloads`). Coalescing state is O(zones-in-flight), a small sharded
+  map / `sync.Map` of atomic states.
+- **Generation CAS backstop:** worker snapshots `zd.generation` at start; drop
+  the publish if it advanced by completion (extend the existing B5b guard to the
+  sign/publish path). Correctness even if a trigger is left un-routed. The guard
+  must be **zone-scoped across engines** — the real collision is refresh-resign
+  vs. resigner, which is also why the single unified entry point matters.
 
 ## Notes for the tdns-debug reload test
 
@@ -206,3 +344,27 @@ cross-check `e117121` (tdns-debug).
 - SQISIGN is unusable at scale for the window (signing cost), but signs fine at
   ~10 records. Calibrate the window with a faster alg (MLDSA) + more records, or
   a mid-cost alg — measured one reload at a time, never a storm.
+
+## Finding — `reset_soa_serial` is dead code (RESURRECT, do not drop) (2026-07-15)
+
+Found while trying to force snapshot republishes for the AXFR-in bombardment:
+`service.reset_soa_serial` is present in the config + sample config (comment:
+"replace inbound SOA serial with unixtime"), but **nothing in the v2 tree
+consumes it** — `grep -rE 'ResetSoaSerial|reset_soa_serial|ResetSOA' v2/*.go`
+returns zero hits, so the key isn't even bound to a struct field (it lands in
+mapstructure's Unused set). Setting it `true` + `config reload` had no effect;
+the served serial stayed the primary's. Almost certainly never ported from the
+legacy tree.
+
+**Decision (Johan): resurrect it — wire it up in v2, do not remove the knob.**
+
+Intended semantics (for whoever ports it): rewrite the **served** SOA serial to
+unixtime at **publish/serve time**, so a secondary emits a monotonic serial to
+downstreams regardless of the primary's serial scheme. Wiring subtlety learned
+here: apply it *after* the change-detection check, NOT before. The refresh path
+decides whether to republish via `new_zd.IncomingSerial == zd.IncomingSerial`
+(FetchFromUpstream, zone_utils.go:303); if the unixtime rewrite happened before
+that check, every refresh would look "changed" and republish on every poll even
+when the primary is stable. Change-detection must use the primary's real serial;
+only the emitted serial is rewritten. (This is why `reset_soa_serial` was not a
+usable churn lever for the swap test — `auth zone bump` was used instead.)

--- a/docs/2026-07-14-snapshot-branch-signing-findings.md
+++ b/docs/2026-07-14-snapshot-branch-signing-findings.md
@@ -1,0 +1,208 @@
+# Snapshot-branch findings from live reload testing (2026-07-14)
+
+**Context:** live bring-up of the `test reload` tdns-debug family against the
+running snapshot-branch `tdns-auth` (the merge gate). Several findings emerged,
+some real bugs, some design decisions. Captured here so they survive.
+
+Server: snapshot-branch build, DNS 127.0.0.1:5354, API 127.0.0.1:8989, zones in
+`/etc/tdns/auth-zones.yaml`, DNSSEC policies in `/etc/tdns/tdns-auth.yaml`.
+
+---
+
+## Finding 1 — a signing failure is silently masked (query-signed, AXFR-unsigned)
+
+**Symptom:** a zone (`test002`) served **signed** answers to queries (every
+`+dnssec` query returned RRSIGs) but its **AXFR carried the DNSKEY and zero
+RRSIGs** — the transferred zone was unsigned, at the same serial. A secondary
+would AXFR it and serve BOGUS.
+
+**Root cause (this instance, partly self-inflicted):** `test002` was created
+under `pq-sqisign` (MAYO5 KSK + SQISIGN1 ZSK), then its config policy was edited
+to `pq-mldsa` (MLDSA44). MLDSA44 ≠ MAYO5, so signing now needs a **KSK
+algorithm rollover** — which is *"not yet built"*. `SignZone` therefore fails on
+every attempt (`zone_utils.go:1104`: *"KSK algorithm rollover not implemented …
+active KSK is MAYO5, policy wants MLDSA44"*), so **no RRSIGs are ever stored**.
+
+**Why queries still look signed:** the query path online-signs **ephemerally**.
+`signedApexRRsets` is explicitly *"without mutating zone data"*
+(`queryresponder.go:92`) and `signRRsetForZone` signs a by-value copy and
+discards it (`queryresponder.go:135`) — so the snapshot is **not** mutated (the
+C1 read-only invariant holds, good). But the fallback at
+`queryresponder.go:141` ephemerally signs **any** stored RRset that lacks
+RRSIGs, using whatever active keys exist (here the leftover SQISIGN1 ZSK). So a
+zone that cannot be signed still *appears* signed to every DO query, while AXFR
+exposes the truth.
+
+**Net:** a genuine, insidious gap — a broken (unsignable) zone looks healthy to
+queries, healthy in `config status`, and only reveals itself via AXFR or a
+validating secondary.
+
+### Decision 1 (Johan): SERVFAIL, not ephemeral-sign, not serve-unsigned
+
+If a zone **must** be signed (online/inline-signing configured) and the served
+RRset has **no** signatures in the snapshot, the zone is broken and the correct
+response is **SERVFAIL**. Both current behaviours are wrong: ephemeral-signing
+masks the failure; serving unsigned is a silent downgrade. Remove the blanket
+ephemeral-sign fallback; scope any *genuinely* ephemeral cases (e.g. CDE)
+explicitly. A broken zone must look broken.
+
+---
+
+## Finding 2 — config-reload is not transactional on a failed policy change
+
+Changing a zone's DNSSEC policy via the **`set-policy`/`change-policy` command**
+IS transactional (`apihandler_zone.go:405-420`): apply new → re-sign → on
+failure **revert to the old policy** and error; on success persist a per-zone
+override (`SetZonePolicyOverride`, `ZonePolicyOverride` DB table,
+`db_schema.go:182`).
+
+But changing the policy via a **config-file edit + reload** takes the
+config-reload path (`parseconfig.go:966`), which applies the new policy, calls
+`SetupZoneSigning`, and on failure merely logs *"SetupZoneSigning failed on
+reload"* and **moves on** — no revert, no transactionality. The zone is left
+bound to the new, unusable policy with no stored signatures (Finding 1).
+
+### Decision 2 (Johan): make reload transactional; persist the effective policy
+
+- **Persist the effective DNSSEC policy for every signed zone** in the DB (reuse
+  / extend the `ZonePolicyOverride` mechanism so it is not limited to
+  command-set changes). The operator's *intent* is the policy; **do not infer
+  the "current" policy from whatever keys happen to be in the keystore** — a
+  keystore can hold retired/multiple-alg keys while the policy is a single
+  operator choice.
+- **At load (reload and restart): compare config-policy vs stored-policy.** If
+  they differ, that is an algorithm rollover — route it through the (unbuilt)
+  auto-rollover engine, or refuse the switch and **keep the previously effective
+  policy**, rather than silently applying an unusable one.
+- **On an unapplicable change: keep the working state and raise a warning** (see
+  Decision 3). On reload the old policy is still in memory; with the persisted
+  policy this also works across restart.
+
+---
+
+## Decision 3 (deferred) — surface signing/policy errors on the zone
+
+The warning/error for a rejected policy change, and for signing failures
+generally (Finding 1, and the falcon/qruov codepoint issues), is the same
+work: a non-service-impacting error/warning set on the zone and surfaced in
+`config status` instead of a swallowed log line. This is the separate
+signing-error design doc (the other agent's), to be undertaken **after the
+snapshot branch merges** (avoids a competing `SetError` redesign vs the
+snapshot branch's — see the branch-strategy note in
+`[[falcon-codepoint-renumber-orphan]]`).
+
+---
+
+## Finding 3 — reload-storm deadlock (OPEN — awaiting goroutine dump)
+
+Under a storm of ~11 concurrent `config reload` / `reload-zones` operations
+(operator reload racing tool-driven reloads) while the PQ zones were re-signing,
+the daemon **deadlocked**: no log activity for minutes, `zone list` blocked on a
+held lock, DNS queries still answered. A `daemon restart` cleared it (no dump
+captured — the daemon's stderr was `/dev/null`; the Go `SIGQUIT` dump was lost).
+
+**CONFIRMED 2026-07-14 (goroutine dump `/tmp/tdns-auth.sigquit2.txt`, 448
+goroutines, 200 blocked on `sync.Mutex.Lock`):** it is a **re-entrant `zd.mu`
+self-deadlock** — the same *class* as the fixed `SignZone` deadlock (6e090a9),
+a NEW instance. Root goroutine holds `zd.mu` and tries to re-lock it:
+
+```
+RefreshEngine → initialLoadZone → Refresh → FetchFromFile
+  → applyRefreshReplacementLocked          (zd.mu HELD from here down)
+    → publishWorkingSetLocked
+      → resignWorkingSetSOAIfSigned
+        → SignRRset
+          → EnsureActiveDnssecKeys
+            → PublishDnskeyRRs
+              → zd.mu.Lock()               ← re-entrant → deadlock
+```
+
+Dominoes: `ParseZones` (holding `confMu`) then blocks on that same `zd.mu`; the
+~200 reload handlers pile up on `confMu` at `ReloadConfig` (config.go:562). One
+self-deadlocked goroutine wedges the whole daemon.
+
+**Trigger:** a refresh/initial-load that re-signs during publish AND hits the
+DNSKEY-publish branch (fresh keys) — test003's initial SQISIGN load did exactly
+that. The concurrent-reload storm only made it *visible* as a mass pile-up; the
+self-deadlock itself is deterministic once that path is reached.
+
+**Fix:** route the publish-resign path through the `*Locked` variants
+(`publishDnskeyRRsLocked` already exists and is what `SignZone` uses) so
+`EnsureActiveDnssecKeys`/`PublishDnskeyRRs` don't re-lock a held `zd.mu`.
+
+**Broader:** this is instance #2 of the "a `zd.mu`-holding `*Locked` path calls
+a method that re-locks `zd.mu`" class. A **systematic audit** of that class
+(grep every lock-holding path for calls into `zd.mu`-locking methods) belongs in
+landing the snapshot branch — there may be a #3.
+
+---
+
+## Status & branch/defer contract (2026-07-14)
+
+**Principle (agreed):** the `SetError` / `DnssecError`-subtype restructuring is
+urgent but does **not gate the snapshot merge.** On THIS branch, ensure the
+server **behaves correctly** for every signing/DNSSEC failure —
+**fail-closed (SERVFAIL / refuse transfer), no deadlock, no crash** — with **no
+error-registry changes.** **Defer all error *surfacing*** (zone-list /
+`config status` `ERROR`, the subtype split, independent set/clear lifecycles) to
+post-merge (item 9, `docs/2026-07-14-dnssec-error-single-bucket.md`).
+
+**Split of every identified signing/DNSSEC issue:**
+
+| Issue | Behave-correctly on THIS branch | Surfacing (→ item 9, deferred) |
+|---|---|---|
+| A1 re-entrant `zd.mu` deadlock | **DONE** `23710d1` | — |
+| Query serves unsigned (must-be-signed) | **DONE** — SERVFAIL, A3 `449a9e2` | zone `ERROR` |
+| **AXFR transfers unsigned (must-be-signed)** | **OPEN** — AXFR analog of A3 (`ZoneTransferOut` must refuse); test002 proved it | zone `ERROR` |
+| A3 **wildcard** branch serves unsigned | **OPEN** — `WildcardReplace` bypasses A3 | — |
+| SignZone fails (falcon/qruov codepoint orphan, alg mismatch) | fail-closed via A3 + AXFR-refuse | subtype `signing` |
+| Unsigned-publish reload window (#2) | fail-closed makes it SAFE; publish-only-when-complete removes the blip → **optional/deferrable** | — |
+| Policy change half-breaks a zone (test002 alg switch) | **OPEN** — minimal guard: refuse an incompatible alg change, keep old policy | full transactional + warn (#4) |
+| falcon "bad private key" vague error | tdns-side clear-error-at-load (Easy) | fuller surfacing |
+| `DnssecError` P1/P2/P3 bucket overload | avoided (A3 doesn't set it) | the whole B2 redesign |
+
+**Fixed + committed (signed):** A1 `23710d1`, A3 `449a9e2` (snapshot); I10
+cross-check `e117121` (tdns-debug).
+- A1: `EnsureActiveDnssecKeys` gained `zdLocked bool`; `resignWorkingSetSOAIfSigned`
+  resolves the dak before the lock and passes it in, routing DNSKEY publish
+  through `publishDnskeyRRsLocked`. All 7 call sites audited; timeout-guarded test.
+- A3: query-path (`ErrZoneUnsigned` → SERVFAIL), P1-safe (does NOT set
+  `DnssecError`); CDE/referral NSECs carved out via `isSynthesizedDenial`.
+
+**OPEN behaviour items for THIS branch (fail-closed correctness — belong here, not deferred):**
+1. **AXFR fail-closed** — `ZoneTransferOut` must refuse to transfer a
+   must-be-signed zone that has no RRSIGs (the AXFR analog of A3). Highest
+   priority: without it a broken zone still hands DNSKEY-but-no-RRSIGs to
+   secondaries (exactly what test002 did).
+2. **A3 wildcard gap** — the `WildcardReplace` positive-answer branch bypasses
+   the A3 SERVFAIL, so a broken-zone wildcard would still serve unsigned.
+3. **Minimal policy-refuse guard** — a config-reload algorithm change that needs
+   the (unbuilt) rollover must be **refused, keeping the old policy**, so a
+   reload can't half-break a zone (the test002 scenario). Behaviour only; the
+   *warn* is #4.
+4. **A1 CLASS AUDIT — IMPORTANT.** A1 was **instance #2** of "a `zd.mu`-holding
+   `*Locked` path calls a method that re-locks `zd.mu`" (first was 6e090a9).
+   Do a **systematic sweep** of every lock-holding path for calls into
+   `zd.mu`-locking methods — there may be a #3 lurking. This is a
+   correctness / merge-gate concern (not surfacing) and belongs on this branch.
+
+**Deferred to post-merge (surfacing / non-gating):**
+- **item 9** — the `DnssecError` subtype (B2) redesign + zone `ERROR`
+  observability + set/clear lifecycle (`docs/2026-07-14-dnssec-error-single-bucket.md`).
+  When it lands, A3 becomes defense-in-depth.
+- **#4** — full transactional config-reload (the *warn* half; the *refuse* half
+  is the on-branch guard above).
+- **#2** — publish-only-when-complete + derive `.Ready()` (an availability
+  optimisation once fail-closed is in; not a safety gate).
+- **falcon Part 1** — tdns-side clear error at load (`keystore.go:894` check
+  before the `readkey.go:285` decode); Easy, no fork, anytime.
+
+## Notes for the tdns-debug reload test
+
+- The masked-signing-failure proves I10 needs a **query-vs-AXFR signedness
+  cross-check**, not just an AXFR latch: query-only misses it (ephemeral mask),
+  AXFR-only latch misses it (never sees a signed transfer to latch on); the
+  **divergence** is the signal.
+- SQISIGN is unusable at scale for the window (signing cost), but signs fine at
+  ~10 records. Calibrate the window with a faster alg (MLDSA) + more records, or
+  a mid-cost alg — measured one reload at a time, never a storm.

--- a/docs/2026-07-14-zdmu-relock-audit.md
+++ b/docs/2026-07-14-zdmu-relock-audit.md
@@ -1,0 +1,200 @@
+# Audit: re-entrant `zd.mu` deadlock class — search for instance #3
+
+Date: 2026-07-14
+Branch: `feature/zone-snapshot-correctness`
+Scope: `v2/` (the maintained tree)
+
+## The class
+
+A path that **already holds `zd.mu`** — either a `*Locked` method, or a caller
+that did `zd.mu.Lock()` and has not yet unlocked — transitively calls a method
+that itself does `zd.mu.Lock()`/`RLock()`. Go's `sync.RWMutex` is **not
+reentrant**, so this is a permanent self-deadlock: the goroutine holding
+`zd.mu` blocks forever waiting for itself, and every other user of that zone
+(queries, zone list, `ParseZones` behind `confMu`) piles up behind it, wedging
+the daemon.
+
+Prior fixed instances:
+
+- **#1 — 6e090a9** `SignZone` (holds `zd.mu`) → `UpdateSigValidityFloor` →
+  `SetError`/`ClearError` re-locked `zd.mu`. Fixed with
+  `setErrorLocked`/`clearErrorLocked` + a `zdLocked` flag on
+  `UpdateSigValidityFloor`.
+- **#2 — 23710d1** `resignWorkingSetSOAIfSigned` (under a held `zd.mu` via
+  `publishWorkingSetLocked`) → `SignRRset` → `EnsureActiveDnssecKeys` →
+  `PublishDnskeyRRs` re-locked `zd.mu`. Fixed by adding a `zdLocked` flag to
+  `EnsureActiveDnssecKeys` that routes the DNSKEY publish through the existing
+  `publishDnskeyRRsLocked`, and by having `resignWorkingSetSOAIfSigned` resolve
+  the `dak` up front and pass it non-nil into `SignRRset`.
+
+## Method
+
+1. Enumerated every `zd.mu` acquisition — the **re-lockers**:
+   `grep -rn 'zd\.mu\.\(R\)\?Lock' --include='*.go' | grep -v _test.go`
+   (52 sites; no `RLock` — every acquisition is a full `Lock()`).
+2. Enumerated every `*Locked` method (`grep -rn 'func .*Locked('`) and every
+   explicit `zd.mu.Lock()` … `Unlock()` region — the **held-lock contexts**.
+3. For each held-lock context, followed the call graph (directly and
+   transitively) to see whether it can reach any re-locker from step 1,
+   focusing on the DNSSEC sign/publish/resign, transport-signal, and
+   zone-update apply paths, and on the specific re-lockers `PublishDnskeyRRs`,
+   `SetError`/`ClearError`, `ErrorList`, `SetStatus`, `UpdateSigValidityFloor`,
+   `Zones.Set`, and the publish/resign helpers.
+4. Classified each candidate REAL vs safe.
+
+## `zd.mu` re-lockers (methods that acquire `zd.mu`)
+
+Error/status setters and readers (all in `enums.go`): `SetError`, `ClearError`,
+`SetStatus`, `GetStatus`, `HasError`, `HasErrorOtherThan`,
+`HasServiceImpactingError`, `HasAutoRolloverImpactingError`, `ErrorList`
+(`SetStatus` also re-enters `Zones.Set`).
+
+DNSSEC/publish: `PublishDnskeyRRs` (`ops_dnskey.go`), `ResignZone`,
+`StripZoneRRSIGs`, `SignZone`, `GenerateNsecChain` (`sign.go`),
+`CreateTransportSignalRRs` (`tsignal.go`).
+
+Publish/mutation: `pendingChanges`, `requestPublish`, `publishSync`,
+`publishNow`, `InstallInitialSnapshot`, `runPublisher` (`zone_mutation.go`),
+`Lock()` (`structs.go`).
+
+Zone data / refresh: `FetchFromFile`, `FetchFromUpstream`, `WriteZone`,
+`SetOption`, `RepopulateDynamicRRs` (`zone_utils.go`),
+`ApplyChildUpdateToZoneData`, `ApplyZoneUpdateToZoneData`, `ZoneUpdaterEngine`
+(`zone_updater.go`), `ProxyDelegationPreRefresh`, `ProxyDelegationPostRefresh`
+(`delsync_proxy.go`), `GetDelegationData`, `ListChildren`
+(`delegation_backend_direct.go`), catalog handlers (`apihandler_catalog.go`),
+`setZonePolicy`, `changeZonePolicy`, `APIzone` (`apihandler_zone.go`),
+`RefreshEngine` / `initialLoadZone` regions (`refreshengine.go`).
+
+## Held-lock contexts checked
+
+The central held-lock context is the **publish path**:
+`publishWorkingSetLocked` (and its wrappers `publishLocked` / `publishSync` /
+`publishNow` / `runPublisher` / `applyRefreshReplacementLocked` /
+`commitTransportSignalLocked`, and the two `initialLoadZone` / refresh
+`serialChanged` blocks in `refreshengine.go`). Everything that re-signs the SOA
+under the lock funnels through:
+
+```
+… (held zd.mu) → publishWorkingSetLocked → resignWorkingSetSOAIfSigned
+    → EnsureActiveDnssecKeys(zdLocked=true)   ← the chokepoint
+    → SignRRset(dak != nil)                    ← no re-enter (dak resolved)
+```
+
+### Direct callees of `publishWorkingSetLocked` — all safe
+
+`zoneStillLive`, `apexFromSnapshotData`, `nextOutboundSerial`,
+`setWorkingSetSOASerial`, `buildSnapshotLocked` (`soaFromApex`,
+`cloneSignalSynth`, `copyIxfrChain`), `snapshot.Store`, `KeyDB.SaveOutgoingSerial`,
+`NotifyDownstreams` (only `dns.Exchange`, no `zd.mu`) — none acquire `zd.mu`.
+
+### `EnsureActiveDnssecKeys(zdLocked=true)` transitive callees
+
+- `kdb.GetDnssecKeys` / `GetDnssecKeysByState` / `PromoteDnssecKey` /
+  `GenerateKeypair` / `RegisterBootstrapActiveKSK` / `UpdateDnssecKeyState` /
+  `LoadRolloverZoneRow` — DB/keystore ops, no `zd` receiver, no `zd.mu`. Safe.
+- `reconcileActiveKeyAlgorithms`, `refreshActiveDnssecKeys` — no `zd.mu`. Safe.
+- `PublishDnskeyRRs` — routed to `publishDnskeyRRsLocked` when `zdLocked` (the
+  #2 fix). Safe.
+- **`WarnLargeAlgKskReusedAsZsk` / `WarnLargeAlgZoneSigningRole` — RE-LOCK.**
+  See #3 below.
+
+### Other signing held-lock contexts — safe
+
+- `SignZone`, `ResignZone`, `GenerateNsecChain`: resolve `dak` via
+  `EnsureActiveDnssecKeys(kdb, false)` **before** `zd.mu.Lock()`, then under the
+  lock call `SignRRset(dak != nil)` (skips the key-ensure path),
+  `publishDnskeyRRsLocked`, `GenerateNsecChainWithDak` (staging only), and
+  `publishLocked` (the chokepoint above). `SignZone` also calls
+  `UpdateSigValidityFloor(zdLocked=true)` (the #1 fix). Safe.
+- `ApplyChildUpdateToZoneData` / `ApplyZoneUpdateToZoneData`: resolve `dak`
+  before the lock, pass non-nil `dak` into `SignRRset` under the lock, and
+  `publishLocked` on the deferred exit (the chokepoint). Safe.
+- `CreateTransportSignalRRs`: resolves `dak` before the lock (its own comment
+  documents the #2 idiom); `createTransportSignal{SVCB,TSYNC}` sign with the
+  non-nil `dak` and then `commitTransportSignalLocked → publishWorkingSetLocked`
+  (the chokepoint). Safe.
+- `SyncZoneDelegationViaNotify` calls `SignRRset(…, nil, …)` (nil dak) — but
+  `delegation_sync.go` holds **no** `zd.mu` anywhere and `GetOwner` reads the
+  published snapshot without holding the lock, so this runs UNLOCKED. Safe.
+- Query path (`queryresponder.go`) online-signs with a nil dak, but holds no
+  `zd.mu` (reads the immutable snapshot). Safe.
+
+### Non-signing held-lock contexts — safe
+
+`refreshengine.go` field-assignment locks (OnFirstLoad swap; the pre-registered
+stub and reload config-merge blocks; `applyReloadedPolicyLocked`) touch only
+fields; their `SetError` / `UpdateSigValidityFloor(zdLocked=false)` /
+`triggerResign` / `GetSOA` calls are all **after** the `Unlock()`. Catalog
+handlers, `delsync_proxy` `ProxyDelegation*`, `zone_utils` `FetchFrom*` /
+`WriteZone` / `SetOption` / `RepopulateDynamicRRs`, `apihandler_zone`
+`setZonePolicy` / `changeZonePolicy` (their `SignZone` /
+`UpdateSigValidityFloor` run after unlock, per #1), `ZoneUpdaterEngine`, and
+`delegation_backend_direct` `GetDelegationData` / `ListChildren` call no
+re-locker inside their lock scope. `InstallInitialSnapshot` builds the snapshot
+via `buildSnapshotLocked` directly (no `resignWorkingSetSOAIfSigned`). Safe.
+
+## Verdict: **instance #3 EXISTS** (fixed here)
+
+`EnsureActiveDnssecKeys` calls two large-algorithm warning helpers that each
+read the zone's error list and set a `DnssecPolicyWarning`:
+
+- `WarnLargeAlgKskReusedAsZsk` (`sign.go`, active-KSK-reused-as-CSK / no real
+  ZSK branch), and
+- `WarnLargeAlgZoneSigningRole` (`sign.go`, right after a fresh ZSK is
+  generated),
+
+and both call `zd.ErrorList()` (`enums.go`, `zd.mu.Lock()`) followed by
+`zd.SetError()` (`enums.go`, `zd.mu.Lock()`).
+
+Real deadlock chain (fresh-key ZSK branch, the common one):
+
+```
+applyRefreshReplacementLocked / publishLocked / commitTransportSignalLocked   (hold zd.mu)
+  → publishWorkingSetLocked
+  → resignWorkingSetSOAIfSigned
+  → EnsureActiveDnssecKeys(zdLocked=true)
+  → (generate ZSK) WarnLargeAlgZoneSigningRole
+  → zd.ErrorList()  → zd.mu.Lock()   ← SELF-DEADLOCK
+```
+
+Reachability: guarded only by `isLarge(alg)`, i.e. the algorithm being listed in
+`dnssec.large_algorithms`. That is exactly the live **PQ-DNSSEC** configuration
+(MLDSA/FALCON/…). The re-lock fires **before** the DNSKEY publish that #2 fixed,
+so 23710d1 did not cover it — and 23710d1's regression test uses ED25519 (not a
+large algorithm), so `WarnLargeAlgZoneSigningRole` returned early and never hit
+the re-lock. On a large-algorithm signed zone, a refresh / initial-load / update
+that re-signs the SOA during publish while the ZSK is first generated
+deterministically wedges the daemon.
+
+### Fix (mirrors #1 / #2)
+
+- `enums.go`: add `errorListLocked()` (unlocked body of `ErrorList`);
+  `setErrorLocked` already exists from #1.
+- `large_ksk.go`: add a `zdLocked bool` parameter to
+  `WarnLargeAlgZoneSigningRole` and `WarnLargeAlgKskReusedAsZsk`. When
+  `zdLocked` they route the read/write through `errorListLocked` /
+  `setErrorLocked` instead of `ErrorList` / `SetError`.
+- `sign.go`: both callsites (the only two callers, both inside
+  `EnsureActiveDnssecKeys`) pass the function's `zdLocked` down. Every other
+  path into `EnsureActiveDnssecKeys` passes `zdLocked=false`, so unlocked
+  callers are unchanged.
+
+### Regression test
+
+`v2/zdmu_relock_largealg_test.go` — `TestResignSOAUnderLockLargeAlgNoSelfDeadlock`
+drives `resignWorkingSetSOAIfSigned` under a held `zd.mu` with an empty keystore
+and ED25519 marked large (`Conf.Internal.LargeAlgorithms`), so the fresh-key ZSK
+generation reaches `WarnLargeAlgZoneSigningRole`. Timeout-guarded: a
+re-introduced re-lock blocks the goroutine forever and the 10s timeout fails the
+test. Verified — flipping the `sign.go:537` flag back to `false` trips the
+timeout exactly after "generated ZSK"; the test also asserts the SOA is signed
+and the `DnssecPolicyWarning` was actually recorded, proving the re-lock site was
+exercised (not skipped).
+
+## Result
+
+`go build ./...` and `go test -race ./...` in `v2/` both pass. One new instance
+(#3) found and fixed; no further reachable re-lock deadlock found in the audited
+paths. With #1/#2/#3 fixed, the audited class is considered closed for the
+DNSSEC sign/publish/resign, transport-signal, and zone-update apply paths.

--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -114,17 +114,33 @@ tdnsnbsd:
 	   echo "TDNS_NBSD_DIR is unset (should be user@host:/dir), rsync not possible" ; \
 	fi
 
+UTILS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+TDNS_ROOT := $(UTILS_DIR)..
+
+# Reject direct zone mutation outside the staging allowlist (B3).
+check-no-mutators:
+	@violations=$$(grep -RnE '\.(RRtypes\.Set|Data\.Set)\(' \
+		$(TDNS_ROOT)/v2 $(TDNS_ROOT)/cmdv2 --include='*.go' \
+		| grep -v zone_mutation.go \
+		| grep -v '_test\.go' \
+		| grep -v 'dnsutils\.go' || true); \
+	if [ -n "$$violations" ]; then \
+		echo "mutator Set() calls outside allowlist:"; \
+		echo "$$violations"; \
+		exit 1; \
+	fi
+
 test:
 	$(GO) test -v -cover
 
 # install:
 # 	install -s -b -c ${PROG} /usr/local/bin/
 
-lint:
+lint: check-no-mutators
 	go fmt ./...
 	go vet ./...
 	staticcheck ./...
 	gosec ./...
 	golangci-lint run
 
-.PHONY: build generate version clean
+.PHONY: build generate version clean check-no-mutators

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -4,4 +4,4 @@ include ../utils/Makefile.common
 
 .PHONY: clean install build version.go
 
-# only interesting target is "lint"
+# only interesting target is "lint" (includes check-no-mutators via Makefile.common)

--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -33,11 +33,11 @@ type KeystorePost struct {
 	Creator         string
 	Force           bool // commit destructive operation; otherwise dry-run (used by 'purge')
 	// TSIG keystore (tsig-mgmt); do not overload Algorithm uint8 above.
-	TsigKeyname   string `json:"tsigkeyname,omitempty"`
-	TsigAlgorithm string `json:"tsigalgorithm,omitempty"`
-	TsigSecret    string `json:"tsigsecret,omitempty"`
-	Owner         string `json:"owner,omitempty"`
-	Interactive   bool   `json:"interactive,omitempty"`
+	TsigKeyname      string   `json:"tsigkeyname,omitempty"`
+	TsigAlgorithm    string   `json:"tsigalgorithm,omitempty"`
+	TsigSecret       string   `json:"tsigsecret,omitempty"`
+	Owner            string   `json:"owner,omitempty"`
+	Interactive      bool     `json:"interactive,omitempty"`
 	TsigImportData   string   `json:"tsigimportdata,omitempty"`
 	TsigImportFormat string   `json:"tsigimportformat,omitempty"`
 	TsigOverwrite    []string `json:"tsigoverwrite,omitempty"`
@@ -320,6 +320,7 @@ type DebugResponse struct {
 	TrustedSig0keys map[string]Sig0Key
 	CachedRRsets    []cache.CachedRRset
 	Validated       bool
+	ZoneTxlog       *PendingChangesView
 	Msg             string
 	Error           bool
 	ErrorMsg        string

--- a/v2/apihandler_catalog.go
+++ b/v2/apihandler_catalog.go
@@ -206,6 +206,7 @@ func handleCatalogDelete(catalogZoneName string, resp *CatalogResponse) error {
 	lgApi.Info("deleting catalog zone", "zone", catalogZoneName)
 
 	// Remove the catalog zone from Zones map
+	stopZonePublisher(catalogZoneName)
 	Zones.Remove(catalogZoneName)
 
 	// Remove catalog membership (it's a regular map, needs mutex)
@@ -330,6 +331,7 @@ func handleCatalogZoneDelete(catalogZoneName, zoneName string, resp *CatalogResp
 			lgApi.Info("auto-removing zone from catalog", "zone", zoneName, "catalog", catalogZoneName)
 
 			// Remove from Zones map
+			stopZonePublisher(zoneName)
 			Zones.Remove(zoneName)
 
 			// Remove from dynamic config file

--- a/v2/apihandler_catalog.go
+++ b/v2/apihandler_catalog.go
@@ -148,15 +148,6 @@ func handleCatalogCreate(catalogZoneName string, resp *CatalogResponse) error {
 		return fmt.Errorf("failed to create version TXT record: %v", err)
 	}
 
-	// Get or create OwnerData for version owner
-	ownerData, exists := zd.Data.Get(versionOwner)
-	if !exists {
-		ownerData = OwnerData{
-			Name:    versionOwner,
-			RRtypes: NewRRTypeStore(),
-		}
-	}
-
 	// Create or update TXT RRset
 	rrset := core.RRset{
 		Name:   versionOwner,
@@ -164,8 +155,11 @@ func handleCatalogCreate(catalogZoneName string, resp *CatalogResponse) error {
 		Class:  dns.ClassINET,
 		RRs:    []dns.RR{versionTxt},
 	}
-	ownerData.RRtypes.Set(dns.TypeTXT, rrset)
-	zd.Data.Set(versionOwner, ownerData)
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRsetLocked(versionOwner, rrset)
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
+	zd.mu.Unlock()
 
 	// Register the zone
 	Zones.Set(catalogZoneName, zd)
@@ -480,11 +474,15 @@ func regenerateCatalogZone(catalogZoneName string) error {
 
 	cm := GetOrCreateCatalogMembership(catalogZoneName)
 
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.ensureWorkingSet()
+
 	// Remove all existing zone records (*.zones.{catalog} and group.*.zones.{catalog})
 	zoneSuffix := fmt.Sprintf(".zones.%s", catalogZoneName)
-	for owner := range zd.Data.IterBuffered() {
-		if strings.HasSuffix(owner.Key, zoneSuffix) {
-			zd.Data.Remove(owner.Key)
+	for name := range zd.workingSet {
+		if strings.HasSuffix(name, zoneSuffix) {
+			zd.stageOwnerDeleteLocked(name)
 		}
 	}
 
@@ -503,37 +501,21 @@ func regenerateCatalogZone(catalogZoneName string) error {
 			continue
 		}
 
-		// Create RRset for PTR record
 		ptrRRset := core.RRset{
 			Name:   ownerName,
 			RRtype: dns.TypePTR,
 			Class:  dns.ClassINET,
 			RRs:    []dns.RR{ptr},
 		}
-
-		// Get or create OwnerData for this owner
-		ownerData, exists := zd.Data.Get(ownerName)
-		if !exists {
-			ownerData = OwnerData{
-				Name:    ownerName,
-				RRtypes: NewRRTypeStore(),
-			}
-		}
-
-		// Add the PTR RRset to the owner
-		ownerData.RRtypes.Set(dns.TypePTR, ptrRRset)
-		zd.Data.Set(ownerName, ownerData)
+		zd.stageRRsetLocked(ownerName, ptrRRset)
 
 		// TXT record for groups: group.{uniqueid}.zones.{catalog} with all groups
 		if len(member.Groups) > 0 {
 			groupOwnerName := fmt.Sprintf("group.%s.zones.%s", member.Hash, catalogZoneName)
 
-			// Create TXT record with all groups as strings
-			// Format: "group1" "group2" "group3" ...
 			txtStrings := make([]string, len(member.Groups))
 			copy(txtStrings, member.Groups)
 
-			// Create TXT RR with all group strings
 			txtRR := &dns.TXT{
 				Hdr: dns.RR_Header{
 					Name:   groupOwnerName,
@@ -544,41 +526,21 @@ func regenerateCatalogZone(catalogZoneName string) error {
 				Txt: txtStrings,
 			}
 
-			// Create RRset for TXT record
 			txtRRset := core.RRset{
 				Name:   groupOwnerName,
 				RRtype: dns.TypeTXT,
 				Class:  dns.ClassINET,
 				RRs:    []dns.RR{txtRR},
 			}
-
-			// Get or create OwnerData for group owner
-			groupOwnerData, exists := zd.Data.Get(groupOwnerName)
-			if !exists {
-				groupOwnerData = OwnerData{
-					Name:    groupOwnerName,
-					RRtypes: NewRRTypeStore(),
-				}
-			}
-
-			// Add the TXT RRset to the group owner
-			groupOwnerData.RRtypes.Set(dns.TypeTXT, txtRRset)
-			zd.Data.Set(groupOwnerName, groupOwnerData)
+			zd.stageRRsetLocked(groupOwnerName, txtRRset)
 		}
 	}
 
-	// Bump SOA serial
-	_, err := zd.BumpSerial()
-	if err != nil {
-		lgApi.Error("error bumping SOA serial for catalog", "catalog", catalogZoneName, "err", err)
-	}
-
-	// Notify downstreams
-	zd.NotifyDownstreams()
+	zd.publishLocked(zd.generation.Load())
 
 	// Write zone file if persistence is enabled
 	if Conf.ShouldPersistZone(zd) {
-		_, err = zd.WriteDynamicZoneFile(Conf.DynamicZones.ZoneDirectory)
+		_, err := zd.WriteDynamicZoneFile(Conf.DynamicZones.ZoneDirectory)
 		if err != nil {
 			lgApi.Warn("failed to write catalog zone file", "zone", catalogZoneName, "err", err)
 			// Don't fail the operation, just log the warning

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -590,6 +590,16 @@ func APIdebug(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 			}
 			resp.CachedRRsets = rrsets
 
+		case "zone-txlog":
+			if zd, ok := Zones.Get(dp.Zone); ok {
+				pc := zd.pendingChanges()
+				resp.ZoneTxlog = pendingChangesView(pc)
+				resp.Msg = FormatPendingChanges(pc)
+			} else {
+				resp.Error = true
+				resp.ErrorMsg = fmt.Sprintf("zone %s is unknown", dp.Zone)
+			}
+
 		default:
 			resp.ErrorMsg = fmt.Sprintf("Unknown command: %s", dp.Command)
 			resp.Error = true

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -406,7 +406,7 @@ func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) 
 	zd.DnssecPolicyName = policyName
 	zd.mu.Unlock()
 
-	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm)
+	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm, false)
 
 	// Additive sign: reconcile (retire wrong-alg, generate new) + add new-key
 	// RRSIGs, leaving the retired keys' RRSIGs in place for a graceful
@@ -553,7 +553,7 @@ func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, erro
 	zd.DnssecPolicyName = policyName
 	zd.mu.Unlock()
 
-	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm)
+	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm, false)
 
 	if _, err := zd.SignZone(kdb, true); err != nil {
 		zd.mu.Lock()

--- a/v2/auth_utils.go
+++ b/v2/auth_utils.go
@@ -13,6 +13,12 @@ import (
 // XXX: This should be merged with the FetchChildDelegationData() function
 // Returns [] NS RRs + [] v4glue RRs + [] v6glue RRs
 func (zd *ZoneData) FindDelegation(qname string, dnssec_ok bool) *ChildDelegationData {
+	return zd.findDelegationFrom(zd.publishedSnapshot(), qname, dnssec_ok)
+}
+
+// findDelegationFrom resolves a child delegation against a pinned snapshot, so
+// the NS RRset and its glue come from one serial (see getOwnerFrom).
+func (zd *ZoneData) findDelegationFrom(snap *zoneSnapshot, qname string, dnssec_ok bool) *ChildDelegationData {
 	var child string
 	labels := strings.Split(qname, ".")
 	for i := 0; i < len(labels)-1; i++ {
@@ -20,9 +26,9 @@ func (zd *ZoneData) FindDelegation(qname string, dnssec_ok bool) *ChildDelegatio
 		if child == zd.ZoneName {
 			break // no point in checking above current zone name
 		}
-		if zd.NameExists(child) {
-			childrrs, err := zd.GetOwner(child)
-			if err != nil || childrrs == nil {
+		if nameExistsFrom(snap, child) {
+			childrrs := getOwnerFrom(snap, child)
+			if childrrs == nil {
 				continue
 			}
 			zd.Logger.Printf("FindDelegation for qname='%s': there are RRs for '%s'", qname, child)
@@ -33,10 +39,8 @@ func (zd *ZoneData) FindDelegation(qname string, dnssec_ok bool) *ChildDelegatio
 					NS_rrset:  &childns,
 					DS_rrset:  &childds,
 				}
-				// zd.Logger.Printf("FindDelegation for qname='%s': there are NS RRs for '%s'", qname, child)
-				// Ok, we found a delegation. Do we need any glue?
 				zd.Logger.Printf("FindDelegation: cdd=%v", cdd)
-				v4glue, v6glue, v4glue_rrsigs, v6glue_rrsigs := zd.FindGlueSimple(childns, dnssec_ok)
+				v4glue, v6glue, v4glue_rrsigs, v6glue_rrsigs := zd.findGlueSimpleFrom(snap, childns, dnssec_ok)
 				cdd.A_glue = v4glue
 				cdd.AAAA_glue = v6glue
 				cdd.A_glue_rrsigs = v4glue_rrsigs
@@ -53,8 +57,11 @@ func (zd *ZoneData) FindDelegation(qname string, dnssec_ok bool) *ChildDelegatio
 // Returns two RRsets with A glue and AAAA glue. Each RRset may be nil.
 // XXX: This is wrong. The v4 (and v6) glue is not an *RRset, but a []*RRset
 func (zd *ZoneData) FindGlue(nsrrs core.RRset, dnssec_ok bool) (*core.RRset, *core.RRset) {
-	// zd.Logger.Printf("FindGlue: nsrrs: %v", nsrrs)
-	// dump.P(nsrrs)
+	return zd.findGlueFrom(zd.publishedSnapshot(), nsrrs, dnssec_ok)
+}
+
+// findGlueFrom resolves in-bailiwick glue against a pinned snapshot.
+func (zd *ZoneData) findGlueFrom(snap *zoneSnapshot, nsrrs core.RRset, dnssec_ok bool) (*core.RRset, *core.RRset) {
 	if len(nsrrs.RRs) == 0 {
 		if zd.Debug {
 			zd.Logger.Printf("FindGlue: nsrrs is empty")
@@ -71,11 +78,11 @@ func (zd *ZoneData) FindGlue(nsrrs core.RRset, dnssec_ok bool) (*core.RRset, *co
 				zd.Logger.Printf("FindGlue: zone '%s' has a nameserver '%s'", zone, nsname)
 			}
 			// nsnidx, exist := zd.OwnerIndex[nsname]
-			if !zd.NameExists(nsname) {
-				continue // no match for nsname in zd.OwnerIndex (i.e nameserver is out of bailiwick)
+			if !nameExistsFrom(snap, nsname) {
+				continue // nameserver is out of bailiwick
 			}
-			nsnamerrs, err := zd.GetOwner(nsname)
-			if err != nil || nsnamerrs == nil {
+			nsnamerrs := getOwnerFrom(snap, nsname)
+			if nsnamerrs == nil {
 				continue
 			}
 
@@ -122,8 +129,11 @@ func (zd *ZoneData) FindGlue(nsrrs core.RRset, dnssec_ok bool) (*core.RRset, *co
 }
 
 func (zd *ZoneData) FindGlueSimple(nsrrs core.RRset, dnssec_ok bool) ([]dns.RR, []dns.RR, []dns.RR, []dns.RR) {
-	// zd.Logger.Printf("FindGlue: nsrrs: %v", nsrrs)
-	// dump.P(nsrrs)
+	return zd.findGlueSimpleFrom(zd.publishedSnapshot(), nsrrs, dnssec_ok)
+}
+
+// findGlueSimpleFrom resolves glue against a pinned snapshot.
+func (zd *ZoneData) findGlueSimpleFrom(snap *zoneSnapshot, nsrrs core.RRset, dnssec_ok bool) ([]dns.RR, []dns.RR, []dns.RR, []dns.RR) {
 	if len(nsrrs.RRs) == 0 {
 		if zd.Debug {
 			zd.Logger.Printf("FindGlueSimple: nsrrs is empty")
@@ -138,11 +148,11 @@ func (zd *ZoneData) FindGlueSimple(nsrrs core.RRset, dnssec_ok bool) ([]dns.RR, 
 			nsname = nsrr.Ns
 			zd.Logger.Printf("FindGlue: zone '%s' has a nameserver '%s'", zone, nsname)
 			// nsnidx, exist := zd.OwnerIndex[nsname]
-			if !zd.NameExists(nsname) {
-				continue // no match for nsname in zd.OwnerIndex (i.e nameserver is out of bailiwick)
+			if !nameExistsFrom(snap, nsname) {
+				continue // nameserver is out of bailiwick
 			}
-			nsnamerrs, err := zd.GetOwner(nsname)
-			if err != nil || nsnamerrs == nil {
+			nsnamerrs := getOwnerFrom(snap, nsname)
+			if nsnamerrs == nil {
 				continue
 			}
 

--- a/v2/catalog.go
+++ b/v2/catalog.go
@@ -53,7 +53,13 @@ func RegisterCatalogZoneCallback(callback CatalogZoneCallback) {
 
 // ParseCatalogZone parses a catalog zone and extracts member zones and groups
 func ParseCatalogZone(zd *ZoneData) (*CatalogZoneUpdate, error) {
-	if zd == nil || zd.Data.IsEmpty() {
+	if zd == nil {
+		return nil, fmt.Errorf("catalog zone data is empty")
+	}
+	// B3: read membership from the published snapshot, not the live zd.Data
+	// (which is no longer written after the dual-write was dropped).
+	snap := zd.publishedSnapshot()
+	if snap == nil || len(snap.Data) == 0 {
 		return nil, fmt.Errorf("catalog zone data is empty")
 	}
 
@@ -77,10 +83,8 @@ func ParseCatalogZone(zd *ZoneData) (*CatalogZoneUpdate, error) {
 
 	zoneSuffix := fmt.Sprintf(".zones.%s", catalogZoneName)
 
-	// Iterate through all owners in the zone
-	for owner := range zd.Data.IterBuffered() {
-		ownerName := owner.Key
-		ownerData := owner.Val
+	// Iterate through all owners in the zone (from the published snapshot).
+	for ownerName, ownerData := range snap.Data {
 
 		// Process *.zones.{catalog-zone}. records (PTR records with zone names)
 		if strings.HasSuffix(ownerName, zoneSuffix) && !strings.HasPrefix(ownerName, "group.") {

--- a/v2/cli/debug_cmds.go
+++ b/v2/cli/debug_cmds.go
@@ -259,7 +259,34 @@ func NewDebugCmd(role string, extras ...*cobra.Command) *cobra.Command {
 		},
 	}
 
-	c.AddCommand(rrset, validateRRset, lav, showTA, showRRsetCache, sig0)
+	zoneTxlog := &cobra.Command{
+		Use:   "zone-txlog",
+		Short: "Show staged-but-unpublished zone changes",
+		Run: func(cmd *cobra.Command, args []string) {
+			if tdns.Globals.Zonename == "" {
+				fmt.Printf("Error: zone name not specified. Terminating.\n")
+				os.Exit(1)
+			}
+			api, err := GetApiClient(role, true)
+			if err != nil {
+				log.Fatalf("Error: %v", err)
+			}
+			dr := SendDebug(api, tdns.DebugPost{
+				Command: "zone-txlog",
+				Zone:    dns.Fqdn(tdns.Globals.Zonename),
+			})
+			if dr.Error {
+				os.Exit(1)
+			}
+			if dr.ZoneTxlog != nil {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(dr.ZoneTxlog)
+			}
+		},
+	}
+
+	c.AddCommand(rrset, validateRRset, lav, showTA, showRRsetCache, zoneTxlog, sig0)
 	for _, e := range extras {
 		c.AddCommand(e)
 	}

--- a/v2/config.go
+++ b/v2/config.go
@@ -646,6 +646,7 @@ func (conf *Config) ReloadZoneConfig(ctx context.Context) (string, error) {
 			continue
 		}
 		lgConfig.Info("ReloadZoneConfig: zone no longer in config, removing from zone list", "zone", zname)
+		stopZonePublisher(zname)
 		Zones.Remove(zname)
 		// Bump generation so any in-flight refresh on the captured pointer fails
 		// the pre-persist guard (B5b) and does not resurrect the removed zone.

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -276,6 +276,16 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, empty SOA RRset", zone)
 		return zd.refuseTransfer(w, r)
 	}
+	// Fail-closed: a zone configured to be signed must never be transferred
+	// unsigned. The SOA is an apex RRset and is always signed in a healthy
+	// signed zone, so an SOA with no RRSIG means the pinned snapshot is not
+	// (yet / any longer) signed — refuse rather than hand a secondary a zone it
+	// would serve BOGUS. Catches both a persistent sign failure and the reload
+	// re-sign window. (Surfacing WHY is deferred to the DnssecError redesign.)
+	if (zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) && len(soaRRset.RRSIGs) == 0 {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, zone is configured to be signed but the SOA has no RRSIG (unsigned/broken)", zone)
+		return zd.refuseTransfer(w, r)
+	}
 	soaOrig, ok := soaRRset.RRs[0].(*dns.SOA)
 	if !ok {
 		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, invalid SOA RR", zone)

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -258,11 +259,14 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 		return zd.refuseTransfer(w, r)
 	}
 
-	apex, err := zd.GetOwner(zd.ZoneName)
-	if err != nil {
-		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, apex lookup failed: %v", zone, err)
+	// Pin ONE snapshot for the whole transfer so every owner comes from the
+	// same serial — no torn AXFR (M1).
+	snap := zd.publishedSnapshot()
+	if snap == nil {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, no published snapshot", zone)
 		return zd.refuseTransfer(w, r)
 	}
+	apex := getOwnerFrom(snap, zd.ZoneName)
 	if apex == nil {
 		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, missing apex", zone)
 		return zd.refuseTransfer(w, r)
@@ -342,17 +346,17 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 		}
 	}
 
-	owners, err := zd.GetOwnerNames()
-	if err != nil {
-		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, owner list failed: %v", zone, err)
-		return zd.refuseTransfer(w, r)
+	names := make([]string, 0, len(snap.Data))
+	for name := range snap.Data {
+		names = append(names, name)
 	}
-	for _, owner := range owners {
+	sort.Strings(names)
+	for _, owner := range names {
 		if owner == zd.ZoneName {
 			continue
 		}
-		omap, err := zd.GetOwner(owner)
-		if err != nil || omap == nil {
+		omap := getOwnerFrom(snap, owner)
+		if omap == nil {
 			continue
 		}
 		for _, rrt := range omap.RRtypes.Keys() {
@@ -629,10 +633,11 @@ func (zd *ZoneData) WriteZoneToFile(f *os.File) error {
 
 	writer := bufio.NewWriter(f)
 
-	apex, err := zd.GetOwner(zd.ZoneName)
-	if err != nil {
-		lgDns.Error("WriteZoneToFile: failed to get zone apex", "zone", zd.ZoneName, "err", err)
-		return err
+	snap := zd.publishedSnapshot()
+	apex := getOwnerFrom(snap, zd.ZoneName)
+	if apex == nil {
+		lgDns.Error("WriteZoneToFile: failed to get zone apex", "zone", zd.ZoneName)
+		return fmt.Errorf("WriteZoneToFile: %s: no apex in published snapshot", zd.ZoneName)
 	}
 	soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
 
@@ -654,17 +659,17 @@ func (zd *ZoneData) WriteZoneToFile(f *os.File) error {
 	}
 
 	// Rest of zone
-	owners, err := zd.GetOwnerNames()
-	if err != nil {
-		lgDns.Error("WriteZoneToFile: failed to list owners", "zone", zd.ZoneName, "err", err)
-		return err
+	names := make([]string, 0, len(snap.Data))
+	for name := range snap.Data {
+		names = append(names, name)
 	}
-	for _, owner := range owners {
+	sort.Strings(names)
+	for _, owner := range names {
 		if owner == zd.ZoneName {
 			continue
 		}
-		omap, err := zd.GetOwner(owner)
-		if err != nil || omap == nil {
+		omap := getOwnerFrom(snap, owner)
+		if omap == nil {
 			continue
 		}
 		for _, rrt := range omap.RRtypes.Keys() {

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -279,7 +279,6 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 	}
 
 	soaCopy := dns.Copy(soaOrig).(*dns.SOA)
-	soaCopy.Serial = zd.CurrentSerial
 	transferSOA := core.RRset{
 		Name:   zd.ZoneName,
 		Class:  dns.ClassINET,
@@ -343,11 +342,19 @@ func (zd *ZoneData) ZoneTransferOut(w dns.ResponseWriter, r *dns.Msg) (int, erro
 		}
 	}
 
-	for _, owner := range zd.Data.Keys() {
+	owners, err := zd.GetOwnerNames()
+	if err != nil {
+		zd.Logger.Printf("ZoneTransferOut: %s: refusing transfer, owner list failed: %v", zone, err)
+		return zd.refuseTransfer(w, r)
+	}
+	for _, owner := range owners {
 		if owner == zd.ZoneName {
 			continue
 		}
-		omap, _ := zd.Data.Get(owner)
+		omap, err := zd.GetOwner(owner)
+		if err != nil || omap == nil {
+			continue
+		}
 		for _, rrt := range omap.RRtypes.Keys() {
 			rrset := omap.RRtypes.GetOnlyRRSet(uint16(rrt))
 			if !appendRRset(bs, rrset) {
@@ -628,7 +635,6 @@ func (zd *ZoneData) WriteZoneToFile(f *os.File) error {
 		return err
 	}
 	soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-	soa.RRs[0].(*dns.SOA).Serial = zd.CurrentSerial
 
 	//	zonedata += soa.String() + "\n"
 	count := 0
@@ -648,9 +654,17 @@ func (zd *ZoneData) WriteZoneToFile(f *os.File) error {
 	}
 
 	// Rest of zone
-	for _, owner := range zd.Data.Keys() {
-		omap, _ := zd.Data.Get(owner)
+	owners, err := zd.GetOwnerNames()
+	if err != nil {
+		lgDns.Error("WriteZoneToFile: failed to list owners", "zone", zd.ZoneName, "err", err)
+		return err
+	}
+	for _, owner := range owners {
 		if owner == zd.ZoneName {
+			continue
+		}
+		omap, err := zd.GetOwner(owner)
+		if err != nil || omap == nil {
 			continue
 		}
 		for _, rrt := range omap.RRtypes.Keys() {

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -798,6 +798,7 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 	}
 	Zones.Set(name, zd)
 	if err := conf.AddDynamicZoneToConfig(zd); err != nil {
+		zd.stopPublisher()
 		Zones.Remove(name)
 		rollbackKey()
 		return "", fmt.Errorf("failed to persist dynamic zone %s: %w", name, err)
@@ -858,6 +859,7 @@ func (conf *Config) RemoveDynamicZone(name string) (string, error) {
 		return "", fmt.Errorf("zone %s is not API-managed and cannot be deleted here", name)
 	}
 
+	stopZonePublisher(name)
 	Zones.Remove(name)
 	// Bump generation AFTER removing from the map so any refresh goroutine that
 	// snapshotted the old generation fails the pre-persist guard (B5b) and does

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -536,6 +536,16 @@ func (zd *ZoneData) HasAutoRolloverImpactingError() bool {
 func (zd *ZoneData) ErrorList() []ZoneError {
 	zd.mu.Lock()
 	defer zd.mu.Unlock()
+	return zd.errorListLocked()
+}
+
+// errorListLocked is ErrorList's body; the caller MUST already hold zd.mu. It
+// exists so a zd.mu-holding path can read the active error list without
+// re-locking — Go mutexes are not reentrant. Concretely: the large-algorithm
+// warning helpers (WarnLargeAlgZoneSigningRole / WarnLargeAlgKskReusedAsZsk) are
+// reached from EnsureActiveDnssecKeys, which the publish-path SOA re-sign
+// (resignWorkingSetSOAIfSigned) now calls with zdLocked=true under zd.mu.
+func (zd *ZoneData) errorListLocked() []ZoneError {
 	if len(zd.Errors) == 0 {
 		return nil
 	}

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -386,6 +386,13 @@ type ZoneError struct {
 func (zd *ZoneData) SetError(errtype ErrorType, errmsg string, args ...interface{}) {
 	zd.mu.Lock()
 	defer zd.mu.Unlock()
+	zd.setErrorLocked(errtype, errmsg, args...)
+}
+
+// setErrorLocked is SetError's body; the caller MUST already hold zd.mu. It
+// exists so a zd.mu-holding path (e.g. SignZone → UpdateSigValidityFloor) can
+// record an error without re-locking — Go mutexes are not reentrant.
+func (zd *ZoneData) setErrorLocked(errtype ErrorType, errmsg string, args ...interface{}) {
 	if errtype == NoError {
 		zd.Errors = nil
 	} else {
@@ -403,6 +410,12 @@ func (zd *ZoneData) SetError(errtype ErrorType, errmsg string, args ...interface
 func (zd *ZoneData) ClearError(errtype ErrorType) {
 	zd.mu.Lock()
 	defer zd.mu.Unlock()
+	zd.clearErrorLocked(errtype)
+}
+
+// clearErrorLocked is ClearError's body; the caller MUST already hold zd.mu.
+// See setErrorLocked for why this exists.
+func (zd *ZoneData) clearErrorLocked(errtype ErrorType) {
 	if errtype == NoError {
 		zd.Errors = nil
 	} else if zd.Errors != nil {

--- a/v2/getsoa_test.go
+++ b/v2/getsoa_test.go
@@ -1,0 +1,28 @@
+package tdns
+
+import "testing"
+
+// TestGetSOANeverReturnsNilNil is the regression test for the RefreshEngine
+// nil-pointer crash (found 2026-07-13 via reload-zones racing a refresh):
+// GetSOA returned (nil, nil) when the apex owner was transiently missing, and
+// RefreshEngine read soa.Refresh in its err==nil branch → nil deref → the
+// process crashed. GetSOA must surface a missing apex as an error, never as a
+// nil SOA with no error.
+func TestGetSOANeverReturnsNilNil(t *testing.T) {
+	// A ready primary MapZone with no published snapshot and no apex owner —
+	// exactly the transient state a concurrent reload can expose.
+	zd := &ZoneData{
+		ZoneName:  "empty.example.",
+		ZoneType:  Primary,
+		ZoneStore: MapZone,
+		Ready:     true,
+	}
+
+	soa, err := zd.GetSOA()
+	if err == nil {
+		t.Fatalf("GetSOA must return an error when the apex owner is missing (got soa=%v, err=nil)", soa)
+	}
+	if soa != nil {
+		t.Fatalf("GetSOA must return a nil SOA alongside its error, got %v", soa)
+	}
+}

--- a/v2/ksk_rollover_validation.go
+++ b/v2/ksk_rollover_validation.go
@@ -418,7 +418,12 @@ func configuredServedTTLForSigValidity(pol *DnssecPolicy, which string) time.Dur
 // UpdateSigValidityFloor applies config-load or runtime sig-validity floor
 // checks and sets/clears DnssecError / DnssecPolicyWarning on zd.
 // When runtime is true, maxObservedTTL is the bound for all three values.
-func UpdateSigValidityFloor(zd *ZoneData, pol *DnssecPolicy, propagationDelay time.Duration, maxObservedTTL uint32, runtime bool, isLarge func(uint8) bool) {
+// UpdateSigValidityFloor evaluates the sig-validity floor and records the
+// resulting DnssecError / DnssecPolicyWarning. It runs both lock-free (config
+// parse, refresh) and while the caller already holds zd.mu (SignZone). Pass
+// zdLocked=true in the latter case so the error updates use the *Locked
+// error setters and do not self-deadlock re-acquiring zd.mu.
+func UpdateSigValidityFloor(zd *ZoneData, pol *DnssecPolicy, propagationDelay time.Duration, maxObservedTTL uint32, runtime bool, isLarge func(uint8) bool, zdLocked bool) {
 	if zd == nil || pol == nil {
 		return
 	}
@@ -426,12 +431,21 @@ func UpdateSigValidityFloor(zd *ZoneData, pol *DnssecPolicy, propagationDelay ti
 		return
 	}
 
+	// Dispatch error updates to the plain (locking) or *Locked setters
+	// depending on whether the caller already holds zd.mu.
+	setErr := zd.SetError
+	clearErr := zd.ClearError
+	if zdLocked {
+		setErr = zd.setErrorLocked
+		clearErr = zd.clearErrorLocked
+	}
+
 	var hardMsgs, warnMsgs []string
 
 	if runtime {
 		if maxObservedTTL == 0 {
-			zd.ClearError(DnssecPolicyWarning)
-			zd.ClearError(DnssecError)
+			clearErr(DnssecPolicyWarning)
+			clearErr(DnssecError)
 			return
 		}
 		served := time.Duration(maxObservedTTL) * time.Second
@@ -480,14 +494,14 @@ func UpdateSigValidityFloor(zd *ZoneData, pol *DnssecPolicy, propagationDelay ti
 	}
 
 	if len(hardMsgs) == 0 {
-		zd.ClearError(DnssecError)
+		clearErr(DnssecError)
 	} else {
-		zd.SetError(DnssecError, "sig-validity floor: %s", strings.Join(hardMsgs, "; "))
+		setErr(DnssecError, "sig-validity floor: %s", strings.Join(hardMsgs, "; "))
 	}
 	warnMsgs = appendDnssecPolicyWarnings(warnMsgs, pol, isLarge)
 	if len(warnMsgs) == 0 {
-		zd.ClearError(DnssecPolicyWarning)
+		clearErr(DnssecPolicyWarning)
 	} else {
-		zd.SetError(DnssecPolicyWarning, "%s", strings.Join(warnMsgs, "; "))
+		setErr(DnssecPolicyWarning, "%s", strings.Join(warnMsgs, "; "))
 	}
 }

--- a/v2/ksk_rollover_validation_test.go
+++ b/v2/ksk_rollover_validation_test.go
@@ -206,7 +206,7 @@ func TestUpdateSigValidityFloorConfig(t *testing.T) {
 	}
 	zd := &ZoneData{ZoneName: "test.example."}
 	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
-	UpdateSigValidityFloor(zd, pol, prop, 0, false, nil)
+	UpdateSigValidityFloor(zd, pol, prop, 0, false, nil, false)
 	if zd.HasError(DnssecError) || zd.HasError(DnssecPolicyWarning) {
 		t.Fatalf("no TTL ceilings: expected no floor errors, got dnssec=%v warn=%v",
 			zd.HasError(DnssecError), zd.HasError(DnssecPolicyWarning))
@@ -216,9 +216,47 @@ func TestUpdateSigValidityFloorConfig(t *testing.T) {
 	pol.SigValidity.Default = 3600 // 1h, H=2h with prop=1h → 2h ≤ 2×H
 	zd2 := &ZoneData{ZoneName: "tight.example."}
 	zd2.Options = map[ZoneOption]bool{OptOnlineSigning: true}
-	UpdateSigValidityFloor(zd2, pol, prop, 0, false, nil)
+	UpdateSigValidityFloor(zd2, pol, prop, 0, false, nil, false)
 	if !zd2.HasError(DnssecError) {
 		t.Fatal("expected hard floor error for short default validity")
+	}
+}
+
+// TestUpdateSigValidityFloorNoSelfDeadlock is the regression test for the
+// SignZone self-deadlock: SignZone holds zd.mu and calls UpdateSigValidityFloor,
+// whose SetError/ClearError re-lock zd.mu (Go mutexes are not reentrant). With
+// zdLocked=true the *Locked setters are used, so no re-lock happens. The call
+// runs in a goroutine holding zd.mu; a regression would block it forever, so
+// the timeout fails the test instead of hanging the whole run.
+func TestUpdateSigValidityFloorNoSelfDeadlock(t *testing.T) {
+	prop := time.Hour
+
+	// hardPol trips the hard floor → exercises SetError(DnssecError) under lock.
+	hardPol := &DnssecPolicy{SigValidity: PolicySigValidity{Default: 3600, DNSKEY: 3600, DS: 3600}}
+	hardPol.TTLS.MaxServed = 3600
+	// laxPol has ample validity → exercises ClearError(DnssecError) under lock.
+	laxPol := &DnssecPolicy{SigValidity: PolicySigValidity{
+		Default: uint32((14 * 24 * time.Hour).Seconds()),
+		DNSKEY:  uint32((30 * 24 * time.Hour).Seconds()),
+		DS:      uint32((14 * 24 * time.Hour).Seconds()),
+	}}
+
+	zd := &ZoneData{ZoneName: "deadlock.example."}
+	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+
+	done := make(chan struct{})
+	go func() {
+		zd.mu.Lock() // the SignZone context: lock held across the calls
+		defer zd.mu.Unlock()
+		UpdateSigValidityFloor(zd, hardPol, prop, 0, false, nil, true) // SetError path
+		UpdateSigValidityFloor(zd, laxPol, prop, 0, false, nil, true)  // ClearError path
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("UpdateSigValidityFloor(zdLocked=true) deadlocked while zd.mu was held")
 	}
 }
 
@@ -233,13 +271,13 @@ func TestUpdateSigValidityFloorRuntime(t *testing.T) {
 	}
 	zd := &ZoneData{ZoneName: "test.example."}
 	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
-	UpdateSigValidityFloor(zd, pol, prop, 300, true, nil)
+	UpdateSigValidityFloor(zd, pol, prop, 300, true, nil, false)
 	if zd.HasError(DnssecError) {
 		t.Fatalf("runtime floor should pass: %s", zd.ErrorMsg)
 	}
 
 	pol.SigValidity.Default = 1800 // 30m
-	UpdateSigValidityFloor(zd, pol, prop, 3600, true, nil)
+	UpdateSigValidityFloor(zd, pol, prop, 3600, true, nil, false)
 	if !zd.HasError(DnssecError) {
 		t.Fatal("expected runtime hard error when validity too short for observed TTL")
 	}

--- a/v2/large_ksk.go
+++ b/v2/large_ksk.go
@@ -213,7 +213,12 @@ func appendDnssecPolicyWarnings(warnMsgs []string, pol *DnssecPolicy, isLarge fu
 
 // WarnLargeAlgZoneSigningRole sets DnssecPolicyWarning when a newly generated
 // ZSK or CSK uses a large algorithm. KSK generation is the supported pattern.
-func WarnLargeAlgZoneSigningRole(zd *ZoneData, keytype string, alg uint8, isLarge func(uint8) bool) {
+//
+// zdLocked signals that the caller already holds zd.mu (the publish-path SOA
+// re-sign reaches this via EnsureActiveDnssecKeys(zdLocked=true)). When true the
+// error read/write is routed through the *Locked variants so this does NOT
+// re-acquire zd.mu and self-deadlock — Go mutexes are not reentrant.
+func WarnLargeAlgZoneSigningRole(zd *ZoneData, keytype string, alg uint8, isLarge func(uint8) bool, zdLocked bool) {
 	if zd == nil || isLarge == nil || !isLarge(alg) {
 		return
 	}
@@ -224,18 +229,25 @@ func WarnLargeAlgZoneSigningRole(zd *ZoneData, keytype string, alg uint8, isLarg
 	if msg == "" {
 		return
 	}
+	errList := zd.ErrorList
+	setErr := zd.SetError
+	if zdLocked {
+		errList = zd.errorListLocked
+		setErr = zd.setErrorLocked
+	}
 	var parts []string
-	for _, e := range zd.ErrorList() {
+	for _, e := range errList() {
 		if e.Type == DnssecPolicyWarning && e.Msg != "" && e.Msg != msg {
 			parts = append(parts, e.Msg)
 		}
 	}
 	parts = append(parts, msg)
-	zd.SetError(DnssecPolicyWarning, "%s", strings.Join(parts, "; "))
+	setErr(DnssecPolicyWarning, "%s", strings.Join(parts, "; "))
 }
 
 // WarnLargeAlgKskReusedAsZsk covers the runtime case where no real ZSK exists.
-func WarnLargeAlgKskReusedAsZsk(zd *ZoneData, alg uint8, isLarge func(uint8) bool) {
+// See WarnLargeAlgZoneSigningRole for the zdLocked contract.
+func WarnLargeAlgKskReusedAsZsk(zd *ZoneData, alg uint8, isLarge func(uint8) bool, zdLocked bool) {
 	if zd == nil || isLarge == nil || !isLarge(alg) {
 		return
 	}
@@ -244,12 +256,18 @@ func WarnLargeAlgKskReusedAsZsk(zd *ZoneData, alg uint8, isLarge func(uint8) boo
 		name = "unknown"
 	}
 	msg := "large algorithm " + name + " signs the bulk of the zone (KSK reused as ZSK); whole-zone signatures inflated"
+	errList := zd.ErrorList
+	setErr := zd.SetError
+	if zdLocked {
+		errList = zd.errorListLocked
+		setErr = zd.setErrorLocked
+	}
 	var parts []string
-	for _, e := range zd.ErrorList() {
+	for _, e := range errList() {
 		if e.Type == DnssecPolicyWarning && e.Msg != "" && e.Msg != msg {
 			parts = append(parts, e.Msg)
 		}
 	}
 	parts = append(parts, msg)
-	zd.SetError(DnssecPolicyWarning, "%s", strings.Join(parts, "; "))
+	setErr(DnssecPolicyWarning, "%s", strings.Join(parts, "; "))
 }

--- a/v2/ops_dnskey.go
+++ b/v2/ops_dnskey.go
@@ -28,6 +28,12 @@ func (zd *ZoneData) PublishDnskeyRRs(dak *DnssecKeys) error {
 		return fmt.Errorf("zone %s does not allow updates or signing", zd.ZoneName)
 	}
 
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	return zd.publishDnskeyRRsLocked(dak)
+}
+
+func (zd *ZoneData) publishDnskeyRRsLocked(dak *DnssecKeys) error {
 	apex, err := zd.GetOwner(zd.ZoneName)
 	if err != nil {
 		return err
@@ -99,7 +105,7 @@ func (zd *ZoneData) PublishDnskeyRRs(dak *DnssecKeys) error {
 		RRs: publishkeys,
 	}
 
-	apex.RRtypes.Set(dns.TypeDNSKEY, dnskeys)
+	zd.stageRRsetLocked(zd.ZoneName, dnskeys)
 
 	return nil
 }

--- a/v2/ops_dnskey.go
+++ b/v2/ops_dnskey.go
@@ -36,9 +36,6 @@ func (zd *ZoneData) PublishDnskeyRRs(dak *DnssecKeys) error {
 func (zd *ZoneData) publishDnskeyRRsLocked(dak *DnssecKeys) error {
 	apex := zd.stagedOwner(zd.ZoneName)
 	if apex == nil {
-		return fmt.Errorf("zone apex not found")
-	}
-	if apex == nil {
 		return fmt.Errorf("PublishDnskeyRRs: zone apex %q not found", zd.ZoneName)
 	}
 

--- a/v2/ops_dnskey.go
+++ b/v2/ops_dnskey.go
@@ -34,9 +34,9 @@ func (zd *ZoneData) PublishDnskeyRRs(dak *DnssecKeys) error {
 }
 
 func (zd *ZoneData) publishDnskeyRRsLocked(dak *DnssecKeys) error {
-	apex, err := zd.GetOwner(zd.ZoneName)
-	if err != nil {
-		return err
+	apex := zd.stagedOwner(zd.ZoneName)
+	if apex == nil {
+		return fmt.Errorf("zone apex not found")
 	}
 	if apex == nil {
 		return fmt.Errorf("PublishDnskeyRRs: zone apex %q not found", zd.ZoneName)

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -973,7 +973,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// policy/kasp edits on reload refresh DnssecError/Warning state.
 		if options[OptOnlineSigning] || options[OptInlineSigning] {
 			if zdp.DnssecPolicy != nil {
-				UpdateSigValidityFloor(zdp, zdp.DnssecPolicy, conf.KaspPropagationDelay(), 0, false, conf.IsLargeAlgorithm)
+				UpdateSigValidityFloor(zdp, zdp.DnssecPolicy, conf.KaspPropagationDelay(), 0, false, conf.IsLargeAlgorithm, false)
 			}
 		}
 

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -271,9 +271,18 @@ func (conf *Config) ParseConfig(reload bool) error {
 	// mapstructure, and mapstructure ignores the yaml.Unmarshaler interface.
 	var md mapstructure.Metadata
 	decoderConfig := &mapstructure.DecoderConfig{
-		TagName:  "yaml",
-		Result:   conf,
-		Metadata: &md,
+		TagName: "yaml",
+		Result:  conf,
+		// Replace, don't merge. Result is the long-lived conf, reused across
+		// reloads, and ParseZones writes template-expanded options/policy back
+		// into conf.Zones[i] (*zconf = updated). Without ZeroFields, a reload
+		// merges the new zones list into the stale slice, so a zone whose YAML
+		// omits a field silently inherits a former slot-neighbour's value —
+		// e.g. a plain secondary gaining online-signing + a dnssecpolicy. It
+		// also drops Templates/Policies deleted from the config. Absent keys are
+		// still skipped, so runtime state in conf.Internal is untouched.
+		ZeroFields: true,
+		Metadata:   &md,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			stringToPeerConfHook(),
 			stringToAclEntryHook(),

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -741,6 +741,14 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			continue
 		}
 
+		publishCadence, err := parsePublishCadence(zconf.PublishCadence)
+		if err != nil {
+			lgConfig.Error("zone publish-cadence invalid, zone in error state", "zone", zname, "err", err)
+			zd.SetError(ConfigError, "publish-cadence: %v", err)
+			broken_zones = append(broken_zones, zname)
+			continue
+		}
+
 		lgConfig.Debug("checking DNSSEC policy", "zone", zname)
 		// dump.P(zconf)
 
@@ -896,6 +904,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 		zdp.mu.Lock()
 		zdp.Options = newOpts
+		zdp.publishCadence = publishCadence
 		zdp.mu.Unlock()
 
 		invokeOptionHandlers(zname, options)

--- a/v2/publish_apexguard_test.go
+++ b/v2/publish_apexguard_test.go
@@ -1,0 +1,44 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestPublishRefusesApexlessSnapshot is the regression test for the atomic-swap
+// invariant break behind the RefreshEngine crash: publishWorkingSetLocked stored
+// whatever the working set held, so an apex-less working set (e.g. an empty
+// rebuild during reload) overwrote a good snapshot with one having nil Apex/SOA,
+// leaving a Ready zone with no servable SOA. The guard must refuse the swap and
+// keep the current snapshot.
+func TestPublishRefusesApexlessSnapshot(t *testing.T) {
+	zd := &ZoneData{ZoneName: "keep.example."}
+
+	// A valid current snapshot with an SOA — what readers are being served.
+	good := &zoneSnapshot{Serial: 42, SOA: &dns.SOA{Serial: 42}}
+	zd.snapshot.Store(good)
+
+	// Registered with a matching generation so zoneStillLive() passes and we
+	// reach the apex guard.
+	Zones.Set(zd.ZoneName, zd)
+	defer Zones.Remove(zd.ZoneName)
+
+	// A non-nil but apex-less working set: the poison the guard must reject.
+	zd.workingSet = map[string]*OwnerData{}
+
+	zd.mu.Lock()
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
+	zd.mu.Unlock()
+
+	got := zd.snapshot.Load()
+	if got != good {
+		t.Fatalf("apex-less publish overwrote the served snapshot (got %+v, want the serial-42 snapshot)", got)
+	}
+	if got == nil || got.SOA == nil {
+		t.Fatal("served snapshot lost its SOA")
+	}
+	if zd.workingSet != nil {
+		t.Errorf("working set should be cleared after a refused publish, got %v", zd.workingSet)
+	}
+}

--- a/v2/publish_apexguard_test.go
+++ b/v2/publish_apexguard_test.go
@@ -63,3 +63,26 @@ func TestInstallInitialSnapshotRefusesApexlessData(t *testing.T) {
 		t.Fatal("InstallInitialSnapshot stored an apex-less snapshot")
 	}
 }
+
+// TestInstallInitialSnapshotMarksReadyWhenSnapshotExists covers the first-load
+// flow on this branch: the load path publishes the snapshot and leaves zd.Data
+// empty, then InstallInitialSnapshot runs only to mark the zone Ready. It must
+// flip Ready off the existing valid snapshot rather than refusing (which would
+// leave the zone stuck "loading" and unable to serve AXFR) or overwriting it.
+func TestInstallInitialSnapshotMarksReadyWhenSnapshotExists(t *testing.T) {
+	zd := &ZoneData{ZoneName: "loaded.example."} // zd.Data empty
+	good := &zoneSnapshot{Serial: 7, SOA: &dns.SOA{Serial: 7}}
+	zd.snapshot.Store(good)
+	Zones.Set(zd.ZoneName, zd)
+	defer Zones.Remove(zd.ZoneName)
+	defer zd.stopPublisher()
+
+	zd.InstallInitialSnapshot()
+
+	if !zd.Ready {
+		t.Fatal("InstallInitialSnapshot left a zone with a valid snapshot not Ready (would refuse AXFR)")
+	}
+	if zd.snapshot.Load() != good {
+		t.Fatal("InstallInitialSnapshot overwrote the existing valid snapshot")
+	}
+}

--- a/v2/publish_apexguard_test.go
+++ b/v2/publish_apexguard_test.go
@@ -42,3 +42,24 @@ func TestPublishRefusesApexlessSnapshot(t *testing.T) {
 		t.Errorf("working set should be cleared after a refused publish, got %v", zd.workingSet)
 	}
 }
+
+// TestInstallInitialSnapshotRefusesApexlessData covers the second store site
+// (the upstream root cause of the reload crash): InstallInitialSnapshot built a
+// snapshot from zd.Data and set Ready=true unconditionally, so an empty/apex-less
+// zd.Data produced a Ready zone with a nil-apex snapshot. It must refuse and
+// leave the zone not-Ready.
+func TestInstallInitialSnapshotRefusesApexlessData(t *testing.T) {
+	zd := &ZoneData{ZoneName: "noapex.example."} // zd.Data nil → no apex
+	Zones.Set(zd.ZoneName, zd)
+	defer Zones.Remove(zd.ZoneName)
+	defer zd.stopPublisher()
+
+	zd.InstallInitialSnapshot()
+
+	if zd.Ready {
+		t.Fatal("InstallInitialSnapshot marked an apex-less zone Ready")
+	}
+	if zd.snapshot.Load() != nil {
+		t.Fatal("InstallInitialSnapshot stored an apex-less snapshot")
+	}
+}

--- a/v2/publish_apexguard_test.go
+++ b/v2/publish_apexguard_test.go
@@ -2,6 +2,7 @@ package tdns
 
 import (
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -84,5 +85,68 @@ func TestInstallInitialSnapshotMarksReadyWhenSnapshotExists(t *testing.T) {
 	}
 	if zd.snapshot.Load() != good {
 		t.Fatal("InstallInitialSnapshot overwrote the existing valid snapshot")
+	}
+}
+
+// TestResignSOAUnderLockNoSelfDeadlock is the regression test for the re-entrant
+// zd.mu self-deadlock (instance #2 of the class 6e090a9 fixed). The publish path
+// holds zd.mu (publishWorkingSetLocked) and re-signs the working-set SOA via
+// resignWorkingSetSOAIfSigned. When the zone has no active keys yet, that reaches
+// EnsureActiveDnssecKeys, which generates them and then publishes the DNSKEY
+// RRset — and PublishDnskeyRRs takes zd.mu, self-deadlocking (Go mutexes are not
+// reentrant). This is the exact production stack:
+//
+//	applyRefreshReplacementLocked -> publishWorkingSetLocked ->
+//	resignWorkingSetSOAIfSigned -> SignRRset -> EnsureActiveDnssecKeys ->
+//	PublishDnskeyRRs -> zd.mu.Lock()  (re-entrant, wedges the daemon)
+//
+// The fix resolves the keys with EnsureActiveDnssecKeys(zdLocked=true), which
+// routes the publish through publishDnskeyRRsLocked (no re-lock). The re-sign
+// runs in a goroutine holding zd.mu; a re-introduced re-lock blocks it forever,
+// so the timeout fails the test instead of hanging the whole run.
+func TestResignSOAUnderLockNoSelfDeadlock(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	zone := `resign.example.	3600	IN	SOA	ns.resign.example. hostmaster.resign.example. 1 7200 1800 604800 7200
+resign.example.	3600	IN	NS	ns.resign.example.
+`
+	zd := testZone(t, "resign.example.", zone)
+	zd.KeyDB = kdb
+	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+	zd.DnssecPolicy = &DnssecPolicy{
+		Mode:         DnssecPolicyModeKSKZSK,
+		KSKAlgorithm: dns.ED25519,
+		ZSKAlgorithm: dns.ED25519,
+	}
+	// No active keys are pre-generated: the first re-sign must GENERATE them and
+	// PUBLISH the DNSKEY RRset — the fresh-key branch that re-locked zd.mu.
+
+	done := make(chan struct{})
+	go func() {
+		zd.mu.Lock() // the publishWorkingSetLocked context: zd.mu held across the re-sign
+		defer zd.mu.Unlock()
+		zd.ensureWorkingSet()
+		zd.resignWorkingSetSOAIfSigned()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("resignWorkingSetSOAIfSigned deadlocked while zd.mu was held (re-entrant zd.mu via EnsureActiveDnssecKeys -> PublishDnskeyRRs)")
+	}
+
+	// The SOA must actually carry an RRSIG now — proves the re-sign ran to
+	// completion (generated keys, published DNSKEYs, signed the SOA) rather than
+	// bailing out early.
+	zd.mu.Lock()
+	apex := zd.workingSet[zd.ZoneName]
+	zd.mu.Unlock()
+	if apex == nil {
+		t.Fatal("apex missing from working set after resign")
+	}
+	soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	if len(soa.RRSIGs) == 0 {
+		t.Fatal("SOA was not signed under the lock (re-sign did not complete)")
 	}
 }

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -367,7 +367,8 @@ func (zd *ZoneData) addNSAndGlue(m *dns.Msg, apex *OwnerData, msgoptions *edns0.
 // addTransportSignal adds transport signal RRs to the Extra section if not already present in Answer.
 // Returns true if any transport signal was added.
 func (zd *ZoneData) addTransportSignal(m *dns.Msg, msgoptions *edns0.MsgOptions, transportSignalInAnswer bool) bool {
-	if !zd.AddTransportSignal || msgoptions.OtsOptOut || zd.TransportSignal == nil || len(zd.TransportSignal.RRs) == 0 {
+	ts := zd.publishedTransportSignal()
+	if !zd.AddTransportSignal || msgoptions.OtsOptOut || ts == nil || len(ts.RRs) == 0 {
 		return false
 	}
 	if transportSignalInAnswer {
@@ -380,7 +381,7 @@ func (zd *ZoneData) addTransportSignal(m *dns.Msg, msgoptions *edns0.MsgOptions,
 		present[h.Name+"|"+dns.TypeToString[h.Rrtype]] = true
 	}
 	addedAny := false
-	for _, trr := range zd.TransportSignal.RRs {
+	for _, trr := range ts.RRs {
 		h := trr.Header()
 		key := h.Name + "|" + dns.TypeToString[h.Rrtype]
 		if !present[key] {
@@ -389,8 +390,8 @@ func (zd *ZoneData) addTransportSignal(m *dns.Msg, msgoptions *edns0.MsgOptions,
 		}
 	}
 	// If we added any TSYNC/SVCB above, consider adding their signatures too
-	if addedAny && msgoptions.DO && len(zd.TransportSignal.RRSIGs) > 0 {
-		m.Extra = append(m.Extra, zd.TransportSignal.RRSIGs...)
+	if addedAny && msgoptions.DO && len(ts.RRSIGs) > 0 {
+		m.Extra = append(m.Extra, ts.RRSIGs...)
 	}
 	return addedAny
 }
@@ -550,18 +551,19 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 	zd.addNSAndGlue(m, apex, msgoptions, minimalResponses)
 
 	// Check for transport signal
-	if zd.AddTransportSignal && zd.TransportSignal != nil {
+	ts := zd.publishedTransportSignal()
+	if zd.AddTransportSignal && ts != nil {
 		for _, arr := range m.Answer {
-			if rrMatchesTransportSignal(arr, zd.TransportSignal) {
+			if rrMatchesTransportSignal(arr, ts) {
 				*transportSignalInAnswer = true
 				break
 			}
 		}
 	}
 	zd.addTransportSignal(m, msgoptions, *transportSignalInAnswer)
-	if msgoptions.DO && zd.AddTransportSignal && !msgoptions.OtsOptOut && zd.TransportSignal != nil {
-		if !*transportSignalInAnswer && len(zd.TransportSignal.RRSIGs) > 0 {
-			m.Extra = append(m.Extra, zd.TransportSignal.RRSIGs...)
+	if msgoptions.DO && zd.AddTransportSignal && !msgoptions.OtsOptOut && ts != nil {
+		if !*transportSignalInAnswer && len(ts.RRSIGs) > 0 {
+			m.Extra = append(m.Extra, ts.RRSIGs...)
 		}
 	}
 
@@ -626,6 +628,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 		w.WriteMsg(m)
 		return fmt.Errorf("failed to get apex data for zone %s: %v", zd.ZoneName, err)
 	}
+	transportSig := zd.publishedTransportSignal()
 
 	// Inline-signed apex RRsets are served from the published zone; online/compact
 	// signatures are added ephemerally on each response path below.
@@ -736,14 +739,14 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 			if qname == origqname {
 				// zd.Logger.Printf("Exact match qname %s %s", qname, dns.TypeToString[qtype])
 				m.Answer = append(m.Answer, rrset.RRs...)
-				if zd.AddTransportSignal && zd.TransportSignal != nil && qtype == zd.TransportSignal.RRtype && (qname == zd.TransportSignal.Name || origqname == zd.TransportSignal.Name) {
+				if zd.AddTransportSignal && transportSig != nil && qtype == transportSig.RRtype && (qname == transportSig.Name || origqname == transportSig.Name) {
 					transportSignalInAnswer = true
 				}
 			} else {
 				// zd.Logger.Printf("Wildcard match qname %s %s", qname, origqname)
 				tmp := WildcardReplace(rrset.RRs, qname, origqname)
 				m.Answer = append(m.Answer, tmp...)
-				if zd.AddTransportSignal && zd.TransportSignal != nil && qtype == zd.TransportSignal.RRtype && (qname == zd.TransportSignal.Name || origqname == zd.TransportSignal.Name) {
+				if zd.AddTransportSignal && transportSig != nil && qtype == transportSig.RRtype && (qname == transportSig.Name || origqname == transportSig.Name) {
 					transportSignalInAnswer = true
 				}
 			}

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -164,7 +164,7 @@ func (zd *ZoneData) signRRsetForZone(rrset core.RRset, name string, msgoptions *
 	if zoneDak == nil || len(zoneDak.ZSKs) == 0 {
 		// No active keys found - try to ensure they exist (promote published or generate new)
 		lgHandler.Warn("no active ZSKs, attempting to ensure keys exist", "zone", zd.ZoneName)
-		zoneDak, err = zd.EnsureActiveDnssecKeys(kdb)
+		zoneDak, err = zd.EnsureActiveDnssecKeys(kdb, false)
 		if err != nil {
 			lgHandler.Error("failed to ensure active DNSSEC keys", "zone", zd.ZoneName, "err", err)
 			return rrset, err

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -362,40 +362,147 @@ func (zd *ZoneData) addNSAndGlue(m *dns.Msg, apex *OwnerData, snap *zoneSnapshot
 	}
 }
 
-// addTransportSignal adds transport signal RRs to the Extra section if not already present in Answer.
-// Returns true if any transport signal was added.
-func (zd *ZoneData) addTransportSignal(m *dns.Msg, ts *core.RRset, msgoptions *edns0.MsgOptions, transportSignalInAnswer bool) bool {
-	if !zd.AddTransportSignal || msgoptions.OtsOptOut || ts == nil || len(ts.RRs) == 0 {
+// addTransportSignal opportunistically adds transport-signal RRs to the Extra
+// section, skipping any (name,type) already present in the Answer (e.g. when the
+// query was a direct lookup for the signal itself). RRSIGs of each injected
+// RRset are added when DO is set. Returns true if anything was added.
+func (zd *ZoneData) addTransportSignal(m *dns.Msg, sigs []core.RRset, msgoptions *edns0.MsgOptions) bool {
+	if msgoptions.OtsOptOut || len(sigs) == 0 {
 		return false
 	}
-	if transportSignalInAnswer {
-		return false
-	}
-	// Build a set of (name, type) present in Answer to avoid duplicates
 	present := map[string]bool{}
 	for _, arr := range m.Answer {
 		h := arr.Header()
 		present[h.Name+"|"+dns.TypeToString[h.Rrtype]] = true
 	}
 	addedAny := false
-	for _, trr := range ts.RRs {
-		h := trr.Header()
-		key := h.Name + "|" + dns.TypeToString[h.Rrtype]
-		if !present[key] {
+	for _, ts := range sigs {
+		rrsAdded := false
+		for _, trr := range ts.RRs {
+			h := trr.Header()
+			key := h.Name + "|" + dns.TypeToString[h.Rrtype]
+			if present[key] {
+				continue
+			}
+			present[key] = true // guard against duplicates across signal RRsets
 			m.Extra = append(m.Extra, trr)
+			rrsAdded = true
 			addedAny = true
 		}
-	}
-	// If we added any TSYNC/SVCB above, consider adding their signatures too
-	if addedAny && msgoptions.DO && len(ts.RRSIGs) > 0 {
-		m.Extra = append(m.Extra, ts.RRSIGs...)
+		if rrsAdded && msgoptions.DO && len(ts.RRSIGs) > 0 {
+			m.Extra = append(m.Extra, ts.RRSIGs...)
+		}
 	}
 	return addedAny
 }
 
+// collectSignalRRsets resolves the transport-signal RRsets to advertise for this
+// zone, at query time, from the pinned snapshot. It derives the signal owners
+// from the apex NS RRset (the authoritative "which nameservers" source) and, for
+// each, reads the stored, resigner-maintained SVCB/TSYNC RRset from its
+// authoritative home — this zone's pinned snapshot when in-bailiwick, another
+// co-hosted zone's snapshot via FindZone otherwise, or the synthesized fallback
+// (Case A). AliasMode targets are chased the same way. A signal whose target
+// cannot be resolved is still returned (the alias is authoritative and the
+// resolver can chase it / may already hold the target); SVCB fails safe.
+func (zd *ZoneData) collectSignalRRsets(snap *zoneSnapshot) []core.RRset {
+	if snap == nil || snap.Apex == nil || !zd.Options[OptAddTransportSignal] {
+		return nil
+	}
+	nsRRset := snap.Apex.RRtypes.GetOnlyRRSet(dns.TypeNS)
+	if len(nsRRset.RRs) == 0 {
+		return nil
+	}
+	var out []core.RRset
+	seen := map[string]bool{}
+	var add func(name string, depth int)
+	add = func(name string, depth int) {
+		if depth > 3 {
+			return
+		}
+		for _, rs := range zd.lookupSignalRRsets(snap, name) {
+			if len(rs.RRs) == 0 {
+				continue
+			}
+			key := fmt.Sprintf("%s|%d", name, rs.RRtype)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, rs)
+			for _, tgt := range signalChaseTargets(rs) {
+				add("_dns."+tgt, depth+1)
+			}
+		}
+	}
+	for _, rr := range nsRRset.RRs {
+		if ns, ok := rr.(*dns.NS); ok {
+			add("_dns."+ns.Ns, 0)
+		}
+	}
+	return out
+}
+
+// lookupSignalRRsets returns the SVCB/TSYNC RRsets stored at a transport-signal
+// owner name, read from its authoritative home. In-bailiwick names read from the
+// pinned snapshot (no intra-response tearing); out-of-bailiwick names read from
+// another co-hosted zone's current snapshot; failing both, the per-snapshot
+// synthesized fallback (Case A) is used.
+func (zd *ZoneData) lookupSignalRRsets(snap *zoneSnapshot, name string) []core.RRset {
+	if dns.IsSubDomain(zd.ZoneName, name) {
+		return signalRRsetsFromOwner(getOwnerFrom(snap, name))
+	}
+	if tz, _ := FindZone(name); tz != nil {
+		if tz == zd {
+			return signalRRsetsFromOwner(getOwnerFrom(snap, name))
+		}
+		if rrs := signalRRsetsFromOwner(getOwnerFrom(tz.publishedSnapshot(), name)); len(rrs) > 0 {
+			return rrs
+		}
+	}
+	if rs, ok := snap.signalSynth[name]; ok && rs != nil {
+		return []core.RRset{*rs}
+	}
+	return nil
+}
+
+// signalRRsetsFromOwner extracts the SVCB and TSYNC RRsets from an owner (if any).
+func signalRRsetsFromOwner(od *OwnerData) []core.RRset {
+	if od == nil {
+		return nil
+	}
+	var out []core.RRset
+	if rs, ok := od.RRtypes.Get(dns.TypeSVCB); ok && len(rs.RRs) > 0 {
+		out = append(out, rs)
+	}
+	if rs, ok := od.RRtypes.Get(core.TypeTSYNC); ok && len(rs.RRs) > 0 {
+		out = append(out, rs)
+	}
+	return out
+}
+
+// signalChaseTargets returns the alias/target hostnames referenced by a signal
+// RRset (SVCB AliasMode Target, TSYNC Alias), for injection-time chasing.
+func signalChaseTargets(rs core.RRset) []string {
+	var out []string
+	for _, rr := range rs.RRs {
+		switch r := rr.(type) {
+		case *dns.SVCB:
+			if r.Target != "." && r.Target != "" {
+				out = append(out, r.Target)
+			}
+		case *dns.PrivateRR:
+			if ts, ok := r.Data.(*core.TSYNC); ok && ts != nil && ts.Alias != "" && ts.Alias != "." {
+				out = append(out, ts.Alias)
+			}
+		}
+	}
+	return out
+}
+
 // handleSOAQuery handles SOA queries for the zone apex.
-func (zd *ZoneData) handleSOAQuery(m *dns.Msg, w dns.ResponseWriter, apex *OwnerData, snap *zoneSnapshot, ts *core.RRset,
-	msgoptions *edns0.MsgOptions, transportSignalInAnswer *bool, minimalResponses bool) {
+func (zd *ZoneData) handleSOAQuery(m *dns.Msg, w dns.ResponseWriter, apex *OwnerData, snap *zoneSnapshot, sigs []core.RRset,
+	msgoptions *edns0.MsgOptions, minimalResponses bool) {
 	soaRRset := zd.soaForResponseFrom(snap, apex)
 	lgHandler.Debug("SOA RRset details", "zone", zd.ZoneName, "count", len(soaRRset.RRs), "rrset", soaRRset)
 
@@ -406,13 +513,13 @@ func (zd *ZoneData) handleSOAQuery(m *dns.Msg, w dns.ResponseWriter, apex *Owner
 		// Note: NS and glue RRSIGs are already added by addNSAndGlue
 	}
 	zd.addNSAndGlue(m, apex, snap, msgoptions, minimalResponses)
-	zd.addTransportSignal(m, ts, msgoptions, *transportSignalInAnswer)
+	zd.addTransportSignal(m, sigs, msgoptions)
 }
 
 // handleCNAMEChain handles CNAME responses, including following CNAME chains across zones.
 // Returns true if a CNAME response was handled and the message should be sent, false otherwise.
 func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname string, qtype uint16, owner *OwnerData, snap *zoneSnapshot,
-	msgoptions *edns0.MsgOptions, kdb *KeyDB, apex *OwnerData, transportSignalInAnswer *bool, minimalResponses bool) (bool, error) {
+	msgoptions *edns0.MsgOptions, kdb *KeyDB, apex *OwnerData, minimalResponses bool) (bool, error) {
 
 	if owner.RRtypes.Count() != 1 {
 		return false, nil // Not a CNAME-only owner
@@ -547,22 +654,9 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 	// Use the original zone's apex for NS records
 	zd.addNSAndGlue(m, apex, snap, msgoptions, minimalResponses)
 
-	// Check for transport signal (from the pinned snapshot)
-	ts := snap.TransportSignal
-	if zd.AddTransportSignal && ts != nil {
-		for _, arr := range m.Answer {
-			if rrMatchesTransportSignal(arr, ts) {
-				*transportSignalInAnswer = true
-				break
-			}
-		}
-	}
-	zd.addTransportSignal(m, ts, msgoptions, *transportSignalInAnswer)
-	if msgoptions.DO && zd.AddTransportSignal && !msgoptions.OtsOptOut && ts != nil {
-		if !*transportSignalInAnswer && len(ts.RRSIGs) > 0 {
-			m.Extra = append(m.Extra, ts.RRSIGs...)
-		}
-	}
+	// Opportunistically attach transport signals, deduped against the Answer
+	// section (addTransportSignal handles their RRSIGs when DO is set).
+	zd.addTransportSignal(m, zd.collectSignalRRsets(snap), msgoptions)
 
 	return true, nil
 }
@@ -580,9 +674,6 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 		return ctx.Err()
 	default:
 	}
-	// Track if the configured transport signal is already present in the Answer section
-	transportSignalInAnswer := false
-
 	// minimal-responses: BIND-style suppression of authority NS RRset and
 	// apex glue on positive answers. Referrals and NXDOMAIN/NODATA paths are
 	// unaffected (their authority/additional sections are still required).
@@ -634,7 +725,9 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 		w.WriteMsg(m)
 		return nil
 	}
-	transportSig := snap.TransportSignal
+	// Transport signals to advertise, resolved once from the pinned snapshot
+	// (in-bailiwick + co-hosted + synthesized fallback, with alias chasing).
+	sigs := zd.collectSignalRRsets(snap)
 
 	// Inline-signed apex RRsets are served from the published zone; online/compact
 	// signatures are added ephemerally on each response path below.
@@ -716,7 +809,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	if len(qname) > len(zd.ZoneName) {
 		// 2. Check for qname + CNAME (only if CNAME is the only RR type)
 		lgHandler.Debug("checking for CNAME", "qname", qname, "zone", zd.ZoneName)
-		handled, err := zd.handleCNAMEChain(m, w, qname, qtype, owner, snap, msgoptions, kdb, apex, &transportSignalInAnswer, minimalResponses)
+		handled, err := zd.handleCNAMEChain(m, w, qname, qtype, owner, snap, msgoptions, kdb, apex, minimalResponses)
 		if err != nil {
 			lgHandler.Error("error handling CNAME chain", "err", err)
 			// Error response already sent by handleCNAMEChain
@@ -749,20 +842,14 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 			if qname == origqname {
 				// zd.Logger.Printf("Exact match qname %s %s", qname, dns.TypeToString[qtype])
 				m.Answer = append(m.Answer, rrset.RRs...)
-				if zd.AddTransportSignal && transportSig != nil && qtype == transportSig.RRtype && (qname == transportSig.Name || origqname == transportSig.Name) {
-					transportSignalInAnswer = true
-				}
 			} else {
 				// zd.Logger.Printf("Wildcard match qname %s %s", qname, origqname)
 				tmp := WildcardReplace(rrset.RRs, qname, origqname)
 				m.Answer = append(m.Answer, tmp...)
-				if zd.AddTransportSignal && transportSig != nil && qtype == transportSig.RRtype && (qname == transportSig.Name || origqname == transportSig.Name) {
-					transportSignalInAnswer = true
-				}
 			}
 			zd.addNSAndGlue(m, apex, snap, msgoptions, minimalResponses)
 			// Add transport signal RRs that aren't already present in the Answer section
-			zd.addTransportSignal(m, transportSig, msgoptions, transportSignalInAnswer)
+			zd.addTransportSignal(m, sigs, msgoptions)
 			if msgoptions.DO {
 				lgHandler.Debug("considering signing", "qname", qname, "qtype", dns.TypeToString[qtype], "origqname", origqname)
 				if qname == origqname {
@@ -799,7 +886,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 
 	lgHandler.Debug("checking for SOA query", "zone", zd.ZoneName)
 	if qtype == dns.TypeSOA && qname == zd.ZoneName {
-		zd.handleSOAQuery(m, w, apex, snap, transportSig, msgoptions, &transportSignalInAnswer, minimalResponses)
+		zd.handleSOAQuery(m, w, apex, snap, sigs, msgoptions, minimalResponses)
 		w.WriteMsg(m)
 		return nil
 	}
@@ -937,13 +1024,4 @@ func (zd *ZoneData) addCDEResponse(m *dns.Msg, qname string, apex *OwnerData, rr
 		lgHandler.Error("failed to sign NSEC RRset for CDE response", "zone", zd.ZoneName, "err", err)
 	}
 	m.Ns = append(m.Ns, nsecRRset.RRSIGs...)
-}
-
-// rrMatchesTransportSignal checks whether a given RR matches the configured transport signal RRset
-func rrMatchesTransportSignal(rr dns.RR, ts *core.RRset) bool {
-	if ts == nil || rr == nil {
-		return false
-	}
-	h := rr.Header()
-	return h.Rrtype == ts.RRtype && h.Name == ts.Name
 }

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -937,19 +937,3 @@ func rrMatchesTransportSignal(rr dns.RR, ts *core.RRset) bool {
 	h := rr.Header()
 	return h.Rrtype == ts.RRtype && h.Name == ts.Name
 }
-
-// findServerTSYNCRRset returns a TSYNC RRset from any owner under this zone that starts with _dns.
-func (zd *ZoneData) XXfindServerTSYNCRRset() *core.RRset {
-	// Look for any TSYNC RRset at owners beginning with _dns.
-	for item := range zd.Data.IterBuffered() {
-		owner := item.Key
-		od := item.Val
-		if strings.HasPrefix(owner, "_dns.") {
-			rrset := od.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
-			if len(rrset.RRs) > 0 {
-				return &rrset
-			}
-		}
-	}
-	return nil
-}

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -894,25 +894,30 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 			zd.addTransportSignal(m, sigs, msgoptions)
 			if msgoptions.DO {
 				lgHandler.Debug("considering signing", "qname", qname, "qtype", dns.TypeToString[qtype], "origqname", origqname)
-				if qname == origqname {
-					signed, err := MaybeSignRRset(rrset, qname)
-					if err != nil {
-						// A must-be-signed zone that cannot produce signatures for
-						// this stored answer is broken → SERVFAIL. Previously the
-						// error was swallowed and the answer served unsigned (or,
-						// via the removed ephemeral-sign fallback, served with a
-						// fabricated signature that masked the broken zone). See
-						// Finding 1 / Decision 1.
-						lgHandler.Error("failed to sign answer RRset; serving SERVFAIL", "qname", qname, "qtype", dns.TypeToString[qtype], "zone", zd.ZoneName, "err", err)
-						servfail := new(dns.Msg)
-						servfail.SetReply(r)
-						servfail.MsgHdr.Authoritative = true
-						servfail.MsgHdr.Rcode = dns.RcodeServerFailure
-						w.WriteMsg(servfail)
-						return nil
-					}
-					rrset = signed
+				// Fail-closed for BOTH the exact-match answer and the wildcard-
+				// synthesized answer: a must-be-signed zone whose stored answer
+				// RRset carries no RRSIGs is broken → SERVFAIL. This check runs on
+				// the stored RRset (owner = qname, which is the *.parent wildcard
+				// name on the wildcard arm) before WildcardReplace. Previously only
+				// the exact-match arm ran it; the wildcard arm (qname != origqname)
+				// served the WildcardReplace'd answer straight from stored RRSIGs and
+				// so emitted an UNSIGNED wildcard answer for a broken zone (there
+				// were no RRSIGs to replace) — a silent downgrade. A genuinely signed
+				// wildcard still carries stored RRSIGs and answers; an unsigned-by-
+				// design zone serves unsigned as before. Ephemeral-signing the answer
+				// is not an option: it would mask the broken zone. See Finding 1 /
+				// Decision 1.
+				signed, err := MaybeSignRRset(rrset, qname)
+				if err != nil {
+					lgHandler.Error("failed to sign answer RRset; serving SERVFAIL", "qname", qname, "qtype", dns.TypeToString[qtype], "origqname", origqname, "zone", zd.ZoneName, "err", err)
+					servfail := new(dns.Msg)
+					servfail.SetReply(r)
+					servfail.MsgHdr.Authoritative = true
+					servfail.MsgHdr.Rcode = dns.RcodeServerFailure
+					w.WriteMsg(servfail)
+					return nil
 				}
+				rrset = signed
 
 				if qname == origqname {
 					m.Answer = append(m.Answer, rrset.RRSIGs...)

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -89,35 +89,36 @@ var standardDNSTypes = map[uint16]bool{
 // 4. If no CNAME match, check for wild card match
 // 5. Give up.
 
-// signApexRRsets signs the SOA and NS RRsets at the zone apex if DNSSEC is requested.
-func (zd *ZoneData) signApexRRsets(apex *OwnerData, msgoptions *edns0.MsgOptions, kdb *KeyDB, dak *DnssecKeys) error {
+// signedApexRRsets returns signed SOA/NS RRsets for the response path without mutating zone data.
+func (zd *ZoneData) signedApexRRsets(apex *OwnerData, msgoptions *edns0.MsgOptions, kdb *KeyDB, dak *DnssecKeys) (soa, ns core.RRset, err error) {
+	soa = apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	ns = apex.RRtypes.GetOnlyRRSet(dns.TypeNS)
 	if !msgoptions.DO {
-		return nil
+		return soa, ns, nil
 	}
 	signFunc := func(rrset core.RRset, qname string) (core.RRset, error) {
 		return zd.signRRsetForZone(rrset, qname, msgoptions, kdb, dak)
 	}
 
 	var errs []error
-
-	soaRRset, err := signFunc(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA), zd.ZoneName)
+	signedSOA, err := signFunc(soa, zd.ZoneName)
 	if err != nil {
 		lgHandler.Error("failed to sign SOA RRset", "zone", zd.ZoneName, "err", err)
 		errs = append(errs, err)
 	} else {
-		apex.RRtypes.Set(dns.TypeSOA, soaRRset)
+		soa = signedSOA
 	}
-	nsRRset, err := signFunc(apex.RRtypes.GetOnlyRRSet(dns.TypeNS), zd.ZoneName)
+	signedNS, err := signFunc(ns, zd.ZoneName)
 	if err != nil {
 		lgHandler.Error("failed to sign NS RRset", "zone", zd.ZoneName, "err", err)
 		errs = append(errs, err)
 	} else {
-		apex.RRtypes.Set(dns.TypeNS, nsRRset)
+		ns = signedNS
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to sign apex RRsets for zone %s: %v", zd.ZoneName, errs)
+		return soa, ns, fmt.Errorf("failed to sign apex RRsets for zone %s: %v", zd.ZoneName, errs)
 	}
-	return nil
+	return soa, ns, nil
 }
 
 // signRRsetForZone signs an RRset using a zone's DNSSEC keys.
@@ -210,7 +211,8 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 			"qname", qname, "zone", zd.ZoneName)
 		// Make sure apex RRsets are signed (SOA in authority for negative
 		// answers; DNSKEY/etc as needed by signApexRRsets).
-		if err := zd.signApexRRsets(apex, msgoptions, kdb, nil); err != nil {
+		soaRRset, _, err := zd.signedApexRRsets(apex, msgoptions, kdb, nil)
+		if err != nil {
 			lgHandler.Error("failed to sign parent apex RRsets for DS query", "err", err)
 			if msgoptions.DO {
 				m.MsgHdr.Rcode = dns.RcodeServerFailure
@@ -240,7 +242,7 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 				m.Answer = append(m.Answer, dsRRset.RRSIGs...)
 			}
 		}
-		m.Ns = append(m.Ns, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs...)
+		m.Ns = append(m.Ns, soaRRset.RRs...)
 		w.WriteMsg(m)
 		return nil
 	}
@@ -274,7 +276,8 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 		lgHandler.Error("failed to get apex data for parent zone", "zone", zd.ZoneName)
 	}
 	// Use parent zone's own keys; let signRRsetForZone fetch them via kdb.
-	if err := zd.signApexRRsets(apex, msgoptions, kdb, nil); err != nil { // force fetch parent zone's DNSSEC keys
+	soaRRset, _, err := zd.signedApexRRsets(apex, msgoptions, kdb, nil)
+	if err != nil {
 		lgHandler.Error("failed to sign parent apex RRsets for DS query", "err", err)
 		if msgoptions.DO {
 			m.MsgHdr.Rcode = dns.RcodeServerFailure
@@ -307,7 +310,7 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 			m.Answer = append(m.Answer, dsRRset.RRSIGs...)
 		}
 	}
-	m.Ns = append(m.Ns, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs...)
+	m.Ns = append(m.Ns, soaRRset.RRs...)
 	w.WriteMsg(m)
 	return nil
 }
@@ -334,12 +337,8 @@ func (zd *ZoneData) sendReferral(m *dns.Msg, w dns.ResponseWriter, cdd *ChildDel
 func (zd *ZoneData) sendNXDOMAIN(m *dns.Msg, w dns.ResponseWriter, qname string, apex *OwnerData,
 	msgoptions *edns0.MsgOptions, signFunc func(core.RRset, string) (core.RRset, error)) {
 	m.MsgHdr.Rcode = dns.RcodeNameError
-	// ensure correct serial
-	soaRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-	soaRRset.RRs[0].(*dns.SOA).Serial = zd.CurrentSerial
-	apex.RRtypes.Set(dns.TypeSOA, soaRRset)
-
-	m.Ns = append(m.Ns, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs...)
+	soaRRset := zd.soaForResponse(apex)
+	m.Ns = append(m.Ns, soaRRset.RRs...)
 	if msgoptions.DO {
 		// RFC 9824: Compact denial if CO bit is set, otherwise traditional DNSSEC negative response
 		zd.addCDEResponse(m, qname, apex, nil, msgoptions, signFunc)
@@ -399,15 +398,13 @@ func (zd *ZoneData) addTransportSignal(m *dns.Msg, msgoptions *edns0.MsgOptions,
 // handleSOAQuery handles SOA queries for the zone apex.
 func (zd *ZoneData) handleSOAQuery(m *dns.Msg, w dns.ResponseWriter, apex *OwnerData,
 	msgoptions *edns0.MsgOptions, transportSignalInAnswer *bool, minimalResponses bool) {
-	soaRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-	soaRRset.RRs[0].(*dns.SOA).Serial = zd.CurrentSerial
+	soaRRset := zd.soaForResponse(apex)
 	lgHandler.Debug("SOA RRset details", "zone", zd.ZoneName, "count", len(soaRRset.RRs), "rrset", soaRRset)
-	apex.RRtypes.Set(dns.TypeSOA, soaRRset)
 
-	m.Answer = append(m.Answer, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs[0])
+	m.Answer = append(m.Answer, soaRRset.RRs[0])
 	if msgoptions.DO {
 		lgHandler.Debug("DNSSEC requested, adding RRSIGs to SOA response")
-		m.Answer = append(m.Answer, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRSIGs...)
+		m.Answer = append(m.Answer, soaRRset.RRSIGs...)
 		// Note: NS and glue RRSIGs are already added by addNSAndGlue
 	}
 	zd.addNSAndGlue(m, apex, msgoptions, minimalResponses)
@@ -446,8 +443,7 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 			w.WriteMsg(m)
 			return false, fmt.Errorf("failed to sign initial CNAME RRset for qname %s: %v", qname, err)
 		} else {
-			owner.RRtypes.Set(dns.TypeCNAME, rrset)
-			m.Answer = append(m.Answer, v.RRs...)
+			m.Answer = append(m.Answer, rrset.RRs...)
 			m.Answer = append(m.Answer, rrset.RRSIGs...)
 		}
 	} else {
@@ -511,7 +507,6 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 					w.WriteMsg(m)
 					return false, fmt.Errorf("failed to sign final answer RRset for CNAME target %s: %v", tgt, err)
 				} else {
-					tgtOwner.RRtypes.Set(qtype, tgtRRset)
 					m.Answer = append(m.Answer, tgtRRset.RRSIGs...)
 				}
 			}
@@ -531,7 +526,6 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 						w.WriteMsg(m)
 						return false, fmt.Errorf("failed to sign intermediate CNAME RRset for %s: %v", tgt, err)
 					} else {
-						tgtOwner.RRtypes.Set(dns.TypeCNAME, rrset)
 						m.Answer = append(m.Answer, rrset.RRSIGs...)
 					}
 				}
@@ -633,17 +627,8 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 		return fmt.Errorf("failed to get apex data for zone %s: %v", zd.ZoneName, err)
 	}
 
-	// Sign apex RRsets if DNSSEC is requested and KeyDB is available
-	if msgoptions.DO && kdb != nil {
-		if err := zd.signApexRRsets(apex, msgoptions, kdb, dak); err != nil {
-			lgHandler.Error("failed to sign apex RRsets", "zone", zd.ZoneName, "err", err)
-			m.MsgHdr.Rcode = dns.RcodeServerFailure
-			w.WriteMsg(m)
-			return fmt.Errorf("failed to sign apex RRsets for zone %s: %v", zd.ZoneName, err)
-		}
-	} else if msgoptions.DO && kdb == nil {
-		lgHandler.Debug("DNSSEC requested but no KeyDB available, responding without DNSSEC", "zone", zd.ZoneName)
-	}
+	// Inline-signed apex RRsets are served from the published zone; online/compact
+	// signatures are added ephemerally on each response path below.
 
 	// Reject explicit queries for NXNAME type (RFC 9824)
 	// NXNAME is only used in NSEC type bitmaps, not as a query type
@@ -697,7 +682,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	// 0. Check for *any* existence of qname in zone
 	// log.Printf("---> Checking for any existence of qname %s", qname)
 	if owner.RRtypes.Count() == 0 {
-		soaRRset, err := MaybeSignRRset(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA), zd.ZoneName)
+		soaRRset, err := MaybeSignRRset(zd.soaForResponse(apex), zd.ZoneName)
 		if err != nil {
 			lgHandler.Error("failed to sign SOA RRset", "zone", zd.ZoneName, "err", err)
 			if msgoptions.DO {
@@ -705,10 +690,13 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 				w.WriteMsg(m)
 				return fmt.Errorf("failed to sign SOA RRset before NXDOMAIN: %v", err)
 			}
-		} else {
-			apex.RRtypes.Set(dns.TypeSOA, soaRRset)
 		}
-		zd.sendNXDOMAIN(m, w, origqname, apex, msgoptions, MaybeSignRRset)
+		m.Ns = append(m.Ns, soaRRset.RRs...)
+		if msgoptions.DO {
+			zd.addCDEResponse(m, origqname, apex, nil, msgoptions, MaybeSignRRset)
+		}
+		m.MsgHdr.Rcode = dns.RcodeNameError
+		w.WriteMsg(m)
 		return nil
 	}
 
@@ -743,10 +731,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	if tdnsSpecialTypes[qtype] || standardDNSTypes[qtype] {
 		if rrset, ok := owner.RRtypes.Get(qtype); ok && len(rrset.RRs) > 0 {
 			if qtype == dns.TypeSOA {
-				soaRR := rrset.RRs[0].(*dns.SOA)
-				soaRR.Serial = zd.CurrentSerial
-				owner.RRtypes.Set(qtype, core.RRset{RRs: []dns.RR{soaRR}})
-				rrset.RRs[0] = soaRR
+				rrset = zd.soaForResponse(apex)
 			}
 			if qname == origqname {
 				// zd.Logger.Printf("Exact match qname %s %s", qname, dns.TypeToString[qtype])
@@ -771,9 +756,9 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 					signed, err := MaybeSignRRset(rrset, qname)
 					if err != nil {
 						lgHandler.Error("failed to sign RRset", "qname", qname, "err", err)
+					} else {
+						rrset = signed
 					}
-					owner.RRtypes.Set(qtype, signed)
-					rrset = signed
 				}
 
 				if qname == origqname {
@@ -786,11 +771,8 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 			}
 		} else {
 			lgHandler.Debug("no exact match for qname+qtype", "qname", qname, "qtype", dns.TypeToString[qtype], "zone", zd.ZoneName)
-			// ensure correct serial
-			soaRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-			soaRRset.RRs[0].(*dns.SOA).Serial = zd.CurrentSerial
-			apex.RRtypes.Set(dns.TypeSOA, soaRRset)
-			m.Ns = append(m.Ns, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs...)
+			soaRRset := zd.soaForResponse(apex)
+			m.Ns = append(m.Ns, soaRRset.RRs...)
 			if msgoptions.DO {
 				// RFC 9824: Compact denial if CO bit is set, otherwise traditional DNSSEC negative response
 				rrtypeList := []uint16{}

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -121,15 +121,45 @@ func (zd *ZoneData) signedApexRRsets(apex *OwnerData, msgoptions *edns0.MsgOptio
 	return soa, ns, nil
 }
 
-// signRRsetForZone signs an RRset using a zone's DNSSEC keys.
-// It checks DNSSEC options, fetches keys if needed, ensures keys exist, and signs the RRset.
+// ErrZoneUnsigned marks a must-be-signed zone (online- or inline-signing) whose
+// published snapshot carries NO RRSIGs for a served, stored RRset — i.e. the
+// zone is broken (e.g. SignZone failed / an unsigned zone was AXFR'd in). The
+// query path turns this into SERVFAIL. Both alternatives are wrong: ephemeral-
+// signing the answer at query time MASKS the failure (the zone looks healthy to
+// DO queries while its stored/transferred zone is unsigned), and serving it
+// unsigned is a silent downgrade. A broken zone must look broken. See
+// docs/2026-07-14-snapshot-branch-signing-findings.md Finding 1 / Decision 1.
+var ErrZoneUnsigned = fmt.Errorf("zone must be signed but has no stored signatures for the RRset")
+
+// isSynthesizedDenial reports whether rrset is a query-time-synthesized denial-
+// of-existence record — an NSEC built by addCDEResponse / addReferralNSEC. These
+// are the ONLY RRsets legitimately signed ephemerally on the query path: they
+// are constructed fresh per response and never stored, so they can't carry
+// pre-computed RRSIGs. Every other RRset served through signRRsetForZone is
+// stored zone data that must already carry its RRSIGs (a signed zone signs its
+// data at SignZone time), so a missing RRSIG there means the zone is broken.
+func isSynthesizedDenial(rrset core.RRset) bool {
+	for _, rr := range rrset.RRs {
+		if rr.Header().Rrtype == dns.TypeNSEC {
+			return true
+		}
+	}
+	return false
+}
+
+// signRRsetForZone returns the RRset ready for a DO response.
+// It checks DNSSEC options and, for a must-be-signed zone, guarantees the served
+// RRset is signed — or reports the zone broken.
 // Parameters:
 //   - rrset: The RRset to sign
 //   - name: The owner name of the RRset
-//   - zone: The zone data containing the zone configuration
 //   - msgoptions: EDNS0 message options (checked for DO bit)
 //   - kdb: Key database for fetching DNSSEC keys
 //   - dak: Optional pre-fetched active DNSSEC keys (if nil, will be fetched from kdb)
+//
+// Behaviour for a must-be-signed zone whose RRset has no stored RRSIGs: a
+// synthesized denial NSEC is signed ephemerally (its only legitimate case);
+// any other (stored) RRset yields ErrZoneUnsigned so the responder SERVFAILs.
 //
 // Returns the signed RRset and any error encountered.
 func (zd *ZoneData) signRRsetForZone(rrset core.RRset, name string, msgoptions *edns0.MsgOptions, kdb *KeyDB, dak *DnssecKeys) (core.RRset, error) {
@@ -137,7 +167,8 @@ func (zd *ZoneData) signRRsetForZone(rrset core.RRset, name string, msgoptions *
 		lgHandler.Debug("DNSSEC not requested, skipping signing", "name", name, "rrtype", dns.TypeToString[rrset.RRtype])
 		return rrset, nil
 	}
-	// If the RRset is already signed (e.g. by inline-signing), return as-is.
+	// If the RRset is already signed (inline-signing, or online-signing RRSIGs
+	// already stored in the snapshot at SignZone time), serve as-is.
 	if len(rrset.RRSIGs) > 0 {
 		return rrset, nil
 	}
@@ -146,8 +177,19 @@ func (zd *ZoneData) signRRsetForZone(rrset core.RRset, name string, msgoptions *
 		return rrset, fmt.Errorf("no KeyDB available for zone %s", zd.ZoneName)
 	}
 	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
-		// No signing configured — return unsigned.
+		// Zone is legitimately unsigned — serve unsigned.
 		return rrset, nil
+	}
+
+	// The zone MUST be signed but this RRset has no stored RRSIGs. Only a
+	// query-time-synthesized denial NSEC may be signed ephemerally here; any
+	// stored RRset with no signatures means the zone is broken → SERVFAIL,
+	// rather than ephemeral-signing (which masks the failure) or serving
+	// unsigned (a silent downgrade).
+	if !isSynthesizedDenial(rrset) {
+		lgHandler.Error("must-be-signed zone has no stored signatures for RRset; serving SERVFAIL",
+			"zone", zd.ZoneName, "name", name, "rrtype", dns.TypeToString[rrset.RRtype])
+		return rrset, ErrZoneUnsigned
 	}
 
 	// Get active DNSSEC keys, using provided dak or fetching from kdb
@@ -855,10 +897,21 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 				if qname == origqname {
 					signed, err := MaybeSignRRset(rrset, qname)
 					if err != nil {
-						lgHandler.Error("failed to sign RRset", "qname", qname, "err", err)
-					} else {
-						rrset = signed
+						// A must-be-signed zone that cannot produce signatures for
+						// this stored answer is broken → SERVFAIL. Previously the
+						// error was swallowed and the answer served unsigned (or,
+						// via the removed ephemeral-sign fallback, served with a
+						// fabricated signature that masked the broken zone). See
+						// Finding 1 / Decision 1.
+						lgHandler.Error("failed to sign answer RRset; serving SERVFAIL", "qname", qname, "qtype", dns.TypeToString[qtype], "zone", zd.ZoneName, "err", err)
+						servfail := new(dns.Msg)
+						servfail.SetReply(r)
+						servfail.MsgHdr.Authoritative = true
+						servfail.MsgHdr.Rcode = dns.RcodeServerFailure
+						w.WriteMsg(servfail)
+						return nil
 					}
+					rrset = signed
 				}
 
 				if qname == origqname {

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -201,7 +201,7 @@ func (zd *ZoneData) signRRsetForZone(rrset core.RRset, name string, msgoptions *
 // Pre-fix behavior was always case (2), which broke DS queries against the
 // parent zone for any child name — the responder walked one zone too far up
 // and failed to find DS data that was correctly present in the parent zone.
-func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string, apex *OwnerData,
+func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string, apex *OwnerData, snap *zoneSnapshot,
 	msgoptions *edns0.MsgOptions, kdb *KeyDB, dak *DnssecKeys, imr *Imr,
 	signFunc func(core.RRset, string) (core.RRset, error)) error {
 
@@ -221,10 +221,7 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 			}
 		}
 		m.MsgHdr.Rcode = dns.RcodeSuccess
-		dsRRset, err := zd.GetRRset(qname, dns.TypeDS)
-		if err != nil {
-			lgHandler.Error("failed to get DS record", "qname", qname)
-		}
+		dsRRset := getRRsetFrom(snap, qname, dns.TypeDS)
 		if dsRRset != nil && len(dsRRset.RRs) > 0 {
 			signed, err := signFunc(*dsRRset, qname)
 			if err != nil {
@@ -269,11 +266,15 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 		w.WriteMsg(m)
 		return nil
 	}
-	// We have the parent zone, so let's try to find the DS record
+	// We have the parent zone; pin ITS snapshot and read the DS from that.
 	zd = pzd
-	apex, err = zd.GetOwner(zd.ZoneName)
-	if err != nil {
+	snap = zd.publishedSnapshot()
+	apex = getOwnerFrom(snap, zd.ZoneName)
+	if apex == nil {
 		lgHandler.Error("failed to get apex data for parent zone", "zone", zd.ZoneName)
+		m.MsgHdr.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return nil
 	}
 	// Use parent zone's own keys; let signRRsetForZone fetch them via kdb.
 	soaRRset, _, err := zd.signedApexRRsets(apex, msgoptions, kdb, nil)
@@ -286,10 +287,7 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 		}
 	}
 	m.MsgHdr.Rcode = dns.RcodeSuccess
-	dsRRset, err := zd.GetRRset(qname, dns.TypeDS)
-	if err != nil {
-		lgHandler.Error("failed to get DS record", "qname", qname)
-	}
+	dsRRset := getRRsetFrom(snap, qname, dns.TypeDS)
 	if dsRRset != nil && len(dsRRset.RRs) > 0 {
 		// Use parent zone's signing context (signFunc closes over the
 		// original zd; route through signRRsetForZone on the parent we
@@ -334,10 +332,10 @@ func (zd *ZoneData) sendReferral(m *dns.Msg, w dns.ResponseWriter, cdd *ChildDel
 }
 
 // sendNXDOMAIN sends an NXDOMAIN response with proper DNSSEC negative response if requested.
-func (zd *ZoneData) sendNXDOMAIN(m *dns.Msg, w dns.ResponseWriter, qname string, apex *OwnerData,
+func (zd *ZoneData) sendNXDOMAIN(m *dns.Msg, w dns.ResponseWriter, qname string, apex *OwnerData, snap *zoneSnapshot,
 	msgoptions *edns0.MsgOptions, signFunc func(core.RRset, string) (core.RRset, error)) {
 	m.MsgHdr.Rcode = dns.RcodeNameError
-	soaRRset := zd.soaForResponse(apex)
+	soaRRset := zd.soaForResponseFrom(snap, apex)
 	m.Ns = append(m.Ns, soaRRset.RRs...)
 	if msgoptions.DO {
 		// RFC 9824: Compact denial if CO bit is set, otherwise traditional DNSSEC negative response
@@ -349,12 +347,12 @@ func (zd *ZoneData) sendNXDOMAIN(m *dns.Msg, w dns.ResponseWriter, qname string,
 // addNSAndGlue adds NS records and glue records (A/AAAA) to the message, along with DNSSEC signatures if requested.
 // When minimalResponses is true, BIND-style minimal-responses semantics apply: the authority NS RRset and
 // its associated additional-section glue (and their RRSIGs) are omitted from positive answers.
-func (zd *ZoneData) addNSAndGlue(m *dns.Msg, apex *OwnerData, msgoptions *edns0.MsgOptions, minimalResponses bool) {
+func (zd *ZoneData) addNSAndGlue(m *dns.Msg, apex *OwnerData, snap *zoneSnapshot, msgoptions *edns0.MsgOptions, minimalResponses bool) {
 	if minimalResponses {
 		return
 	}
 	m.Ns = append(m.Ns, apex.RRtypes.GetOnlyRRSet(dns.TypeNS).RRs...)
-	v4glue, v6glue := zd.FindGlue(apex.RRtypes.GetOnlyRRSet(dns.TypeNS), msgoptions.DO)
+	v4glue, v6glue := zd.findGlueFrom(snap, apex.RRtypes.GetOnlyRRSet(dns.TypeNS), msgoptions.DO)
 	m.Extra = append(m.Extra, v4glue.RRs...)
 	m.Extra = append(m.Extra, v6glue.RRs...)
 	if msgoptions.DO {
@@ -366,8 +364,7 @@ func (zd *ZoneData) addNSAndGlue(m *dns.Msg, apex *OwnerData, msgoptions *edns0.
 
 // addTransportSignal adds transport signal RRs to the Extra section if not already present in Answer.
 // Returns true if any transport signal was added.
-func (zd *ZoneData) addTransportSignal(m *dns.Msg, msgoptions *edns0.MsgOptions, transportSignalInAnswer bool) bool {
-	ts := zd.publishedTransportSignal()
+func (zd *ZoneData) addTransportSignal(m *dns.Msg, ts *core.RRset, msgoptions *edns0.MsgOptions, transportSignalInAnswer bool) bool {
 	if !zd.AddTransportSignal || msgoptions.OtsOptOut || ts == nil || len(ts.RRs) == 0 {
 		return false
 	}
@@ -397,9 +394,9 @@ func (zd *ZoneData) addTransportSignal(m *dns.Msg, msgoptions *edns0.MsgOptions,
 }
 
 // handleSOAQuery handles SOA queries for the zone apex.
-func (zd *ZoneData) handleSOAQuery(m *dns.Msg, w dns.ResponseWriter, apex *OwnerData,
+func (zd *ZoneData) handleSOAQuery(m *dns.Msg, w dns.ResponseWriter, apex *OwnerData, snap *zoneSnapshot, ts *core.RRset,
 	msgoptions *edns0.MsgOptions, transportSignalInAnswer *bool, minimalResponses bool) {
-	soaRRset := zd.soaForResponse(apex)
+	soaRRset := zd.soaForResponseFrom(snap, apex)
 	lgHandler.Debug("SOA RRset details", "zone", zd.ZoneName, "count", len(soaRRset.RRs), "rrset", soaRRset)
 
 	m.Answer = append(m.Answer, soaRRset.RRs[0])
@@ -408,13 +405,13 @@ func (zd *ZoneData) handleSOAQuery(m *dns.Msg, w dns.ResponseWriter, apex *Owner
 		m.Answer = append(m.Answer, soaRRset.RRSIGs...)
 		// Note: NS and glue RRSIGs are already added by addNSAndGlue
 	}
-	zd.addNSAndGlue(m, apex, msgoptions, minimalResponses)
-	zd.addTransportSignal(m, msgoptions, *transportSignalInAnswer)
+	zd.addNSAndGlue(m, apex, snap, msgoptions, minimalResponses)
+	zd.addTransportSignal(m, ts, msgoptions, *transportSignalInAnswer)
 }
 
 // handleCNAMEChain handles CNAME responses, including following CNAME chains across zones.
 // Returns true if a CNAME response was handled and the message should be sent, false otherwise.
-func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname string, qtype uint16, owner *OwnerData,
+func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname string, qtype uint16, owner *OwnerData, snap *zoneSnapshot,
 	msgoptions *edns0.MsgOptions, kdb *KeyDB, apex *OwnerData, transportSignalInAnswer *bool, minimalResponses bool) (bool, error) {
 
 	if owner.RRtypes.Count() != 1 {
@@ -489,9 +486,9 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 			break
 		}
 
-		// Get owner data from the target zone
-		tgtOwner, err := tgtZone.GetOwner(tgt)
-		if err != nil || tgtOwner == nil {
+		// Get owner data from the target zone (pin ITS snapshot).
+		tgtOwner := getOwnerFrom(tgtZone.publishedSnapshot(), tgt)
+		if tgtOwner == nil {
 			lgHandler.Error("failed to get owner for CNAME target", "target", tgt, "zone", tgtZone.ZoneName)
 			break
 		}
@@ -548,10 +545,10 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 
 	// Add NS and glue records from the zone where we found the final answer (or last CNAME)
 	// Use the original zone's apex for NS records
-	zd.addNSAndGlue(m, apex, msgoptions, minimalResponses)
+	zd.addNSAndGlue(m, apex, snap, msgoptions, minimalResponses)
 
-	// Check for transport signal
-	ts := zd.publishedTransportSignal()
+	// Check for transport signal (from the pinned snapshot)
+	ts := snap.TransportSignal
 	if zd.AddTransportSignal && ts != nil {
 		for _, arr := range m.Answer {
 			if rrMatchesTransportSignal(arr, ts) {
@@ -560,7 +557,7 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 			}
 		}
 	}
-	zd.addTransportSignal(m, msgoptions, *transportSignalInAnswer)
+	zd.addTransportSignal(m, ts, msgoptions, *transportSignalInAnswer)
 	if msgoptions.DO && zd.AddTransportSignal && !msgoptions.OtsOptOut && ts != nil {
 		if !*transportSignalInAnswer && len(ts.RRSIGs) > 0 {
 			m.Extra = append(m.Extra, ts.RRSIGs...)
@@ -621,14 +618,23 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	m.SetReply(r)
 	m.MsgHdr.Authoritative = true
 
-	apex, err := zd.GetOwner(zd.ZoneName)
-	if err != nil {
-		lgHandler.Error("failed to get apex data", "zone", zd.ZoneName, "err", err)
+	// Pin ONE snapshot for the whole response so the answer, authority SOA, NS,
+	// and glue all come from the same serial — no intra-response tearing (C1).
+	snap := zd.publishedSnapshot()
+	if snap == nil {
+		lgHandler.Error("no published snapshot; serving SERVFAIL", "zone", zd.ZoneName)
 		m.MsgHdr.Rcode = dns.RcodeServerFailure
 		w.WriteMsg(m)
-		return fmt.Errorf("failed to get apex data for zone %s: %v", zd.ZoneName, err)
+		return nil
 	}
-	transportSig := zd.publishedTransportSignal()
+	apex := getOwnerFrom(snap, zd.ZoneName)
+	if apex == nil {
+		lgHandler.Error("missing apex in snapshot; serving SERVFAIL", "zone", zd.ZoneName)
+		m.MsgHdr.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return nil
+	}
+	transportSig := snap.TransportSignal
 
 	// Inline-signed apex RRsets are served from the published zone; online/compact
 	// signatures are added ephemerally on each response path below.
@@ -647,16 +653,16 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 
 	// 0. Is this a DS query? If so, trap it ASAP and try to find the parent zone
 	if qtype == dns.TypeDS {
-		return zd.handleDSQuery(m, w, qname, apex, msgoptions, kdb, dak, imr, MaybeSignRRset)
+		return zd.handleDSQuery(m, w, qname, apex, snap, msgoptions, kdb, dak, imr, MaybeSignRRset)
 	}
 
 	// log.Printf("---> Checking for existence of qname %s", qname)
-	if !zd.NameExists(qname) {
+	if !nameExistsFrom(snap, qname) {
 		lgHandler.Debug("no exact match for qname", "qname", qname, "zone", zd.ZoneName)
 
 		// 1. Check for child delegation
 		lgHandler.Debug("checking for child delegation", "qname", qname)
-		cdd := zd.FindDelegation(qname, msgoptions.DO)
+		cdd := zd.findDelegationFrom(snap, qname, msgoptions.DO)
 
 		// If there is delegation data and an NS RRset is present, return a referral
 		if cdd != nil && cdd.NS_rrset != nil && qtype != dns.TypeDS && qtype != core.TypeDELEG {
@@ -667,9 +673,9 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 		wildqname = "*." + strings.Join(strings.Split(qname, ".")[1:], ".")
 		// log.Printf("---> Checking for existence of wildcard %s", wildqname)
 
-		if !zd.NameExists(wildqname) {
+		if !nameExistsFrom(snap, wildqname) {
 			// return NXDOMAIN
-			zd.sendNXDOMAIN(m, w, qname, apex, msgoptions, MaybeSignRRset)
+			zd.sendNXDOMAIN(m, w, qname, apex, snap, msgoptions, MaybeSignRRset)
 			return nil
 		}
 		lgHandler.Debug("wildcard match", "qname", qname, "wildcard", wildqname, "zone", zd.ZoneName)
@@ -677,15 +683,19 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 		qname = wildqname
 	}
 
-	owner, err := zd.GetOwner(qname)
-	if err != nil {
-		lgHandler.Error("failed to get owner for qname", "qname", qname)
+	owner := getOwnerFrom(snap, qname)
+	if owner == nil {
+		// NameExists (against this same snapshot) passed, so this shouldn't
+		// happen; guard rather than panic on owner.RRtypes below.
+		m.MsgHdr.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return nil
 	}
 
 	// 0. Check for *any* existence of qname in zone
 	// log.Printf("---> Checking for any existence of qname %s", qname)
 	if owner.RRtypes.Count() == 0 {
-		soaRRset, err := MaybeSignRRset(zd.soaForResponse(apex), zd.ZoneName)
+		soaRRset, err := MaybeSignRRset(zd.soaForResponseFrom(snap, apex), zd.ZoneName)
 		if err != nil {
 			lgHandler.Error("failed to sign SOA RRset", "zone", zd.ZoneName, "err", err)
 			if msgoptions.DO {
@@ -706,7 +716,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	if len(qname) > len(zd.ZoneName) {
 		// 2. Check for qname + CNAME (only if CNAME is the only RR type)
 		lgHandler.Debug("checking for CNAME", "qname", qname, "zone", zd.ZoneName)
-		handled, err := zd.handleCNAMEChain(m, w, qname, qtype, owner, msgoptions, kdb, apex, &transportSignalInAnswer, minimalResponses)
+		handled, err := zd.handleCNAMEChain(m, w, qname, qtype, owner, snap, msgoptions, kdb, apex, &transportSignalInAnswer, minimalResponses)
 		if err != nil {
 			lgHandler.Error("error handling CNAME chain", "err", err)
 			// Error response already sent by handleCNAMEChain
@@ -719,7 +729,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 
 		// 1. If qname is below the zone apex, check for child delegation
 		// log.Printf("---> Checking for child delegation for %s", qname)
-		cdd := zd.FindDelegation(qname, msgoptions.DO)
+		cdd := zd.findDelegationFrom(snap, qname, msgoptions.DO)
 
 		// If there is delegation data and an NS RRset is present, return a referral
 		if cdd != nil && cdd.NS_rrset != nil && qtype != dns.TypeDS && qtype != core.TypeDELEG {
@@ -734,7 +744,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	if tdnsSpecialTypes[qtype] || standardDNSTypes[qtype] {
 		if rrset, ok := owner.RRtypes.Get(qtype); ok && len(rrset.RRs) > 0 {
 			if qtype == dns.TypeSOA {
-				rrset = zd.soaForResponse(apex)
+				rrset = zd.soaForResponseFrom(snap, apex)
 			}
 			if qname == origqname {
 				// zd.Logger.Printf("Exact match qname %s %s", qname, dns.TypeToString[qtype])
@@ -750,9 +760,9 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 					transportSignalInAnswer = true
 				}
 			}
-			zd.addNSAndGlue(m, apex, msgoptions, minimalResponses)
+			zd.addNSAndGlue(m, apex, snap, msgoptions, minimalResponses)
 			// Add transport signal RRs that aren't already present in the Answer section
-			zd.addTransportSignal(m, msgoptions, transportSignalInAnswer)
+			zd.addTransportSignal(m, transportSig, msgoptions, transportSignalInAnswer)
 			if msgoptions.DO {
 				lgHandler.Debug("considering signing", "qname", qname, "qtype", dns.TypeToString[qtype], "origqname", origqname)
 				if qname == origqname {
@@ -774,7 +784,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 			}
 		} else {
 			lgHandler.Debug("no exact match for qname+qtype", "qname", qname, "qtype", dns.TypeToString[qtype], "zone", zd.ZoneName)
-			soaRRset := zd.soaForResponse(apex)
+			soaRRset := zd.soaForResponseFrom(snap, apex)
 			m.Ns = append(m.Ns, soaRRset.RRs...)
 			if msgoptions.DO {
 				// RFC 9824: Compact denial if CO bit is set, otherwise traditional DNSSEC negative response
@@ -789,7 +799,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 
 	lgHandler.Debug("checking for SOA query", "zone", zd.ZoneName)
 	if qtype == dns.TypeSOA && qname == zd.ZoneName {
-		zd.handleSOAQuery(m, w, apex, msgoptions, &transportSignalInAnswer, minimalResponses)
+		zd.handleSOAQuery(m, w, apex, snap, transportSig, msgoptions, &transportSignalInAnswer, minimalResponses)
 		w.WriteMsg(m)
 		return nil
 	}
@@ -812,7 +822,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	// the REFUSED catch-all we keep the pre-existing behavior (always
 	// include authority NS + glue) regardless of the option.
 	m.MsgHdr.Rcode = dns.RcodeRefused
-	zd.addNSAndGlue(m, apex, msgoptions, false)
+	zd.addNSAndGlue(m, apex, snap, msgoptions, false)
 	w.WriteMsg(m)
 
 	_ = origqname

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -147,7 +147,10 @@ func initialLoadZone(ctx context.Context, zd *ZoneData, zone string, zr ZoneRefr
 				}
 			}
 			if serialChanged {
-				setApexSOASerial(zd)
+				zd.mu.Lock()
+				zd.ensureWorkingSet()
+				zd.publishWorkingSetLocked(zd.generation.Load(), false)
+				zd.mu.Unlock()
 			}
 		}
 		zd.NotifyDownstreams()
@@ -708,7 +711,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 								}
 							}
 							if serialChanged {
-								setApexSOASerial(zd)
+								zd.mu.Lock()
+								zd.ensureWorkingSet()
+								zd.publishWorkingSetLocked(zd.generation.Load(), false)
+								zd.mu.Unlock()
 							}
 						}
 

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -159,6 +159,47 @@ func initialLoadZone(ctx context.Context, zd *ZoneData, zone string, zr ZoneRefr
 	return updated, nil
 }
 
+// applyReloadedPolicyLocked rebinds a signed zone to a DNSSEC policy freshly
+// resolved from the config on RELOAD, UNLESS doing so would change the zone's
+// effective KSK or ZSK ALGORITHM.
+//
+// An algorithm change requires a key rollover that is not yet implemented:
+// SignZone (reconcileActiveKeyAlgorithms, sign.go) refuses the mismatch, so
+// blindly rebinding to the new policy would leave the zone bound to a policy it
+// can never sign under — it would go unsigned. To preserve availability we
+// REFUSE the change here: keep the OLD policy bound, log a warning, and let the
+// zone keep signing with its existing keys. A benign edit (same effective KSK
+// and ZSK algorithms, only lifetimes/sigvalidity/rollover/ttls changed) applies
+// normally.
+//
+// This runs only on the reload path (FirstZoneLoad == false), where the current
+// binding is the OLD policy; a first bind (nil current policy) is always
+// applied. The separate set-policy/change-policy command path
+// (apihandler_zone.go) has its own revert-on-failure handling and must not use
+// this guard. The effective algorithms are the resolved DnssecPolicy.KSKAlgorithm
+// / .ZSKAlgorithm fields (top-level algorithm plus any per-role override), the
+// same fields SignZone and set-policy compare against the active keys.
+//
+// Caller must hold zd.mu. Returns true if newPol was applied.
+func (zd *ZoneData) applyReloadedPolicyLocked(newPol *DnssecPolicy, newName string) bool {
+	if cur := zd.DnssecPolicy; cur != nil &&
+		(cur.KSKAlgorithm != newPol.KSKAlgorithm || cur.ZSKAlgorithm != newPol.ZSKAlgorithm) {
+		lgEngine.Warn("refused incompatible DNSSEC algorithm change on reload; keeping existing policy",
+			"zone", zd.ZoneName,
+			"effective_policy", zd.DnssecPolicyName,
+			"config_policy", newName,
+			"effective_ksk_alg", dns.AlgorithmToString[cur.KSKAlgorithm],
+			"config_ksk_alg", dns.AlgorithmToString[newPol.KSKAlgorithm],
+			"effective_zsk_alg", dns.AlgorithmToString[cur.ZSKAlgorithm],
+			"config_zsk_alg", dns.AlgorithmToString[newPol.ZSKAlgorithm],
+			"reason", "algorithm change requires a key rollover (not implemented)")
+		return false
+	}
+	zd.DnssecPolicy = newPol
+	zd.DnssecPolicyName = newName
+	return true
+}
+
 func RefreshEngine(ctx context.Context, conf *Config) {
 
 	var zonerefch = conf.Internal.RefreshZoneCh
@@ -371,16 +412,20 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 								polName = eff
 							}
 							if dp, exists := conf.Internal.DnssecPolicies[polName]; exists {
-								// Always rebind: the policy struct is rebuilt from
-								// scratch by parseDnssecConfig on every reload, so even
-								// a same-name policy may have changed internals (e.g.
-								// an edited KSK algorithm). Re-binding + a re-sign below
-								// converges the zone; the algorithm reconcile in
-								// EnsureActiveDnssecKeys is idempotent (no churn when
-								// keys already match).
-								zd.DnssecPolicy = &dp
-								zd.DnssecPolicyName = polName
-								reapplyPolicy = true
+								// Rebind so a same-name policy whose internals changed
+								// on reload (lifetimes, sigvalidity, rollover, ttls, …)
+								// takes effect; the re-sign below converges the zone
+								// (the algorithm reconcile in EnsureActiveDnssecKeys is
+								// idempotent — no key churn when keys already match).
+								// BUT applyReloadedPolicyLocked refuses a change that
+								// alters the effective KSK/ZSK algorithm: that needs a
+								// key rollover that is not yet built, and applying it
+								// would leave the zone bound to an unusable policy and
+								// serving unsigned. On refusal the OLD policy stays
+								// bound (no re-sign) so the zone keeps signing.
+								if zd.applyReloadedPolicyLocked(&dp, polName) {
+									reapplyPolicy = true
+								}
 							} else {
 								lgEngine.Warn("DNSSEC policy not found, keeping existing", "policy", polName, "zone", zone)
 							}

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -287,6 +287,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							}
 							continue
 						}
+						zd.InstallInitialSnapshot()
 					} else {
 						// EXISTING ZONE: already loaded, normal refresh path.
 						if zd.HasServiceImpactingError() {
@@ -625,6 +626,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							lgEngine.Error("SetupZoneSigning failed", "zone", zone, "error", err)
 						}
 					}
+					zd.InstallInitialSnapshot()
 				}
 			}
 			if zr.Response != nil && !zr.Wait {

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -263,7 +263,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							zd.mu.Unlock()
 							if zd.DnssecPolicy != nil &&
 								(zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) {
-								UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false, conf.IsLargeAlgorithm)
+								UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false, conf.IsLargeAlgorithm, false)
 							}
 						}
 
@@ -403,7 +403,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// key churn.
 						if reapplyPolicy && zd.DnssecPolicy != nil &&
 							(zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) {
-							UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false, conf.IsLargeAlgorithm)
+							UpdateSigValidityFloor(zd, zd.DnssecPolicy, conf.KaspPropagationDelay(), 0, false, conf.IsLargeAlgorithm, false)
 							triggerResign(conf, zone)
 						}
 						lgEngine.Debug("updated configuration for zone", "zone", zone, "notify", zd.Notify, "primaries", zd.PrimariesConf, "upstreams", zd.Upstreams, "zonefile", zd.Zonefile, "store", ZoneStoreToString[zd.ZoneStore])

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -415,7 +415,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							lgEngine.Error("GetSOA failed", "zone", zone, "error", err)
 							zd.SetError(RefreshError, "get soa error: %v", err)
 							zd.LatestError = time.Now()
-						} else {
+						} else if soa != nil {
 							refresh = soa.Refresh
 						}
 						if rc, haveParams := refreshCounters.Get(zone); haveParams {

--- a/v2/reload_policy_alg_guard_test.go
+++ b/v2/reload_policy_alg_guard_test.go
@@ -1,0 +1,134 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestApplyReloadedPolicyLocked exercises the config-reload guard that refuses
+// an incompatible DNSSEC-algorithm policy change (which would need an
+// unimplemented key rollover) while still applying benign, same-algorithm
+// edits. This is the reload-path (FirstZoneLoad == false) analogue of the
+// SignZone algorithm check in reconcileActiveKeyAlgorithms (sign.go).
+func TestApplyReloadedPolicyLocked(t *testing.T) {
+	// A KSK+ZSK policy currently bound to the zone (the OLD, effective policy).
+	oldPol := &DnssecPolicy{
+		Name:         "pq-sqisign",
+		Mode:         DnssecPolicyModeKSKZSK,
+		Algorithm:    dns.ED25519,
+		KSKAlgorithm: dns.ED25519,
+		ZSKAlgorithm: dns.ECDSAP256SHA256,
+	}
+
+	tests := []struct {
+		name       string
+		newPol     *DnssecPolicy
+		newName    string
+		wantApply  bool   // did the rebind happen?
+		wantPolPtr string // expected DnssecPolicyName after the call
+	}{
+		{
+			// Effective KSK algorithm changes (ED25519 -> RSASHA256): needs a
+			// KSK rollover, not implemented -> REFUSE, keep the old policy.
+			name: "ksk-algorithm-change-refused",
+			newPol: &DnssecPolicy{
+				Name:         "pq-mldsa",
+				Mode:         DnssecPolicyModeKSKZSK,
+				Algorithm:    dns.RSASHA256,
+				KSKAlgorithm: dns.RSASHA256,
+				ZSKAlgorithm: dns.ECDSAP256SHA256,
+			},
+			newName:    "pq-mldsa",
+			wantApply:  false,
+			wantPolPtr: "pq-sqisign",
+		},
+		{
+			// Effective ZSK algorithm changes (ECDSAP256 -> ED25519): also an
+			// algorithm change -> REFUSE, keep the old policy.
+			name: "zsk-algorithm-change-refused",
+			newPol: &DnssecPolicy{
+				Name:         "pq-mldsa",
+				Mode:         DnssecPolicyModeKSKZSK,
+				Algorithm:    dns.ED25519,
+				KSKAlgorithm: dns.ED25519,
+				ZSKAlgorithm: dns.ED25519,
+			},
+			newName:    "pq-mldsa",
+			wantApply:  false,
+			wantPolPtr: "pq-sqisign",
+		},
+		{
+			// Same effective KSK and ZSK algorithms, only non-algorithm fields
+			// changed (mode/rollover/name) -> benign, APPLY.
+			name: "benign-same-algorithm-edit-applied",
+			newPol: &DnssecPolicy{
+				Name:         "pq-sqisign-v2",
+				Mode:         DnssecPolicyModeKSKZSK,
+				Algorithm:    dns.ED25519,
+				KSKAlgorithm: dns.ED25519,
+				ZSKAlgorithm: dns.ECDSAP256SHA256,
+				Rollover:     RolloverPolicy{Method: RolloverMethodMultiDS},
+			},
+			newName:    "pq-sqisign-v2",
+			wantApply:  true,
+			wantPolPtr: "pq-sqisign-v2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			zd := &ZoneData{
+				ZoneName:         "example.",
+				DnssecPolicy:     oldPol,
+				DnssecPolicyName: oldPol.Name,
+			}
+			zd.mu.Lock()
+			applied := zd.applyReloadedPolicyLocked(tc.newPol, tc.newName)
+			zd.mu.Unlock()
+
+			if applied != tc.wantApply {
+				t.Fatalf("applyReloadedPolicyLocked returned %v, want %v", applied, tc.wantApply)
+			}
+			if zd.DnssecPolicyName != tc.wantPolPtr {
+				t.Fatalf("DnssecPolicyName = %q, want %q", zd.DnssecPolicyName, tc.wantPolPtr)
+			}
+			if tc.wantApply {
+				// Benign edit: the new policy struct is now bound.
+				if zd.DnssecPolicy != tc.newPol {
+					t.Fatalf("expected new policy pointer to be bound after a benign edit")
+				}
+			} else {
+				// Refusal: the OLD policy struct must still be bound, so the
+				// zone keeps signing with its existing keys.
+				if zd.DnssecPolicy != oldPol {
+					t.Fatalf("expected the old policy pointer to remain bound after a refused algorithm change")
+				}
+			}
+		})
+	}
+}
+
+// TestApplyReloadedPolicyLocked_FirstBind verifies that a zone with no policy
+// yet bound (the nil-current case) always applies the new policy — the guard
+// only fires when there is an OLD effective policy to compare against.
+func TestApplyReloadedPolicyLocked_FirstBind(t *testing.T) {
+	zd := &ZoneData{ZoneName: "example."}
+	newPol := &DnssecPolicy{
+		Name:         "pq-mldsa",
+		Mode:         DnssecPolicyModeKSKZSK,
+		Algorithm:    dns.RSASHA256,
+		KSKAlgorithm: dns.RSASHA256,
+		ZSKAlgorithm: dns.RSASHA256,
+	}
+	zd.mu.Lock()
+	applied := zd.applyReloadedPolicyLocked(newPol, "pq-mldsa")
+	zd.mu.Unlock()
+
+	if !applied {
+		t.Fatalf("expected a first bind (nil current policy) to apply")
+	}
+	if zd.DnssecPolicyName != "pq-mldsa" || zd.DnssecPolicy != newPol {
+		t.Fatalf("first bind did not bind the new policy: name=%q", zd.DnssecPolicyName)
+	}
+}

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -614,21 +614,14 @@ func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
 		return 0, err
 	}
 
-	names, err := zd.GetOwnerNames()
-	if err != nil {
-		return 0, err
-	}
-	sort.Strings(names)
+	names := zd.workingOwnerNamesLocked()
 
 	var delegations []string
 	for _, name := range names {
 		if name == zd.ZoneName {
 			continue
 		}
-		owner, err := zd.GetOwner(name)
-		if err != nil {
-			return 0, err
-		}
+		owner := zd.stagedOwner(name)
 		if owner == nil {
 			continue
 		}
@@ -639,10 +632,7 @@ func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
 
 	newrrsigs := 0
 	for _, name := range names {
-		owner, err := zd.GetOwner(name)
-		if err != nil {
-			return 0, err
-		}
+		owner := zd.stagedOwner(name)
 		if owner == nil {
 			continue
 		}
@@ -803,12 +793,6 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 		return rrset, resigned
 	}
 
-	names, err := zd.GetOwnerNames()
-	if err != nil {
-		return 0, err
-	}
-	sort.Strings(names)
-
 	zd.mu.Lock()
 	defer zd.mu.Unlock()
 	zd.ensureWorkingSet()
@@ -823,20 +807,14 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 		return 0, err
 	}
 
-	// apex, err := zd.GetOwner(zd.ZoneName)
-	// if err != nil {
-	// 	return err
-	// }
+	names := zd.workingOwnerNamesLocked()
 
 	var delegations []string
 	for _, name := range names {
 		if name == zd.ZoneName {
 			continue
 		}
-		owner, err := zd.GetOwner(name)
-		if err != nil {
-			return 0, err
-		}
+		owner := zd.stagedOwner(name)
 		if owner == nil {
 			continue
 		}
@@ -850,10 +828,7 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 	var maxObservedTTL uint32
 	for _, name := range names {
 		// log.Printf("SignZone: signing RRsets under name %s", name)
-		owner, err := zd.GetOwner(name)
-		if err != nil {
-			return 0, err
-		}
+		owner := zd.stagedOwner(name)
 		if owner == nil {
 			continue
 		}
@@ -946,11 +921,7 @@ func (zd *ZoneData) GenerateNsecChainWithDak(dak *DnssecKeys) error {
 	//		return rrset
 	//	}
 
-	names, err := zd.GetOwnerNames()
-	if err != nil {
-		return err
-	}
-	sort.Strings(names)
+	names := zd.workingOwnerNamesLocked()
 
 	var nextidx int
 	var nextname string
@@ -958,10 +929,7 @@ func (zd *ZoneData) GenerateNsecChainWithDak(dak *DnssecKeys) error {
 	var hasRRSIG bool
 
 	for idx, name := range names {
-		owner, err := zd.GetOwner(name)
-		if err != nil {
-			return err
-		}
+		owner := zd.stagedOwner(name)
 		if owner == nil {
 			continue
 		}

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -122,8 +122,10 @@ func (zd *ZoneData) SignRRset(rrset *core.RRset, name string, dak *DnssecKeys, f
 	var err error
 
 	if dak == nil {
-		// Ensure active keys exist (will generate if needed)
-		dak, err = zd.EnsureActiveDnssecKeys(zd.KeyDB)
+		// Ensure active keys exist (will generate if needed). SignRRset is never
+		// reached with dak==nil while zd.mu is held (the one such caller,
+		// resignWorkingSetSOAIfSigned, resolves the dak first), so zdLocked=false.
+		dak, err = zd.EnsureActiveDnssecKeys(zd.KeyDB, false)
 		if err != nil {
 			lgSigner.Error("failed to ensure active DNSSEC keys", "zone", zd.ZoneName, "err", err)
 			return false, err
@@ -389,7 +391,14 @@ func (zd *ZoneData) reconcileActiveKeyAlgorithms(kdb *KeyDB, dak *DnssecKeys) (b
 // 1. Try to promote published keys to active (if available)
 // 2. Generate new KSK and ZSK keys if needed
 // Returns the active DNSSEC keys or an error if key generation fails.
-func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB) (*DnssecKeys, error) {
+//
+// zdLocked signals that the caller already holds zd.mu. When true the final
+// DNSKEY publish is routed through publishDnskeyRRsLocked (which does NOT take
+// zd.mu) instead of PublishDnskeyRRs (which does) — otherwise the re-lock would
+// self-deadlock (Go mutexes are not reentrant). The only zd.mu-holding caller is
+// resignWorkingSetSOAIfSigned (via the publish path); every other caller resolves
+// keys before taking zd.mu and passes false.
+func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB, zdLocked bool) (*DnssecKeys, error) {
 	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
 		return nil, fmt.Errorf("EnsureActiveDnssecKeys: zone %s does not allow signing (neither online-signing nor inline-signing)", zd.ZoneName)
 	}
@@ -543,8 +552,14 @@ func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB) (*DnssecKeys, error) {
 		return nil, err
 	}
 
-	// Publish DNSKEYs to the zone so they're available in queries and AXFR
-	err = zd.PublishDnskeyRRs(dak)
+	// Publish DNSKEYs to the zone so they're available in queries and AXFR.
+	// When the caller already holds zd.mu (zdLocked), use the *Locked variant so
+	// we don't re-acquire zd.mu and self-deadlock.
+	if zdLocked {
+		err = zd.publishDnskeyRRsLocked(dak)
+	} else {
+		err = zd.PublishDnskeyRRs(dak)
+	}
 	if err != nil {
 		lgSigner.Warn("failed to publish DNSKEY RRs", "zone", zd.ZoneName, "err", err)
 		// Don't fail if publishing fails, keys are still usable for signing
@@ -585,7 +600,7 @@ func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
 		return 0, fmt.Errorf("ResignZone: zone %s has DNSSEC error: %s", zd.ZoneName, zd.ErrorMsg)
 	}
 
-	dak, err := zd.EnsureActiveDnssecKeys(kdb)
+	dak, err := zd.EnsureActiveDnssecKeys(kdb, false)
 	if err != nil {
 		lgSigner.Error("ResignZone: failed to ensure active DNSSEC keys", "zone", zd.ZoneName, "err", err)
 		return 0, err
@@ -762,8 +777,9 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 	// Single-signer signing (mode 1). Multi-provider signing
 	// (modes 2-4) is handled by mpzd.SignZone() in tdns-mp.
 
-	// Ensure active DNSSEC keys exist (will generate if needed)
-	dak, err := zd.EnsureActiveDnssecKeys(kdb)
+	// Ensure active DNSSEC keys exist (will generate if needed). SignZone takes
+	// zd.mu below (line ~801), after this call, so zdLocked=false here.
+	dak, err := zd.EnsureActiveDnssecKeys(kdb, false)
 	if err != nil {
 		lgSigner.Error("failed to ensure active DNSSEC keys", "zone", zd.ZoneName, "err", err)
 		return 0, err

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -706,19 +706,22 @@ func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
 // cancelled (e.g. on shutdown); callers without a meaningful context may pass
 // context.Background().
 func (zd *ZoneData) StripZoneRRSIGs(ctx context.Context, remove func(*dns.RRSIG) bool) (int, error) {
-	names, err := zd.GetOwnerNames()
-	if err != nil {
-		return 0, err
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.ensureWorkingSet()
+
+	names := make([]string, 0, len(zd.workingSet))
+	for name := range zd.workingSet {
+		names = append(names, name)
 	}
+	sort.Strings(names)
+
 	removed := 0
 	for _, name := range names {
 		if err := ctx.Err(); err != nil {
 			return removed, err
 		}
-		owner, err := zd.GetOwner(name)
-		if err != nil {
-			return removed, err
-		}
+		owner := zd.workingSet[name]
 		if owner == nil {
 			continue
 		}
@@ -739,11 +742,12 @@ func (zd *ZoneData) StripZoneRRSIGs(ctx context.Context, remove func(*dns.RRSIG)
 			}
 			if changed {
 				rrset.RRSIGs = kept
-				owner.RRtypes.Set(rrt, rrset)
+				zd.stageRRsetLocked(name, rrset)
 			}
 		}
 	}
 	if removed > 0 {
+		zd.publishLocked(zd.generation.Load())
 		lgSigner.Info("stripped orphan RRSIGs from zone", "zone", zd.ZoneName, "count", removed)
 	}
 	return removed, nil

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -591,12 +591,6 @@ func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
 		return 0, err
 	}
 
-	if !zd.Options[OptBlackLies] {
-		if err := zd.GenerateNsecChain(kdb); err != nil {
-			return 0, err
-		}
-	}
-
 	var clamp *ClampParams
 	if zd.DnssecPolicy != nil {
 		clamp, err = ClampParamsForZone(kdb, zd.ZoneName, zd.DnssecPolicy, time.Now())
@@ -606,7 +600,17 @@ func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
 		}
 	}
 
-	if err := zd.PublishDnskeyRRs(dak); err != nil {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.ensureWorkingSet()
+
+	if !zd.Options[OptBlackLies] {
+		if err := zd.GenerateNsecChainWithDak(dak); err != nil {
+			return 0, err
+		}
+	}
+
+	if err := zd.publishDnskeyRRsLocked(dak); err != nil {
 		return 0, err
 	}
 
@@ -674,12 +678,14 @@ func (zd *ZoneData) ResignZone(kdb *KeyDB) (int, error) {
 					"rrtype", dns.TypeToString[rrt], "err", err)
 				return newrrsigs, err
 			}
-			owner.RRtypes.Set(rrt, rrset)
+			zd.stageRRsetLocked(name, rrset)
 			if resigned {
 				newrrsigs++
 			}
 		}
 	}
+
+	zd.publishLocked(zd.generation.Load())
 
 	lgSigner.Info("ResignZone completed",
 		"zone", zd.ZoneName, "rrsigs_written", newrrsigs)
@@ -766,14 +772,6 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 
 	newrrsigs := 0
 
-	// It's either black lies or we need a traditional NSEC chain
-	if !zd.Options[OptBlackLies] {
-		err = zd.GenerateNsecChain(kdb)
-		if err != nil {
-			return 0, err
-		}
-	}
-
 	// 4D K-step TTL clamp: build ClampParams once per pass so every RRset
 	// signed in this pass observes the same K. nil for non-clamping zones
 	// (or zones with no scheduled rollover, mid-rollover, etc.).
@@ -807,8 +805,17 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 	}
 	sort.Strings(names)
 
-	err = zd.PublishDnskeyRRs(dak)
-	if err != nil {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.ensureWorkingSet()
+
+	if !zd.Options[OptBlackLies] {
+		if err = zd.GenerateNsecChainWithDak(dak); err != nil {
+			return 0, err
+		}
+	}
+
+	if err = zd.publishDnskeyRRsLocked(dak); err != nil {
 		return 0, err
 	}
 
@@ -836,7 +843,6 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 
 	lgSigner.Debug("zone delegations", "zone", zd.ZoneName, "delegations", delegations)
 
-	var signed, zoneResigned bool
 	var maxObservedTTL uint32
 	for _, name := range names {
 		// log.Printf("SignZone: signing RRsets under name %s", name)
@@ -871,8 +877,8 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 			if wasglue {
 				continue
 			}
-			rrset, signed = MaybeSignRRset(rrset, zd.ZoneName)
-			owner.RRtypes.Set(rrt, rrset)
+			rrset, _ = MaybeSignRRset(rrset, zd.ZoneName)
+			zd.stageRRsetLocked(name, rrset)
 
 			// Record TTL after clamping. applyClampToRRset (called from
 			// SignRRset) rewrites headers to min(UnclampedTTL, K*margin,
@@ -884,27 +890,11 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 					maxObservedTTL = t
 				}
 			}
-
-			if signed {
-				zoneResigned = true
-			}
 		}
 	}
 
-	if zoneResigned {
-		//		zd.CurrentSerial++
-		//		apex, _ := zd.GetOwner(zd.ZoneName)
-		//		apex.RRtypes[dns.TypeSOA].RRs[0].(*dns.SOA).Serial = zd.CurrentSerial
-		_, err := zd.BumpSerial()
-		if err != nil {
-			lgSigner.Error("failed to bump SOA serial", "zone", zd.ZoneName, "err", err)
-			return 0, err
-		}
-	}
+	zd.publishLocked(zd.generation.Load())
 
-	// Persist the highest RRset TTL seen this pass. Used by the rollover
-	// worker's pending-child-withdraw phase to compute effective_margin.
-	// Reset per pass: a TTL reduction takes effect after one full cycle.
 	if err := UpsertZoneSigningMaxTTL(kdb, zd.ZoneName, maxObservedTTL); err != nil {
 		lgSigner.Warn("SignZone: persist max_observed_ttl", "zone", zd.ZoneName, "err", err)
 	}
@@ -924,7 +914,14 @@ func (zd *ZoneData) GenerateNsecChain(kdb *KeyDB) error {
 		lgSigner.Error("failed to get DNSSEC active keys for NSEC chain", "zone", zd.ZoneName, "err", err)
 		return err
 	}
-	return zd.GenerateNsecChainWithDak(dak)
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.ensureWorkingSet()
+	if err := zd.GenerateNsecChainWithDak(dak); err != nil {
+		return err
+	}
+	zd.publishLocked(zd.generation.Load())
+	return nil
 }
 
 // GenerateNsecChainWithDak builds or refreshes the NSEC chain using the given active DNSSEC keys.
@@ -1005,7 +1002,7 @@ func (zd *ZoneData) GenerateNsecChainWithDak(dak *DnssecKeys) error {
 		}
 		tmp := owner.RRtypes.GetOnlyRRSet(dns.TypeNSEC)
 		tmp.RRs = []dns.RR{nsecrr}
-		owner.RRtypes.Set(dns.TypeNSEC, tmp)
+		zd.stageRRsetLocked(name, tmp)
 
 	}
 

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -883,7 +883,7 @@ func (zd *ZoneData) SignZone(kdb *KeyDB, force bool) (int, error) {
 		lgSigner.Warn("SignZone: persist max_observed_ttl", "zone", zd.ZoneName, "err", err)
 	}
 	if zd.DnssecPolicy != nil {
-		UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), maxObservedTTL, true, Conf.IsLargeAlgorithm)
+		UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), maxObservedTTL, true, Conf.IsLargeAlgorithm, true)
 	}
 
 	return newrrsigs, nil

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -443,7 +443,7 @@ func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB, zdLocked bool) (*DnssecKe
 		if zd.DnssecPolicy != nil {
 			for _, zsk := range dak.ZSKs {
 				if zsk.DnskeyRR.Flags == 257 {
-					WarnLargeAlgKskReusedAsZsk(zd, zsk.DnskeyRR.Algorithm, Conf.IsLargeAlgorithm)
+					WarnLargeAlgKskReusedAsZsk(zd, zsk.DnskeyRR.Algorithm, Conf.IsLargeAlgorithm, zdLocked)
 					break
 				}
 			}
@@ -534,7 +534,7 @@ func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB, zdLocked bool) (*DnssecKe
 			return nil, fmt.Errorf("EnsureActiveDnssecKeys: failed to generate ZSK for zone %s: %v", zd.ZoneName, err)
 		}
 		lgSigner.Info("generated ZSK", "msg", msg)
-		WarnLargeAlgZoneSigningRole(zd, "ZSK", zd.DnssecPolicy.ZSKAlgorithm, Conf.IsLargeAlgorithm)
+		WarnLargeAlgZoneSigningRole(zd, "ZSK", zd.DnssecPolicy.ZSKAlgorithm, Conf.IsLargeAlgorithm, zdLocked)
 		// Invalidate cache and re-fetch active keys after ZSK generation
 		dak, err = zd.refreshActiveDnssecKeys(kdb, "after ZSK generation")
 		if err != nil {

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -731,6 +731,11 @@ func (zd *ZoneData) StripZoneRRSIGs(ctx context.Context, remove func(*dns.RRSIG)
 				kept = append(kept, sig)
 			}
 			if changed {
+				// GetOnlyRRSet returns an RRset whose RRtype field is unset
+				// (the store keys by type); set it to the actual type so
+				// stageRRsetLocked keys the stripped RRset correctly rather
+				// than under type 0.
+				rrset.RRtype = rrt
 				rrset.RRSIGs = kept
 				zd.stageRRsetLocked(name, rrset)
 			}

--- a/v2/sign_reconcile_test.go
+++ b/v2/sign_reconcile_test.go
@@ -25,6 +25,7 @@ func testZone(t *testing.T, name, zoneStr string) *ZoneData {
 	// Publish the initial snapshot so post-B3 readers (GetOwner etc.) see the
 	// data, mirroring the refresh engine (and testSnapshotZone/newMapZone).
 	zd.InstallInitialSnapshot()
+	t.Cleanup(zd.stopPublisher)
 	return zd
 }
 

--- a/v2/sign_reconcile_test.go
+++ b/v2/sign_reconcile_test.go
@@ -22,6 +22,9 @@ func testZone(t *testing.T, name, zoneStr string) *ZoneData {
 		t.Fatalf("ReadZoneData: %v", err)
 	}
 	zd.Ready = true
+	// Publish the initial snapshot so post-B3 readers (GetOwner etc.) see the
+	// data, mirroring the refresh engine (and testSnapshotZone/newMapZone).
+	zd.InstallInitialSnapshot()
 	return zd
 }
 
@@ -31,13 +34,19 @@ example.		3600	IN	NS	ns.example.
 www.example.		3600	IN	A	192.0.2.1
 `
 	zd := testZone(t, "example.", zone)
+	// Register the zone so StripZoneRRSIGs' publishLocked is not dropped by the
+	// zoneStillLive (registry + generation) guard — in production the zone is
+	// always registered.
+	registerZones(t, zd)
 
-	// Attach two RRSIGs (keytags 1111 and 2222) to the www A RRset.
-	owner, err := zd.GetOwner("www.example.")
-	if err != nil || owner == nil {
-		t.Fatalf("GetOwner www: owner=%v err=%v", owner, err)
+	// Attach two RRSIGs (keytags 1111 and 2222) to the www A RRset via the live
+	// store, then re-publish so the snapshot carries them. Post-B3, GetOwner
+	// returns the immutable snapshot, so it must not be mutated in place.
+	od, ok := zd.Data.Get("www.example.")
+	if !ok {
+		t.Fatal("www owner missing from zd.Data")
 	}
-	rrset := owner.RRtypes.GetOnlyRRSet(dns.TypeA)
+	rrset := od.RRtypes.GetOnlyRRSet(dns.TypeA)
 	mkSig := func(keytag uint16) *dns.RRSIG {
 		return &dns.RRSIG{
 			Hdr:         dns.RR_Header{Name: "www.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
@@ -47,7 +56,8 @@ www.example.		3600	IN	A	192.0.2.1
 		}
 	}
 	rrset.RRSIGs = []dns.RR{mkSig(1111), mkSig(2222)}
-	owner.RRtypes.Set(dns.TypeA, rrset)
+	od.RRtypes.Set(dns.TypeA, rrset)
+	zd.InstallInitialSnapshot()
 
 	// Strip only keytag 1111.
 	removed, err := zd.StripZoneRRSIGs(context.Background(), func(s *dns.RRSIG) bool { return s.KeyTag == 1111 })

--- a/v2/signal_republish_test.go
+++ b/v2/signal_republish_test.go
@@ -41,6 +41,9 @@ func newMapZone(name string, ztype ZoneType, owners map[string][]dns.RR) *ZoneDa
 		}
 		zd.Data.Set(oname, od)
 	}
+	// Publish the initial snapshot so post-cutover readers (GetOwner, etc.) see
+	// the data, mirroring what the refresh engine does for real zones.
+	zd.InstallInitialSnapshot()
 	return zd
 }
 

--- a/v2/signal_republish_test.go
+++ b/v2/signal_republish_test.go
@@ -173,7 +173,16 @@ func drainUpdateQ(q chan UpdateRequest) []UpdateRequest {
 // UpdateQ we can drain.
 func signalTarget(name string, owners map[string][]dns.RR) (*ZoneData, chan UpdateRequest) {
 	q := make(chan UpdateRequest, 16)
-	zd := newMapZone(name, Primary, owners)
+	// A real primary always has an apex SOA; inject one (merged with any
+	// caller-supplied apex records) so InstallInitialSnapshot produces a
+	// servable snapshot — the apex guard refuses apex-less zones.
+	soa, _ := dns.NewRR(name + " 3600 IN SOA ns." + name + " hostmaster." + name + " 1 3600 600 604800 300")
+	ns, _ := dns.NewRR(name + " 3600 IN NS ns." + name)
+	full := map[string][]dns.RR{name: {soa, ns}}
+	for oname, rrs := range owners {
+		full[oname] = append(full[oname], rrs...)
+	}
+	zd := newMapZone(name, Primary, full)
 	zd.KeyDB = &KeyDB{UpdateQ: q}
 	return zd, q
 }

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -173,6 +173,17 @@ type ZoneData struct {
 	ParentDSTTLObserved uint32
 	TransportSignal     *core.RRset // transport signal RRset (SVCB or TSYNC)
 	AddTransportSignal  bool        // whether to attach TransportSignal in responses
+
+	// Zone snapshot publish path (Project B).
+	snapshot          atomic.Pointer[ZoneSnapshot]
+	workingSet        map[string]*OwnerData
+	wsTransportSignal *core.RRset
+	publishCadence    time.Duration
+	publishQueued     bool
+	publishUrgent     bool
+	lastPublish       time.Time
+	publishWake       chan struct{}
+	publisherOnce     sync.Once
 	// RemoteDNSKEYs holds DNSKEY RRs from other signers (multi-signer mode 4).
 	// These are DNSKEYs found in the incoming zone that do not match keys in our
 	// local keystore. They are preserved across resignings and merged into the
@@ -263,6 +274,9 @@ type ZoneConf struct {
 	// add/delete/modify). Persisted so OptApiManagedZone can be re-derived on
 	// reload — a dedicated bool, not a SourceCatalog="api" sentinel.
 	ApiManaged bool `yaml:"apimanaged" mapstructure:"apimanaged"`
+	// PublishCadence is the minimum interval between coalesced snapshot publishes
+	// for this zone (default 5s when unset). RFC 2136 urgent publishes bypass.
+	PublishCadence string `yaml:"publish-cadence" mapstructure:"publish-cadence"`
 	// Provisioning is a display-only derived lifecycle string
 	// ("pending"|"loading"|"ready"|"error") populated by the list handlers from
 	// ZoneStatus + the error registry. Not config; not serialized to YAML.
@@ -270,16 +284,17 @@ type ZoneConf struct {
 }
 
 type TemplateConf struct {
-	Name         string `validate:"required"`
-	Zonefile     string
-	Type         string
-	Store        string
-	Primary      string // upstream, for secondary zones
-	Notify       []string
-	OptionsStrs  []string `yaml:"options" mapstructure:"options"`
-	UpdatePolicy UpdatePolicyConf
-	DnssecPolicy string `yaml:"dnssecpolicy" mapstructure:"dnssecpolicy"`
-	MultiSigner  string `yaml:"multisigner" mapstructure:"multisigner"`
+	Name           string `validate:"required"`
+	Zonefile       string
+	Type           string
+	Store          string
+	Primary        string // upstream, for secondary zones
+	Notify         []string
+	OptionsStrs    []string `yaml:"options" mapstructure:"options"`
+	UpdatePolicy   UpdatePolicyConf
+	DnssecPolicy   string `yaml:"dnssecpolicy" mapstructure:"dnssecpolicy"`
+	MultiSigner    string `yaml:"multisigner" mapstructure:"multisigner"`
+	PublishCadence string `yaml:"publish-cadence" mapstructure:"publish-cadence"`
 }
 
 type UpdatePolicyConf struct {

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -171,21 +171,22 @@ type ZoneData struct {
 	// call. Zero means "not yet observed" — the E10 cache-flush invariant
 	// check defers until either this value or DnssecPolicy.TTLS.ParentDS is set.
 	ParentDSTTLObserved uint32
-	TransportSignal     *core.RRset // transport signal RRset (SVCB or TSYNC)
-	AddTransportSignal  bool        // whether to attach TransportSignal in responses
 
 	// Zone snapshot publish path (Project B).
-	snapshot          atomic.Pointer[zoneSnapshot]
-	workingSet        map[string]*OwnerData
-	wsTransportSignal *core.RRset
-	publishCadence    time.Duration
-	publishQueued     bool
-	publishUrgent     bool
-	lastPublish       time.Time
-	publishWake       chan struct{}
-	publisherOnce     sync.Once
-	publishStop       chan struct{}
-	publishStopOnce   sync.Once
+	snapshot   atomic.Pointer[zoneSnapshot]
+	workingSet map[string]*OwnerData
+	// wsSignalSynth stages the synthesized-transport-signal fallback map for the
+	// next publish (see zoneSnapshot.signalSynth). Seeded from the published
+	// snapshot in ensureWorkingSet so unrelated publishes preserve it.
+	wsSignalSynth   map[string]*core.RRset
+	publishCadence  time.Duration
+	publishQueued   bool
+	publishUrgent   bool
+	lastPublish     time.Time
+	publishWake     chan struct{}
+	publisherOnce   sync.Once
+	publishStop     chan struct{}
+	publishStopOnce sync.Once
 	// RemoteDNSKEYs holds DNSKEY RRs from other signers (multi-signer mode 4).
 	// These are DNSKEYs found in the incoming zone that do not match keys in our
 	// local keystore. They are preserved across resignings and merged into the

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -184,6 +184,8 @@ type ZoneData struct {
 	lastPublish       time.Time
 	publishWake       chan struct{}
 	publisherOnce     sync.Once
+	publishStop       chan struct{}
+	publishStopOnce   sync.Once
 	// RemoteDNSKEYs holds DNSKEY RRs from other signers (multi-signer mode 4).
 	// These are DNSKEYs found in the incoming zone that do not match keys in our
 	// local keystore. They are preserved across resignings and merged into the

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -175,7 +175,7 @@ type ZoneData struct {
 	AddTransportSignal  bool        // whether to attach TransportSignal in responses
 
 	// Zone snapshot publish path (Project B).
-	snapshot          atomic.Pointer[ZoneSnapshot]
+	snapshot          atomic.Pointer[zoneSnapshot]
 	workingSet        map[string]*OwnerData
 	wsTransportSignal *core.RRset
 	publishCadence    time.Duration

--- a/v2/transport_signal_inject_test.go
+++ b/v2/transport_signal_inject_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"testing"
+
+	core "github.com/johanix/tdns/v2/core"
+	edns0 "github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// mapZoneWithSignal builds a ready MapZone whose apex has a single NS and which
+// carries the given _dns.<ns> owner RRs, with add-transport-signal enabled.
+func mapZoneWithSignal(name, nsName string, signalRRs []dns.RR) *ZoneData {
+	owners := map[string][]dns.RR{
+		name: {mustNS(name, nsName)},
+	}
+	if len(signalRRs) > 0 {
+		owners["_dns."+nsName] = signalRRs
+	}
+	zd := newMapZone(name, Primary, owners)
+	zd.Options[OptAddTransportSignal] = true
+	return zd
+}
+
+func mustNS(owner, ns string) dns.RR {
+	rr, err := dns.NewRR(owner + " 3600 IN NS " + ns)
+	if err != nil {
+		panic(err)
+	}
+	return rr
+}
+
+func mustSVCB(t *testing.T, s string) dns.RR {
+	t.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		t.Fatalf("parse SVCB %q: %v", s, err)
+	}
+	return rr
+}
+
+func hasSignal(sigs []core.RRset, owner string) bool {
+	for _, rs := range sigs {
+		if rs.Name == owner {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCollectSignalRRsets_InBailiwick(t *testing.T) {
+	zd := mapZoneWithSignal("example.com.", "ns.example.com.",
+		[]dns.RR{mustSVCB(t, `_dns.ns.example.com. 10800 IN SVCB 1 . alpn="dot"`)})
+	registerZones(t, zd)
+
+	sigs := zd.collectSignalRRsets(zd.publishedSnapshot())
+	if len(sigs) != 1 {
+		t.Fatalf("want 1 signal RRset, got %d: %+v", len(sigs), sigs)
+	}
+	if sigs[0].Name != "_dns.ns.example.com." {
+		t.Fatalf("want owner _dns.ns.example.com., got %q", sigs[0].Name)
+	}
+}
+
+func TestCollectSignalRRsets_AliasChasedCrossZone(t *testing.T) {
+	child := mapZoneWithSignal("example.com.", "ns.example.com.",
+		[]dns.RR{mustSVCB(t, `_dns.ns.example.com. 10800 IN SVCB 0 ns.provider.com.`)})
+	provider := mapZoneWithSignal("provider.com.", "ns.provider.com.",
+		[]dns.RR{mustSVCB(t, `_dns.ns.provider.com. 10800 IN SVCB 1 . alpn="dot"`)})
+	registerZones(t, child, provider)
+
+	sigs := child.collectSignalRRsets(child.publishedSnapshot())
+	if len(sigs) != 2 {
+		t.Fatalf("want alias + chased target (2), got %d: %+v", len(sigs), sigs)
+	}
+	if !hasSignal(sigs, "_dns.ns.example.com.") {
+		t.Errorf("missing local alias signal")
+	}
+	if !hasSignal(sigs, "_dns.ns.provider.com.") {
+		t.Errorf("missing cross-zone target signal")
+	}
+}
+
+func TestCollectSignalRRsets_UnresolvableTargetStillReturnsAlias(t *testing.T) {
+	// provider.com is NOT registered, so the alias target cannot be resolved.
+	child := mapZoneWithSignal("example.com.", "ns.example.com.",
+		[]dns.RR{mustSVCB(t, `_dns.ns.example.com. 10800 IN SVCB 0 ns.provider.com.`)})
+	registerZones(t, child)
+
+	sigs := child.collectSignalRRsets(child.publishedSnapshot())
+	if len(sigs) != 1 {
+		t.Fatalf("want just the alias (1), got %d: %+v", len(sigs), sigs)
+	}
+	if sigs[0].Name != "_dns.ns.example.com." {
+		t.Fatalf("want the alias owner, got %q", sigs[0].Name)
+	}
+}
+
+func TestCollectSignalRRsets_DisabledOption(t *testing.T) {
+	zd := mapZoneWithSignal("example.com.", "ns.example.com.",
+		[]dns.RR{mustSVCB(t, `_dns.ns.example.com. 10800 IN SVCB 1 . alpn="dot"`)})
+	zd.Options[OptAddTransportSignal] = false
+	registerZones(t, zd)
+
+	if sigs := zd.collectSignalRRsets(zd.publishedSnapshot()); len(sigs) != 0 {
+		t.Fatalf("disabled option must yield no signals, got %d", len(sigs))
+	}
+}
+
+func TestAddTransportSignal_DedupAgainstAnswer(t *testing.T) {
+	zd := mapZoneWithSignal("example.com.", "ns.example.com.",
+		[]dns.RR{mustSVCB(t, `_dns.ns.example.com. 10800 IN SVCB 1 . alpn="dot"`)})
+	registerZones(t, zd)
+	sigs := zd.collectSignalRRsets(zd.publishedSnapshot())
+
+	// Simulate a direct query for the signal: it is already in the Answer.
+	m := new(dns.Msg)
+	m.Answer = append(m.Answer, mustSVCB(t, `_dns.ns.example.com. 10800 IN SVCB 1 . alpn="dot"`))
+	if zd.addTransportSignal(m, sigs, &edns0.MsgOptions{}) {
+		t.Fatalf("signal already in Answer must not be re-added to Extra")
+	}
+	if len(m.Extra) != 0 {
+		t.Fatalf("Extra must stay empty, got %d", len(m.Extra))
+	}
+
+	// A plain query (signal not in Answer) should inject it into Extra.
+	m2 := new(dns.Msg)
+	if !zd.addTransportSignal(m2, sigs, &edns0.MsgOptions{}) {
+		t.Fatalf("signal not in Answer must be injected into Extra")
+	}
+	if len(m2.Extra) != 1 {
+		t.Fatalf("want 1 injected RR, got %d", len(m2.Extra))
+	}
+}

--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -56,6 +56,16 @@ func matchesConfiguredAddrs(hostports []string, rrset *core.RRset) bool {
 // for this zone. It delegates to the chosen mechanism (svcb|tsync) and assigns
 // zd.TransportSignal and zd.AddTransportSignal when successful.
 func (zd *ZoneData) CreateTransportSignalRRs(conf *Config) error {
+	// Resolve DNSSEC keys BEFORE taking zd.mu: signing the transport signal with
+	// a nil dak can reach PublishDnskeyRRs, which locks zd.mu, so signing under
+	// the lock with an unresolved dak self-deadlocks during key bootstrap.
+	var dak *DnssecKeys
+	if zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning] {
+		var err error
+		if dak, err = zd.EnsureActiveDnssecKeys(zd.KeyDB); err != nil {
+			return err
+		}
+	}
 	zd.mu.Lock()
 	defer zd.mu.Unlock()
 	zd.ensureWorkingSet()
@@ -66,9 +76,9 @@ func (zd *ZoneData) CreateTransportSignalRRs(conf *Config) error {
 			"zone", zd.ZoneName)
 		return nil
 	case "svcb":
-		return zd.createTransportSignalSVCB(conf)
+		return zd.createTransportSignalSVCB(conf, dak)
 	case "tsync":
-		return zd.createTransportSignalTSYNC(conf)
+		return zd.createTransportSignalTSYNC(conf, dak)
 	default:
 		lgDns.Debug("CreateTransportSignalRRs: unknown transport type, skipping",
 			"type", conf.Service.Transport.Type,
@@ -90,7 +100,7 @@ func (zd *ZoneData) commitTransportSignalLocked(nsOwner string, rrset core.RRset
 }
 
 // SVCB path
-func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
+func (zd *ZoneData) createTransportSignalSVCB(conf *Config, dak *DnssecKeys) error {
 	apex := zd.stagedOwner(zd.ZoneName)
 	if apex == nil {
 		return fmt.Errorf("zone apex not found")
@@ -319,7 +329,7 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 						"ns", nsName)
 					lgDns.Debug("CreateTransportSignalRRs(SVCB): SVCB", "svcb", tmp.String())
 
-					if _, err := zd.SignRRset(zd.TransportSignal, "", nil, false, nil); err != nil {
+					if _, err := zd.SignRRset(zd.TransportSignal, "", dak, false, nil); err != nil {
 						lgDns.Debug("CreateTransportSignalRRs(SVCB): error signing SVCB", "owner", "_dns."+nsName, "err", err)
 					}
 					// Add into zone data
@@ -340,7 +350,7 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 }
 
 // TSYNC path
-func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
+func (zd *ZoneData) createTransportSignalTSYNC(conf *Config, dak *DnssecKeys) error {
 	apex := zd.stagedOwner(zd.ZoneName)
 	if apex == nil {
 		return fmt.Errorf("zone apex not found")
@@ -455,7 +465,7 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
 					"ns", nsName,
 					"rr", trr.String())
 				// Sign TSYNC if online signing is enabled; QueryResponder will include RRSIGs when present
-				if _, err := zd.SignRRset(zd.TransportSignal, "", nil, false, nil); err != nil {
+				if _, err := zd.SignRRset(zd.TransportSignal, "", dak, false, nil); err != nil {
 					lgDns.Debug("createTransportSignalTSYNC: error signing TSYNC", "owner", "_dns."+nsName, "err", err)
 				}
 				return nil

--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -268,7 +268,9 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config, dak *DnssecKeys) err
 		// _dns.<ns> owner RRset (replacing any prior synthesized server SVCB),
 		// so it is directly queryable and injected from the stored copy.
 		if _, err := zd.SignRRset(stored, "", dak, false, nil); err != nil {
-			lgDns.Debug("createTransportSignalSVCB: error signing SVCB", "owner", ownerName, "err", err)
+			lgDns.Error("createTransportSignalSVCB: error signing SVCB; not staging unsigned signal",
+				"owner", ownerName, "err", err)
+			return fmt.Errorf("createTransportSignalSVCB: failed to sign SVCB for %q: %w", ownerName, err)
 		}
 		lgDns.Debug("createTransportSignalSVCB: stored synthesized server SVCB",
 			"zone", zd.ZoneName, "ns", nsName, "owner", ownerName)
@@ -344,7 +346,9 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config, dak *DnssecKeys) er
 		// Sign BEFORE staging (fixes the prior sign-after-commit ordering that
 		// froze an unsigned TSYNC into the snapshot).
 		if _, err := zd.SignRRset(&stored, "", dak, false, nil); err != nil {
-			lgDns.Debug("createTransportSignalTSYNC: error signing TSYNC", "owner", ownerName, "err", err)
+			lgDns.Error("createTransportSignalTSYNC: error signing TSYNC; not staging unsigned signal",
+				"owner", ownerName, "err", err)
+			return fmt.Errorf("createTransportSignalTSYNC: failed to sign TSYNC for %q: %w", ownerName, err)
 		}
 		lgDns.Debug("createTransportSignalTSYNC: stored synthesized TSYNC",
 			"zone", zd.ZoneName, "ns", nsName, "owner", ownerName, "rr", trr.String())

--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -56,6 +56,10 @@ func matchesConfiguredAddrs(hostports []string, rrset *core.RRset) bool {
 // for this zone. It delegates to the chosen mechanism (svcb|tsync) and assigns
 // zd.TransportSignal and zd.AddTransportSignal when successful.
 func (zd *ZoneData) CreateTransportSignalRRs(conf *Config) error {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.ensureWorkingSet()
+
 	switch conf.Service.Transport.Type {
 	case "none", "":
 		lgDns.Debug("CreateTransportSignalRRs: service.transport.type=none; skipping transport signal synthesis for zone",
@@ -71,6 +75,18 @@ func (zd *ZoneData) CreateTransportSignalRRs(conf *Config) error {
 			"zone", zd.ZoneName)
 		return nil
 	}
+}
+
+func (zd *ZoneData) commitTransportSignalLocked(nsOwner string, rrset core.RRset, signal *core.RRset) {
+	if nsOwner != "" && len(rrset.RRs) > 0 {
+		zd.stageRRsetLocked(nsOwner, rrset)
+	}
+	if signal != nil {
+		zd.TransportSignal = signal
+		zd.wsTransportSignal = cloneTransportSignal(signal)
+		zd.AddTransportSignal = true
+	}
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
 }
 
 // SVCB path
@@ -136,6 +152,7 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 					"zone", zd.ZoneName,
 					"ns", nsName)
 				lgDns.Debug("CreateTransportSignalRRs(SVCB): SVCB", "svcb", tmp.String())
+				zd.commitTransportSignalLocked("", core.RRset{}, zd.TransportSignal)
 				return nil
 			}
 		}
@@ -195,6 +212,7 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 							lgDns.Debug("CreateTransportSignalRRs(SVCB): using existing SVCB",
 								"owner", ownerName,
 								"zone", zd.ZoneName)
+							zd.commitTransportSignalLocked("", core.RRset{}, zd.TransportSignal)
 							return nil
 						}
 					}
@@ -303,12 +321,14 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 					}
 					// Add into zone data
 					serversvcbs := nsData.RRtypes.GetOnlyRRSet(dns.TypeSVCB)
+					var staged core.RRset
 					if len(serversvcbs.RRs) == 0 {
-						nsData.RRtypes.Set(dns.TypeSVCB, core.RRset{RRs: []dns.RR{tmp}})
+						staged = core.RRset{RRtype: dns.TypeSVCB, RRs: []dns.RR{tmp}}
 					} else {
-						nsData.RRtypes.Set(dns.TypeSVCB, core.RRset{RRs: append(serversvcbs.RRs, tmp)})
+						staged = core.RRset{RRtype: dns.TypeSVCB, RRs: append(serversvcbs.RRs, tmp)}
 						lgDns.Debug("CreateTransportSignalRRs(SVCB): added server SVCB to existing SVCB RRset", "ns", nsName)
 					}
+					zd.commitTransportSignalLocked(nsName, staged, zd.TransportSignal)
 					return nil
 				}
 			}
@@ -382,6 +402,7 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
 							"owner", ownerName,
 							"alias", alias,
 							"ns", nsName)
+						zd.commitTransportSignalLocked("", core.RRset{}, zd.TransportSignal)
 						return nil
 					}
 				}
@@ -416,13 +437,14 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
 				}
 				// Store in zone data
 				existing := nsData.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
+				var staged core.RRset
 				if len(existing.RRs) == 0 {
-					nsData.RRtypes.Set(core.TypeTSYNC, core.RRset{RRs: []dns.RR{trr}})
+					staged = core.RRset{RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
 				} else {
-					nsData.RRtypes.Set(core.TypeTSYNC, core.RRset{RRs: append(existing.RRs, trr)})
+					staged = core.RRset{RRtype: core.TypeTSYNC, RRs: append(existing.RRs, trr)}
 				}
-				zd.TransportSignal = &core.RRset{Name: "_dns." + nsName, RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
-				zd.AddTransportSignal = true
+				signal := &core.RRset{Name: "_dns." + nsName, RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
+				zd.commitTransportSignalLocked(nsName, staged, signal)
 				lgDns.Debug("createTransportSignalTSYNC: added TSYNC for in-bailiwick NS",
 					"zone", zd.ZoneName,
 					"ns", nsName,

--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -53,8 +53,12 @@ func matchesConfiguredAddrs(hostports []string, rrset *core.RRset) bool {
 }
 
 // CreateTransportSignalRRs orchestrates construction of a transport signal RRset
-// for this zone. It delegates to the chosen mechanism (svcb|tsync) and assigns
-// zd.TransportSignal and zd.AddTransportSignal when successful.
+// for this zone. It delegates to the chosen mechanism (svcb|tsync). In-bailiwick
+// signals are synthesized, SIGNED, and stored as real "_dns.<ns>" owner RRsets
+// (the resigner keeps their signatures fresh); they are served on direct query
+// and injected opportunistically at query time. The only materialized state is
+// the per-snapshot signalSynth fallback for an out-of-bailiwick identity NS whose
+// own zone this server does not host (Case A).
 func (zd *ZoneData) CreateTransportSignalRRs(conf *Config) error {
 	// Resolve DNSSEC keys BEFORE taking zd.mu: signing the transport signal with
 	// a nil dak can reach PublishDnskeyRRs, which locks zd.mu, so signing under
@@ -87,19 +91,97 @@ func (zd *ZoneData) CreateTransportSignalRRs(conf *Config) error {
 	}
 }
 
-func (zd *ZoneData) commitTransportSignalLocked(nsOwner string, rrset core.RRset, signal *core.RRset) {
-	if nsOwner != "" && len(rrset.RRs) > 0 {
-		zd.stageRRsetLocked(nsOwner, rrset)
+// commitTransportSignalLocked stages a signal owner RRset and/or records a
+// synthesized fallback, then publishes.
+//
+//	storedOwner: "_dns.<ns>" owner to stage `stored` under ("" stages nothing)
+//	stored:      the already-signed SVCB/TSYNC RRset for storedOwner
+//	synthName:   "_dns.<ns>" name for a synthesized fallback signal ("" = none)
+//	synth:       the synthesized (unsigned) RRset for synthName (Case A only)
+func (zd *ZoneData) commitTransportSignalLocked(storedOwner string, stored core.RRset, synthName string, synth *core.RRset) {
+	if storedOwner != "" && len(stored.RRs) > 0 {
+		zd.stageRRsetLocked(storedOwner, stored)
 	}
-	if signal != nil {
-		zd.TransportSignal = signal
-		zd.wsTransportSignal = cloneTransportSignal(signal)
-		zd.AddTransportSignal = true
+	if synthName != "" && synth != nil {
+		if zd.wsSignalSynth == nil {
+			zd.wsSignalSynth = map[string]*core.RRset{}
+		}
+		zd.wsSignalSynth[synthName] = synth
 	}
 	zd.publishWorkingSetLocked(zd.generation.Load(), false)
 }
 
-// SVCB path
+// svcbHasAlias reports whether the RRset contains an AliasMode SVCB (non-terminal
+// Target) — i.e. an operator-authored bridge rather than a synthesized server SVCB.
+func svcbHasAlias(rrset core.RRset) bool {
+	for _, rr := range rrset.RRs {
+		if svcb, ok := rr.(*dns.SVCB); ok {
+			if svcb.Target != "." && svcb.Target != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// tsyncHasAlias reports whether the RRset contains an aliased TSYNC — an
+// operator-authored bridge to another nameserver's signal.
+func tsyncHasAlias(rrset core.RRset) bool {
+	for _, rr := range rrset.RRs {
+		if prr, ok := rr.(*dns.PrivateRR); ok {
+			if ts, ok2 := prr.Data.(*core.TSYNC); ok2 && ts != nil && ts.Alias != "" && ts.Alias != "." {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// buildServerSVCB constructs a synthesized ServiceMode "_dns.<ns> SVCB" RRset from
+// the server's configured SVCB parameters, optional address hints, the transport
+// signal, and a DANE-EE TLSA for the server certificate.
+func (zd *ZoneData) buildServerSVCB(conf *Config, nsName string, ipv4s, ipv6s []net.IP) (*core.RRset, error) {
+	if Globals.ServerSVCB == nil {
+		return nil, fmt.Errorf("buildServerSVCB: no server SVCB configured")
+	}
+	values := append([]dns.SVCBKeyValue(nil), Globals.ServerSVCB.Value...)
+	if len(ipv4s) > 0 {
+		values = append(values, &dns.SVCBIPv4Hint{Hint: ipv4s})
+	}
+	if len(ipv6s) > 0 {
+		values = append(values, &dns.SVCBIPv6Hint{Hint: ipv6s})
+	}
+	if sig := conf.Service.Transport.Signal; sig != "" {
+		values = append(values, &dns.SVCBLocal{KeyCode: dns.SVCBKey(SvcbTransportKey), Data: []byte(sig)})
+	}
+	certData, err := parseCertificate(conf.Internal.CertData)
+	if err != nil {
+		return nil, fmt.Errorf("buildServerSVCB: failed to parse certificate: %v", err)
+	}
+	tlsaRR := dns.TLSA{
+		Hdr:          dns.RR_Header{Name: "_443._tcp." + nsName, Rrtype: dns.TypeTLSA, Class: dns.ClassINET, Ttl: 10800},
+		Usage:        3, // DANE-EE
+		Selector:     1, // SPKI
+		MatchingType: 1, // SHA-256
+		Certificate:  certData,
+	}
+	tlsastr, err := MarshalTLSAToString(&tlsaRR)
+	if err != nil {
+		return nil, fmt.Errorf("buildServerSVCB: failed to marshal TLSA: %v", err)
+	}
+	values = append(values, &dns.SVCBLocal{KeyCode: dns.SVCBKey(SvcbTLSAKey), Data: []byte(tlsastr)})
+
+	owner := "_dns." + nsName
+	svcb := &dns.SVCB{
+		Hdr:      dns.RR_Header{Name: owner, Rrtype: dns.TypeSVCB, Class: dns.ClassINET, Ttl: 10800},
+		Priority: 1,
+		Target:   ".",
+		Value:    values,
+	}
+	return &core.RRset{Name: owner, RRtype: dns.TypeSVCB, RRs: []dns.RR{svcb}}, nil
+}
+
+// SVCB path. See CreateTransportSignalRRs for the storage/injection model.
 func (zd *ZoneData) createTransportSignalSVCB(conf *Config, dak *DnssecKeys) error {
 	apex := zd.stagedOwner(zd.ZoneName)
 	if apex == nil {
@@ -110,246 +192,93 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config, dak *DnssecKeys) err
 		return fmt.Errorf("no NS records found at zone apex")
 	}
 
-	// Identity NS short-circuit (out-of-bailiwick identity)
 	for _, rr := range nsRRset.RRs {
-		if ns, ok := rr.(*dns.NS); ok {
-			nsName := ns.Ns
-			lgDns.Debug("CreateTransportSignalRRs(SVCB): checking NS", "zone", zd.ZoneName, "ns", nsName)
-			if Globals.ServerSVCB != nil {
-				lgDns.Debug("CreateTransportSignalRRs(SVCB): server SVCB configured", "svcb", Globals.ServerSVCB.String())
+		ns, ok := rr.(*dns.NS)
+		if !ok {
+			continue
+		}
+		nsName := ns.Ns
+		ownerName := "_dns." + nsName
+
+		if !dns.IsSubDomain(zd.ZoneName, nsName) {
+			// Out-of-bailiwick nameserver. Only advertise a signal for one of
+			// THIS server's own identities (Case A). If we also host the
+			// nameserver's own zone, its authoritative _dns.<ns> signal is
+			// injected directly at query time via FindZone — nothing to store
+			// here. Otherwise synthesize an (unsigned) fallback hint from the
+			// server's SVCB config; it can never be a signed owner RRset in this
+			// zone because _dns.<ns> is out of bailiwick.
+			if !CaseFoldContains(conf.Service.Identities, nsName) || Globals.ServerSVCB == nil {
+				continue
 			}
-			if CaseFoldContains(conf.Service.Identities, nsName) {
-				if strings.HasSuffix(nsName, zd.ZoneName) {
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): NS is in-bailiwick, skipping identity path", "zone", zd.ZoneName, "ns", nsName)
-					continue // in-bailiwick; handled below
-				}
-				if Globals.ServerSVCB == nil {
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): no server SVCB configured, skipping identity NS", "ns", nsName)
-					continue
-				}
-				values := append([]dns.SVCBKeyValue(nil), Globals.ServerSVCB.Value...)
-				if sig := conf.Service.Transport.Signal; sig != "" {
-					values = append(values, &dns.SVCBLocal{KeyCode: dns.SVCBKey(SvcbTransportKey), Data: []byte(sig)})
-				}
+			if tz, _ := FindZone(ownerName); tz != nil {
+				lgDns.Debug("createTransportSignalSVCB: identity NS zone is co-hosted; will inject its authoritative signal",
+					"zone", zd.ZoneName, "ns", nsName)
+				return nil
+			}
+			synth, err := zd.buildServerSVCB(conf, nsName, nil, nil)
+			if err != nil {
+				return err
+			}
+			lgDns.Debug("createTransportSignalSVCB: synthesized fallback signal for out-of-bailiwick identity NS",
+				"zone", zd.ZoneName, "ns", nsName, "owner", ownerName)
+			zd.commitTransportSignalLocked("", core.RRset{}, ownerName, synth)
+			return nil
+		}
 
-				certData, err := parseCertificate(conf.Internal.CertData)
-				if err != nil {
-					return fmt.Errorf("CreateTransportSignalRRs(SVCB): failed to parse certificate: %v", err)
-				} else {
-					tlsaRR := dns.TLSA{
-						Hdr:          dns.RR_Header{Name: "_443._tcp." + nsName, Rrtype: dns.TypeTLSA, Class: dns.ClassINET, Ttl: 10800},
-						Usage:        3, // DANE-EE
-						Selector:     1, // SPKI
-						MatchingType: 1, // SHA-256
-						Certificate:  certData,
-					}
-					tlsastr, err := MarshalTLSAToString(&tlsaRR)
-					if err != nil {
-						return fmt.Errorf("CreateTransportSignalRRs(SVCB): failed to marshal TLSA: %v", err)
-					}
-					values = append(values, &dns.SVCBLocal{KeyCode: dns.SVCBKey(SvcbTLSAKey), Data: []byte(tlsastr)})
-				}
-
-				tmp := &dns.SVCB{
-					Hdr:      dns.RR_Header{Name: "_dns." + nsName, Rrtype: dns.TypeSVCB, Class: dns.ClassINET, Ttl: 10800},
-					Priority: 1,
-					Target:   ".",
-					Value:    values,
-				}
-				zd.TransportSignal = &core.RRset{Name: "_dns." + nsName, RRtype: dns.TypeSVCB, RRs: []dns.RR{tmp}}
-				zd.AddTransportSignal = true
-				lgDns.Debug("CreateTransportSignalRRs(SVCB): Adding server SVCB to zone using identity NS",
-					"zone", zd.ZoneName,
-					"ns", nsName)
-				lgDns.Debug("CreateTransportSignalRRs(SVCB): SVCB", "svcb", tmp.String())
-				zd.commitTransportSignalLocked("", core.RRset{}, zd.TransportSignal)
+		// In-bailiwick nameserver.
+		nsData := zd.stagedOwner(nsName)
+		if nsData == nil {
+			continue
+		}
+		// An operator-authored AliasMode SVCB at _dns.<ns> is a bridge to another
+		// nameserver's signal — leave it untouched; it is served on direct query
+		// and its target is chased at injection time.
+		if ownerData := zd.stagedOwner(ownerName); ownerData != nil {
+			if svcbHasAlias(ownerData.RRtypes.GetOnlyRRSet(dns.TypeSVCB)) {
+				lgDns.Debug("createTransportSignalSVCB: keeping operator SVCB alias", "owner", ownerName, "zone", zd.ZoneName)
 				return nil
 			}
 		}
-	}
 
-	// In-bailiwick NS path
-	for _, rr := range nsRRset.RRs {
-		if ns, ok := rr.(*dns.NS); ok {
-			nsName := ns.Ns
-			if !dns.IsSubDomain(zd.ZoneName, nsName) {
-				lgDns.Debug("CreateTransportSignalRRs(SVCB): NS is out-of-bailiwick, skipping",
-					"zone", zd.ZoneName,
-					"ns", nsName)
-				continue
-			}
-			nsData := zd.stagedOwner(nsName)
-			if nsData == nil {
-				continue
-			}
-				ownerName := "_dns." + nsName
-				ownerData := zd.stagedOwner(ownerName)
-				if ownerData != nil {
-					existingSvcb := ownerData.RRtypes.GetOnlyRRSet(dns.TypeSVCB)
-					if len(existingSvcb.RRs) > 0 {
-						valid := true
-						for _, rr := range existingSvcb.RRs {
-							if svcb, ok := rr.(*dns.SVCB); ok {
-								if err := ValidateExplicitServerSVCB(svcb); err != nil {
-									lgDns.Debug("CreateTransportSignalRRs(SVCB): rejecting explicit SVCB", "owner", ownerName, "err", err)
-									valid = false
-									break
-								}
-							}
-						}
-						if valid {
-							// Start with the explicit SVCB RRset
-							zd.TransportSignal = &core.RRset{Name: ownerName, RRtype: dns.TypeSVCB, RRs: append([]dns.RR(nil), existingSvcb.RRs...), RRSIGs: append([]dns.RR(nil), existingSvcb.RRSIGs...)}
-
-							// If any SVCB has a non-terminal Target (not "."), attempt to include the target SVCB as well.
-							// This mirrors the TSYNC alias behavior so clients get both the original and the target.
-							for _, rr := range existingSvcb.RRs {
-								if svcb, ok := rr.(*dns.SVCB); ok {
-									if svcb.Target != "." && svcb.Target != "" {
-										if bestZD, _ := FindZone(svcb.Target); bestZD != nil {
-											targetOwner := "_dns." + svcb.Target
-								if tOwner, err := bestZD.GetOwner(targetOwner); err == nil && tOwner != nil {
-									targetRRset := tOwner.RRtypes.GetOnlyRRSet(dns.TypeSVCB)
-												if len(targetRRset.RRs) > 0 {
-													zd.TransportSignal.RRs = append(zd.TransportSignal.RRs, targetRRset.RRs...)
-													if len(targetRRset.RRSIGs) > 0 {
-														zd.TransportSignal.RRSIGs = append(zd.TransportSignal.RRSIGs, targetRRset.RRSIGs...)
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							zd.AddTransportSignal = true
-							lgDns.Debug("CreateTransportSignalRRs(SVCB): using existing SVCB",
-								"owner", ownerName,
-								"zone", zd.ZoneName)
-							zd.commitTransportSignalLocked("", core.RRset{}, zd.TransportSignal)
-							return nil
-						}
-					}
-				}
-
-				// Collect A/AAAA
-				aRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeA)
-				aaaaRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeAAAA)
-				var ipv4s []net.IP
-				var ipv6s []net.IP
-				if aRRset.RRs != nil {
-					for _, rr := range aRRset.RRs {
-						if a, ok := rr.(*dns.A); ok {
-							ipv4s = append(ipv4s, a.A)
-						}
-					}
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): found A records for in-bailiwick NS",
-						"zone", zd.ZoneName,
-						"count", len(ipv4s),
-						"ns", nsName,
-						"addrs", ipv4s)
-				}
-				if aaaaRRset.RRs != nil {
-					for _, rr := range aaaaRRset.RRs {
-						if aaaa, ok := rr.(*dns.AAAA); ok {
-							ipv6s = append(ipv6s, aaaa.AAAA)
-						}
-					}
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): found AAAA records for in-bailiwick NS",
-						"zone", zd.ZoneName,
-						"count", len(ipv6s),
-						"ns", nsName,
-						"addrs", ipv6s)
-				}
-
-				// If any address matches configured addresses, publish SVCB
-				if !matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aRRset) && !matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aaaaRRset) {
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): no addresses match configured for in-bailiwick NS",
-						"zone", zd.ZoneName,
-						"ns", nsName)
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): configured addresses",
-						"zone", zd.ZoneName,
-						"addresses", conf.DnsEngine.Addresses)
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): A RRset", "zone", zd.ZoneName, "rrset", aRRset.RRs)
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): AAAA RRset", "zone", zd.ZoneName, "rrset", aaaaRRset.RRs)
-					continue
-				} else {
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): addresses match configured for in-bailiwick NS",
-						"zone", zd.ZoneName,
-						"ns", nsName,
-						"a_rrs", aRRset.RRs,
-						"aaaa_rrs", aaaaRRset.RRs)
-					values := append([]dns.SVCBKeyValue(nil), Globals.ServerSVCB.Value...)
-					if len(ipv4s) > 0 {
-						values = append(values, &dns.SVCBIPv4Hint{Hint: ipv4s})
-					}
-					if len(ipv6s) > 0 {
-						values = append(values, &dns.SVCBIPv6Hint{Hint: ipv6s})
-					}
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): added IP hints for in-bailiwick NS",
-						"zone", zd.ZoneName,
-						"ipv4hints", ipv4s,
-						"ipv6hints", ipv6s,
-						"ns", nsName)
-					if sig := conf.Service.Transport.Signal; sig != "" {
-						lgDns.Debug("CreateTransportSignalRRs(SVCB): adding transport signal for in-bailiwick NS",
-							"zone", zd.ZoneName,
-							"signal", sig,
-							"ns", nsName)
-						values = append(values, &dns.SVCBLocal{KeyCode: dns.SVCBKey(SvcbTransportKey), Data: []byte(sig)})
-					}
-
-					certData, err := parseCertificate(conf.Internal.CertData)
-					if err != nil {
-						return fmt.Errorf("CreateTransportSignalRRs(SVCB): failed to parse certificate: %v", err)
-					} else {
-						tlsaRR := dns.TLSA{
-							Hdr:          dns.RR_Header{Name: "_443._tcp." + nsName, Rrtype: dns.TypeTLSA, Class: dns.ClassINET, Ttl: 10800},
-							Usage:        3, // DANE-EE
-							Selector:     1, // SPKI
-							MatchingType: 1, // SHA-256
-							Certificate:  certData,
-						}
-						tlsastr, err := MarshalTLSAToString(&tlsaRR)
-						if err != nil {
-							return fmt.Errorf("CreateTransportSignalRRs(SVCB): failed to marshal TLSA: %v", err)
-						}
-						values = append(values, &dns.SVCBLocal{KeyCode: dns.SVCBKey(SvcbTLSAKey), Data: []byte(tlsastr)})
-					}
-
-					tmp := &dns.SVCB{
-						Hdr:      dns.RR_Header{Name: "_dns." + nsName, Rrtype: dns.TypeSVCB, Class: dns.ClassINET, Ttl: 10800},
-						Priority: 1,
-						Target:   ".",
-						Value:    values,
-					}
-					zd.TransportSignal = &core.RRset{Name: "_dns." + nsName, RRtype: dns.TypeSVCB, RRs: []dns.RR{tmp}}
-					zd.AddTransportSignal = true
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): Adding server SVCB to zone using in-bailiwick NS",
-						"zone", zd.ZoneName,
-						"ns", nsName)
-					lgDns.Debug("CreateTransportSignalRRs(SVCB): SVCB", "svcb", tmp.String())
-
-					if _, err := zd.SignRRset(zd.TransportSignal, "", dak, false, nil); err != nil {
-						lgDns.Debug("CreateTransportSignalRRs(SVCB): error signing SVCB", "owner", "_dns."+nsName, "err", err)
-					}
-					// Add into zone data
-					serversvcbs := nsData.RRtypes.GetOnlyRRSet(dns.TypeSVCB)
-					var staged core.RRset
-					if len(serversvcbs.RRs) == 0 {
-						staged = core.RRset{RRtype: dns.TypeSVCB, RRs: []dns.RR{tmp}}
-					} else {
-						staged = core.RRset{RRtype: dns.TypeSVCB, RRs: append(serversvcbs.RRs, tmp)}
-						lgDns.Debug("CreateTransportSignalRRs(SVCB): added server SVCB to existing SVCB RRset", "ns", nsName)
-					}
-					zd.commitTransportSignalLocked(nsName, staged, zd.TransportSignal)
-					return nil
-				}
+		aRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeA)
+		aaaaRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeAAAA)
+		if !matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aRRset) && !matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aaaaRRset) {
+			lgDns.Debug("createTransportSignalSVCB: NS addresses do not match configured; skipping",
+				"zone", zd.ZoneName, "ns", nsName)
+			continue
+		}
+		var ipv4s, ipv6s []net.IP
+		for _, rr := range aRRset.RRs {
+			if a, ok := rr.(*dns.A); ok {
+				ipv4s = append(ipv4s, a.A)
 			}
 		}
+		for _, rr := range aaaaRRset.RRs {
+			if aaaa, ok := rr.(*dns.AAAA); ok {
+				ipv6s = append(ipv6s, aaaa.AAAA)
+			}
+		}
+		stored, err := zd.buildServerSVCB(conf, nsName, ipv4s, ipv6s)
+		if err != nil {
+			return err
+		}
+		// Sign BEFORE staging so the snapshot freezes a signed signal; the
+		// resigner keeps its signature fresh thereafter. Store as a real
+		// _dns.<ns> owner RRset (replacing any prior synthesized server SVCB),
+		// so it is directly queryable and injected from the stored copy.
+		if _, err := zd.SignRRset(stored, "", dak, false, nil); err != nil {
+			lgDns.Debug("createTransportSignalSVCB: error signing SVCB", "owner", ownerName, "err", err)
+		}
+		lgDns.Debug("createTransportSignalSVCB: stored synthesized server SVCB",
+			"zone", zd.ZoneName, "ns", nsName, "owner", ownerName)
+		zd.commitTransportSignalLocked(ownerName, *stored, "", nil)
+		return nil
+	}
 	return nil
 }
 
-// TSYNC path
+// TSYNC path. See CreateTransportSignalRRs for the storage/injection model.
 func (zd *ZoneData) createTransportSignalTSYNC(conf *Config, dak *DnssecKeys) error {
 	apex := zd.stagedOwner(zd.ZoneName)
 	if apex == nil {
@@ -360,116 +289,67 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config, dak *DnssecKeys) er
 		return fmt.Errorf("no NS records found at zone apex")
 	}
 
-	// TSYNC: we only synthesize for in-bailiwick
+	// TSYNC is only synthesized for in-bailiwick nameservers.
 	for _, rr := range nsRRset.RRs {
-		if ns, ok := rr.(*dns.NS); ok {
-			nsName := ns.Ns
-			if !dns.IsSubDomain(zd.ZoneName, nsName) {
-				continue
-			}
-			nsData := zd.stagedOwner(nsName)
-			if nsData == nil {
-				continue
-			}
-			ownerName := "_dns." + nsName
-			ownerData := zd.stagedOwner(ownerName)
-			if ownerData != nil {
-				existingTS := ownerData.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
-					if len(existingTS.RRs) > 0 {
-						// Base RRset is the explicit TSYNC
-						zd.TransportSignal = &core.RRset{Name: ownerName, RRtype: core.TypeTSYNC, RRs: append([]dns.RR(nil), existingTS.RRs...)}
-						zd.AddTransportSignal = true
-						// Check for alias indirection
-						alias := "."
-						if prr, ok := existingTS.RRs[0].(*dns.PrivateRR); ok {
-							if ts, ok2 := prr.Data.(*core.TSYNC); ok2 && ts != nil && ts.Alias != "" {
-								alias = ts.Alias
-							}
-						}
-						if alias != "." {
-							lgDns.Debug("createTransportSignalTSYNC: looking up zone for TSYNC alias target",
-								"owner", ownerName,
-								"target", alias)
-							// Resolve alias target to the closest enclosing zone we serve.
-							if bestZD, _ := FindZone(alias); bestZD != nil {
-								targetOwner := "_dns." + alias
-								lgDns.Debug("createTransportSignalTSYNC: resolved TSYNC alias target",
-									"owner", ownerName,
-									"targetowner", targetOwner)
-								if tOwner, err := bestZD.GetOwner(targetOwner); err == nil && tOwner != nil {
-									targetTS := tOwner.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
-									lgDns.Debug("createTransportSignalTSYNC: found TSYNC RRs at target", "count", len(targetTS.RRs), "target", targetOwner)
-									if len(targetTS.RRs) > 0 {
-										zd.TransportSignal.RRs = append(zd.TransportSignal.RRs, targetTS.RRs...)
-										// also carry over RRSIGs for Additional section symmetry
-										if len(targetTS.RRSIGs) > 0 {
-											zd.TransportSignal.RRSIGs = append(zd.TransportSignal.RRSIGs, targetTS.RRSIGs...)
-										}
-									}
-								} else {
-									lgDns.Debug("createTransportSignalTSYNC: no TSYNC RRset data found for target", "target", targetOwner)
-								}
-							} else {
-								lgDns.Debug("createTransportSignalTSYNC: no zone found for TSYNC target", "target", "_dns."+alias)
-							}
-						}
-						lgDns.Debug("createTransportSignalTSYNC: using existing TSYNC for in-bailiwick NS",
-							"owner", ownerName,
-							"alias", alias,
-							"ns", nsName)
-						zd.commitTransportSignalLocked("", core.RRset{}, zd.TransportSignal)
-						return nil
-					}
-				}
-				aRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeA)
-				aaaaRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeAAAA)
-				// Only synthesize TSYNC for nameservers whose address matches configured addresses
-				if !(matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aRRset) || matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aaaaRRset)) {
-					continue
-				}
-				var ipv4s []string
-				var ipv6s []string
-				for _, rr := range aRRset.RRs {
-					if a, ok := rr.(*dns.A); ok {
-						ipv4s = append(ipv4s, a.A.String())
-					}
-				}
-				for _, rr := range aaaaRRset.RRs {
-					if aaaa, ok := rr.(*dns.AAAA); ok {
-						ipv6s = append(ipv6s, aaaa.AAAA.String())
-					}
-				}
-				tsyncStr := fmt.Sprintf("_dns.%s 10800 IN TSYNC . %q %q %q",
-					nsName,
-					fmt.Sprintf("transport=%s", conf.Service.Transport.Signal),
-					fmt.Sprintf("v4=%s", strings.Join(ipv4s, ",")),
-					fmt.Sprintf("v6=%s", strings.Join(ipv6s, ",")),
-				)
-				trr, err := dns.NewRR(tsyncStr)
-				if err != nil {
-					lgDns.Error("createTransportSignalTSYNC: failed to build TSYNC", "err", err)
-					continue
-				}
-				// Store in zone data
-				existing := nsData.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
-				var staged core.RRset
-				if len(existing.RRs) == 0 {
-					staged = core.RRset{RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
-				} else {
-					staged = core.RRset{RRtype: core.TypeTSYNC, RRs: append(existing.RRs, trr)}
-				}
-				signal := &core.RRset{Name: "_dns." + nsName, RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
-				zd.commitTransportSignalLocked(nsName, staged, signal)
-				lgDns.Debug("createTransportSignalTSYNC: added TSYNC for in-bailiwick NS",
-					"zone", zd.ZoneName,
-					"ns", nsName,
-					"rr", trr.String())
-				// Sign TSYNC if online signing is enabled; QueryResponder will include RRSIGs when present
-				if _, err := zd.SignRRset(zd.TransportSignal, "", dak, false, nil); err != nil {
-					lgDns.Debug("createTransportSignalTSYNC: error signing TSYNC", "owner", "_dns."+nsName, "err", err)
-				}
+		ns, ok := rr.(*dns.NS)
+		if !ok {
+			continue
+		}
+		nsName := ns.Ns
+		ownerName := "_dns." + nsName
+		if !dns.IsSubDomain(zd.ZoneName, nsName) {
+			continue
+		}
+		nsData := zd.stagedOwner(nsName)
+		if nsData == nil {
+			continue
+		}
+		// Operator-authored aliased TSYNC at _dns.<ns>: leave it; served on
+		// direct query and its target is chased at injection time.
+		if ownerData := zd.stagedOwner(ownerName); ownerData != nil {
+			if tsyncHasAlias(ownerData.RRtypes.GetOnlyRRSet(core.TypeTSYNC)) {
+				lgDns.Debug("createTransportSignalTSYNC: keeping operator TSYNC alias", "owner", ownerName, "zone", zd.ZoneName)
 				return nil
 			}
 		}
+
+		aRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeA)
+		aaaaRRset := nsData.RRtypes.GetOnlyRRSet(dns.TypeAAAA)
+		if !(matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aRRset) || matchesConfiguredAddrs(conf.DnsEngine.Addresses, &aaaaRRset)) {
+			continue
+		}
+		var ipv4s, ipv6s []string
+		for _, rr := range aRRset.RRs {
+			if a, ok := rr.(*dns.A); ok {
+				ipv4s = append(ipv4s, a.A.String())
+			}
+		}
+		for _, rr := range aaaaRRset.RRs {
+			if aaaa, ok := rr.(*dns.AAAA); ok {
+				ipv6s = append(ipv6s, aaaa.AAAA.String())
+			}
+		}
+		tsyncStr := fmt.Sprintf("_dns.%s 10800 IN TSYNC . %q %q %q",
+			nsName,
+			fmt.Sprintf("transport=%s", conf.Service.Transport.Signal),
+			fmt.Sprintf("v4=%s", strings.Join(ipv4s, ",")),
+			fmt.Sprintf("v6=%s", strings.Join(ipv6s, ",")),
+		)
+		trr, err := dns.NewRR(tsyncStr)
+		if err != nil {
+			lgDns.Error("createTransportSignalTSYNC: failed to build TSYNC", "err", err)
+			continue
+		}
+		stored := core.RRset{Name: ownerName, RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
+		// Sign BEFORE staging (fixes the prior sign-after-commit ordering that
+		// froze an unsigned TSYNC into the snapshot).
+		if _, err := zd.SignRRset(&stored, "", dak, false, nil); err != nil {
+			lgDns.Debug("createTransportSignalTSYNC: error signing TSYNC", "owner", ownerName, "err", err)
+		}
+		lgDns.Debug("createTransportSignalTSYNC: stored synthesized TSYNC",
+			"zone", zd.ZoneName, "ns", nsName, "owner", ownerName, "rr", trr.String())
+		zd.commitTransportSignalLocked(ownerName, stored, "", nil)
+		return nil
+	}
 	return nil
 }

--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -91,8 +91,8 @@ func (zd *ZoneData) commitTransportSignalLocked(nsOwner string, rrset core.RRset
 
 // SVCB path
 func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
-	apex, exists := zd.Data.Get(zd.ZoneName)
-	if !exists {
+	apex := zd.stagedOwner(zd.ZoneName)
+	if apex == nil {
 		return fmt.Errorf("zone apex not found")
 	}
 	nsRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeNS)
@@ -168,10 +168,13 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 					"ns", nsName)
 				continue
 			}
-			if nsData, exists := zd.Data.Get(nsName); exists {
-				// Prefer explicit SVCB at _dns.<nsName> if valid
+			nsData := zd.stagedOwner(nsName)
+			if nsData == nil {
+				continue
+			}
 				ownerName := "_dns." + nsName
-				if ownerData, ok := zd.Data.Get(ownerName); ok {
+				ownerData := zd.stagedOwner(ownerName)
+				if ownerData != nil {
 					existingSvcb := ownerData.RRtypes.GetOnlyRRSet(dns.TypeSVCB)
 					if len(existingSvcb.RRs) > 0 {
 						valid := true
@@ -195,8 +198,8 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 									if svcb.Target != "." && svcb.Target != "" {
 										if bestZD, _ := FindZone(svcb.Target); bestZD != nil {
 											targetOwner := "_dns." + svcb.Target
-											if tOwnerData, ok := bestZD.Data.Get(targetOwner); ok {
-												targetRRset := tOwnerData.RRtypes.GetOnlyRRSet(dns.TypeSVCB)
+								if tOwner, err := bestZD.GetOwner(targetOwner); err == nil && tOwner != nil {
+									targetRRset := tOwner.RRtypes.GetOnlyRRSet(dns.TypeSVCB)
 												if len(targetRRset.RRs) > 0 {
 													zd.TransportSignal.RRs = append(zd.TransportSignal.RRs, targetRRset.RRs...)
 													if len(targetRRset.RRSIGs) > 0 {
@@ -333,14 +336,13 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config) error {
 				}
 			}
 		}
-	}
 	return nil
 }
 
 // TSYNC path
 func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
-	apex, exists := zd.Data.Get(zd.ZoneName)
-	if !exists {
+	apex := zd.stagedOwner(zd.ZoneName)
+	if apex == nil {
 		return fmt.Errorf("zone apex not found")
 	}
 	nsRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeNS)
@@ -355,11 +357,14 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
 			if !dns.IsSubDomain(zd.ZoneName, nsName) {
 				continue
 			}
-			if nsData, exists := zd.Data.Get(nsName); exists {
-				// Prefer explicit TSYNC at _dns.<nsName>; handle indirect via alias if present
-				ownerName := "_dns." + nsName
-				if ownerData, ok := zd.Data.Get(ownerName); ok {
-					existingTS := ownerData.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
+			nsData := zd.stagedOwner(nsName)
+			if nsData == nil {
+				continue
+			}
+			ownerName := "_dns." + nsName
+			ownerData := zd.stagedOwner(ownerName)
+			if ownerData != nil {
+				existingTS := ownerData.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
 					if len(existingTS.RRs) > 0 {
 						// Base RRset is the explicit TSYNC
 						zd.TransportSignal = &core.RRset{Name: ownerName, RRtype: core.TypeTSYNC, RRs: append([]dns.RR(nil), existingTS.RRs...)}
@@ -381,8 +386,8 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
 								lgDns.Debug("createTransportSignalTSYNC: resolved TSYNC alias target",
 									"owner", ownerName,
 									"targetowner", targetOwner)
-								if tOwnerData, ok := bestZD.Data.Get(targetOwner); ok {
-									targetTS := tOwnerData.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
+								if tOwner, err := bestZD.GetOwner(targetOwner); err == nil && tOwner != nil {
+									targetTS := tOwner.RRtypes.GetOnlyRRSet(core.TypeTSYNC)
 									lgDns.Debug("createTransportSignalTSYNC: found TSYNC RRs at target", "count", len(targetTS.RRs), "target", targetOwner)
 									if len(targetTS.RRs) > 0 {
 										zd.TransportSignal.RRs = append(zd.TransportSignal.RRs, targetTS.RRs...)
@@ -456,6 +461,5 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config) error {
 				return nil
 			}
 		}
-	}
 	return nil
 }

--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -66,7 +66,7 @@ func (zd *ZoneData) CreateTransportSignalRRs(conf *Config) error {
 	var dak *DnssecKeys
 	if zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning] {
 		var err error
-		if dak, err = zd.EnsureActiveDnssecKeys(zd.KeyDB); err != nil {
+		if dak, err = zd.EnsureActiveDnssecKeys(zd.KeyDB, false); err != nil {
 			return err
 		}
 	}

--- a/v2/zdmu_relock_largealg_test.go
+++ b/v2/zdmu_relock_largealg_test.go
@@ -1,0 +1,99 @@
+package tdns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// withLargeAlgorithm marks alg as a "large algorithm" in the global config for
+// the duration of a test and restores the previous set on cleanup. The
+// large-algorithm warning helpers read Conf.IsLargeAlgorithm (backed by
+// Conf.Internal.LargeAlgorithms).
+func withLargeAlgorithm(t *testing.T, alg uint8) {
+	t.Helper()
+	prev := Conf.Internal.LargeAlgorithms
+	Conf.Internal.LargeAlgorithms = map[uint8]bool{alg: true}
+	t.Cleanup(func() { Conf.Internal.LargeAlgorithms = prev })
+}
+
+// TestResignSOAUnderLockLargeAlgNoSelfDeadlock is the regression test for
+// instance #3 of the re-entrant zd.mu self-deadlock class (instances #1/#2 fixed
+// in 6e090a9 and 23710d1). The publish-path SOA re-sign holds zd.mu
+// (publishWorkingSetLocked -> resignWorkingSetSOAIfSigned) and resolves the keys
+// via EnsureActiveDnssecKeys(zdLocked=true). On a zone whose ZSK algorithm is a
+// LARGE (PQ) algorithm, the fresh-key generate branch calls
+// WarnLargeAlgZoneSigningRole, which read the error list and set a
+// DnssecPolicyWarning via zd.ErrorList()/zd.SetError() — both re-acquire zd.mu.
+// Go mutexes are not reentrant, so this self-deadlocks and wedges the daemon:
+//
+//	applyRefreshReplacementLocked -> publishWorkingSetLocked ->
+//	resignWorkingSetSOAIfSigned -> EnsureActiveDnssecKeys(zdLocked=true) ->
+//	WarnLargeAlgZoneSigningRole -> zd.ErrorList()/zd.SetError() -> zd.mu.Lock()
+//
+// 23710d1 routed only the DNSKEY publish (PublishDnskeyRRs) through a *Locked
+// variant; the large-algorithm warning re-lock — which fires BEFORE the publish
+// and only on a large algorithm, so 23710d1's ED25519 test never reached it —
+// was missed. The fix threads zdLocked into the two Warn helpers so they use
+// errorListLocked/setErrorLocked when the caller already holds zd.mu.
+//
+// The re-sign runs in a goroutine holding zd.mu; a re-introduced re-lock blocks
+// it forever, so the timeout fails the test instead of hanging the whole run.
+func TestResignSOAUnderLockLargeAlgNoSelfDeadlock(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// Mark ED25519 "large" so the ZSK generated below drives the large-algorithm
+	// warning path under the lock — without needing a real (expensive) PQ key.
+	withLargeAlgorithm(t, dns.ED25519)
+
+	zone := `resign-large.example.	3600	IN	SOA	ns.resign-large.example. hostmaster.resign-large.example. 1 7200 1800 604800 7200
+resign-large.example.	3600	IN	NS	ns.resign-large.example.
+`
+	zd := testZone(t, "resign-large.example.", zone)
+	zd.KeyDB = kdb
+	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+	zd.DnssecPolicy = &DnssecPolicy{
+		Mode:         DnssecPolicyModeKSKZSK,
+		KSKAlgorithm: dns.ED25519,
+		ZSKAlgorithm: dns.ED25519,
+	}
+	// No active keys are pre-generated: the first re-sign must GENERATE the ZSK,
+	// which triggers WarnLargeAlgZoneSigningRole — the large-algorithm branch that
+	// re-locked zd.mu via ErrorList()/SetError().
+
+	done := make(chan struct{})
+	go func() {
+		zd.mu.Lock() // the publishWorkingSetLocked context: zd.mu held across the re-sign
+		defer zd.mu.Unlock()
+		zd.ensureWorkingSet()
+		zd.resignWorkingSetSOAIfSigned()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("resignWorkingSetSOAIfSigned deadlocked while zd.mu was held (re-entrant zd.mu via EnsureActiveDnssecKeys -> WarnLargeAlgZoneSigningRole -> ErrorList/SetError)")
+	}
+
+	// The SOA must actually carry an RRSIG now — proves the re-sign ran to
+	// completion (generated keys, published DNSKEYs, signed the SOA).
+	zd.mu.Lock()
+	apex := zd.workingSet[zd.ZoneName]
+	zd.mu.Unlock()
+	if apex == nil {
+		t.Fatal("apex missing from working set after resign")
+	}
+	soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	if len(soa.RRSIGs) == 0 {
+		t.Fatal("SOA was not signed under the lock (re-sign did not complete)")
+	}
+
+	// The large-algorithm DnssecPolicyWarning must have been recorded — this
+	// proves the warning helper actually executed under the held lock (the exact
+	// re-lock site), rather than the test passing because the branch was skipped.
+	if !zd.HasError(DnssecPolicyWarning) {
+		t.Fatal("expected a DnssecPolicyWarning from the large-algorithm ZSK warning path; the re-lock site was not exercised")
+	}
+}

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -198,7 +198,17 @@ func (zd *ZoneData) resignWorkingSetSOAIfSigned() {
 	if len(rs.RRs) == 0 {
 		return
 	}
-	if _, err := zd.SignRRset(&rs, zd.ZoneName, nil, true, nil); err != nil {
+	// This runs UNDER zd.mu (called from publishWorkingSetLocked). Resolve the
+	// active keys here with zdLocked=true and pass the non-nil dak into
+	// SignRRset, so SignRRset does NOT fall into its own EnsureActiveDnssecKeys
+	// call (which would reach PublishDnskeyRRs and re-lock zd.mu → self-deadlock,
+	// the same class as the SignZone/UpdateSigValidityFloor deadlock in 6e090a9).
+	dak, err := zd.EnsureActiveDnssecKeys(zd.KeyDB, true)
+	if err != nil {
+		lg.Error("publish: failed to ensure DNSSEC keys for SOA re-sign", "zone", zd.ZoneName, "err", err)
+		return
+	}
+	if _, err := zd.SignRRset(&rs, zd.ZoneName, dak, true, nil); err != nil {
 		lg.Error("publish: failed to re-sign SOA", "zone", zd.ZoneName, "err", err)
 		return
 	}

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -414,6 +414,15 @@ func (zd *ZoneData) stopPublisher() {
 	})
 }
 
+// stopZonePublisher stops the per-zone publisher goroutine for the zone
+// currently registered under name (if any), so it does not leak when the zone is
+// removed from the Zones registry.
+func stopZonePublisher(name string) {
+	if zd, ok := Zones.Get(name); ok && zd != nil {
+		zd.stopPublisher()
+	}
+}
+
 func (zd *ZoneData) wakePublisher() {
 	select {
 	case zd.publishWake <- struct{}{}:

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -219,8 +219,17 @@ func (zd *ZoneData) publishSync() (BumperResponse, error) {
 }
 
 func (zd *ZoneData) stageRRsetLocked(name string, rs core.RRset) {
+	// The store keys by RR type, but callers frequently build rs via
+	// GetOnlyRRSet (which leaves rs.RRtype unset) or via signing helpers that
+	// drop it. Derive the type from the RRs when rs.RRtype is 0 so the RRset is
+	// never mis-keyed under type 0.
+	rrtype := rs.RRtype
+	if rrtype == 0 && len(rs.RRs) > 0 {
+		rrtype = rs.RRs[0].Header().Rrtype
+	}
+	rs.RRtype = rrtype
 	zd.ensureWorkingSet()
-	zd.cloneOwner(name).RRtypes.Set(rs.RRtype, cloneRRset(rs))
+	zd.cloneOwner(name).RRtypes.Set(rrtype, cloneRRset(rs))
 }
 
 func (zd *ZoneData) stageDeleteLocked(name string, rrtype uint16) {
@@ -350,14 +359,18 @@ func (zd *ZoneData) setWorkingSetSOASerial(serial uint32) {
 	if apex == nil {
 		return
 	}
-	rs := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	rs := cloneRRset(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA))
 	if len(rs.RRs) == 0 {
 		return
 	}
-	soa := dns.Copy(rs.RRs[0]).(*dns.SOA)
+	soa, ok := rs.RRs[0].(*dns.SOA)
+	if !ok {
+		return
+	}
 	soa.Serial = serial
-	rs.RRs[0] = soa
-	apex.RRtypes.Set(dns.TypeSOA, rs)
+	// Stage into a cloned apex owner rather than writing through the shared
+	// snapshot store — the previous in-place Set tore concurrent readers.
+	zd.cloneOwner(zd.ZoneName).RRtypes.Set(dns.TypeSOA, rs)
 }
 
 func (zd *ZoneData) publishNow(gen uint64) {
@@ -384,7 +397,20 @@ func (zd *ZoneData) InstallInitialSnapshot() {
 func (zd *ZoneData) startPublisher() {
 	zd.publisherOnce.Do(func() {
 		zd.publishWake = make(chan struct{}, 1)
+		zd.publishStop = make(chan struct{})
 		go zd.runPublisher()
+	})
+}
+
+// stopPublisher terminates the per-zone publisher goroutine started by
+// startPublisher. Safe to call at most once; a no-op if the publisher never
+// started. Callers that remove or replace a zone should call this so the
+// goroutine does not stay parked on publishWake forever.
+func (zd *ZoneData) stopPublisher() {
+	zd.publishStopOnce.Do(func() {
+		if zd.publishStop != nil {
+			close(zd.publishStop)
+		}
 	})
 }
 
@@ -400,6 +426,11 @@ func (zd *ZoneData) runPublisher() {
 	var timerC <-chan time.Time
 	for {
 		select {
+		case <-zd.publishStop:
+			if timer != nil {
+				timer.Stop()
+			}
+			return
 		case <-zd.publishWake:
 		case <-timerC:
 		}

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -408,14 +408,22 @@ func (zd *ZoneData) InstallInitialSnapshot() {
 	defer zd.mu.Unlock()
 
 	data := snapshotMapFromData(zd.Data)
-	// Atomic-swap invariant (same as publishWorkingSetLocked): never install an
-	// apex-less snapshot and — critically — never mark such a zone Ready. All
-	// callers install after reading zone data, so an empty apex here is an
-	// anomaly (e.g. an unpopulated zd.Data during reload); marking Ready with a
-	// nil apex/SOA is exactly the state that crashed readers (GetSOA -> nil).
-	// Refuse: leave the zone not-Ready with whatever snapshot it already had.
 	if apexFromSnapshotData(zd, data) == nil {
-		lg.Error("InstallInitialSnapshot: refusing apex-less snapshot; zone left not Ready", "zone", zd.ZoneName)
+		// zd.Data carries no apex. Two cases:
+		//   1. The load path (initialLoadZone -> applyRefreshReplacementLocked)
+		//      already published a valid snapshot and left zd.Data empty; here
+		//      InstallInitialSnapshot's only job is to mark the zone Ready. Do NOT
+		//      overwrite the good snapshot with an apex-less one — just flip Ready.
+		//   2. There is also no valid snapshot: genuinely nothing to serve (e.g.
+		//      an empty rebuild during reload). Refuse and leave the zone not
+		//      Ready — marking a zone with a nil apex/SOA Ready is exactly what
+		//      crashed readers (GetSOA -> nil).
+		if cur := zd.snapshot.Load(); cur != nil && cur.SOA != nil {
+			zd.Ready = true
+			zd.Status = ZoneStatusReady
+			return
+		}
+		lg.Error("InstallInitialSnapshot: no apex in data and no valid snapshot; zone left not Ready", "zone", zd.ZoneName)
 		return
 	}
 	snap := zd.buildSnapshotLocked(zd.CurrentSerial, data, nil)

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -408,6 +408,16 @@ func (zd *ZoneData) InstallInitialSnapshot() {
 	defer zd.mu.Unlock()
 
 	data := snapshotMapFromData(zd.Data)
+	// Atomic-swap invariant (same as publishWorkingSetLocked): never install an
+	// apex-less snapshot and — critically — never mark such a zone Ready. All
+	// callers install after reading zone data, so an empty apex here is an
+	// anomaly (e.g. an unpopulated zd.Data during reload); marking Ready with a
+	// nil apex/SOA is exactly the state that crashed readers (GetSOA -> nil).
+	// Refuse: leave the zone not-Ready with whatever snapshot it already had.
+	if apexFromSnapshotData(zd, data) == nil {
+		lg.Error("InstallInitialSnapshot: refusing apex-less snapshot; zone left not Ready", "zone", zd.ZoneName)
+		return
+	}
 	snap := zd.buildSnapshotLocked(zd.CurrentSerial, data, nil)
 	zd.snapshot.Store(snap)
 	zd.Ready = true

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -144,14 +144,66 @@ func rrsetEqual(a, b core.RRset) bool {
 }
 
 func (zd *ZoneData) requestPublish(urgent bool) {
+	if urgent {
+		_, _ = zd.publishSync()
+		return
+	}
 	zd.startPublisher()
 	zd.mu.Lock()
 	zd.publishQueued = true
-	if urgent {
-		zd.publishUrgent = true
-	}
 	zd.mu.Unlock()
 	zd.wakePublisher()
+}
+
+// publishSync runs publish immediately under zd.mu (serial bump + dual-write).
+func (zd *ZoneData) resignWorkingSetSOAIfSigned() {
+	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+		return
+	}
+	if zd.workingSet == nil {
+		return
+	}
+	apex := zd.workingSet[zd.ZoneName]
+	if apex == nil {
+		return
+	}
+	rs := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	if len(rs.RRs) == 0 {
+		return
+	}
+	if _, err := zd.SignRRset(&rs, zd.ZoneName, nil, true, nil); err != nil {
+		lg.Error("publish: failed to re-sign SOA", "zone", zd.ZoneName, "err", err)
+		return
+	}
+	zd.cloneOwner(zd.ZoneName).RRtypes.Set(dns.TypeSOA, cloneRRset(rs))
+}
+
+func (zd *ZoneData) publishSync() (BumperResponse, error) {
+	resp := BumperResponse{Zone: zd.ZoneName}
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	resp.OldSerial = zd.CurrentSerial
+	if zd.workingSet == nil {
+		zd.ensureWorkingSet()
+	}
+	zd.publishLocked(zd.generation.Load())
+	resp.NewSerial = zd.CurrentSerial
+	return resp, nil
+}
+
+func (zd *ZoneData) stageRRsetLocked(name string, rs core.RRset) {
+	zd.ensureWorkingSet()
+	zd.cloneOwner(name).RRtypes.Set(rs.RRtype, cloneRRset(rs))
+}
+
+func (zd *ZoneData) stageDeleteLocked(name string, rrtype uint16) {
+	zd.ensureWorkingSet()
+	zd.cloneOwner(name).RRtypes.Delete(rrtype)
+}
+
+func (zd *ZoneData) stageOwnerReplaceLocked(name string, od *OwnerData) {
+	zd.ensureWorkingSet()
+	zd.workingSet[name] = od
 }
 
 func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerData, transport *core.RRset) *ZoneSnapshot {
@@ -219,6 +271,8 @@ func (zd *ZoneData) publishLocked(gen uint64) {
 	zd.CurrentSerial = nextOutboundSerial(zd)
 	serial := zd.CurrentSerial
 	zd.setWorkingSetSOASerial(serial)
+
+	zd.resignWorkingSetSOAIfSigned()
 
 	transport := zd.wsTransportSignal
 	if transport == nil {

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -143,6 +143,19 @@ func rrsetEqual(a, b core.RRset) bool {
 	return true
 }
 
+func (zd *ZoneData) stagedOwner(name string) *OwnerData {
+	zd.ensureWorkingSet()
+	return zd.workingSet[name]
+}
+
+func (zd *ZoneData) getOrCreateWorkingOwner(name string) *OwnerData {
+	zd.ensureWorkingSet()
+	if od := zd.workingSet[name]; od != nil {
+		return od
+	}
+	return zd.cloneOwner(name)
+}
+
 func (zd *ZoneData) requestPublish(urgent bool) {
 	if urgent {
 		_, _ = zd.publishSync()

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -319,7 +319,11 @@ func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs [
 	zd.repopulateWorkingSetLocked(dynamicRRs)
 	zd.publishWorkingSetLocked(zd.generation.Load(), false)
 
-	if !firstLoad {
+	// Only advertise the zone as Ready once a snapshot actually exists. If the
+	// publish was dropped (zone no longer live / generation guard), leaving
+	// Ready=true with snapshot==nil would let a query dereference a nil apex
+	// (M2). Gate Ready on a real published snapshot.
+	if !firstLoad && zd.snapshot.Load() != nil {
 		zd.Ready = true
 		zd.Status = ZoneStatusReady
 	}

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -1,0 +1,379 @@
+package tdns
+
+import (
+	"time"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+func (zd *ZoneData) ensureWorkingSet() {
+	if zd.workingSet != nil {
+		return
+	}
+	snap := zd.snapshot.Load()
+	if snap == nil {
+		zd.workingSet = snapshotMapFromData(zd.Data)
+		return
+	}
+	zd.workingSet = make(map[string]*OwnerData, len(snap.Data))
+	for k, v := range snap.Data {
+		zd.workingSet[k] = v
+	}
+	if zd.wsTransportSignal == nil {
+		zd.wsTransportSignal = cloneTransportSignal(snap.TransportSignal)
+	}
+}
+
+func (zd *ZoneData) cloneOwner(name string) *OwnerData {
+	src := zd.workingSet[name]
+	nod := &OwnerData{Name: name, RRtypes: NewRRTypeStore()}
+	if src != nil {
+		for _, t := range src.RRtypes.Keys() {
+			rs, _ := src.RRtypes.Get(t)
+			nod.RRtypes.Set(t, rs)
+		}
+	}
+	zd.workingSet[name] = nod
+	return nod
+}
+
+func (zd *ZoneData) stageRRset(name string, rs core.RRset) {
+	zd.ensureWorkingSet()
+	zd.cloneOwner(name).RRtypes.Set(rs.RRtype, cloneRRset(rs))
+}
+
+func (zd *ZoneData) stageDelete(name string, rrtype uint16) {
+	zd.ensureWorkingSet()
+	zd.cloneOwner(name).RRtypes.Delete(rrtype)
+}
+
+func (zd *ZoneData) stageOwnerReplace(name string, od *OwnerData) {
+	zd.ensureWorkingSet()
+	zd.workingSet[name] = od
+}
+
+func (zd *ZoneData) pendingChanges() *PendingChanges {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	if zd.workingSet == nil {
+		return nil
+	}
+	snap := zd.snapshot.Load()
+	publishedSerial := zd.CurrentSerial
+	if snap != nil {
+		publishedSerial = snap.Serial
+	}
+	pc := &PendingChanges{
+		PublishedSerial: publishedSerial,
+		PublishQueued:   zd.publishQueued,
+	}
+	published := map[string]*OwnerData{}
+	if snap != nil {
+		published = snap.Data
+	}
+	seen := map[string]bool{}
+	for name, wsOd := range zd.workingSet {
+		seen[name] = true
+		pubOd := published[name]
+		if pubOd == nil {
+			pc.Added = append(pc.Added, name)
+			continue
+		}
+		changed := ownerTypesChanged(pubOd, wsOd)
+		if len(changed) > 0 {
+			pc.Replaced = append(pc.Replaced, pendingOwnerChange{Owner: name, RRtypes: changed})
+		}
+	}
+	for name, pubOd := range published {
+		if seen[name] {
+			continue
+		}
+		if pubOd == nil {
+			continue
+		}
+		pc.Deleted = append(pc.Deleted, pendingOwnerChange{Owner: name, RRtypes: pubOd.RRtypes.Keys()})
+	}
+	if len(pc.Added) == 0 && len(pc.Replaced) == 0 && len(pc.Deleted) == 0 && !pc.PublishQueued {
+		return nil
+	}
+	return pc
+}
+
+func ownerTypesChanged(a, b *OwnerData) []uint16 {
+	if a == nil || b == nil {
+		return nil
+	}
+	aTypes := map[uint16]bool{}
+	for _, t := range a.RRtypes.Keys() {
+		aTypes[t] = true
+	}
+	var changed []uint16
+	for _, t := range b.RRtypes.Keys() {
+		brs, ok := b.RRtypes.Get(t)
+		if !ok {
+			continue
+		}
+		ars, aok := a.RRtypes.Get(t)
+		if !aok || !rrsetEqual(ars, brs) {
+			changed = append(changed, t)
+		}
+		delete(aTypes, t)
+	}
+	for t := range aTypes {
+		changed = append(changed, t)
+	}
+	return changed
+}
+
+func rrsetEqual(a, b core.RRset) bool {
+	if len(a.RRs) != len(b.RRs) || len(a.RRSIGs) != len(b.RRSIGs) {
+		return false
+	}
+	for i := range a.RRs {
+		if a.RRs[i].String() != b.RRs[i].String() {
+			return false
+		}
+	}
+	for i := range a.RRSIGs {
+		if a.RRSIGs[i].String() != b.RRSIGs[i].String() {
+			return false
+		}
+	}
+	return true
+}
+
+func (zd *ZoneData) requestPublish(urgent bool) {
+	zd.startPublisher()
+	zd.mu.Lock()
+	zd.publishQueued = true
+	if urgent {
+		zd.publishUrgent = true
+	}
+	zd.mu.Unlock()
+	zd.wakePublisher()
+}
+
+func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerData, transport *core.RRset) *ZoneSnapshot {
+	apex := apexFromSnapshotData(zd, data)
+	return &ZoneSnapshot{
+		Serial:          serial,
+		SOA:             soaFromApex(serial, apex),
+		Apex:            apex,
+		Data:            data,
+		TransportSignal: cloneTransportSignal(transport),
+		IxfrChain:       copyIxfrChain(zd.IxfrChain),
+	}
+}
+
+func (zd *ZoneData) syncLegacyFromSnapshot(snap *ZoneSnapshot) {
+	if snap == nil {
+		return
+	}
+	if zd.Data == nil {
+		zd.Data = core.NewCmap[OwnerData]()
+	} else {
+		zd.Data.Clear()
+	}
+	for name, od := range snap.Data {
+		if od != nil {
+			zd.Data.Set(name, *od)
+		}
+	}
+	zd.TransportSignal = cloneTransportSignal(snap.TransportSignal)
+	zd.IxfrChain = copyIxfrChain(snap.IxfrChain)
+}
+
+func (zd *ZoneData) setWorkingSetSOASerial(serial uint32) {
+	if zd.workingSet == nil {
+		return
+	}
+	apex := zd.workingSet[zd.ZoneName]
+	if apex == nil {
+		return
+	}
+	rs := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	if len(rs.RRs) == 0 {
+		return
+	}
+	soa := dns.Copy(rs.RRs[0]).(*dns.SOA)
+	soa.Serial = serial
+	rs.RRs[0] = soa
+	apex.RRtypes.Set(dns.TypeSOA, rs)
+}
+
+func (zd *ZoneData) publishLocked(gen uint64) {
+	if zd.workingSet == nil {
+		zd.publishQueued = false
+		zd.publishUrgent = false
+		return
+	}
+	if !zoneStillLive(zd, gen) {
+		zd.workingSet = nil
+		zd.wsTransportSignal = nil
+		zd.publishQueued = false
+		zd.publishUrgent = false
+		return
+	}
+
+	zd.CurrentSerial = nextOutboundSerial(zd)
+	serial := zd.CurrentSerial
+	zd.setWorkingSetSOASerial(serial)
+
+	transport := zd.wsTransportSignal
+	if transport == nil {
+		transport = zd.TransportSignal
+	}
+
+	data := zd.workingSet
+	snap := zd.buildSnapshotLocked(serial, data, transport)
+	zd.snapshot.Store(snap)
+	zd.syncLegacyFromSnapshot(snap)
+
+	zd.workingSet = nil
+	zd.wsTransportSignal = nil
+	zd.publishQueued = false
+	zd.publishUrgent = false
+	zd.lastPublish = time.Now()
+
+	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
+		if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
+			lg.Error("publish: failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
+		}
+	}
+
+	if loaded := zd.snapshot.Load(); loaded != nil && loaded.Serial != zd.CurrentSerial {
+		lg.Error("publish: serial mirror drift", "zone", zd.ZoneName, "current", zd.CurrentSerial, "snapshot", loaded.Serial)
+	}
+
+	_ = zd.NotifyDownstreams()
+}
+
+func (zd *ZoneData) publishNow(gen uint64) {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.publishLocked(gen)
+}
+
+// InstallInitialSnapshot builds the first published snapshot from the fully
+// initialized zone data (after OnFirstLoad / SetupZoneSigning) and marks the
+// zone genuinely servable. Discharges the Ready=true "lie".
+func (zd *ZoneData) InstallInitialSnapshot() {
+	zd.startPublisher()
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+
+	data := snapshotMapFromData(zd.Data)
+	snap := zd.buildSnapshotLocked(zd.CurrentSerial, data, zd.TransportSignal)
+	zd.snapshot.Store(snap)
+	zd.syncLegacyFromSnapshot(snap)
+	zd.Ready = true
+	zd.Status = ZoneStatusReady
+}
+
+func (zd *ZoneData) startPublisher() {
+	zd.publisherOnce.Do(func() {
+		zd.publishWake = make(chan struct{}, 1)
+		go zd.runPublisher()
+	})
+}
+
+func (zd *ZoneData) wakePublisher() {
+	select {
+	case zd.publishWake <- struct{}{}:
+	default:
+	}
+}
+
+func (zd *ZoneData) runPublisher() {
+	var timer *time.Timer
+	var timerC <-chan time.Time
+	for {
+		select {
+		case <-zd.publishWake:
+		case <-timerC:
+		}
+		if timer != nil {
+			timer.Stop()
+			timer = nil
+			timerC = nil
+		}
+
+		for {
+			zd.mu.Lock()
+			if !zd.publishQueued {
+				zd.mu.Unlock()
+				break
+			}
+			urgent := zd.publishUrgent
+			cadence := publishCadenceForZone(zd)
+			since := time.Since(zd.lastPublish)
+			if urgent || zd.lastPublish.IsZero() || since >= cadence {
+				gen := zd.generation.Load()
+				zd.publishLocked(gen)
+				zd.mu.Unlock()
+				continue
+			}
+			wait := cadence - since
+			zd.mu.Unlock()
+			timer = time.NewTimer(wait)
+			timerC = timer.C
+			break
+		}
+	}
+}
+
+// snapshotGeneration returns the live snapshot serial for tests.
+func (zd *ZoneData) snapshotGeneration() uint32 {
+	snap := zd.snapshot.Load()
+	if snap == nil {
+		return 0
+	}
+	return snap.Serial
+}
+
+// legacyMatchesSnapshot reports dual-write consistency for tests.
+func (zd *ZoneData) legacyMatchesSnapshot() bool {
+	snap := zd.snapshot.Load()
+	if snap == nil {
+		return zd.Data == nil || zd.Data.IsEmpty()
+	}
+	if zd.Data == nil {
+		return len(snap.Data) == 0
+	}
+	if zd.Data.Count() != len(snap.Data) {
+		return false
+	}
+	for name, snapOd := range snap.Data {
+		legOd, ok := zd.Data.Get(name)
+		if !ok || snapOd == nil {
+			return false
+		}
+		if legOd.RRtypes != snapOd.RRtypes {
+			return false
+		}
+	}
+	if !transportSignalEqual(zd.TransportSignal, snap.TransportSignal) {
+		return false
+	}
+	if len(zd.IxfrChain) != len(snap.IxfrChain) {
+		return false
+	}
+	return zd.CurrentSerial == snap.Serial
+}
+
+func transportSignalEqual(a, b *core.RRset) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return rrsetEqual(*a, *b)
+}
+
+// test-only hooks (none currently)
+
+func (zd *ZoneData) testPublishNow() {
+	zd.publishNow(zd.generation.Load())
+}

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -326,9 +326,9 @@ func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs [
 	return nil
 }
 
-func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerData, transport *core.RRset) *ZoneSnapshot {
+func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerData, transport *core.RRset) *zoneSnapshot {
 	apex := apexFromSnapshotData(zd, data)
-	return &ZoneSnapshot{
+	return &zoneSnapshot{
 		Serial:          serial,
 		SOA:             soaFromApex(serial, apex),
 		Apex:            apex,

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -1,6 +1,7 @@
 package tdns
 
 import (
+	"fmt"
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -219,6 +220,100 @@ func (zd *ZoneData) stageOwnerReplaceLocked(name string, od *OwnerData) {
 	zd.workingSet[name] = od
 }
 
+func (zd *ZoneData) stageOwnerDeleteLocked(name string) {
+	zd.ensureWorkingSet()
+	delete(zd.workingSet, name)
+}
+
+func (zd *ZoneData) publishLocked(gen uint64) {
+	zd.publishWorkingSetLocked(gen, true)
+}
+
+// publishWorkingSetLocked stores the current working set. When bumpSerial is
+// false the caller has already set zd.CurrentSerial (refresh flips, transport
+// signal synthesis without a content serial change).
+func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
+	if zd.workingSet == nil {
+		zd.publishQueued = false
+		zd.publishUrgent = false
+		return
+	}
+	if !zoneStillLive(zd, gen) {
+		zd.workingSet = nil
+		zd.wsTransportSignal = nil
+		zd.publishQueued = false
+		zd.publishUrgent = false
+		return
+	}
+
+	serial := zd.CurrentSerial
+	if bumpSerial {
+		zd.CurrentSerial = nextOutboundSerial(zd)
+		serial = zd.CurrentSerial
+	}
+	zd.setWorkingSetSOASerial(serial)
+
+	zd.resignWorkingSetSOAIfSigned()
+
+	transport := zd.wsTransportSignal
+	if transport == nil {
+		transport = zd.TransportSignal
+	}
+
+	data := zd.workingSet
+	snap := zd.buildSnapshotLocked(serial, data, transport)
+	zd.snapshot.Store(snap)
+	zd.syncLegacyFromSnapshot(snap)
+
+	zd.workingSet = nil
+	zd.wsTransportSignal = nil
+	zd.publishQueued = false
+	zd.publishUrgent = false
+	zd.lastPublish = time.Now()
+
+	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
+		if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
+			lg.Error("publish: failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
+		}
+	}
+
+	if loaded := zd.snapshot.Load(); loaded != nil && loaded.Serial != zd.CurrentSerial {
+		lg.Error("publish: serial mirror drift", "zone", zd.ZoneName, "current", zd.CurrentSerial, "snapshot", loaded.Serial)
+	}
+
+	_ = zd.NotifyDownstreams()
+}
+
+func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs []*core.RRset, firstLoad bool) error {
+	zd.IncomingSerial = new_zd.IncomingSerial
+	if firstLoad {
+		zd.CurrentSerial = new_zd.CurrentSerial
+		zd.FirstZoneLoad = false
+	} else {
+		zd.CurrentSerial++
+		if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
+			if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
+				return fmt.Errorf("persist outgoing serial for zone %s: %w", zd.ZoneName, err)
+			}
+		}
+	}
+	zd.ApexLen = new_zd.ApexLen
+	zd.XfrType = new_zd.XfrType
+	zd.ZoneStore = new_zd.ZoneStore
+	zd.ZoneType = new_zd.ZoneType
+
+	zd.workingSet = snapshotMapFromData(new_zd.Data)
+	zd.wsTransportSignal = nil
+	zd.repopulateWorkingSetLocked(dynamicRRs)
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
+
+	if !firstLoad {
+		zd.Ready = true
+		zd.Status = ZoneStatusReady
+	}
+	return nil
+}
+
 func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerData, transport *core.RRset) *ZoneSnapshot {
 	apex := apexFromSnapshotData(zd, data)
 	return &ZoneSnapshot{
@@ -265,55 +360,6 @@ func (zd *ZoneData) setWorkingSetSOASerial(serial uint32) {
 	soa.Serial = serial
 	rs.RRs[0] = soa
 	apex.RRtypes.Set(dns.TypeSOA, rs)
-}
-
-func (zd *ZoneData) publishLocked(gen uint64) {
-	if zd.workingSet == nil {
-		zd.publishQueued = false
-		zd.publishUrgent = false
-		return
-	}
-	if !zoneStillLive(zd, gen) {
-		zd.workingSet = nil
-		zd.wsTransportSignal = nil
-		zd.publishQueued = false
-		zd.publishUrgent = false
-		return
-	}
-
-	zd.CurrentSerial = nextOutboundSerial(zd)
-	serial := zd.CurrentSerial
-	zd.setWorkingSetSOASerial(serial)
-
-	zd.resignWorkingSetSOAIfSigned()
-
-	transport := zd.wsTransportSignal
-	if transport == nil {
-		transport = zd.TransportSignal
-	}
-
-	data := zd.workingSet
-	snap := zd.buildSnapshotLocked(serial, data, transport)
-	zd.snapshot.Store(snap)
-	zd.syncLegacyFromSnapshot(snap)
-
-	zd.workingSet = nil
-	zd.wsTransportSignal = nil
-	zd.publishQueued = false
-	zd.publishUrgent = false
-	zd.lastPublish = time.Now()
-
-	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
-		if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
-			lg.Error("publish: failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
-		}
-	}
-
-	if loaded := zd.snapshot.Load(); loaded != nil && loaded.Serial != zd.CurrentSerial {
-		lg.Error("publish: serial mirror drift", "zone", zd.ZoneName, "current", zd.CurrentSerial, "snapshot", loaded.Serial)
-	}
-
-	_ = zd.NotifyDownstreams()
 }
 
 func (zd *ZoneData) publishNow(gen uint64) {

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -22,8 +22,8 @@ func (zd *ZoneData) ensureWorkingSet() {
 	for k, v := range snap.Data {
 		zd.workingSet[k] = v
 	}
-	if zd.wsTransportSignal == nil {
-		zd.wsTransportSignal = cloneTransportSignal(snap.TransportSignal)
+	if zd.wsSignalSynth == nil {
+		zd.wsSignalSynth = cloneSignalSynth(snap.signalSynth)
 	}
 }
 
@@ -262,7 +262,7 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 	}
 	if !zoneStillLive(zd, gen) {
 		zd.workingSet = nil
-		zd.wsTransportSignal = nil
+		zd.wsSignalSynth = nil
 		zd.publishQueued = false
 		zd.publishUrgent = false
 		return
@@ -277,17 +277,12 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 
 	zd.resignWorkingSetSOAIfSigned()
 
-	transport := zd.wsTransportSignal
-	if transport == nil {
-		transport = zd.TransportSignal
-	}
-
 	data := zd.workingSet
-	snap := zd.buildSnapshotLocked(serial, data, transport)
+	snap := zd.buildSnapshotLocked(serial, data, zd.wsSignalSynth)
 	zd.snapshot.Store(snap)
 
 	zd.workingSet = nil
-	zd.wsTransportSignal = nil
+	zd.wsSignalSynth = nil
 	zd.publishQueued = false
 	zd.publishUrgent = false
 	zd.lastPublish = time.Now()
@@ -324,7 +319,15 @@ func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs [
 	zd.ZoneType = new_zd.ZoneType
 
 	zd.workingSet = snapshotMapFromData(new_zd.Data)
-	zd.wsTransportSignal = nil
+	// A refresh replaces zone data wholesale; carry the synthesized-signal
+	// fallback over from the current snapshot so it survives until the transport
+	// postpass recomputes it. The stored _dns.<ns> owner RRsets are preserved
+	// separately by CollectDynamicRRs -> repopulateWorkingSetLocked.
+	if old := zd.snapshot.Load(); old != nil {
+		zd.wsSignalSynth = cloneSignalSynth(old.signalSynth)
+	} else {
+		zd.wsSignalSynth = nil
+	}
 	zd.repopulateWorkingSetLocked(dynamicRRs)
 	zd.publishWorkingSetLocked(zd.generation.Load(), false)
 
@@ -339,15 +342,15 @@ func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs [
 	return nil
 }
 
-func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerData, transport *core.RRset) *zoneSnapshot {
+func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerData, signalSynth map[string]*core.RRset) *zoneSnapshot {
 	apex := apexFromSnapshotData(zd, data)
 	return &zoneSnapshot{
-		Serial:          serial,
-		SOA:             soaFromApex(serial, apex),
-		Apex:            apex,
-		Data:            data,
-		TransportSignal: cloneTransportSignal(transport),
-		IxfrChain:       copyIxfrChain(zd.IxfrChain),
+		Serial:      serial,
+		SOA:         soaFromApex(serial, apex),
+		Apex:        apex,
+		Data:        data,
+		signalSynth: cloneSignalSynth(signalSynth),
+		IxfrChain:   copyIxfrChain(zd.IxfrChain),
 	}
 }
 
@@ -388,7 +391,7 @@ func (zd *ZoneData) InstallInitialSnapshot() {
 	defer zd.mu.Unlock()
 
 	data := snapshotMapFromData(zd.Data)
-	snap := zd.buildSnapshotLocked(zd.CurrentSerial, data, zd.TransportSignal)
+	snap := zd.buildSnapshotLocked(zd.CurrentSerial, data, nil)
 	zd.snapshot.Store(snap)
 	zd.Ready = true
 	zd.Status = ZoneStatusReady

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -268,6 +268,23 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 		return
 	}
 
+	// Atomic-swap invariant: never store a snapshot without an apex. An
+	// apex-less working set (e.g. an empty rebuild during reload) would yield a
+	// snapshot with nil Apex/SOA; storing it would leave a Ready zone with no
+	// servable SOA and crash readers (GetSOA -> nil). A zone with no apex SOA is
+	// not servable, so refuse the swap and keep serving the current snapshot; a
+	// later valid rebuild will publish correctly. Serial is not bumped here, so
+	// the refused publish does not advance the zone's serial.
+	if apexFromSnapshotData(zd, zd.workingSet) == nil {
+		lg.Error("publish: refusing to swap in an apex-less snapshot; keeping current snapshot",
+			"zone", zd.ZoneName)
+		zd.workingSet = nil
+		zd.wsSignalSynth = nil
+		zd.publishQueued = false
+		zd.publishUrgent = false
+		return
+	}
+
 	serial := zd.CurrentSerial
 	if bumpSerial {
 		zd.CurrentSerial = nextOutboundSerial(zd)

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -2,6 +2,7 @@ package tdns
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -157,6 +158,18 @@ func (zd *ZoneData) getOrCreateWorkingOwner(name string) *OwnerData {
 	return zd.cloneOwner(name)
 }
 
+func (zd *ZoneData) workingOwnerNamesLocked() []string {
+	if zd.workingSet == nil {
+		return nil
+	}
+	names := make([]string, 0, len(zd.workingSet))
+	for name := range zd.workingSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func (zd *ZoneData) requestPublish(urgent bool) {
 	if urgent {
 		_, _ = zd.publishSync()
@@ -169,7 +182,7 @@ func (zd *ZoneData) requestPublish(urgent bool) {
 	zd.wakePublisher()
 }
 
-// publishSync runs publish immediately under zd.mu (serial bump + dual-write).
+// publishSync runs publish immediately under zd.mu (serial bump + snapshot swap).
 func (zd *ZoneData) resignWorkingSetSOAIfSigned() {
 	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
 		return
@@ -263,7 +276,6 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 	data := zd.workingSet
 	snap := zd.buildSnapshotLocked(serial, data, transport)
 	zd.snapshot.Store(snap)
-	zd.syncLegacyFromSnapshot(snap)
 
 	zd.workingSet = nil
 	zd.wsTransportSignal = nil
@@ -326,24 +338,6 @@ func (zd *ZoneData) buildSnapshotLocked(serial uint32, data map[string]*OwnerDat
 	}
 }
 
-func (zd *ZoneData) syncLegacyFromSnapshot(snap *ZoneSnapshot) {
-	if snap == nil {
-		return
-	}
-	if zd.Data == nil {
-		zd.Data = core.NewCmap[OwnerData]()
-	} else {
-		zd.Data.Clear()
-	}
-	for name, od := range snap.Data {
-		if od != nil {
-			zd.Data.Set(name, *od)
-		}
-	}
-	zd.TransportSignal = cloneTransportSignal(snap.TransportSignal)
-	zd.IxfrChain = copyIxfrChain(snap.IxfrChain)
-}
-
 func (zd *ZoneData) setWorkingSetSOASerial(serial uint32) {
 	if zd.workingSet == nil {
 		return
@@ -379,7 +373,6 @@ func (zd *ZoneData) InstallInitialSnapshot() {
 	data := snapshotMapFromData(zd.Data)
 	snap := zd.buildSnapshotLocked(zd.CurrentSerial, data, zd.TransportSignal)
 	zd.snapshot.Store(snap)
-	zd.syncLegacyFromSnapshot(snap)
 	zd.Ready = true
 	zd.Status = ZoneStatusReady
 }
@@ -444,48 +437,6 @@ func (zd *ZoneData) snapshotGeneration() uint32 {
 	}
 	return snap.Serial
 }
-
-// legacyMatchesSnapshot reports dual-write consistency for tests.
-func (zd *ZoneData) legacyMatchesSnapshot() bool {
-	snap := zd.snapshot.Load()
-	if snap == nil {
-		return zd.Data == nil || zd.Data.IsEmpty()
-	}
-	if zd.Data == nil {
-		return len(snap.Data) == 0
-	}
-	if zd.Data.Count() != len(snap.Data) {
-		return false
-	}
-	for name, snapOd := range snap.Data {
-		legOd, ok := zd.Data.Get(name)
-		if !ok || snapOd == nil {
-			return false
-		}
-		if legOd.RRtypes != snapOd.RRtypes {
-			return false
-		}
-	}
-	if !transportSignalEqual(zd.TransportSignal, snap.TransportSignal) {
-		return false
-	}
-	if len(zd.IxfrChain) != len(snap.IxfrChain) {
-		return false
-	}
-	return zd.CurrentSerial == snap.Serial
-}
-
-func transportSignalEqual(a, b *core.RRset) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return rrsetEqual(*a, *b)
-}
-
-// test-only hooks (none currently)
 
 func (zd *ZoneData) testPublishNow() {
 	zd.publishNow(zd.generation.Load())

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -1,0 +1,141 @@
+package tdns
+
+import (
+	"time"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+const DefaultPublishCadence = 5 * time.Second
+
+// ZoneSnapshot is the immutable reader-facing view of a zone at one serial
+// boundary. Published snapshots are never mutated in place.
+type ZoneSnapshot struct {
+	Serial          uint32
+	SOA             *dns.SOA
+	Apex            *OwnerData
+	Data            map[string]*OwnerData
+	TransportSignal *core.RRset
+	IxfrChain       []Ixfr
+}
+
+// PendingChanges describes staged-but-unpublished zone deltas (B2 observability).
+type PendingChanges struct {
+	PublishedSerial uint32
+	PublishQueued   bool
+	Added           []string
+	Replaced        []pendingOwnerChange
+	Deleted         []pendingOwnerChange
+}
+
+type pendingOwnerChange struct {
+	Owner   string
+	RRtypes []uint16
+}
+
+func parsePublishCadence(s string) (time.Duration, error) {
+	if s == "" {
+		return DefaultPublishCadence, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	if d < time.Second {
+		return 0, errPublishCadenceTooShort
+	}
+	return d, nil
+}
+
+var errPublishCadenceTooShort = &publishCadenceError{"publish-cadence must be at least 1s"}
+
+type publishCadenceError struct{ msg string }
+
+func (e *publishCadenceError) Error() string { return e.msg }
+
+// cloneRRset returns a fresh RRset with copied RRs and RRSIGs. Whole-RRset
+// replace and append paths must use this when rs may alias published snapshot
+// memory (e.g. built from a GetOwner handle).
+func cloneRRset(rs core.RRset) core.RRset {
+	out := rs
+	if len(rs.RRs) > 0 {
+		out.RRs = make([]dns.RR, len(rs.RRs))
+		for i, rr := range rs.RRs {
+			out.RRs[i] = dns.Copy(rr)
+		}
+	} else {
+		out.RRs = nil
+	}
+	if len(rs.RRSIGs) > 0 {
+		out.RRSIGs = make([]dns.RR, len(rs.RRSIGs))
+		for i, rr := range rs.RRSIGs {
+			out.RRSIGs[i] = dns.Copy(rr)
+		}
+	} else {
+		out.RRSIGs = nil
+	}
+	return out
+}
+
+func cloneTransportSignal(ts *core.RRset) *core.RRset {
+	if ts == nil {
+		return nil
+	}
+	cloned := cloneRRset(*ts)
+	return &cloned
+}
+
+func snapshotMapFromData(data *core.ConcurrentMap[string, OwnerData]) map[string]*OwnerData {
+	if data == nil || data.IsEmpty() {
+		return map[string]*OwnerData{}
+	}
+	out := make(map[string]*OwnerData, data.Count())
+	for _, name := range data.Keys() {
+		if od, ok := data.Get(name); ok {
+			odCopy := od
+			out[name] = &odCopy
+		}
+	}
+	return out
+}
+
+func apexFromSnapshotData(zd *ZoneData, data map[string]*OwnerData) *OwnerData {
+	if zd == nil || data == nil {
+		return nil
+	}
+	return data[zd.ZoneName]
+}
+
+func soaFromApex(serial uint32, apex *OwnerData) *dns.SOA {
+	if apex == nil {
+		return nil
+	}
+	rs := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	if len(rs.RRs) == 0 {
+		return nil
+	}
+	soa, ok := rs.RRs[0].(*dns.SOA)
+	if !ok {
+		return nil
+	}
+	copy := dns.Copy(soa).(*dns.SOA)
+	copy.Serial = serial
+	return copy
+}
+
+func copyIxfrChain(chain []Ixfr) []Ixfr {
+	if len(chain) == 0 {
+		return nil
+	}
+	out := make([]Ixfr, len(chain))
+	copy(out, chain)
+	return out
+}
+
+func publishCadenceForZone(zd *ZoneData) time.Duration {
+	if zd == nil || zd.publishCadence == 0 {
+		return DefaultPublishCadence
+	}
+	return zd.publishCadence
+}

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -11,9 +11,10 @@ import (
 
 const DefaultPublishCadence = 5 * time.Second
 
-// ZoneSnapshot is the immutable reader-facing view of a zone at one serial
-// boundary. Published snapshots are never mutated in place.
-type ZoneSnapshot struct {
+// zoneSnapshot is the immutable reader-facing view of a zone at one serial
+// boundary. Published snapshots are never mutated in place. The type is
+// unexported so callers cannot mutate served data without going through publish.
+type zoneSnapshot struct {
 	Serial          uint32
 	SOA             *dns.SOA
 	Apex            *OwnerData
@@ -218,7 +219,7 @@ func publishCadenceForZone(zd *ZoneData) time.Duration {
 	return zd.publishCadence
 }
 
-func (zd *ZoneData) publishedSnapshot() *ZoneSnapshot {
+func (zd *ZoneData) publishedSnapshot() *zoneSnapshot {
 	if zd == nil {
 		return nil
 	}

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -248,7 +248,13 @@ func (zd *ZoneData) publishedTransportSignal() *core.RRset {
 
 // soaForResponse returns a response-only SOA RRset from the published snapshot.
 func (zd *ZoneData) soaForResponse(apex *OwnerData) core.RRset {
-	if snap := zd.publishedSnapshot(); snap != nil && snap.SOA != nil {
+	return zd.soaForResponseFrom(zd.publishedSnapshot(), apex)
+}
+
+// soaForResponseFrom builds the response SOA from an ALREADY-PINNED snapshot so
+// the SOA serial matches the rest of the response (no intra-response tearing).
+func (zd *ZoneData) soaForResponseFrom(snap *zoneSnapshot, apex *OwnerData) core.RRset {
+	if snap != nil && snap.SOA != nil {
 		rs := core.RRset{
 			Name:   snap.SOA.Hdr.Name,
 			Class:  snap.SOA.Hdr.Class,

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -15,12 +15,18 @@ const DefaultPublishCadence = 5 * time.Second
 // boundary. Published snapshots are never mutated in place. The type is
 // unexported so callers cannot mutate served data without going through publish.
 type zoneSnapshot struct {
-	Serial          uint32
-	SOA             *dns.SOA
-	Apex            *OwnerData
-	Data            map[string]*OwnerData
-	TransportSignal *core.RRset
-	IxfrChain       []Ixfr
+	Serial uint32
+	SOA    *dns.SOA
+	Apex   *OwnerData
+	Data   map[string]*OwnerData
+	// signalSynth holds synthesized transport-signal RRsets for owner names
+	// that have no authoritative home on this server (Case A: an out-of-bailiwick
+	// identity nameserver whose own zone we do not host). Keyed by "_dns.<ns>".
+	// Normally empty: in-bailiwick and co-hosted signals are served from their
+	// real, resigner-maintained owner RRsets in Data (or another zone's Data),
+	// not from here. Injection prefers an authoritative copy over a synth entry.
+	signalSynth map[string]*core.RRset
+	IxfrChain   []Ixfr
 }
 
 // PendingChanges describes staged-but-unpublished zone deltas (B2 observability).
@@ -157,12 +163,19 @@ func cloneRRset(rs core.RRset) core.RRset {
 	return out
 }
 
-func cloneTransportSignal(ts *core.RRset) *core.RRset {
-	if ts == nil {
+func cloneSignalSynth(m map[string]*core.RRset) map[string]*core.RRset {
+	if len(m) == 0 {
 		return nil
 	}
-	cloned := cloneRRset(*ts)
-	return &cloned
+	out := make(map[string]*core.RRset, len(m))
+	for k, v := range m {
+		if v == nil {
+			continue
+		}
+		cloned := cloneRRset(*v)
+		out[k] = &cloned
+	}
+	return out
 }
 
 // snapshotMapFromData builds the snapshot's owner map from a source store.
@@ -236,14 +249,6 @@ func (zd *ZoneData) publishedSnapshot() *zoneSnapshot {
 		return nil
 	}
 	return zd.snapshot.Load()
-}
-
-func (zd *ZoneData) publishedTransportSignal() *core.RRset {
-	snap := zd.publishedSnapshot()
-	if snap == nil {
-		return nil
-	}
-	return snap.TransportSignal
 }
 
 // soaForResponse returns a response-only SOA RRset from the published snapshot.

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -165,6 +165,18 @@ func cloneTransportSignal(ts *core.RRset) *core.RRset {
 	return &cloned
 }
 
+// snapshotMapFromData builds the snapshot's owner map from a source store.
+//
+// IMMUTABILITY INVARIANT (copy-strategy-A, per the snapshot-correctness design):
+// each entry is a FRESH *OwnerData, but its RRtypes (*RRTypeStore) pointer is
+// SHARED with the source by design — deliberately, so large PQ signature bytes
+// are not re-copied on every publish. The immutability guarantee therefore rests
+// on the source store being FROZEN once snapshotted: callers must never mutate
+// `data` (zd.Data, or a discarded new_zd.Data) in place afterwards. Post-B3 all
+// writers stage into a fresh workingSet and publish; the CI grep gate forbids
+// direct RRtypes.Set/Data.Set on the live path. A future direct writer to a
+// snapshotted store would silently reintroduce the serial-tearing bug — keep
+// this invariant loud.
 func snapshotMapFromData(data *core.ConcurrentMap[string, OwnerData]) map[string]*OwnerData {
 	if data == nil || data.IsEmpty() {
 		return map[string]*OwnerData{}
@@ -247,6 +259,12 @@ func (zd *ZoneData) soaForResponse(apex *OwnerData) core.RRset {
 			rs.RRSIGs = cloneRRset(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)).RRSIGs
 		}
 		return rs
+	}
+	// Fallback (no published snapshot yet): guard a nil apex so a query racing
+	// zone initialization cannot panic here. Hot-path callers also SERVFAIL
+	// when publishedSnapshot()==nil (see QueryResponder).
+	if apex == nil {
+		return core.RRset{}
 	}
 	rs := cloneRRset(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA))
 	if len(rs.RRs) > 0 {

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -1,6 +1,8 @@
 package tdns
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -29,9 +31,85 @@ type PendingChanges struct {
 	Deleted         []pendingOwnerChange
 }
 
+// PendingChangesView is the JSON/API representation of pendingChanges().
+type PendingChangesView struct {
+	PublishedSerial uint32                   `json:"published_serial"`
+	PublishQueued   bool                     `json:"publish_queued"`
+	Added           []string                 `json:"added,omitempty"`
+	Replaced        []PendingOwnerChangeJSON `json:"replaced,omitempty"`
+	Deleted         []PendingOwnerChangeJSON `json:"deleted,omitempty"`
+}
+
+func pendingChangesView(pc *PendingChanges) *PendingChangesView {
+	if pc == nil {
+		return nil
+	}
+	v := &PendingChangesView{
+		PublishedSerial: pc.PublishedSerial,
+		PublishQueued:   pc.PublishQueued,
+		Added:           append([]string(nil), pc.Added...),
+	}
+	for _, ch := range pc.Replaced {
+		v.Replaced = append(v.Replaced, pendingOwnerChangeJSON(ch))
+	}
+	for _, ch := range pc.Deleted {
+		v.Deleted = append(v.Deleted, pendingOwnerChangeJSON(ch))
+	}
+	return v
+}
+
+func pendingOwnerChangeJSON(ch pendingOwnerChange) PendingOwnerChangeJSON {
+	out := PendingOwnerChangeJSON{
+		Owner:   ch.Owner,
+		RRtypes: append([]uint16(nil), ch.RRtypes...),
+	}
+	for _, t := range ch.RRtypes {
+		out.TypeNames = append(out.TypeNames, dns.TypeToString[t])
+	}
+	return out
+}
+
+// FormatPendingChanges returns a human-readable summary for CLI output.
+func FormatPendingChanges(pc *PendingChanges) string {
+	if pc == nil {
+		return "no pending changes"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "published serial: %d\n", pc.PublishedSerial)
+	fmt.Fprintf(&b, "publish queued: %v\n", pc.PublishQueued)
+	for _, name := range pc.Added {
+		fmt.Fprintf(&b, "added owner: %s\n", name)
+	}
+	for _, ch := range pc.Replaced {
+		fmt.Fprintf(&b, "replaced owner: %s types: %s\n", ch.Owner, rrtypesString(ch.RRtypes))
+	}
+	for _, ch := range pc.Deleted {
+		fmt.Fprintf(&b, "deleted owner: %s types: %s\n", ch.Owner, rrtypesString(ch.RRtypes))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func rrtypesString(types []uint16) string {
+	if len(types) == 0 {
+		return "-"
+	}
+	names := make([]string, len(types))
+	for i, t := range types {
+		names[i] = dns.TypeToString[t]
+	}
+	return strings.Join(names, ",")
+}
+
 type pendingOwnerChange struct {
 	Owner   string
 	RRtypes []uint16
+}
+
+// PendingOwnerChangeJSON is the API/CLI view of a pending owner delta.
+type PendingOwnerChangeJSON struct {
+	Owner     string   `json:"owner"`
+	RRtypes   []uint16 `json:"rrtypes"`
+	TypeNames []string `json:"type_names,omitempty"`
 }
 
 func parsePublishCadence(s string) (time.Duration, error) {

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -139,3 +139,14 @@ func publishCadenceForZone(zd *ZoneData) time.Duration {
 	}
 	return zd.publishCadence
 }
+
+// soaForResponse returns a response-only SOA RRset stamped with the served serial.
+func (zd *ZoneData) soaForResponse(apex *OwnerData) core.RRset {
+	rs := cloneRRset(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA))
+	if len(rs.RRs) > 0 {
+		if soa, ok := rs.RRs[0].(*dns.SOA); ok {
+			soa.Serial = zd.CurrentSerial
+		}
+	}
+	return rs
+}

--- a/v2/zone_snapshot.go
+++ b/v2/zone_snapshot.go
@@ -218,8 +218,35 @@ func publishCadenceForZone(zd *ZoneData) time.Duration {
 	return zd.publishCadence
 }
 
-// soaForResponse returns a response-only SOA RRset stamped with the served serial.
+func (zd *ZoneData) publishedSnapshot() *ZoneSnapshot {
+	if zd == nil {
+		return nil
+	}
+	return zd.snapshot.Load()
+}
+
+func (zd *ZoneData) publishedTransportSignal() *core.RRset {
+	snap := zd.publishedSnapshot()
+	if snap == nil {
+		return nil
+	}
+	return snap.TransportSignal
+}
+
+// soaForResponse returns a response-only SOA RRset from the published snapshot.
 func (zd *ZoneData) soaForResponse(apex *OwnerData) core.RRset {
+	if snap := zd.publishedSnapshot(); snap != nil && snap.SOA != nil {
+		rs := core.RRset{
+			Name:   snap.SOA.Hdr.Name,
+			Class:  snap.SOA.Hdr.Class,
+			RRtype: dns.TypeSOA,
+			RRs:    []dns.RR{dns.Copy(snap.SOA)},
+		}
+		if apex != nil {
+			rs.RRSIGs = cloneRRset(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)).RRSIGs
+		}
+		return rs
+	}
 	rs := cloneRRset(apex.RRtypes.GetOnlyRRSet(dns.TypeSOA))
 	if len(rs.RRs) > 0 {
 		if soa, ok := rs.RRs[0].(*dns.SOA); ok {

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -90,6 +90,30 @@ www.example.	3600	IN	A	192.0.2.1
 	}
 }
 
+func TestCurrentSerialMatchesSnapshot(t *testing.T) {
+	zd := testSnapshotZone(t, "example.", `example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+www.example. 3600 IN A 192.0.2.1
+`)
+	if snap := zd.snapshot.Load(); snap == nil || snap.Serial != zd.CurrentSerial {
+		t.Fatalf("initial serial mirror drift: snap=%v current=%d", snap, zd.CurrentSerial)
+	}
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, "192.0.2.55"))
+	zd.mu.Unlock()
+	zd.testPublishNow()
+
+	snap := zd.snapshot.Load()
+	if snap == nil || snap.Serial != zd.CurrentSerial || snap.Serial != 2 {
+		t.Fatalf("post-publish serial mirror drift: snap=%v current=%d", snap, zd.CurrentSerial)
+	}
+	if soa := snap.SOA; soa == nil || soa.Serial != snap.Serial {
+		t.Fatalf("SOA serial != snapshot serial: soa=%v snap=%d", soa, snap.Serial)
+	}
+}
+
 func TestInitialSnapshotBeforeReady(t *testing.T) {
 	zd := &ZoneData{
 		ZoneName:      "example.",

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -28,6 +28,7 @@ func testSnapshotZone(t *testing.T, name, zoneStr string) *ZoneData {
 	Zones.Set(name, zd)
 	t.Cleanup(func() { Zones.Remove(name) })
 	zd.InstallInitialSnapshot()
+	t.Cleanup(zd.stopPublisher)
 	return zd
 }
 

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -1,10 +1,12 @@
 package tdns
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -194,6 +196,104 @@ func TestParsePublishCadence(t *testing.T) {
 	if err != nil || d != 10*time.Second {
 		t.Fatalf("10s: d=%v err=%v", d, err)
 	}
+}
+
+func TestPendingChanges(t *testing.T) {
+	zd := testSnapshotZone(t, "example.", `example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+www.example. 3600 IN A 192.0.2.1
+`)
+	serialBefore := zd.snapshotGeneration()
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, "192.0.2.50"))
+	zd.mu.Unlock()
+
+	pc := zd.pendingChanges()
+	if pc == nil {
+		t.Fatal("expected pending changes after staging")
+	}
+	if pc.PublishedSerial != serialBefore {
+		t.Fatalf("published serial = %d, want %d", pc.PublishedSerial, serialBefore)
+	}
+	if len(pc.Replaced) != 1 || pc.Replaced[0].Owner != "www.example." {
+		t.Fatalf("replaced = %+v, want www.example.", pc.Replaced)
+	}
+
+	zd.testPublishNow()
+	if pc2 := zd.pendingChanges(); pc2 != nil {
+		t.Fatalf("expected nil pending changes after publish, got %+v", pc2)
+	}
+	if zd.snapshotGeneration() != serialBefore+1 {
+		t.Fatalf("serial = %d, want %d", zd.snapshotGeneration(), serialBefore+1)
+	}
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("new.example.", coreRRset("new.example.", dns.TypeA, "192.0.2.2"))
+	zd.mu.Unlock()
+	pc = zd.pendingChanges()
+	if pc == nil || len(pc.Added) != 1 || pc.Added[0] != "new.example." {
+		t.Fatalf("added = %+v, want new.example.", pc)
+	}
+}
+
+func TestConcurrentServeAndUpdate(t *testing.T) {
+	zd := testSnapshotZone(t, "example.", `example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+www.example. 3600 IN A 192.0.2.1
+`)
+	zd.publishCadence = 100 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				owner, err := zd.GetOwner("www.example.")
+				if err != nil || owner == nil {
+					continue
+				}
+				_ = owner.RRtypes.GetOnlyRRSet(dns.TypeA)
+			}
+		}()
+	}
+
+	for i := 0; i < 30; i++ {
+		zd.mu.Lock()
+		zd.ensureWorkingSet()
+		zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, fmt.Sprintf("192.0.2.%d", 20+i%80)))
+		zd.mu.Unlock()
+		if i%5 == 0 {
+			zd.requestPublish(true)
+		} else {
+			zd.requestPublish(false)
+		}
+		deadline := time.Now().Add(500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			zd.mu.Lock()
+			ok := zd.workingSet == nil && zd.legacyMatchesSnapshot()
+			zd.mu.Unlock()
+			if ok {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		zd.mu.Lock()
+		ok := zd.workingSet == nil && zd.legacyMatchesSnapshot()
+		zd.mu.Unlock()
+		if !ok {
+			t.Fatalf("dual-write mismatch after publish cycle %d", i)
+		}
+	}
+
+	cancel()
+	wg.Wait()
 }
 
 func coreRRset(name string, rrtype uint16, ip string) core.RRset {

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -52,23 +52,20 @@ www.example.	3600	IN	A	192.0.2.1
 	}
 	owner, _ := zd.GetOwner("www.example.")
 	if owner == nil {
-		t.Fatal("missing www owner in legacy store")
+		t.Fatal("missing www owner in published snapshot")
 	}
 	a := owner.RRtypes.GetOnlyRRSet(dns.TypeA)
 	if len(a.RRs) == 0 || a.RRs[0].(*dns.A).A.String() != "192.0.2.1" {
-		t.Fatalf("legacy store mutated during staging: %v", a.RRs)
+		t.Fatalf("published snapshot mutated during staging: %v", a.RRs)
 	}
 }
 
-func TestDualWriteConsistency(t *testing.T) {
+func TestPublishedSnapshotAfterPublish(t *testing.T) {
 	zone := `example.	3600	IN	SOA	ns.example. hostmaster.example. 1 7200 1800 604800 7200
 example.	3600	IN	NS	ns.example.
 www.example.	3600	IN	A	192.0.2.1
 `
 	zd := testSnapshotZone(t, "example.", zone)
-	if !zd.legacyMatchesSnapshot() {
-		t.Fatal("initial dual-write mismatch")
-	}
 
 	zd.mu.Lock()
 	zd.ensureWorkingSet()
@@ -76,11 +73,20 @@ www.example.	3600	IN	A	192.0.2.1
 	zd.mu.Unlock()
 	zd.testPublishNow()
 
-	if !zd.legacyMatchesSnapshot() {
-		t.Fatal("dual-write mismatch after publish")
+	owner, err := zd.GetOwner("www.example.")
+	if err != nil || owner == nil {
+		t.Fatal("missing www owner after publish")
+	}
+	a := owner.RRtypes.GetOnlyRRSet(dns.TypeA)
+	if len(a.RRs) == 0 || a.RRs[0].(*dns.A).A.String() != "192.0.2.99" {
+		t.Fatalf("published A = %v, want 192.0.2.99", a.RRs)
 	}
 	if zd.CurrentSerial != 2 {
 		t.Fatalf("serial = %d, want 2", zd.CurrentSerial)
+	}
+	snap := zd.snapshot.Load()
+	if snap == nil || snap.Serial != 2 {
+		t.Fatalf("snapshot serial = %v, want 2", snap)
 	}
 }
 
@@ -277,18 +283,56 @@ www.example. 3600 IN A 192.0.2.1
 		deadline := time.Now().Add(500 * time.Millisecond)
 		for time.Now().Before(deadline) {
 			zd.mu.Lock()
-			ok := zd.workingSet == nil && zd.legacyMatchesSnapshot()
+			idle := zd.workingSet == nil
 			zd.mu.Unlock()
-			if ok {
+			if !idle {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			snap := zd.snapshot.Load()
+			if snap == nil {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			if snap.Serial != zd.snapshotGeneration() {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			got, err := zd.GetOwner("www.example.")
+			if err != nil || got == nil {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			snapOwner := snap.Data["www.example."]
+			if snapOwner == nil {
+				time.Sleep(5 * time.Millisecond)
+				continue
+			}
+			aSnap := snapOwner.RRtypes.GetOnlyRRSet(dns.TypeA)
+			aGet := got.RRtypes.GetOnlyRRSet(dns.TypeA)
+			if len(aSnap.RRs) > 0 && len(aGet.RRs) > 0 &&
+				aSnap.RRs[0].(*dns.A).A.String() == aGet.RRs[0].(*dns.A).A.String() {
 				break
 			}
 			time.Sleep(5 * time.Millisecond)
 		}
-		zd.mu.Lock()
-		ok := zd.workingSet == nil && zd.legacyMatchesSnapshot()
-		zd.mu.Unlock()
-		if !ok {
-			t.Fatalf("dual-write mismatch after publish cycle %d", i)
+		snap := zd.snapshot.Load()
+		got, err := zd.GetOwner("www.example.")
+		if snap == nil || err != nil || got == nil {
+			t.Fatalf("snapshot reader mismatch after publish cycle %d", i)
+		}
+		snapOwner := snap.Data["www.example."]
+		if snapOwner == nil {
+			t.Fatalf("missing www in snapshot after publish cycle %d", i)
+		}
+		aSnap := snapOwner.RRtypes.GetOnlyRRSet(dns.TypeA)
+		aGet := got.RRtypes.GetOnlyRRSet(dns.TypeA)
+		if len(aSnap.RRs) == 0 || len(aGet.RRs) == 0 ||
+			aSnap.RRs[0].(*dns.A).A.String() != aGet.RRs[0].(*dns.A).A.String() {
+			t.Fatalf("GetOwner != snapshot after publish cycle %d", i)
+		}
+		if snap.Serial != zd.snapshotGeneration() {
+			t.Fatalf("serial invariant broken after publish cycle %d: snap=%d gen=%d", i, snap.Serial, zd.snapshotGeneration())
 		}
 	}
 

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
+	edns0 "github.com/johanix/tdns/v2/edns0"
 	"github.com/miekg/dns"
 )
 
@@ -362,6 +363,84 @@ www.example. 3600 IN A 192.0.2.1
 
 	cancel()
 	wg.Wait()
+}
+
+// TestQueryResponderNoIntraResponseTearing (m3) drives the real QueryResponder
+// under concurrent publishes and asserts that a single response is internally
+// consistent: the publisher keeps www.example. A and the apex-NS glue
+// (ns.example. A) in lockstep, so within any one published snapshot they carry
+// the same octet. A response therefore has matching answer/glue octets only if
+// the whole response is served from ONE pinned snapshot (C1). Before C1 the
+// answer and the glue were independent snapshot loads and could straddle two
+// publishes.
+func TestQueryResponderNoIntraResponseTearing(t *testing.T) {
+	zd := testSnapshotZone(t, "example.", `example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+ns.example. 3600 IN A 10.0.0.1
+www.example. 3600 IN A 10.0.0.1
+`)
+	zd.publishCadence = 10 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for v := 2; ctx.Err() == nil; v++ {
+			ip := fmt.Sprintf("10.0.0.%d", v%250+1)
+			zd.mu.Lock()
+			zd.ensureWorkingSet()
+			zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, ip))
+			zd.stageRRset("ns.example.", coreRRset("ns.example.", dns.TypeA, ip))
+			zd.mu.Unlock()
+			zd.requestPublish(true)
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	msgo := &edns0.MsgOptions{}
+	checks := 0
+	for i := 0; i < 5000 && ctx.Err() == nil; i++ {
+		req := new(dns.Msg)
+		req.SetQuestion("www.example.", dns.TypeA)
+		rw := &fakeRW{}
+		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeA, msgo, nil, nil); err != nil {
+			continue
+		}
+		resp := rw.written
+		if resp == nil {
+			continue
+		}
+		ans := lastOctetOf(resp.Answer, "www.example.")
+		glue := lastOctetOf(resp.Extra, "ns.example.")
+		if ans < 0 || glue < 0 {
+			continue
+		}
+		checks++
+		if ans != glue {
+			t.Fatalf("intra-response tearing: answer www A .%d != authority glue ns A .%d", ans, glue)
+		}
+	}
+	cancel()
+	wg.Wait()
+	if checks == 0 {
+		t.Fatal("test exercised no comparable responses (answer+glue never both present)")
+	}
+}
+
+func lastOctetOf(rrs []dns.RR, name string) int {
+	for _, rr := range rrs {
+		a, ok := rr.(*dns.A)
+		if !ok || a.Hdr.Name != name {
+			continue
+		}
+		if ip := a.A.To4(); ip != nil {
+			return int(ip[3])
+		}
+	}
+	return -1
 }
 
 func coreRRset(name string, rrtype uint16, ip string) core.RRset {

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -1,0 +1,212 @@
+package tdns
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+func testSnapshotZone(t *testing.T, name, zoneStr string) *ZoneData {
+	t.Helper()
+	zd := &ZoneData{
+		ZoneName:  name,
+		ZoneStore: MapZone,
+		Logger:    log.New(os.Stderr, "", 0),
+	}
+	if _, _, err := zd.ReadZoneData(zoneStr, true); err != nil {
+		t.Fatalf("ReadZoneData: %v", err)
+	}
+	Zones.Set(name, zd)
+	t.Cleanup(func() { Zones.Remove(name) })
+	zd.InstallInitialSnapshot()
+	return zd
+}
+
+func TestSnapshotImmutability(t *testing.T) {
+	zone := `example.	3600	IN	SOA	ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example.	3600	IN	NS	ns.example.
+www.example.	3600	IN	A	192.0.2.1
+`
+	zd := testSnapshotZone(t, "example.", zone)
+	before := zd.snapshot.Load()
+	if before == nil {
+		t.Fatal("expected initial snapshot")
+	}
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, "192.0.2.2"))
+	zd.mu.Unlock()
+
+	after := zd.snapshot.Load()
+	if after != before {
+		t.Fatal("published snapshot pointer changed without publish")
+	}
+	owner, _ := zd.GetOwner("www.example.")
+	if owner == nil {
+		t.Fatal("missing www owner in legacy store")
+	}
+	a := owner.RRtypes.GetOnlyRRSet(dns.TypeA)
+	if len(a.RRs) == 0 || a.RRs[0].(*dns.A).A.String() != "192.0.2.1" {
+		t.Fatalf("legacy store mutated during staging: %v", a.RRs)
+	}
+}
+
+func TestDualWriteConsistency(t *testing.T) {
+	zone := `example.	3600	IN	SOA	ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example.	3600	IN	NS	ns.example.
+www.example.	3600	IN	A	192.0.2.1
+`
+	zd := testSnapshotZone(t, "example.", zone)
+	if !zd.legacyMatchesSnapshot() {
+		t.Fatal("initial dual-write mismatch")
+	}
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, "192.0.2.99"))
+	zd.mu.Unlock()
+	zd.testPublishNow()
+
+	if !zd.legacyMatchesSnapshot() {
+		t.Fatal("dual-write mismatch after publish")
+	}
+	if zd.CurrentSerial != 2 {
+		t.Fatalf("serial = %d, want 2", zd.CurrentSerial)
+	}
+}
+
+func TestInitialSnapshotBeforeReady(t *testing.T) {
+	zd := &ZoneData{
+		ZoneName:      "example.",
+		ZoneStore:     MapZone,
+		Logger:        log.New(os.Stderr, "", 0),
+		CurrentSerial: 1,
+	}
+	if _, _, err := zd.ReadZoneData(`example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+`, true); err != nil {
+		t.Fatalf("ReadZoneData: %v", err)
+	}
+	if zd.Ready {
+		t.Fatal("Ready before InstallInitialSnapshot")
+	}
+	zd.InstallInitialSnapshot()
+	if !zd.Ready {
+		t.Fatal("Ready not set after InstallInitialSnapshot")
+	}
+	if zd.snapshot.Load() == nil {
+		t.Fatal("snapshot not installed")
+	}
+}
+
+func TestPublishCoalescing(t *testing.T) {
+	zd := testSnapshotZone(t, "example.", `example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+www.example. 3600 IN A 192.0.2.1
+`)
+	zd.publishCadence = 200 * time.Millisecond
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, "192.0.2.2"))
+	zd.mu.Unlock()
+	zd.requestPublish(false)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if zd.snapshotGeneration() == 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	first := zd.snapshotGeneration()
+	if first != 2 {
+		t.Fatalf("first publish serial = %d, want 2", first)
+	}
+
+	for i := 0; i < 5; i++ {
+		zd.mu.Lock()
+		zd.ensureWorkingSet()
+		zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, fmt.Sprintf("192.0.2.%d", 10+i)))
+		zd.mu.Unlock()
+		zd.requestPublish(false)
+		time.Sleep(15 * time.Millisecond)
+	}
+
+	time.Sleep(350 * time.Millisecond)
+	second := zd.snapshotGeneration()
+	if second != first+1 {
+		t.Fatalf("coalesced publishes: serial went %d -> %d, want one bump", first, second)
+	}
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, "192.0.2.99"))
+	zd.mu.Unlock()
+	zd.requestPublish(true)
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if zd.snapshotGeneration() == second+1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("urgent publish did not bump serial from %d", second)
+}
+
+func TestPublishGenerationGuard(t *testing.T) {
+	zd := testSnapshotZone(t, "example.", `example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+`)
+
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.stageRRset("www.example.", coreRRset("www.example.", dns.TypeA, "192.0.2.1"))
+	staleGen := zd.generation.Load()
+	zd.generation.Add(1)
+	zd.publishLocked(staleGen)
+	zd.mu.Unlock()
+
+	if zd.workingSet != nil {
+		t.Fatal("working set should be cleared when generation guard drops publish")
+	}
+	if zd.snapshotGeneration() != 1 {
+		t.Fatalf("serial = %d, want 1 (publish dropped)", zd.snapshotGeneration())
+	}
+}
+
+func TestParsePublishCadence(t *testing.T) {
+	d, err := parsePublishCadence("")
+	if err != nil || d != DefaultPublishCadence {
+		t.Fatalf("default: d=%v err=%v", d, err)
+	}
+	if _, err := parsePublishCadence("500ms"); err == nil {
+		t.Fatal("expected error for sub-1s cadence")
+	}
+	d, err = parsePublishCadence("10s")
+	if err != nil || d != 10*time.Second {
+		t.Fatalf("10s: d=%v err=%v", d, err)
+	}
+}
+
+func coreRRset(name string, rrtype uint16, ip string) core.RRset {
+	if rrtype == dns.TypeA {
+		return core.RRset{
+			Name:   name,
+			Class:  dns.ClassINET,
+			RRtype: dns.TypeA,
+			RRs: []dns.RR{&dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+				A:   net.ParseIP(ip).To4(),
+			}},
+		}
+	}
+	return core.RRset{}
+}

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -565,3 +565,149 @@ func TestSignRRsetForZoneBrokenZone(t *testing.T) {
 		t.Fatal("a stored A RRset must not be treated as ephemeral")
 	}
 }
+
+// answerHasRRSIG reports whether any RRSIG (optionally covering a specific type,
+// 0 = any) sits in the Answer section.
+func answerHasRRSIG(m *dns.Msg, typeCovered uint16) bool {
+	for _, rr := range m.Answer {
+		if s, ok := rr.(*dns.RRSIG); ok {
+			if typeCovered == 0 || s.TypeCovered == typeCovered {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// answerHasA reports whether the Answer section carries an A RR with the given
+// owner name.
+func answerHasA(m *dns.Msg, owner string) bool {
+	for _, rr := range m.Answer {
+		if a, ok := rr.(*dns.A); ok && a.Hdr.Name == owner {
+			return true
+		}
+	}
+	return false
+}
+
+// TestWildcardAnswerFailClosed extends Finding 1 / Decision 1 to the wildcard-
+// answer path. A wildcard match (qname != origqname) builds its answer via
+// WildcardReplace and previously served stored RRSIGs directly, bypassing the
+// must-be-signed fail-closed check that the exact-match arm performs. A broken
+// (must-be-signed, unsigned) zone therefore served a wildcard-covered name
+// UNSIGNED — a silent downgrade. The wildcard arm must now SERVFAIL exactly like
+// the exact-match arm, while genuinely-signed and unsigned-by-design wildcards
+// keep answering.
+func TestWildcardAnswerFailClosed(t *testing.T) {
+	ctx := context.Background()
+
+	// Case 1: broken zone — must be signed, but nothing carries RRSIGs. A DO
+	// query for a wildcard-covered name must SERVFAIL, with no fabricated RRSIG.
+	t.Run("broken_wildcard_servfail", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := testSnapshotZone(t, "broken-wild.example.", `broken-wild.example. 3600 IN SOA ns.broken-wild.example. hostmaster.broken-wild.example. 1 7200 1800 604800 7200
+broken-wild.example. 3600 IN NS ns.broken-wild.example.
+ns.broken-wild.example. 3600 IN A 10.0.0.1
+*.broken-wild.example. 3600 IN A 10.0.0.5
+`)
+		zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+		zd.KeyDB = kdb
+
+		req := new(dns.Msg)
+		req.SetQuestion("nothere.broken-wild.example.", dns.TypeA)
+		rw := &fakeRW{}
+		if err := zd.QueryResponder(ctx, rw, req, "nothere.broken-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+			t.Fatalf("QueryResponder (DO wildcard): %v", err)
+		}
+		resp := rw.written
+		if resp == nil {
+			t.Fatal("no response written for DO wildcard query")
+		}
+		if resp.MsgHdr.Rcode != dns.RcodeServerFailure {
+			t.Fatalf("broken-zone wildcard DO query: expected SERVFAIL, got %s", dns.RcodeToString[resp.MsgHdr.Rcode])
+		}
+		for _, rr := range append(append([]dns.RR{}, resp.Answer...), resp.Ns...) {
+			if _, ok := rr.(*dns.RRSIG); ok {
+				t.Fatalf("SERVFAIL must not carry a synthesized RRSIG: %s", rr.String())
+			}
+			if _, ok := rr.(*dns.A); ok {
+				t.Fatalf("SERVFAIL must not serve the unsigned wildcard answer: %s", rr.String())
+			}
+		}
+	})
+
+	// Case 2: healthy signed zone — the wildcard RRset carries a stored RRSIG. A
+	// DO query for a covered name must answer NOERROR with the wildcard-replaced
+	// A record and its wildcard-replaced RRSIG, both owned by the queried name.
+	t.Run("signed_wildcard_answers", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := testSnapshotZone(t, "signed-wild.example.", `signed-wild.example. 3600 IN SOA ns.signed-wild.example. hostmaster.signed-wild.example. 1 7200 1800 604800 7200
+signed-wild.example. 3600 IN NS ns.signed-wild.example.
+ns.signed-wild.example. 3600 IN A 10.0.0.1
+*.signed-wild.example. 3600 IN A 10.0.0.5
+*.signed-wild.example. 3600 IN RRSIG A 13 2 3600 20260801000000 20260701000000 12345 signed-wild.example. AwEAAcBadDummySignatureBytesForTestingWildcardRRSIGPresence0000000000000000000000000000AA==
+`)
+		zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+		zd.KeyDB = kdb
+
+		req := new(dns.Msg)
+		req.SetQuestion("host.signed-wild.example.", dns.TypeA)
+		rw := &fakeRW{}
+		if err := zd.QueryResponder(ctx, rw, req, "host.signed-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+			t.Fatalf("QueryResponder (DO signed wildcard): %v", err)
+		}
+		resp := rw.written
+		if resp == nil {
+			t.Fatal("no response written for signed wildcard query")
+		}
+		if resp.MsgHdr.Rcode != dns.RcodeSuccess {
+			t.Fatalf("signed wildcard DO query: expected NOERROR, got %s", dns.RcodeToString[resp.MsgHdr.Rcode])
+		}
+		if !answerHasA(resp, "host.signed-wild.example.") {
+			t.Fatalf("signed wildcard answer missing A owned by the queried name; answer=%v", resp.Answer)
+		}
+		if !answerHasRRSIG(resp, dns.TypeA) {
+			t.Fatalf("signed wildcard answer must carry the (wildcard-replaced) A RRSIG; answer=%v", resp.Answer)
+		}
+		// The wildcard-replaced RRSIG must be re-owned by the queried name.
+		for _, rr := range resp.Answer {
+			if s, ok := rr.(*dns.RRSIG); ok && s.TypeCovered == dns.TypeA && s.Hdr.Name != "host.signed-wild.example." {
+				t.Fatalf("wildcard A RRSIG owner = %s, want host.signed-wild.example.", s.Hdr.Name)
+			}
+		}
+	})
+
+	// Case 3: unsigned-by-design zone — no signing configured. A DO query for a
+	// wildcard-covered name still answers NOERROR, served unsigned (as before);
+	// the fail-closed check applies only to must-be-signed zones.
+	t.Run("unsigned_wildcard_answers", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := testSnapshotZone(t, "plain-wild.example.", `plain-wild.example. 3600 IN SOA ns.plain-wild.example. hostmaster.plain-wild.example. 1 7200 1800 604800 7200
+plain-wild.example. 3600 IN NS ns.plain-wild.example.
+ns.plain-wild.example. 3600 IN A 10.0.0.1
+*.plain-wild.example. 3600 IN A 10.0.0.5
+`)
+		// No OptOnlineSigning / OptInlineSigning — legitimately unsigned.
+		zd.KeyDB = kdb
+
+		req := new(dns.Msg)
+		req.SetQuestion("host.plain-wild.example.", dns.TypeA)
+		rw := &fakeRW{}
+		if err := zd.QueryResponder(ctx, rw, req, "host.plain-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+			t.Fatalf("QueryResponder (DO unsigned wildcard): %v", err)
+		}
+		resp := rw.written
+		if resp == nil {
+			t.Fatal("no response written for unsigned wildcard query")
+		}
+		if resp.MsgHdr.Rcode != dns.RcodeSuccess {
+			t.Fatalf("unsigned-by-design wildcard DO query: expected NOERROR, got %s", dns.RcodeToString[resp.MsgHdr.Rcode])
+		}
+		if !answerHasA(resp, "host.plain-wild.example.") {
+			t.Fatalf("unsigned wildcard answer missing A owned by the queried name; answer=%v", resp.Answer)
+		}
+		if answerHasRRSIG(resp, 0) {
+			t.Fatalf("unsigned-by-design zone must not fabricate an RRSIG; answer=%v", resp.Answer)
+		}
+	})
+}

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -2,6 +2,7 @@ package tdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -457,4 +458,110 @@ func coreRRset(name string, rrtype uint16, ip string) core.RRset {
 		}
 	}
 	return core.RRset{}
+}
+
+// TestQueryServfailForUnsignedMustBeSignedZone is the regression test for
+// Finding 1 / Decision 1: a zone that MUST be signed (online/inline-signing) but
+// whose published snapshot carries no RRSIGs for a served RRset is broken. A DO
+// query must SERVFAIL rather than ephemeral-sign the answer (which masked the
+// failure — the zone looked signed to DO queries while its AXFR was unsigned) or
+// serve it unsigned (a silent downgrade).
+func TestQueryServfailForUnsignedMustBeSignedZone(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := testSnapshotZone(t, "broken.example.", `broken.example. 3600 IN SOA ns.broken.example. hostmaster.broken.example. 1 7200 1800 604800 7200
+broken.example. 3600 IN NS ns.broken.example.
+ns.broken.example. 3600 IN A 10.0.0.1
+www.broken.example. 3600 IN A 10.0.0.2
+`)
+	// The zone must be signed, but nothing in the snapshot is signed (SignZone
+	// never ran / failed) — a broken signed zone.
+	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+	zd.KeyDB = kdb
+
+	ctx := context.Background()
+
+	// A DO query for the stored, unsigned A RRset must SERVFAIL...
+	req := new(dns.Msg)
+	req.SetQuestion("www.broken.example.", dns.TypeA)
+	rw := &fakeRW{}
+	if err := zd.QueryResponder(ctx, rw, req, "www.broken.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+		t.Fatalf("QueryResponder (DO): %v", err)
+	}
+	resp := rw.written
+	if resp == nil {
+		t.Fatal("no response written for DO query")
+	}
+	if resp.MsgHdr.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("DO query on a broken signed zone: expected SERVFAIL, got %s", dns.RcodeToString[resp.MsgHdr.Rcode])
+	}
+	// ...and must NOT serve a fabricated RRSIG.
+	for _, rr := range append(append([]dns.RR{}, resp.Answer...), resp.Ns...) {
+		if _, ok := rr.(*dns.RRSIG); ok {
+			t.Fatalf("SERVFAIL must not carry a synthesized RRSIG: %s", rr.String())
+		}
+	}
+
+	// Control: without DO, the same unsigned data answers normally (NOERROR) —
+	// an unsigned answer is fine when DNSSEC is not requested.
+	req2 := new(dns.Msg)
+	req2.SetQuestion("www.broken.example.", dns.TypeA)
+	rw2 := &fakeRW{}
+	if err := zd.QueryResponder(ctx, rw2, req2, "www.broken.example.", dns.TypeA, &edns0.MsgOptions{}, kdb, nil); err != nil {
+		t.Fatalf("QueryResponder (non-DO): %v", err)
+	}
+	if rw2.written == nil || rw2.written.MsgHdr.Rcode != dns.RcodeSuccess {
+		t.Fatalf("non-DO query should be NOERROR, got %+v", rw2.written)
+	}
+	if len(rw2.written.Answer) == 0 {
+		t.Fatal("non-DO query should still carry the A answer")
+	}
+}
+
+// TestSignRRsetForZoneBrokenZone locks the two branches of signRRsetForZone's
+// must-be-signed / no-stored-RRSIG decision directly: a stored RRset yields
+// ErrZoneUnsigned (→ SERVFAIL) with no fabricated signature, while the
+// synthesized-denial NSEC carve-out (the one legitimate query-time ephemeral
+// case) is preserved.
+func TestSignRRsetForZoneBrokenZone(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := &ZoneData{
+		ZoneName: "broken.example.",
+		Options:  map[ZoneOption]bool{OptOnlineSigning: true},
+		Logger:   log.New(os.Stderr, "", 0),
+	}
+
+	a, err := dns.NewRR("www.broken.example. 3600 IN A 10.0.0.2")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	stored := core.RRset{RRtype: dns.TypeA, RRs: []dns.RR{a}}
+
+	// Stored, unsigned RRset on a must-be-signed zone → ErrZoneUnsigned, no
+	// fabricated signature.
+	got, err := zd.signRRsetForZone(stored, "www.broken.example.", &edns0.MsgOptions{DO: true}, kdb, nil)
+	if !errors.Is(err, ErrZoneUnsigned) {
+		t.Fatalf("stored unsigned RRset on a must-be-signed zone: want ErrZoneUnsigned, got %v", err)
+	}
+	if len(got.RRSIGs) != 0 {
+		t.Fatalf("broken-zone path must not fabricate a signature, got %d RRSIG(s)", len(got.RRSIGs))
+	}
+
+	// Non-DO query returns the RRset unsigned without error (DNSSEC not asked).
+	if _, err := zd.signRRsetForZone(stored, "www.broken.example.", &edns0.MsgOptions{}, kdb, nil); err != nil {
+		t.Fatalf("non-DO signRRsetForZone should not error, got %v", err)
+	}
+
+	// The synthesized-denial carve-out: an NSEC is exempt from the broken-zone
+	// SERVFAIL (it is signed on the fly), a stored A RRset is not.
+	nsec := &dns.NSEC{
+		Hdr:        dns.RR_Header{Name: "broken.example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 3600},
+		NextDomain: "\000.broken.example.",
+		TypeBitMap: []uint16{dns.TypeNSEC, dns.TypeRRSIG, dns.TypeNXNAME},
+	}
+	if !isSynthesizedDenial(core.RRset{RRs: []dns.RR{nsec}}) {
+		t.Fatal("a synthesized NSEC must be treated as ephemeral-signable")
+	}
+	if isSynthesizedDenial(stored) {
+		t.Fatal("a stored A RRset must not be treated as ephemeral")
+	}
 }

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -119,6 +119,7 @@ func loadTestTransferZone(t *testing.T, zoneData string) *ZoneData {
 	// Publish the initial snapshot so post-B3 readers (the transfer path) see
 	// the data, mirroring the refresh engine.
 	zd.InstallInitialSnapshot()
+	t.Cleanup(zd.stopPublisher)
 	return zd
 }
 

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -463,6 +463,27 @@ func TestZoneTransferOut_RefusesWhenNotReady(t *testing.T) {
 	}
 }
 
+// TestZoneTransferOut_RefusesUnsignedMustBeSignedZone: a zone configured for
+// online/inline signing whose SOA carries no RRSIG (unsigned/broken) must be
+// refused, never transferred unsigned to a secondary (fail-closed).
+func TestZoneTransferOut_RefusesUnsignedMustBeSignedZone(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone) // basicZone is unsigned (no RRSIGs)
+	zd.Options = map[ZoneOption]bool{OptOnlineSigning: true}
+	w := &fakeRW{remote: udpAddr("127.0.0.1")}
+	r := new(dns.Msg)
+	r.SetAxfr(zd.ZoneName)
+	sent, err := zd.ZoneTransferOut(w, r)
+	if err != nil {
+		t.Fatalf("ZoneTransferOut: %v", err)
+	}
+	if sent != 0 {
+		t.Fatalf("expected 0 RRs sent for an unsigned must-be-signed zone, got %d", sent)
+	}
+	if w.written == nil || w.written.Rcode != dns.RcodeRefused {
+		t.Fatalf("expected REFUSED (fail-closed), got %v", w.written)
+	}
+}
+
 // TestZoneTransferOut_TSIGRoundTrip exercises AXFR over TCP with TSIG on both
 // request and response envelopes (production uses TsigSigningHandler + TsigProvider).
 func TestZoneTransferOut_TSIGRoundTrip(t *testing.T) {

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -116,6 +116,9 @@ func loadTestTransferZone(t *testing.T, zoneData string) *ZoneData {
 	}
 	zd.Ready = true
 	zd.Status = ZoneStatusReady
+	// Publish the initial snapshot so post-B3 readers (the transfer path) see
+	// the data, mirroring the refresh engine.
+	zd.InstallInitialSnapshot()
 	return zd
 }
 
@@ -363,6 +366,9 @@ func TestZoneTransferOut_OversizeRRsetAborts(t *testing.T) {
 		RRs:    []dns.RR{txt},
 	})
 	zd.Data.Set("big.example.test.", od)
+	// Re-publish so the transfer (which reads the published snapshot) sees the
+	// oversize RRset that was just added to the live store.
+	zd.InstallInitialSnapshot()
 
 	srv := startTestAXFRServer(t, zd)
 	defer srv.shutdown()

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -623,6 +623,12 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 				RRs:    []dns.RR{},
 				RRSIGs: []dns.RR{},
 			}
+		} else {
+			// Get returns an RRset whose RRs/RRSIGs slices alias the published
+			// snapshot's backing arrays (cloneOwner shares them). The in-place
+			// RemoveRR / append / SignRRset below would otherwise tear the live
+			// view for concurrent readers — clone before mutating.
+			rrset = cloneRRset(rrset)
 		}
 
 		switch class {

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -409,11 +409,12 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 	var updated bool
 	zd.mu.Lock()
 	defer func() {
-		zd.mu.Unlock()
 		if updated {
-			zd.BumpSerial()
+			zd.publishLocked(zd.generation.Load())
 		}
+		zd.mu.Unlock()
 	}()
+	zd.ensureWorkingSet()
 
 	for _, rr := range ur.Actions {
 		class := rr.Header().Class
@@ -434,22 +435,14 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 		// XXX: The logic here is a bit involved. If this is a delete then it is ~ok that the owner doesn't exist.
 		// If it is an add then it is not ok, and then the owner must be created.
 
-		owner, err := zd.GetOwner(ownerName)
-		if err != nil {
-			lg.Warn("ApplyChildUpdateToZoneData: unknown owner name", "owner", ownerName)
+		owner := zd.stagedOwner(ownerName)
+		if owner == nil {
 			if class == dns.ClassNONE || class == dns.ClassANY {
-				// If this is a delete then it is ok that the owner doesn't exist.
+				lg.Warn("ApplyChildUpdateToZoneData: unknown owner name", "owner", ownerName)
 				continue
 			}
-		}
-		if owner == nil {
-			owner = &OwnerData{
-				Name:    ownerName,
-				RRtypes: NewRRTypeStore(),
-			}
-			zd.AddOwner(owner)
+			owner = zd.getOrCreateWorkingOwner(ownerName)
 			updated = true
-			// zd.Options["dirty"] = true
 		}
 
 		rrset, exists := owner.RRtypes.Get(rrtype)
@@ -471,7 +464,7 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 			lg.Debug("ApplyChildUpdateToZoneData: Remove RR", "owner", ownerName, "rrtype", rrtypestr, "rr", rrcopy.String())
 			rrset.RemoveRR(rrcopy, Globals.Verbose, Globals.Debug) // Cannot remove rr, because it is in the wrong class.
 			if len(rrset.RRs) == 0 {
-				owner.RRtypes.Delete(rrtype)
+				zd.stageDeleteLocked(ownerName, rrtype)
 			} else {
 				// RFC 4035 §2.2: at a delegation point, only DS is
 				// authoritative parent data and gets an RRSIG. NS and
@@ -482,7 +475,7 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 						lg.Error("ApplyChildUpdateToZoneData: signing failed after RR removal", "rrtype", rrtypestr, "owner", ownerName, "error", err)
 					}
 				}
-				owner.RRtypes.Set(rrtype, rrset)
+				zd.stageRRsetLocked(ownerName, rrset)
 			}
 			updated = true
 			// zd.Options["dirty"] = true
@@ -492,7 +485,7 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 		case dns.ClassANY:
 			// ClassANY: Remove RRset
 			lg.Debug("ApplyChildUpdateToZoneData: Remove RRset", "rr", rr.String())
-			owner.RRtypes.Delete(rrtype)
+			zd.stageDeleteLocked(ownerName, rrtype)
 			updated = true
 			// zd.Options["dirty"] = true
 			continue
@@ -525,7 +518,7 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 					lg.Error("ApplyChildUpdateToZoneData: signing failed after RR add", "rrtype", rrtypestr, "owner", ownerName, "error", err)
 				}
 			}
-			owner.RRtypes.Set(rrtype, rrset)
+			zd.stageRRsetLocked(ownerName, rrset)
 			updated = true
 			zd.Options[OptDirty] = true
 		}
@@ -561,11 +554,12 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 
 	zd.mu.Lock()
 	defer func() {
-		zd.mu.Unlock()
 		if updated {
-			zd.BumpSerial()
+			zd.publishLocked(zd.generation.Load())
 		}
+		zd.mu.Unlock()
 	}()
+	zd.ensureWorkingSet()
 
 	lg.Debug("ApplyZoneUpdateToZoneData: processing actions", "zone", zd.ZoneName, "count", len(ur.Actions))
 	for _, rr := range ur.Actions {
@@ -579,7 +573,7 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 		// engine's queued publish is landing on disk and surviving.
 		if rrtype == dns.TypeCDS {
 			before := 0
-			if owner, _ := zd.GetOwner(ownerName); owner != nil {
+			if owner := zd.stagedOwner(ownerName); owner != nil {
 				if rs, ok := owner.RRtypes.Get(dns.TypeCDS); ok {
 					before = len(rs.RRs)
 				}
@@ -605,22 +599,14 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 		// XXX: The logic here is a bit involved. If this is a delete then it is ~ok that the owner doesn't exist.
 		// If it is an add then it is not ok, and then the owner must be created.
 
-		owner, err := zd.GetOwner(ownerName)
-		if err != nil {
-			lg.Warn("ApplyZoneUpdateToZoneData: unknown owner name", "owner", ownerName)
+		owner := zd.stagedOwner(ownerName)
+		if owner == nil {
 			if class == dns.ClassNONE || class == dns.ClassANY {
+				lg.Warn("ApplyZoneUpdateToZoneData: unknown owner name", "owner", ownerName)
 				continue
 			}
-		}
-
-		if owner == nil {
-			owner = &OwnerData{
-				Name:    ownerName,
-				RRtypes: NewRRTypeStore(),
-			}
-			zd.AddOwner(owner)
+			owner = zd.getOrCreateWorkingOwner(ownerName)
 			updated = true
-			// zd.Options["dirty"] = true
 		}
 
 		rrset, exists := owner.RRtypes.Get(rrtype)
@@ -640,14 +626,14 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 			// ClassNONE: Remove exact RR
 			rrset.RemoveRR(rrcopy, Globals.Verbose, Globals.Debug) // Cannot remove rr, because it is in the wrong class.
 			if len(rrset.RRs) == 0 {
-				owner.RRtypes.Delete(rrtype)
+				zd.stageDeleteLocked(ownerName, rrtype)
 			} else {
 				_, err := zd.SignRRset(&rrset, ownerName, dak, true, nil)
 				if err != nil {
 					lg.Error("ApplyZoneUpdateToZoneData: signing failed after RR removal", "rrtype", rrtypestr, "owner", ownerName, "error", err)
 					// Continue anyway - the record is still added, just not signed
 				}
-				owner.RRtypes.Set(rrtype, rrset)
+				zd.stageRRsetLocked(ownerName, rrset)
 			}
 			updated = true
 			// zd.Options["dirty"] = true
@@ -656,7 +642,7 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 
 		case dns.ClassANY:
 			// ClassANY: Remove RRset
-			owner.RRtypes.Delete(rrtype)
+			zd.stageDeleteLocked(ownerName, rrtype)
 			// XXX: As long as we don't maintain any NSEC chain removing a complete RRset should not require any resigning.
 			updated = true
 			// zd.Options["dirty"] = true
@@ -690,7 +676,7 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 				lg.Error("ApplyZoneUpdateToZoneData: signing failed after RR add", "rrtype", rrtypestr, "owner", ownerName, "error", err)
 				// Continue anyway - the record is still added, just not signed
 			}
-			owner.RRtypes.Set(rrtype, rrset)
+			zd.stageRRsetLocked(ownerName, rrset)
 			updated = true
 			if rrtype == dns.TypeCDS {
 				lgRollover.Debug("zone-update CDS add committed",

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -536,7 +536,11 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 	// log.Printf("**** ApplyZoneUpdateToZoneData: ur=%+v", ur)
 
 	dak, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
-	if err != nil && (zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) && (err != nil || dak == nil || len(dak.KSKs) == 0) {
+	// Resolve keys (generating if needed) BEFORE taking zd.mu below — including
+	// the (nil,nil) "no error, no keys" case. Otherwise SignRRset is later called
+	// under zd.mu with a nil dak, reaches PublishDnskeyRRs, and self-deadlocks
+	// re-locking zd.mu.
+	if (zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) && (err != nil || dak == nil || len(dak.KSKs) == 0) {
 		lg.Debug("ApplyZoneUpdateToZoneData: GetDnssecKeys failed, attempting to ensure keys exist", "zone", zd.ZoneName)
 		// Try to ensure active keys exist (will generate if needed)
 		dak, err = zd.EnsureActiveDnssecKeys(kdb)

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -395,7 +395,7 @@ func (zd *ZoneData) ApplyChildUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (bo
 		var err error
 		dak, err = kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
 		if err != nil || dak == nil || len(dak.ZSKs) == 0 {
-			dak, err = zd.EnsureActiveDnssecKeys(kdb)
+			dak, err = zd.EnsureActiveDnssecKeys(kdb, false)
 			if err != nil {
 				lg.Error("ApplyChildUpdateToZoneData: failed to ensure active DNSSEC keys", "zone", zd.ZoneName, "error", err)
 				return false, err
@@ -543,7 +543,7 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 	if (zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]) && (err != nil || dak == nil || len(dak.KSKs) == 0) {
 		lg.Debug("ApplyZoneUpdateToZoneData: GetDnssecKeys failed, attempting to ensure keys exist", "zone", zd.ZoneName)
 		// Try to ensure active keys exist (will generate if needed)
-		dak, err = zd.EnsureActiveDnssecKeys(kdb)
+		dak, err = zd.EnsureActiveDnssecKeys(kdb, false)
 		if err != nil {
 			lg.Error("ApplyZoneUpdateToZoneData: failed to ensure active DNSSEC keys", "zone", zd.ZoneName, "error", err)
 			return false, err

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -946,26 +946,12 @@ func (zd *ZoneData) CollectDynamicRRs(conf *Config) []*core.RRset {
 		}
 	}
 
-	// 3. Collect transport signals (if add-transport-signal enabled)
-	// Collect from zd.TransportSignal if it exists, and also from zone data at _dns.* owners
+	// 3. Preserve stored transport-signal owner RRsets across a refresh replace.
+	// A refresh rebuilds the working set from the freshly transferred zone data,
+	// which does not include server-synthesized _dns.<ns> signals; carry them
+	// over so they survive until the transport postpass regenerates them. (The
+	// synthesized-fallback map is carried separately in applyRefreshReplacementLocked.)
 	if zd.Options[OptAddTransportSignal] {
-		if ts := zd.publishedTransportSignal(); ts != nil && len(ts.RRs) > 0 {
-			tsClone := &core.RRset{
-				Name:   ts.Name,
-				Class:  dns.ClassINET,
-				RRtype: ts.RRtype,
-				RRs:    make([]dns.RR, len(ts.RRs)),
-				RRSIGs: make([]dns.RR, len(ts.RRSIGs)),
-			}
-			for i, rr := range ts.RRs {
-				tsClone.RRs[i] = dns.Copy(rr)
-			}
-			for i, rr := range ts.RRSIGs {
-				tsClone.RRSIGs[i] = dns.Copy(rr)
-			}
-			dynamicRRs = append(dynamicRRs, tsClone)
-		}
-
 		snap := zd.publishedSnapshot()
 		if snap == nil {
 			return dynamicRRs
@@ -1058,12 +1044,6 @@ func (zd *ZoneData) repopulateWorkingSetLocked(dynamicRRs []*core.RRset) {
 			zd.stageRRsetLocked(rrset.Name, existing)
 		} else {
 			zd.stageRRsetLocked(rrset.Name, cloneRRset(*rrset))
-		}
-
-		if (rrset.RRtype == dns.TypeSVCB || rrset.RRtype == core.TypeTSYNC) && zd.wsTransportSignal == nil {
-			zd.wsTransportSignal = cloneTransportSignal(rrset)
-			zd.TransportSignal = rrset
-			zd.AddTransportSignal = true
 		}
 	}
 

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -1035,18 +1035,23 @@ func (zd *ZoneData) repopulateWorkingSetLocked(dynamicRRs []*core.RRset) {
 
 		existing, exists := owner.RRtypes.Get(rrset.RRtype)
 		if exists {
+			// Get returns an RRset whose RRs slice shares the published
+			// snapshot's backing array; copy it before appending so a
+			// spare-capacity append cannot mutate the live snapshot.
+			merged := append([]dns.RR(nil), existing.RRs...)
 			for _, newRR := range rrset.RRs {
 				present := false
-				for _, oldRR := range existing.RRs {
+				for _, oldRR := range merged {
 					if dns.IsDuplicate(newRR, oldRR) {
 						present = true
 						break
 					}
 				}
 				if !present {
-					existing.RRs = append(existing.RRs, newRR)
+					merged = append(merged, newRR)
 				}
 			}
+			existing.RRs = merged
 			if len(rrset.RRSIGs) > 0 {
 				existing.RRSIGs = rrset.RRSIGs
 			}

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -220,9 +220,6 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 		return false, nil // new zone not loaded, but not returning any error
 	}
 
-	zd.mu.Lock()
-	zd.Ready = true // this is a lie
-	zd.mu.Unlock()
 	new_zd.Ready = true
 
 	// Pre-refresh callbacks: analysis of old vs new zone data + modification of new_zd.
@@ -234,6 +231,7 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 
 	// Hard flip: update served zone data atomically.
 	zd.mu.Lock()
+	firstLoad := zd.FirstZoneLoad
 	zd.IncomingSerial = new_zd.IncomingSerial
 	if zd.FirstZoneLoad {
 		zd.CurrentSerial = new_zd.CurrentSerial
@@ -253,8 +251,10 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 	zd.ZoneStore = new_zd.ZoneStore
 	zd.ZoneType = new_zd.ZoneType
 	zd.Data = new_zd.Data
-	zd.Ready = true
-	zd.Status = ZoneStatusReady // co-located with Ready; set directly (already under zd.mu)
+	if !firstLoad {
+		zd.Ready = true
+		zd.Status = ZoneStatusReady // co-located with Ready; set directly (already under zd.mu)
+	}
 	zd.mu.Unlock()
 
 	// Repopulate all dynamically generated RRs after zone refresh
@@ -336,6 +336,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 
 	// Hard flip: update served zone data atomically.
 	zd.mu.Lock()
+	firstLoad := zd.FirstZoneLoad
 	zd.IncomingSerial = new_zd.IncomingSerial
 	if zd.FirstZoneLoad {
 		zd.CurrentSerial = new_zd.CurrentSerial
@@ -355,8 +356,10 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 	zd.ZoneStore = new_zd.ZoneStore
 	zd.ZoneType = new_zd.ZoneType
 	zd.Data = new_zd.Data
-	zd.Ready = true
-	zd.Status = ZoneStatusReady // co-located with Ready; set directly (already under zd.mu)
+	if !firstLoad {
+		zd.Ready = true
+		zd.Status = ZoneStatusReady // co-located with Ready; set directly (already under zd.mu)
+	}
 	zd.mu.Unlock()
 
 	// Repopulate all dynamically generated RRs after zone refresh
@@ -1409,7 +1412,7 @@ $TTL 86400
 		return nil, fmt.Errorf("failed to read zone data: %v", err)
 	}
 
-	zd.Ready = true
+	zd.InstallInitialSnapshot()
 	Zones.Set(zonename, zd)
 
 	return zd, nil

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -707,53 +707,12 @@ func setApexSOASerial(zd *ZoneData) bool {
 // notification is not appropriate (e.g. inside a NOTIFY handler
 // where triggering downstream NOTIFYs could cause side effects).
 func (zd *ZoneData) BumpSerialOnly() (BumperResponse, error) {
-	resp := BumperResponse{
-		Zone: zd.ZoneName,
-	}
-
 	lg.Debug("BumpSerialOnly: bumping SOA serial", "zone", zd.ZoneName)
-	zd.mu.Lock()
-	defer zd.mu.Unlock()
-
-	resp.OldSerial = zd.CurrentSerial
-	zd.CurrentSerial = nextOutboundSerial(zd)
-	resp.NewSerial = zd.CurrentSerial
-	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
-		if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
-			lg.Error("failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
-			return resp, fmt.Errorf("persist outgoing serial for zone %s: %w", zd.ZoneName, err)
-		}
-	}
-	if !setApexSOASerial(zd) {
-		// No apex SOA to rewrite: nothing more to do (caller may be
-		// bumping serial on a not-yet-loaded zone).
-		return resp, nil
-	}
-	if zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning] {
-		apex, err := zd.GetOwner(zd.ZoneName)
-		if err != nil {
-			lg.Error("GetOwner failed", "zone", zd.ZoneName, "err", err)
-			return resp, err
-		}
-		rrset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-		_, err = zd.SignRRset(&rrset, zd.ZoneName, nil, true, nil) // true = force signing, as we know the SOA has changed
-		if err != nil {
-			lg.Error("BumpSerialOnly: failed to sign SOA RRset", "zone", zd.ZoneName, "err", err)
-			return resp, err
-		}
-		apex.RRtypes.Set(dns.TypeSOA, rrset)
-	}
-
-	return resp, nil
+	return zd.publishSync()
 }
 
 func (zd *ZoneData) BumpSerial() (BumperResponse, error) {
-	resp, err := zd.BumpSerialOnly()
-	if err != nil {
-		return resp, err
-	}
-	zd.NotifyDownstreams()
-	return resp, nil
+	return zd.BumpSerialOnly()
 }
 
 func (zd *ZoneData) FetchChildDelegationData(childname string) (*ChildDelegationData, error) {

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -390,10 +391,14 @@ func (zd *ZoneData) SetOption(option ZoneOption, value bool) {
 }
 
 func (zd *ZoneData) NameExists(qname string) bool {
-	if zd.ZoneStore != MapZone || zd.Data == nil || zd.Data.IsEmpty() {
+	if zd.ZoneStore != MapZone {
 		return false
 	}
-	_, ok := zd.Data.Get(qname)
+	snap := zd.publishedSnapshot()
+	if snap == nil || len(snap.Data) == 0 {
+		return false
+	}
+	_, ok := snap.Data[qname]
 	lg.Debug("NameExists result", "qname", qname, "exists", ok)
 	return ok
 }
@@ -406,18 +411,11 @@ func (zd *ZoneData) GetOwner(qname string) (*OwnerData, error) {
 		return nil, fmt.Errorf("getOwner: only supported for MapZone, not %s",
 			ZoneStoreToString[zd.ZoneStore])
 	}
-	if zd.Data.IsEmpty() {
+	snap := zd.publishedSnapshot()
+	if snap == nil || len(snap.Data) == 0 {
 		return nil, nil
 	}
-	if owner, ok := zd.Data.Get(qname); ok {
-		return &owner, nil
-	}
-	return nil, nil
-}
-
-// XXX: This MUST ONLY be called from the ZoneUpdater, due to locking issues
-func (zd *ZoneData) AddOwner(owner *OwnerData) {
-	zd.Data.Set(owner.Name, *owner)
+	return snap.Data[qname], nil
 }
 
 func (zd *ZoneData) GetRRset(qname string, rrtype uint16) (*core.RRset, error) {
@@ -448,10 +446,16 @@ func (zd *ZoneData) GetOwnerNames() ([]string, error) {
 		return nil, fmt.Errorf("getOwnerNames: only supported for MapZone, not %s",
 			ZoneStoreToString[zd.ZoneStore])
 	}
-	if zd.Data.IsEmpty() {
+	snap := zd.publishedSnapshot()
+	if snap == nil || len(snap.Data) == 0 {
 		return nil, nil
 	}
-	return zd.Data.Keys(), nil
+	names := make([]string, 0, len(snap.Data))
+	for name := range snap.Data {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 // XXX: Is qname the name of a zone cut for a child zone?
@@ -498,6 +502,9 @@ func (zd *ZoneData) GetSOA() (*dns.SOA, error) {
 	}
 
 	// For all other cases (primary zones, ready zones, catalog zones), require real data
+	if snap := zd.publishedSnapshot(); snap != nil && snap.SOA != nil {
+		return snap.SOA, nil
+	}
 	owner, err := zd.GetOwner(zd.ZoneName)
 	if err != nil || owner == nil {
 		return nil, err
@@ -628,32 +635,6 @@ func nextOutboundSerial(zd *ZoneData) uint32 {
 		}
 	}
 	return zd.CurrentSerial + 1
-}
-
-// setApexSOASerial rewrites the in-memory apex SOA RDATA so its Serial field
-// matches zd.CurrentSerial. Caller must hold zd.mu (or be in a context where
-// no concurrent reader/writer can observe the zone). Returns true if the SOA
-// RR was found and updated, false otherwise (zone not loaded, no apex, no
-// SOA RRset).
-func setApexSOASerial(zd *ZoneData) bool {
-	if zd == nil {
-		return false
-	}
-	apex, err := zd.GetOwner(zd.ZoneName)
-	if err != nil || apex == nil {
-		return false
-	}
-	soaRRset := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
-	if len(soaRRset.RRs) == 0 {
-		return false
-	}
-	soa, ok := soaRRset.RRs[0].(*dns.SOA)
-	if !ok {
-		return false
-	}
-	soa.Serial = zd.CurrentSerial
-	apex.RRtypes.Set(dns.TypeSOA, soaRRset)
-	return true
 }
 
 // BumpSerialOnly advances the SOA serial per the configured
@@ -941,65 +922,62 @@ func (zd *ZoneData) CollectDynamicRRs(conf *Config) []*core.RRset {
 	// 3. Collect transport signals (if add-transport-signal enabled)
 	// Collect from zd.TransportSignal if it exists, and also from zone data at _dns.* owners
 	if zd.Options[OptAddTransportSignal] {
-		// Collect from zd.TransportSignal field
-		if zd.TransportSignal != nil && len(zd.TransportSignal.RRs) > 0 {
-			// Clone the transport signal RRset
+		if ts := zd.publishedTransportSignal(); ts != nil && len(ts.RRs) > 0 {
 			tsClone := &core.RRset{
-				Name:   zd.TransportSignal.Name,
+				Name:   ts.Name,
 				Class:  dns.ClassINET,
-				RRtype: zd.TransportSignal.RRtype,
-				RRs:    make([]dns.RR, len(zd.TransportSignal.RRs)),
-				RRSIGs: make([]dns.RR, len(zd.TransportSignal.RRSIGs)),
+				RRtype: ts.RRtype,
+				RRs:    make([]dns.RR, len(ts.RRs)),
+				RRSIGs: make([]dns.RR, len(ts.RRSIGs)),
 			}
-			for i, rr := range zd.TransportSignal.RRs {
+			for i, rr := range ts.RRs {
 				tsClone.RRs[i] = dns.Copy(rr)
 			}
-			for i, rr := range zd.TransportSignal.RRSIGs {
+			for i, rr := range ts.RRSIGs {
 				tsClone.RRSIGs[i] = dns.Copy(rr)
 			}
 			dynamicRRs = append(dynamicRRs, tsClone)
 		}
 
-		// Also collect transport signals from zone data at _dns.* owners
-		// (they may exist in zone data even if TransportSignal field is not set)
-		for item := range zd.Data.IterBuffered() {
-			owner := item.Key
-			if strings.HasPrefix(owner, "_dns.") {
-				od := item.Val
-				// Check for SVCB
-				if svcbRRset, exists := od.RRtypes.Get(dns.TypeSVCB); exists && len(svcbRRset.RRs) > 0 {
-					svcbClone := &core.RRset{
-						Name:   owner,
-						Class:  dns.ClassINET,
-						RRtype: dns.TypeSVCB,
-						RRs:    make([]dns.RR, len(svcbRRset.RRs)),
-						RRSIGs: make([]dns.RR, len(svcbRRset.RRSIGs)),
-					}
-					for i, rr := range svcbRRset.RRs {
-						svcbClone.RRs[i] = dns.Copy(rr)
-					}
-					for i, rr := range svcbRRset.RRSIGs {
-						svcbClone.RRSIGs[i] = dns.Copy(rr)
-					}
-					dynamicRRs = append(dynamicRRs, svcbClone)
+		snap := zd.publishedSnapshot()
+		if snap == nil {
+			return dynamicRRs
+		}
+		for owner, od := range snap.Data {
+			if od == nil || !strings.HasPrefix(owner, "_dns.") {
+				continue
+			}
+			if svcbRRset, exists := od.RRtypes.Get(dns.TypeSVCB); exists && len(svcbRRset.RRs) > 0 {
+				svcbClone := &core.RRset{
+					Name:   owner,
+					Class:  dns.ClassINET,
+					RRtype: dns.TypeSVCB,
+					RRs:    make([]dns.RR, len(svcbRRset.RRs)),
+					RRSIGs: make([]dns.RR, len(svcbRRset.RRSIGs)),
 				}
-				// Check for TSYNC
-				if tsyncRRset, exists := od.RRtypes.Get(core.TypeTSYNC); exists && len(tsyncRRset.RRs) > 0 {
-					tsyncClone := &core.RRset{
-						Name:   owner,
-						Class:  dns.ClassINET,
-						RRtype: core.TypeTSYNC,
-						RRs:    make([]dns.RR, len(tsyncRRset.RRs)),
-						RRSIGs: make([]dns.RR, len(tsyncRRset.RRSIGs)),
-					}
-					for i, rr := range tsyncRRset.RRs {
-						tsyncClone.RRs[i] = dns.Copy(rr)
-					}
-					for i, rr := range tsyncRRset.RRSIGs {
-						tsyncClone.RRSIGs[i] = dns.Copy(rr)
-					}
-					dynamicRRs = append(dynamicRRs, tsyncClone)
+				for i, rr := range svcbRRset.RRs {
+					svcbClone.RRs[i] = dns.Copy(rr)
 				}
+				for i, rr := range svcbRRset.RRSIGs {
+					svcbClone.RRSIGs[i] = dns.Copy(rr)
+				}
+				dynamicRRs = append(dynamicRRs, svcbClone)
+			}
+			if tsyncRRset, exists := od.RRtypes.Get(core.TypeTSYNC); exists && len(tsyncRRset.RRs) > 0 {
+				tsyncClone := &core.RRset{
+					Name:   owner,
+					Class:  dns.ClassINET,
+					RRtype: core.TypeTSYNC,
+					RRs:    make([]dns.RR, len(tsyncRRset.RRs)),
+					RRSIGs: make([]dns.RR, len(tsyncRRset.RRSIGs)),
+				}
+				for i, rr := range tsyncRRset.RRs {
+					tsyncClone.RRs[i] = dns.Copy(rr)
+				}
+				for i, rr := range tsyncRRset.RRSIGs {
+					tsyncClone.RRSIGs[i] = dns.Copy(rr)
+				}
+				dynamicRRs = append(dynamicRRs, tsyncClone)
 			}
 		}
 	}

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -390,17 +390,44 @@ func (zd *ZoneData) SetOption(option ZoneOption, value bool) {
 	zd.mu.Unlock()
 }
 
+// getOwnerFrom reads an owner from an ALREADY-PINNED snapshot. Response paths
+// (QueryResponder, ZoneTransferOut) pin one snapshot at the top and read
+// everything through the *From helpers, so every read in one response comes from
+// the same serial — no intra-response tearing. snap==nil yields nil (the caller
+// SERVFAILs / refuses).
+func getOwnerFrom(snap *zoneSnapshot, qname string) *OwnerData {
+	if snap == nil {
+		return nil
+	}
+	return snap.Data[qname]
+}
+
+// getRRsetFrom reads one RRset from a pinned snapshot.
+func getRRsetFrom(snap *zoneSnapshot, qname string, rrtype uint16) *core.RRset {
+	owner := getOwnerFrom(snap, qname)
+	if owner == nil {
+		return nil
+	}
+	if rrset, ok := owner.RRtypes.Get(rrtype); ok {
+		return &rrset
+	}
+	return nil
+}
+
+// nameExistsFrom reports whether qname exists in a pinned snapshot.
+func nameExistsFrom(snap *zoneSnapshot, qname string) bool {
+	if snap == nil {
+		return false
+	}
+	_, ok := snap.Data[qname]
+	return ok
+}
+
 func (zd *ZoneData) NameExists(qname string) bool {
 	if zd.ZoneStore != MapZone {
 		return false
 	}
-	snap := zd.publishedSnapshot()
-	if snap == nil || len(snap.Data) == 0 {
-		return false
-	}
-	_, ok := snap.Data[qname]
-	lg.Debug("NameExists result", "qname", qname, "exists", ok)
-	return ok
+	return nameExistsFrom(zd.publishedSnapshot(), qname)
 }
 
 func (zd *ZoneData) GetOwner(qname string) (*OwnerData, error) {
@@ -411,11 +438,7 @@ func (zd *ZoneData) GetOwner(qname string) (*OwnerData, error) {
 		return nil, fmt.Errorf("getOwner: only supported for MapZone, not %s",
 			ZoneStoreToString[zd.ZoneStore])
 	}
-	snap := zd.publishedSnapshot()
-	if snap == nil || len(snap.Data) == 0 {
-		return nil, nil
-	}
-	return snap.Data[qname], nil
+	return getOwnerFrom(zd.publishedSnapshot(), qname), nil
 }
 
 func (zd *ZoneData) GetRRset(qname string, rrtype uint16) (*core.RRset, error) {

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -514,7 +514,11 @@ func (zd *ZoneData) GetSOA() (*dns.SOA, error) {
 }
 
 func (zd *ZoneData) PrintOwners() {
-	for _, key := range zd.Data.Keys() {
+	names, err := zd.GetOwnerNames()
+	if err != nil {
+		return
+	}
+	for _, key := range names {
 		fmt.Printf("%s\n", key)
 	}
 }

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -524,16 +524,30 @@ func (zd *ZoneData) GetSOA() (*dns.SOA, error) {
 		}, nil
 	}
 
-	// For all other cases (primary zones, ready zones, catalog zones), require real data
+	// For all other cases (primary zones, ready zones, catalog zones), require real data.
+	// GetSOA must never return (nil, nil): a nil SOA with no error is a landmine for
+	// callers that read soa.* only in the err==nil branch (e.g. RefreshEngine). During a
+	// concurrent reload the apex owner can be transiently absent — surface that as an
+	// error, not a nil SOA.
 	if snap := zd.publishedSnapshot(); snap != nil && snap.SOA != nil {
 		return snap.SOA, nil
 	}
 	owner, err := zd.GetOwner(zd.ZoneName)
-	if err != nil || owner == nil {
+	if err != nil {
 		return nil, err
 	}
-	soa := owner.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs[0]
-	return soa.(*dns.SOA), nil
+	if owner == nil {
+		return nil, fmt.Errorf("GetSOA: zone %s: apex owner not found", zd.ZoneName)
+	}
+	soaSet := owner.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	if len(soaSet.RRs) == 0 {
+		return nil, fmt.Errorf("GetSOA: zone %s: no SOA record at apex", zd.ZoneName)
+	}
+	soa, ok := soaSet.RRs[0].(*dns.SOA)
+	if !ok {
+		return nil, fmt.Errorf("GetSOA: zone %s: apex SOA record is not a *dns.SOA (got %T)", zd.ZoneName, soaSet.RRs[0])
+	}
+	return soa, nil
 }
 
 func (zd *ZoneData) PrintOwners() {

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -229,37 +229,15 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 		cb(zd, &new_zd)
 	}
 
-	// Hard flip: update served zone data atomically.
+	// Publish replacement: working set from refreshed data + dynamic RRs.
 	zd.mu.Lock()
 	firstLoad := zd.FirstZoneLoad
-	zd.IncomingSerial = new_zd.IncomingSerial
-	if zd.FirstZoneLoad {
-		zd.CurrentSerial = new_zd.CurrentSerial
-		zd.FirstZoneLoad = false
-	} else {
-		zd.CurrentSerial++
-		if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
-			if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
-				zd.mu.Unlock()
-				lg.Error("failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
-				return false, fmt.Errorf("persist outgoing serial for zone %s: %w", zd.ZoneName, err)
-			}
-		}
-	}
-	zd.ApexLen = new_zd.ApexLen
-	zd.XfrType = new_zd.XfrType
-	zd.ZoneStore = new_zd.ZoneStore
-	zd.ZoneType = new_zd.ZoneType
-	zd.Data = new_zd.Data
-	if !firstLoad {
-		zd.Ready = true
-		zd.Status = ZoneStatusReady // co-located with Ready; set directly (already under zd.mu)
+	if err := zd.applyRefreshReplacementLocked(&new_zd, dynamicRRs, firstLoad); err != nil {
+		zd.mu.Unlock()
+		lg.Error("failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
+		return false, err
 	}
 	zd.mu.Unlock()
-
-	// Repopulate all dynamically generated RRs after zone refresh
-	// (they may have been lost if not present in the zone file)
-	zd.RepopulateDynamicRRs(dynamicRRs)
 
 	// Post-refresh callbacks: queue sends and notifications that need the live zone pointer.
 	for _, cb := range zd.OnZonePostRefresh {
@@ -334,37 +312,15 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 		cb(zd, &new_zd)
 	}
 
-	// Hard flip: update served zone data atomically.
+	// Publish replacement: working set from transferred data + dynamic RRs.
 	zd.mu.Lock()
 	firstLoad := zd.FirstZoneLoad
-	zd.IncomingSerial = new_zd.IncomingSerial
-	if zd.FirstZoneLoad {
-		zd.CurrentSerial = new_zd.CurrentSerial
-		zd.FirstZoneLoad = false
-	} else {
-		zd.CurrentSerial++
-		if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
-			if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
-				zd.mu.Unlock()
-				lg.Error("failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
-				return false, fmt.Errorf("persist outgoing serial for zone %s: %w", zd.ZoneName, err)
-			}
-		}
-	}
-	zd.ApexLen = new_zd.ApexLen
-	zd.XfrType = new_zd.XfrType
-	zd.ZoneStore = new_zd.ZoneStore
-	zd.ZoneType = new_zd.ZoneType
-	zd.Data = new_zd.Data
-	if !firstLoad {
-		zd.Ready = true
-		zd.Status = ZoneStatusReady // co-located with Ready; set directly (already under zd.mu)
+	if err := zd.applyRefreshReplacementLocked(&new_zd, dynamicRRs, firstLoad); err != nil {
+		zd.mu.Unlock()
+		lg.Error("failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
+		return false, err
 	}
 	zd.mu.Unlock()
-
-	// Repopulate all dynamically generated RRs after zone refresh
-	// (they may have been lost if not present in the transferred zone)
-	zd.RepopulateDynamicRRs(dynamicRRs)
 
 	// Post-refresh callbacks: queue sends and notifications that need the live zone pointer.
 	for _, cb := range zd.OnZonePostRefresh {
@@ -1051,9 +1007,9 @@ func (zd *ZoneData) CollectDynamicRRs(conf *Config) []*core.RRset {
 	return dynamicRRs
 }
 
-// RepopulateDynamicRRs repopulates dynamically generated RRsets into the zone data after refresh.
-// The RRsets are passed in from RefreshEngine which collected them before the refresh.
-func (zd *ZoneData) RepopulateDynamicRRs(dynamicRRs []*core.RRset) {
+// repopulateWorkingSetLocked merges dynamic RRsets into the working set.
+// Caller must hold zd.mu and have initialized zd.workingSet.
+func (zd *ZoneData) repopulateWorkingSetLocked(dynamicRRs []*core.RRset) {
 	if len(dynamicRRs) == 0 {
 		return
 	}
@@ -1063,25 +1019,17 @@ func (zd *ZoneData) RepopulateDynamicRRs(dynamicRRs []*core.RRset) {
 			continue
 		}
 
-		owner, err := zd.GetOwner(rrset.Name)
-		if err != nil || owner == nil {
-			// Owner doesn't exist, create it
-			if zd.ZoneStore == MapZone {
-				owner = &OwnerData{
-					Name:    rrset.Name,
-					RRtypes: NewRRTypeStore(),
-				}
-				zd.Data.Set(rrset.Name, *owner)
-			} else {
-				lg.Error("RepopulateDynamicRRs: failed to get/create owner", "owner", rrset.Name, "zone", zd.ZoneName, "err", err)
+		owner := zd.stagedOwner(rrset.Name)
+		if owner == nil {
+			if zd.ZoneStore != MapZone {
+				lg.Error("RepopulateDynamicRRs: failed to get/create owner", "owner", rrset.Name, "zone", zd.ZoneName)
 				continue
 			}
+			owner = zd.getOrCreateWorkingOwner(rrset.Name)
 		}
 
-		// Get existing RRset if any, or create new one
 		existing, exists := owner.RRtypes.Get(rrset.RRtype)
 		if exists {
-			// Merge: add any RRs that don't already exist
 			for _, newRR := range rrset.RRs {
 				present := false
 				for _, oldRR := range existing.RRs {
@@ -1094,24 +1042,16 @@ func (zd *ZoneData) RepopulateDynamicRRs(dynamicRRs []*core.RRset) {
 					existing.RRs = append(existing.RRs, newRR)
 				}
 			}
-			// Merge RRSIGs (replace if new ones exist)
 			if len(rrset.RRSIGs) > 0 {
 				existing.RRSIGs = rrset.RRSIGs
 			}
-			owner.RRtypes.Set(rrset.RRtype, existing)
+			zd.stageRRsetLocked(rrset.Name, existing)
 		} else {
-			// Set new RRset
-			owner.RRtypes.Set(rrset.RRtype, *rrset)
+			zd.stageRRsetLocked(rrset.Name, cloneRRset(*rrset))
 		}
 
-		// Update owner in zone data (in case we created it or modified it)
-		if zd.ZoneStore == MapZone {
-			zd.Data.Set(rrset.Name, *owner)
-		}
-
-		// Special handling for transport signals: also set zd.TransportSignal
-		// Use the first transport signal RRset found as the primary one
-		if (rrset.RRtype == dns.TypeSVCB || rrset.RRtype == core.TypeTSYNC) && zd.TransportSignal == nil {
+		if (rrset.RRtype == dns.TypeSVCB || rrset.RRtype == core.TypeTSYNC) && zd.wsTransportSignal == nil {
+			zd.wsTransportSignal = cloneTransportSignal(rrset)
 			zd.TransportSignal = rrset
 			zd.AddTransportSignal = true
 		}
@@ -1119,23 +1059,26 @@ func (zd *ZoneData) RepopulateDynamicRRs(dynamicRRs []*core.RRset) {
 
 	lg.Info("RepopulateDynamicRRs: repopulated dynamic RRsets", "count", len(dynamicRRs), "zone", zd.ZoneName)
 
-	// CDS-publication observability: report whether the apex CDS RRset
-	// survived this refresh. CDS is currently NOT on the
-	// CollectDynamicRRs allowlist, so any CDS the rollover engine
-	// queued via pushDSRRsetViaNotify is wiped here unless the source
-	// zone file re-asserts it. The rollover engine's CDS-ownership
-	// marker (RolloverZoneState.last_published_cds_index_low/high)
-	// outlives the refresh, so the next push will re-publish — but
-	// with a churn cycle visible in zone-update logs as
-	// "no RRset for owner" warnings.
 	apexCdsRRs := 0
-	if owner, _ := zd.GetOwner(zd.ZoneName); owner != nil {
+	if owner := zd.stagedOwner(zd.ZoneName); owner != nil {
 		if rs, ok := owner.RRtypes.Get(dns.TypeCDS); ok {
 			apexCdsRRs = len(rs.RRs)
 		}
 	}
 	lgRollover.Debug("post-refresh apex CDS observation",
 		"zone", zd.ZoneName, "apex_cds_rrs", apexCdsRRs)
+}
+
+// RepopulateDynamicRRs repopulates dynamically generated RRsets and publishes.
+func (zd *ZoneData) RepopulateDynamicRRs(dynamicRRs []*core.RRset) {
+	if len(dynamicRRs) == 0 {
+		return
+	}
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	zd.ensureWorkingSet()
+	zd.repopulateWorkingSetLocked(dynamicRRs)
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
 }
 
 func (zd *ZoneData) SetupZoneSigning(resignq chan<- *ZoneData) error {


### PR DESCRIPTION
## What

Project B — **zone-mutation snapshot correctness**. Publishes an immutable,
per-serial zone snapshot behind an `atomic.Pointer`, stages mutations into a
working set, and flips atomically at a serial boundary. This eliminates the
serial-tearing bug the project was chartered to fix: two secondaries serving
different content under the same SOA serial (readers used to write back into
published data while the serial was bumped separately).

Design: `docs/2026-07-02-zone-mutation-snapshot-correctness.md`.
Built as a B1 → B2 → B3 dual-write strangler; readers lock-free via
`snapshot.Load()`.

## Review fixes

An eval pass (`docs/2026-07-08-snapshot-corrections-eval.md`) found the B3 reader
cutover was incomplete and several defects remained. All are fixed here — the
doc's **Resolution** table maps each item to its commit. Highlights:

- **C1** — the query path now pins **one** snapshot per response and threads it
  through every reader (`…From(snap,…)` variants; public methods delegate, so
  other callers are unchanged). Previously each reader did an independent
  `Load()`, so a mid-response publish could tear the answer against the
  authority SOA — i.e. the bug was *moved, not fixed*.
- **M1** — `ZoneTransferOut` / `WriteZoneToFile` pin one snapshot (no torn AXFR).
- **C2 / M2 / R1 / m1 / m2** — catalog reads, nil-snapshot guard + `Ready`
  gating, test-harness snapshot install, dead-reader removal, immutability-
  invariant doc.
- **m3** — new `TestQueryResponderNoIntraResponseTearing` drives QueryResponder
  under concurrent publishes.
- **+14 pre-existing test-harness failures**, and a **real `StripZoneRRSIGs`
  bug** (it staged stripped RRsets under `rrset.RRtype`, which `GetOnlyRRSet`
  leaves unset → every strip landed under type 0 and nothing was actually
  removed) that the harness gaps had been hiding.

## Verification

- `go build ./...` and `go vet ./...` clean.
- `go test -race .` in `v2/` fully green (0 failures), including the new
  concurrent-publish tearing test.

## Not yet verified — please weigh in

- **Only `v2` unit tests were run.** No testbed/integration pass, no live
  query + AXFR smoke test. C1/M1 is a refactor of the auth server's hot query
  and transfer path — that specifically wants a real-traffic check.
- **Vacuous-pass audit is incomplete** — a real signing bug surfaced from behind
  one such test; there may be more tests that pass for the wrong reason.
- `m2` immutability is enforced by the CI grep gate + discipline, not by a
  deep-copy (deliberately, to keep copy-strategy-A's PQ-signature perf goal).

Self-assessed verdict: **conditionally mergeable** — the original "do not merge"
blockers are discharged and the suite is green, but merge should be gated on
human review of the read-path refactor and a testbed smoke test under a
concurrent publish, not on green unit tests alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `zone-txlog` debug command to inspect a zone’s pending changes.
  * Added per-zone and per-template `publish-cadence` configuration.
* **Bug Fixes**
  * Improved DNS consistency by pinning responses to a single published snapshot throughout request handling.
  * Updated zone transfers, zone signing/resigning, catalog operations, delegation/glue resolution, and dynamic/transport-signal handling to use snapshot/work-queue staging with atomic publishes.
  * Hardened initial snapshot installation and ensured zone publishers stop during removals.
* **Tests**
  * Added snapshot immutability, publish/coalescing, pending-change tracking, and no-tearing query coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->