### PR TITLE
Add a Configuration Guide, and repair the sample configs it points at

### DIFF
--- a/cmdv2/auth/auth-templates.sample.yaml
+++ b/cmdv2/auth/auth-templates.sample.yaml
@@ -3,17 +3,51 @@
 # Templates allow you to define reusable zone configurations.
 # Individual zones can reference a template and override specific settings.
 #
-# Template properties that can be set:
-#   - type:            Zone type: primary | secondary
-#   - store:           Storage backend: map | slice | xfr
-#                      - map:   Default, general-purpose (recommended for most zones)
-#                      - slice: Experimental alternative (may be faster/use less memory)
-#                      - xfr:   Zone transfer only (AXFR in/out, NO normal queries)
-#   - primaries:       Upstream servers for secondary zones — list of {addr, key}
-#   - notify:          Downstream servers to notify — list of {addr, key}
-#   - options:         List of zone options (see below)
-#   - dnssec_policy:   DNSSEC policy name (from dnssecpolicies section)
-#   - multi_signer:    Multi-signer configuration name
+# ==============================================================================
+# SHAPE: templates: is a LIST, and every entry needs its own name:
+# ==============================================================================
+#
+# A template is an ordinary zone declaration that carries a name and is not
+# itself served. It therefore accepts every key a zone accepts (see
+# auth-zones.sample.yaml), including primaries:, notify:, allow-notify:,
+# downstreams:, updatepolicy: and delegationbackend:.
+#
+#     templates:
+#        - name:   my-template
+#          type:   primary
+#          store:  map
+#
+# NOT a map keyed by template name. A mapping shape fails to load with
+# "'templates': source data must be an array or slice, got map".
+#
+# ==============================================================================
+# HOW A TEMPLATE MERGES INTO A ZONE
+# ==============================================================================
+#
+# A zone opts in with `template: <name>`. The merge is a GAP FILL — the zone's
+# own value always wins, and the template only supplies fields the zone left
+# unset. Four rules are worth knowing:
+#
+#   1. options: is a UNION, not a gap fill. Template options are appended to the
+#      zone's list. A zone can ADD options but cannot REMOVE one the template
+#      supplies.
+#
+#   2. zonefile: in a template is a fmt.Sprintf PATTERN, %-substituted with the
+#      zone name (which includes its trailing dot), not copied verbatim. So
+#      `zonefile: /etc/tdns/zones/%szone` yields /etc/tdns/zones/example.org.zone
+#      for zone example.org.  A pattern producing ".." is rejected.
+#
+#   3. dnssecpolicy: is gap-filled for tdns-auth, but never for tdns-agent
+#      (agents do not sign).
+#
+#   4. A field counts as "set" only if it is non-zero. A zone therefore cannot
+#      override a template value back to an empty/zero value ("", 0, false).
+#      If a template sets `store: xfr`, a zone cannot revert it to the default
+#      by writing `store: ""` — it must name the other value explicitly.
+#
+# name: and template: are never copied from a template. A template may itself
+# set `template:` to inherit from another template; cycles are detected and
+# rejected.
 #
 # ==============================================================================
 # COMPLETE LIST OF ZONE OPTIONS
@@ -26,19 +60,34 @@
 #   delegation-sync-child:   Attempt delegation sync with parent zone
 #                           (child zone pushes DS/NS/A/AAAA updates to parent)
 #
+#   delegation-sync-proxy:   Agent secondary proxies CDS/CSYNC NOTIFYs upstream
+#                           on behalf of a DSYNC-unaware primary
+#                           (see guide/agent-dsync-proxy.md)
+#
 # ZONE MODIFICATION OPTIONS:
 #   allow-updates:           Allow zone modifications via DNS UPDATE
 #                           (general updates to any RRset in the zone)
 #
 #   allow-child-updates:     Allow updates to child delegation data via DNS UPDATE
-#                           (only child NS, DS, A, AAAA records)
+#                           (only child NS, DS, A, AAAA records).
+#                           Forced off if the child update policy type is
+#                           "none" or unset. A zone with this option MUST also
+#                           set delegationbackend:.
 #
-#   allow-edits:           Allow zone apex RRsets to be dynamically modified
+#   allow-edits:             Allow zone apex RRsets to be dynamically modified
 #                           (NS, DNSKEY, CDS, CSYNC at zone apex)
 #
 # DNSSEC OPTIONS:
 #   online-signing:          Sign zone on-the-fly as needed
 #                           (creates DNSSEC keypair if needed, signs responses)
+#
+#   inline-signing:          Maintain a signed copy of the zone
+#
+#                           BOTH signing options REQUIRE the zone to set
+#                           dnssecpolicy:. Without one the option is dropped and
+#                           the zone goes to ERROR state ("... is ignored because
+#                           the DNSSEC policy is not set"). Neither is accepted
+#                           by tdns-agent, which does not sign.
 #
 #   dont-publish-key:        Don't publish the public SIG(0) key in zone
 #                           (key exists but is not published in zone data)
@@ -47,11 +96,17 @@
 #   fold-case:               Fold domain name case before comparisons
 #                           (case-insensitive matching for owner names)
 #
-#   black-lies:              Implement "black lies" negative responses
-#                           (RFC 7816 - minimizes NSEC exposure)
+#   black-lies:              Compact denial of existence: synthesize a minimally
+#                           covering NSEC for a negative answer instead of
+#                           returning the zone's precomputed NSEC records
 #
 #   add-transport-signal:    Automatically synthesize SVCB RRs
 #                           (adds transport signals to Additional section)
+#
+# MULTI-PROVIDER OPTIONS:
+#   multi-provider:          Zone is served by several providers (RFC 8901).
+#                           Changes signing and rollover behaviour; the
+#                           multi-provider machinery lives in tdns-mp.
 #
 # CATALOG ZONE OPTIONS (RFC 9432):
 #   catalog-zone:            Mark zone as RFC 9432 catalog zone
@@ -59,119 +114,138 @@
 #                           (zone will contain member zone PTR records and group TXT records)
 #
 #   catalog-member-auto-create:   Auto-create member zones from this catalog
-#                                (only valid on catalog zones)
+#                                (only valid on catalog zones — the same zone must
+#                                 also carry the catalog-zone option)
 #                                (when enabled, zones in catalog are automatically configured)
 #
 #   catalog-member-auto-delete:   Auto-delete member zones when removed from this catalog
 #                                (only valid on catalog zones)
 #                                (when enabled, removed zones are automatically deleted)
 #
-# INTERNAL/READ-ONLY OPTIONS (not configurable):
-#   automatic-zone:          Zone was auto-created from catalog
-#                           (internal marker, set automatically, not a config option)
+# INTERNAL / READ-ONLY OPTIONS (set by the server; NOT valid in options:)
+#   These are real zone options, but they are set programmatically and are
+#   REJECTED if they appear in a config file — the zone goes to ERROR state with
+#   "unknown config option". They are listed here only so you recognize them in
+#   `tdns-cli auth zone list` output.
 #
 #   dirty:                   Zone has pending modifications
-#                           (internal state, managed automatically)
-#
-#   frozen:                  Zone is locked against modifications
-#                           (internal state, managed automatically)
-#
-#   multisigner:             Multi-signer mode (OBE - obsolete)
+#   frozen:                  Zone is locked against modifications (freeze/thaw API)
+#   automatic-zone:          Zone was auto-created from a catalog
+#   api-managed-zone:        Zone was created via the dynamic-zones API
+#   multi-signer:            Set by the signer when HSYNC shows multiple signers
+#   dont-publish-jwk:        Unused
 #
 # ==============================================================================
 
 templates:
    # Basic primary zone template
-   parent-primary:
-      type:            primary
-      store:           map
-      options:
-         - delegation-sync-parent  # Provide delegation sync for children
-      dnssec_policy:   default
+   - name:            parent-primary
+     type:            primary
+     store:           map
+     options:
+        - delegation-sync-parent  # Provide delegation sync for children
+     dnssecpolicy:    default
 
    # Primary zone with online signing
-   signed-primary:
-      type:            primary
-      store:           map
-      options:
-         - delegation-sync-parent
-         - online-signing         # Sign on-the-fly
-      dnssec_policy:   default
+   - name:            signed-primary
+     type:            primary
+     store:           map
+     options:
+        - delegation-sync-parent
+        - online-signing         # Sign on-the-fly
+     dnssecpolicy:    default
 
    # Primary zone allowing dynamic updates
-   dynamic-primary:
-      type:            primary
-      store:           map
-      options:
-         - allow-updates          # Allow DNS UPDATE
-         - delegation-sync-parent
-         - online-signing
-      dnssec_policy:   default
+   - name:            dynamic-primary
+     type:            primary
+     store:           map
+     options:
+        - allow-updates          # Allow DNS UPDATE
+        - delegation-sync-parent
+        - online-signing
+     dnssecpolicy:    default
 
    # Basic secondary zone template
-   basic-secondary:
-      type:            secondary
-      store:           map         # Default storage (serves normal DNS queries)
-      # primaries: must be set per-zone or overridden
+   - name:            basic-secondary
+     type:            secondary
+     store:           map         # Default storage (serves normal DNS queries)
+     # primaries: must be set per-zone or overridden
 
    # Secondary with child sync
-   child-secondary:
-      type:            secondary
-      store:           map
-      options:
-         - delegation-sync-child  # Push updates to parent
+   - name:            child-secondary
+     type:            secondary
+     store:           map
+     options:
+        - delegation-sync-child  # Push updates to parent
 
    # Hidden primary (doesn't notify, used with API)
-   hidden-primary:
-      type:            primary
-      store:           map
-      # notify: intentionally empty - hidden primary doesn't notify
+   - name:            hidden-primary
+     type:            primary
+     store:           map
+     # notify: intentionally empty - hidden primary doesn't notify
+     # downstreams: intentionally empty - and nobody may transfer from it
 
    # Catalog zone template (primary catalog publisher)
-   catalog-primary:
-      type:            primary
-      store:           map
-      options:
-         - catalog-zone                   # RFC 9432 catalog zone
-         - catalog-member-auto-create     # Auto-create member zones
-         - catalog-member-auto-delete     # Auto-delete removed zones
+   - name:            catalog-primary
+     type:            primary
+     store:           map
+     options:
+        - catalog-zone                   # RFC 9432 catalog zone
+        - catalog-member-auto-create     # Auto-create member zones
+        - catalog-member-auto-delete     # Auto-delete removed zones
 
    # Catalog zone template (secondary catalog consumer)
-   catalog-secondary:
-      type:            secondary
-      store:           map
-      options:
-         - catalog-zone                   # RFC 9432 catalog zone
-         - catalog-member-auto-create     # Auto-create member zones
-         - catalog-member-auto-delete     # Auto-delete removed zones
-      # primaries: must be set per-zone
+   - name:            catalog-secondary
+     type:            secondary
+     store:           map
+     options:
+        - catalog-zone                   # RFC 9432 catalog zone
+        - catalog-member-auto-create     # Auto-create member zones
+        - catalog-member-auto-delete     # Auto-delete removed zones
+     # primaries: must be set per-zone
 
    # Read-only catalog (metadata only, no auto-configuration)
-   catalog-readonly:
-      type:            secondary
-      store:           map
-      options:
-         - catalog-zone                   # Parse catalog but don't auto-configure
+   - name:            catalog-readonly
+     type:            secondary
+     store:           map
+     options:
+        - catalog-zone                   # Parse catalog but don't auto-configure
 
    # Fast-rolling DNSSEC zone
-   fast-roll-primary:
-      type:            primary
-      store:           map
-      options:
-         - delegation-sync-parent
-         - online-signing
-      dnssec_policy:   fastroll           # Use fast-rolling policy
+   - name:            fast-roll-primary
+     type:            primary
+     store:           map
+     options:
+        - delegation-sync-parent
+        - online-signing
+     dnssecpolicy:    fastroll           # Use fast-rolling policy
 
    # Stealth primary (serves, but upstream fetches from it)
-   stealth-primary:
-      type:            primary
-      store:           map
-      notify:
-         - addr: "192.0.2.1:53"           # Notify public secondaries
-           key:  NOKEY
-         - addr: "192.0.2.2:53"
-           key:  NOKEY
-      options:
-         - delegation-sync-parent
-         - online-signing
-      dnssec_policy:   default
+   - name:            stealth-primary
+     type:            primary
+     store:           map
+     notify:
+        - addr: "192.0.2.1:53"           # Notify public secondaries
+          key:  NOKEY
+        - addr: "192.0.2.2:53"
+          key:  NOKEY
+     downstreams:                        # ...and let them transfer
+        - prefix: "192.0.2.1"
+          key:    NOKEY
+        - prefix: "192.0.2.2"
+          key:    NOKEY
+     options:
+        - delegation-sync-parent
+        - online-signing
+     dnssecpolicy:    default
+
+   # Zonefile-pattern template: a zone that sets no zonefile: of its own gets
+   # /etc/tdns/zones/<zonename>zone — note the trailing dot in the zone name
+   # supplies the dot before "zone".
+   - name:            pattern-primary
+     type:            primary
+     store:           map
+     zonefile:        /etc/tdns/zones/%szone
+     downstreams:
+        - prefix: "2001:db8::/32"
+          key:    NOKEY

--- a/cmdv2/auth/auth-zones.sample.yaml
+++ b/cmdv2/auth/auth-zones.sample.yaml
@@ -5,25 +5,79 @@
 #
 # Zone declaration properties:
 #   name:            Zone name (required, FQDN with trailing dot)
-#   type:            primary | secondary (required unless using template)
+#   type:            primary | secondary (required unless inherited from a template)
 #   zonefile:        Path to zone file (required for primary, optional for secondary)
-#   store:           map | slice | xfr (defaults to "map" if not specified)
+#   store:           map | xfr (defaults to "map" if not specified)
 #                    - map:   Default, general-purpose (recommended for most zones)
-#                    - slice: Experimental alternative (may be faster/use less memory)
 #                    - xfr:   Zone transfer only (AXFR in/out, NO normal queries)
+#                    ("slice" is deprecated: it logs a warning and falls back to
+#                     "map". Any other value also falls back to "map".)
 #   template:        Template name to inherit settings from (optional)
 #   primaries:       Upstream servers for secondary zones — a LIST of {addr, key}
 #                    entries (addr is IP:port or host:port; key is a TSIG key name,
 #                    or NOKEY for none). More than one provides redundancy; a host
 #                    name is resolved at load time and may expand to several
 #                    addresses (A + AAAA), each tried in turn on failure.
-#   notify:          Downstream servers to notify — a LIST of {addr, key} entries
-#   downstreams:     Alias for notify (same meaning)
+#   notify:          Downstream servers to notify — a LIST of {addr, key} entries.
+#                    This is a list of DESTINATIONS we send NOTIFY to, so each
+#                    entry needs an address (host:port), not a prefix.
+#   allow-notify:    Secondary-side ACL: who may send NOTIFY *to* us.
+#                    A LIST of {prefix, key} entries. See "ACLs" below.
+#   downstreams:     Primary-side ACL: who may AXFR/IXFR *from* us (the
+#                    "provide-xfr" ACL). A LIST of {prefix, key} entries.
+#                    NOT an alias for notify: notify entries are destinations
+#                    ({addr, key}); downstreams entries are source-address ACL
+#                    rules ({prefix, key}).
 #   options:         List of zone options (see auth-templates.sample.yaml for complete list)
-#   dnssec_policy:   DNSSEC policy name (from dnssecpolicies: section)
-#   multi_signer:    Multi-signer configuration name (from multisigner: section)
+#   dnssecpolicy:    DNSSEC policy name (from the dnssec.policies: section).
+#                    NOTE: one word, no underscore and no hyphen. "none" means
+#                    the same as leaving it unset.
+#   multisigner:     Multi-signer configuration name (from multisigner: section).
+#                    NOTE: one word, no underscore.
 #
 # Properties set in templates can be overridden in individual zone declarations.
+#
+# ==============================================================================
+# ACLs: allow-notify: and downstreams:
+# ==============================================================================
+#
+# Both are ordered lists of { prefix, key } entries. They differ only in what
+# they guard: allow-notify: guards inbound NOTIFY on a secondary, downstreams:
+# guards outbound zone transfer on a primary.
+#
+# prefix — an ip-spec matched against the SOURCE address of the request:
+#     bare IP     192.0.2.1              ::1
+#     CIDR        192.0.2.0/24           2001:db8::/32
+#     netmask     192.0.2.0&255.255.255.0
+#     range       192.0.2.10-192.0.2.20  2001:db8::10-2001:db8::20
+#     any         0.0.0.0/0              ::/0
+#   Note that 0.0.0.0/0 matches IPv4 sources only and ::/0 matches IPv6 sources
+#   only — to allow both you need both entries.
+#
+# key — what authentication that source must present:
+#     <name>      a TSIG key name (from keys.tsig: or the keystore). The request
+#                 MUST carry a valid TSIG signed with that key.
+#     NOKEY       the source is trusted by address alone. Unsigned is accepted;
+#                 a TSIG that happens to be present is not enforced.
+#     BLOCKED     deny this source. BLOCKED supersedes any allow entry anywhere
+#                 in the list, regardless of order (NSD semantics).
+#
+# Matching collects EVERY non-BLOCKED entry whose prefix matches, and the
+# request is accepted if it satisfies ANY one of the collected keys. Two
+# consequences worth knowing:
+#
+#   1. A NOKEY entry that matches a source makes TSIG optional for that source
+#      even if a named-key entry also matches it. If you want TSIG enforced,
+#      do not leave a broader NOKEY entry covering the same addresses.
+#
+#   2. Listing two named keys for one source accepts either — which is how you
+#      roll a TSIG key without downtime: add the new key alongside the old,
+#      migrate the client, then drop the old entry.
+#
+# Empty-ACL defaults differ, and the difference is deliberate:
+#   downstreams:  empty => DENY all transfers (closes the legacy open-AXFR default)
+#   allow-notify: empty => accept unsigned NOTIFY from any configured primary's
+#                 address, and nothing else
 #
 # ==============================================================================
 
@@ -40,10 +94,15 @@ zones:
           key:  NOKEY
         - addr: "192.0.2.2:53"     # And this one
           key:  NOKEY
+     downstreams:                  # ...and let those same secondaries transfer
+        - prefix: "192.0.2.1"
+          key:    NOKEY
+        - prefix: "192.0.2.2"
+          key:    NOKEY
      options:
         - delegation-sync-parent   # Provide delegation sync for children
         - online-signing           # Sign responses on-the-fly
-     dnssec_policy:   default
+     dnssecpolicy:    default      # online-signing REQUIRES a dnssecpolicy
 
    # ===========================================================================
    # EXAMPLE 2: Complete SECONDARY zone declaration (no template)
@@ -57,6 +116,11 @@ zones:
           key:  NOKEY
         - addr: "203.0.113.2:53"
           key:  NOKEY
+     allow-notify:                                           # Only these may NOTIFY us
+        - prefix: "203.0.113.1"
+          key:    NOKEY
+        - prefix: "203.0.113.2"
+          key:    NOKEY
      options:
         - delegation-sync-child    # Push DS/NS updates to parent
 
@@ -71,7 +135,7 @@ zones:
           key:  NOKEY
         - addr: "192.0.2.11:53"
           key:  NOKEY
-     # type, store, options, dnssec_policy inherited from template
+     # type, store, options, dnssecpolicy inherited from template
 
    # ===========================================================================
    # EXAMPLE 4: Simple zone using template (minimal declaration)
@@ -81,7 +145,79 @@ zones:
      template:        signed-primary     # Everything inherited from template
 
    # ===========================================================================
-   # EXAMPLE 5: PRIMARY catalog zone (with auto-create/delete)
+   # EXAMPLE 5: AXFR open to everyone, unsigned (IPv4 + IPv6)
+   # ===========================================================================
+   # Two entries are needed: 0.0.0.0/0 covers IPv4 sources, ::/0 covers IPv6.
+   # NOKEY means "trusted by address" — the transfer is accepted unsigned, and
+   # a TSIG is NOT required even if the client sends one.
+   #
+   # This is a lab/testing posture. It is the open-AXFR configuration; prefer
+   # EXAMPLE 6 or 7 for anything reachable from the network.
+   - name:            open.example.
+     type:            primary
+     zonefile:        /etc/tdns/zones/open.example.zone
+     downstreams:
+        - prefix: "0.0.0.0/0"      # every IPv4 source
+          key:    NOKEY
+        - prefix: "::/0"           # every IPv6 source
+          key:    NOKEY
+
+   # ===========================================================================
+   # EXAMPLE 6: AXFR restricted by prefix, unsigned (IPv4 + IPv6)
+   # ===========================================================================
+   # Still NOKEY (no TSIG), but only from our own secondary networks. Note the
+   # mixed ip-spec forms: CIDR, a bare host address, and a range.
+   - name:            prefix-acl.example.
+     type:            primary
+     zonefile:        /etc/tdns/zones/prefix-acl.example.zone
+     downstreams:
+        - prefix: "192.0.2.0/24"                     # IPv4 CIDR
+          key:    NOKEY
+        - prefix: "2001:db8:1::/48"                  # IPv6 CIDR
+          key:    NOKEY
+        - prefix: "203.0.113.7"                      # a single IPv4 host
+          key:    NOKEY
+        - prefix: "2001:db8:2::10-2001:db8:2::1f"    # an IPv6 range
+          key:    NOKEY
+        - prefix: "192.0.2.66"                       # ...but never this one:
+          key:    BLOCKED                            # BLOCKED beats every allow
+
+   # ===========================================================================
+   # EXAMPLE 7: AXFR requiring a real TSIG key
+   # ===========================================================================
+   # Each downstream must present a valid TSIG signed with the named key. The
+   # key names below must be defined in the keys.tsig: section of the main
+   # config (tdns-auth.yaml) or exist in the TSIG keystore, otherwise the zone
+   # is quarantined at config load with "unknown key".
+   #
+   # Because NO entry says NOKEY, an unsigned AXFR from any of these addresses
+   # is REFUSED. Adding a NOKEY entry covering the same addresses would silently
+   # make TSIG optional again — see note (1) in the ACL section above.
+   #
+   # The two entries for 2001:db8:1::/48 are a dual-key rotation overlap: the
+   # secondary on that network is accepted with EITHER key while it migrates
+   # from xfr-key-2025 to xfr-key-2026. Drop the old entry when done.
+   - name:            tsig-acl.example.
+     type:            primary
+     zonefile:        /etc/tdns/zones/tsig-acl.example.zone
+     notify:
+        - addr: "192.0.2.53:53"
+          key:  xfr-key-2026        # NOTIFY to this secondary is TSIG-signed too
+     downstreams:
+        - prefix: "192.0.2.0/24"    # IPv4 secondaries: new key only
+          key:    xfr-key-2026
+        - prefix: "2001:db8:1::/48" # IPv6 secondaries: either key (rotation)
+          key:    xfr-key-2026
+        - prefix: "2001:db8:1::/48"
+          key:    xfr-key-2025
+        - prefix: "192.0.2.66"      # compromised host: denied even with a key
+          key:    BLOCKED
+     options:
+        - online-signing
+     dnssecpolicy:    default
+
+   # ===========================================================================
+   # EXAMPLE 8: PRIMARY catalog zone (with auto-create/delete)
    # ===========================================================================
    - name:            catalog.example.
      type:            primary
@@ -90,13 +226,16 @@ zones:
      notify:
         - addr: "192.0.2.20:53"    # Notify secondaries about catalog changes
           key:  NOKEY
+     downstreams:
+        - prefix: "192.0.2.20"
+          key:    NOKEY
      options:
         - catalog-zone                    # RFC 9432 catalog zone
         - catalog-member-auto-create      # Auto-create zones from catalog
         - catalog-member-auto-delete      # Auto-delete zones removed from catalog
 
    # ===========================================================================
-   # EXAMPLE 6: SECONDARY catalog zone (fetched from upstream)
+   # EXAMPLE 9: SECONDARY catalog zone (fetched from upstream)
    # ===========================================================================
    - name:            catalog-upstream.
      type:            secondary
@@ -111,7 +250,7 @@ zones:
         - catalog-member-auto-delete           # Auto-remove deleted zones
 
    # ===========================================================================
-   # EXAMPLE 7: Read-only catalog (metadata only, no auto-config)
+   # EXAMPLE 10: Read-only catalog (metadata only, no auto-config)
    # ===========================================================================
    - name:            catalog-readonly.
      type:            secondary
@@ -124,14 +263,14 @@ zones:
                                  # (no catalog-member-auto-create option)
 
    # ===========================================================================
-   # EXAMPLE 8: Root zone (special case)
+   # EXAMPLE 11: Root zone (special case)
    # ===========================================================================
    - name:            .
      zonefile:        /etc/tdns/zones/root.zone
      template:        parent-primary
 
    # ===========================================================================
-   # EXAMPLE 9: Stealth primary (hidden, notifies public secondaries)
+   # EXAMPLE 12: Stealth primary (hidden, notifies public secondaries)
    # ===========================================================================
    - name:            stealth.example.
      zonefile:        /etc/tdns/zones/stealth.example.zone
@@ -143,7 +282,7 @@ zones:
           key:  NOKEY
 
    # ===========================================================================
-   # EXAMPLE 10: Fast-rolling DNSSEC zone
+   # EXAMPLE 13: Fast-rolling DNSSEC zone
    # ===========================================================================
    - name:            fastroll.example.
      zonefile:        /etc/tdns/zones/fastroll.example.zone
@@ -153,7 +292,7 @@ zones:
           key:  NOKEY
 
    # ===========================================================================
-   # EXAMPLE 11: Zone with dynamic updates enabled
+   # EXAMPLE 14: Zone with dynamic updates enabled
    # ===========================================================================
    - name:            dynamic.example.
      zonefile:        /etc/tdns/zones/dynamic.example.zone

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -29,11 +29,15 @@ service:
 dnsengine:
    addresses:    [ 127.0.0.1:5354, '[::1]:5354' ]
    transports:   [ doq, dot, doh ]
+   # Ports per encrypted transport. Defaults: doq 853, dot 853, doh 443.
+   # NOTE: dnsengine.ports.do53 is NOT read. Do53 always listens on the ports
+   # embedded in dnsengine.addresses above.
    ports:
-      do53:  [ 53 ]
       doq:   [ 853 ]
       dot:   [ 853 ]
       doh:   [ 443 ]
+   # certfile/keyfile are required for dot, doh and doq. If either is empty
+   # those listeners are not started (do53 is unaffected).
    certfile:  /etc/tdns/certs/servers/localhost..crt
    keyfile:   /etc/tdns/certs/servers/localhost..key
    # outbound_soa_serial controls the SOA serial advertised to secondaries:
@@ -59,9 +63,13 @@ dnsengine:
 
 resignerengine:
    interval:  300    # seconds between runs. Reasonable value is likely ~3600
-   keygen:
-      mode:       internal    # internal | external
-      generator:  /usr/sbin/dnssec-keygen
+                     # clamped to the range 60..3600
+   # NOTE: resignerengine.keygen is NOT read by the code. Key generation is
+   # always internal. Left here only to document that the keys are not
+   # produced by an external generator.
+   # keygen:
+   #    mode:       internal
+   #    generator:  /usr/sbin/dnssec-keygen
 
 imrengine:
    active:             true                    # true | false, default is true
@@ -74,18 +82,56 @@ apiserver:
    certfile:   /etc/tdns/certs/servers/localhost..crt
    keyfile:    /etc/tdns/certs/servers/localhost..key
 
+# Statically declared TSIG keys.
+#
+# Every key named here is synced into the TSIG keystore in the database
+# (db.file below) as an origin=config row at startup, and the live key cache is
+# then rebuilt from the database. Keys may also be added at runtime with
+#   tdns-cli auth keystore tsig add ...
+# which stores them with origin=keystore. There is no separate keystore path:
+# the keystore IS the db.file SQLite database.
+#
+# A key name referenced from a zone's primaries:, notify:, allow-notify: or
+# downstreams: must resolve either here or in the keystore, otherwise that zone
+# is quarantined at config load with "unknown key".
+#
+# NOKEY and BLOCKED are reserved ACL sentinels and may NOT be used as key names.
+# Supported algorithms: hmac-sha1, hmac-sha224, hmac-sha256, hmac-sha384,
+# hmac-sha512.
+#
+# owner: is an optional free-text provenance LABEL shown by
+#   tdns-cli auth keystore tsig list
+# It does not scope the key to a zone and grants no authority of its own. It
+# defaults to the key's origin ("config" for entries declared here).
+keys:
+   tsig:
+      # The two keys referenced by the tsig-acl.example. zone in
+      # auth-zones.sample.yaml. Generate a secret with e.g.
+      #   openssl rand -base64 32
+      # and prefer adding it via `tdns-cli auth keystore tsig add --secret-file`
+      # over pasting it into a config file.
+      - name:       xfr-key-2026.
+        algorithm:  hmac-sha256
+        secret:     "REPLACE-ME-base64-secret-for-the-2026-key="
+        owner:      rollover-2026   # optional label, not a zone scope
+
+      - name:       xfr-key-2025.   # kept alive during the rotation overlap
+        algorithm:  hmac-sha256
+        secret:     "REPLACE-ME-base64-secret-for-the-2025-key="
+        owner:      rollover-2025
+
 server:
    id:        ooga booga boo
    version:   tdns-server {version}
    hostname:  there-is-no-place-like-127.0.0.1
 
 childsync:                 # What to do when we are the child
-   schemes:         [ update ]    # , notify ] # this child will use either
+   # NOTE: only update-ns, update-a and update-aaaa are read from this block.
+   # Child scheme selection is configured under delegationsync.child.schemes
+   # below; childsync.schemes / sync-on-boot / syncwithparent are NOT read.
    update-ns:       true
    update-a:        true
    update-aaaa:     true
-   sync-on-boot:    false
-   syncwithparent:  true
 
 # Named delegation backends for parent zones that receive child UPDATEs.
 # Predefined: "db" and "direct" (no config needed).
@@ -115,18 +161,18 @@ delegationsync:
          target:     updates.{ZONENAME}
          addresses:  [ 127.0.0.1, '::1' ]
          keygen:
-            mode:       internal               # internal | external
-            generator:  /opt/local/bin/dnssec-keygen
+            # Only `algorithm` is read on the parent side; `mode` and
+            # `generator` are not.
             algorithm:  ED25519
 
    child:
       # in child zones, we attempt the following schemes, if the parent supports
       # them and we're allowed to modify the child zone (adding CDS, CSYNC, KEY
       # RRs, re-signing, etc):
-      schemes:  [ notify, update ]
+      schemes:  [ notify, update ]      # REQUIRED for child-side delegation sync
       update:
          keygen:
-            mode:       internal               # internal | external
+            # `algorithm` and `generator` are read on the child side; `mode` is not.
             generator:  /opt/local/bin/dnssec-keygen
             algorithm:  ED25519
 
@@ -140,15 +186,18 @@ scanner:
       checks:    1     # consecutive all-NS checks before accepting (default: 1)
       interval:  300   # seconds between checks (default: 300)
 
-keybootstrap:
-   consistent-lookup:
-      iterations:   3
-      interval:     60     # seconds between lookups
-      nameservers:  all    # one | all
+# NOTE: there is no `keybootstrap:` config block. The key-bootstrap knobs the
+# code actually reads are:
+#   keystate.require_manual_bootstrap   (bool)
+#   keystate.allow_auto_bootstrap       (bool)
+#   verifyengine.attempts               (default 3)
+#   verifyengine.retry_interval         (default 60, seconds)
+# Per-zone bootstrap methods are set under a zone's updatepolicy.child.keybootstrap.
 
-# DNSSEC policies. Each policy is referenced from a zone's `dnssec-policy:`
-# field. The rollover, ttls, and clamping subtrees are optional; omitting
-# them gives a static-key policy with no automated rollover.
+# DNSSEC policies. Each policy is referenced from a zone's `dnssecpolicy:`
+# field (one word: no underscore, no hyphen). The rollover, ttls, and clamping
+# subtrees are optional; omitting them gives a static-key policy with no
+# automated rollover.
 #
 # Rollover (Phase 4 of the automated KSK rollover plan):
 #   method: none | multi-ds | double-signature
@@ -250,7 +299,7 @@ dnssec:
          ttls:
             dnskey:  2h
 
-   # Named DNSSEC policies. Each zone references one via its dnssec_policy
+   # Named DNSSEC policies. Each zone references one via its dnssecpolicy:
    # field. A policy that sets different ksk.algorithm and zsk.algorithm must
    # have that pair allowlisted in dnssec.split_algorithms above, or config
    # load fails. A policy may also set `template: <name>` to inherit defaults
@@ -404,9 +453,8 @@ catalog:
       kdc:                          # Group name (matches "configkdc" in catalog zone)
          upstream:  "127.0.0.1:5353"   # Where to AXFR member zones from (REQUIRED)
          tsig_key:  ""                 # Optional TSIG key name for authentication
-         store:     map                # Zone store type: map (default), slice, or xfr
+         store:     map                # Zone store type: map (default) or xfr
                                        # - map:   Default, general-purpose (recommended)
-                                       # - slice: Experimental (may be faster/use less memory)
                                        # - xfr:   Zone transfer only (AXFR, NO normal queries)
          options:   []                 # Optional zone options to apply to member zones
                                        # Example: ["delegation-sync-child"]
@@ -415,7 +463,7 @@ catalog:
          upstream:  "192.0.2.1:5353"
          tsig_key:  ""
          store:     map                # Default storage (recommended)
-         options:   []
+         options:   []                 # e.g. ["delegation-sync-child"]
 
    # Signing groups (documentation/informational only, not used for auto-configuration).
    # These groups can be used to indicate which signing infrastructure is
@@ -491,7 +539,7 @@ log:
    #   conn-retry: info
 
 common:
-   servername:  tdns-auth
+   # NOTE: only common.command is read. common.servername is not.
    command:     /usr/local/libexec/tdns-auth
 
 # Registrars are declared here, including where they want notifications/updates.

--- a/cmdv2/dog/dog.go
+++ b/cmdv2/dog/dog.go
@@ -53,7 +53,7 @@ var rootCmd = &cobra.Command{
 	Long: `dog is a CLI utility used issue DNS queries and present the result.
 	
 	Options:
-		+DNSSEC: Set the DO (DNSEC OK) bit in queries
+		+DNSSEC or +DO: Set the DO (DNSSEC OK) bit in queries
 		+CD: Set the CD (Checking Disabled) bit in queries
 		+COMPACT: Set the COMPACT bit in queries (for compact denial of existence proofs)
 		+TCP: Force TCP transport
@@ -64,7 +64,6 @@ var rootCmd = &cobra.Command{
 		+OPCODE=QUERY|NOTIFY|UPDATE: Set the opcode of the query
 		+OTS=opt_in|opt_out: Set the OTS (transport signaling) EDNS(0)option
 		+ER=agent.domain: Add EDNS(0) Error Reporting option with agent domain (RFC9567)
-		+DO_BIT: Set the DO (DNSEC OK) bit
 		+DELEG: Set the DELEG bit in queries
 		+PRIVACY or +PR: Set the PR (Privacy Requested) bit in queries (requires encrypted transport)
 		+MULTI: Present RRs in multi-line format

--- a/cmdv2/imr/root.go
+++ b/cmdv2/imr/root.go
@@ -133,7 +133,7 @@ func initConfig() {
 
 // initImr initializes the application, prepares configuration, sets up the IMR API router, and starts the IMR service.
 //
-// It receives a context that should be cancelled on SIGINT or SIGTERM (handled in main), calls cli.Conf.MainInit with the default IMR config file, and aborts via tdns.Shutdowner on initialization errors. It installs a SIGHUP watcher that triggers cli.Conf.ParseZones to reload zones, logs reload errors, and then creates the API router with cli.Conf.SetupSimpleAPIRouter. Finally it starts the IMR via cli.Conf.StartImr and invokes tdns.Shutdowner on any fatal startup errors.
+// It receives a context that should be cancelled on SIGINT or SIGTERM (handled in main), calls cli.Conf.MainInit with the config file initConfig resolved (--config, else the default), and aborts via tdns.Shutdowner on initialization errors. It installs a SIGHUP watcher that triggers cli.Conf.ParseZones to reload zones, logs reload errors, and then creates the API router with cli.Conf.SetupSimpleAPIRouter. Finally it starts the IMR via cli.Conf.StartImr and invokes tdns.Shutdowner on any fatal startup errors.
 func initImr() {
 	// --version must be answered before any startup work. initImr runs via
 	// cobra.OnInitialize, i.e. BEFORE rootCmd.Run, and it performs the full
@@ -157,10 +157,16 @@ func initImr() {
 	appCancel = cancel
 
 	if tdns.Globals.Debug {
-		fmt.Printf("initImr: Calling conf.MainInit(\"\") // Empty string means derive from Globals.App.Name\n")
+		fmt.Printf("initImr: Calling conf.MainInit(%q)\n", cfgFileUsed)
 	}
 
-	err := cli.Conf.MainInit(appCtx, "") // Empty string means derive from Globals.App.Name
+	// Hand MainInit the file initConfig actually read: --config if given,
+	// otherwise tdns.DefaultImrCfgFile. MainInit does not parse flags for
+	// AppTypeImr (see the comment there), so it cannot discover --config on
+	// its own; passing "" would make it fall back to the default file and
+	// decode that over the config the user asked for. cobra.OnInitialize
+	// runs initConfig before initImr, so cfgFileUsed is already set.
+	err := cli.Conf.MainInit(appCtx, cfgFileUsed)
 	if err != nil {
 		tdns.Shutdowner(&cli.Conf, fmt.Sprintf("Error initializing tdns-imr: %v", err))
 	}

--- a/cmdv2/imr/tdns-imr.sample.yaml
+++ b/cmdv2/imr/tdns-imr.sample.yaml
@@ -1,11 +1,35 @@
+# Sample configuration for tdns-imr, the iterative/recursive resolver.
+#
+# The three things tdns-imr will not start without:
+#   imrengine.addresses    (validated: required)
+#   imrengine.transports   (validated: required)
+#   log.file               (validated: required, and read before anything else)
+#   apiserver.apikey       (not validated, but the API router refuses to start
+#                           without it, and that aborts startup)
+#
+# Everything else below is optional and shown with its default.
+#
+# NOTE the block is named `imrengine:`, not `imr:`. The only `imr.`-prefixed
+# key is `imr.localconfig` (see the bottom of this file).
+
 imrengine:
    active:              true   # Set to false to disable IMR. Defaults to true if not specified.
-   root-hints:          "/etc/tdns/root.hints"   # Optional: path to root hints file. If empty, uses compiled-in hints.
-   addresses:           [ 127.0.0.1:99, '[::1]:99']
-   transports:          [ do53, dot, doq ]
-   certfile:            /etc/hsync-test/certs/hoola.bandoola.crt
-   keyfile:             /etc/hsync-test/certs/hoola.bandoola.key
-   
+
+   # Optional: path to a root hints file. If empty, uses compiled-in hints.
+   root-hints:          "/etc/tdns/root.hints"
+
+   # REQUIRED. Addresses (with port) the resolver listens on for DNS queries.
+   addresses:           [ 127.0.0.1:53, '[::1]:53' ]
+
+   # REQUIRED. Any of: do53, dot, doh, doq.
+   # do53 needs no certificate. dot/doh/doq each need certfile+keyfile below;
+   # without them those listeners are silently skipped.
+   transports:          [ do53 ]
+
+   # Ports for the encrypted transports default to dot 853, doh 443, doq 853.
+   # certfile:            /etc/tdns/certs/imr.crt
+   # keyfile:             /etc/tdns/certs/imr.key
+
    # IMR Options (all are boolean flags, no values needed):
    # - query-for-transport: Query for transport signals opportunistically when observed
    # - always-query-for-transport: Always query for new auth servers
@@ -17,6 +41,54 @@ imrengine:
       # - always-query-for-transport
       # - query-for-transport-tlsa
 
+   # DNSSEC trust anchors. Choose ONE of the three forms below.
+   #
+   # IMPORTANT: if none is set, the tdns-imr DAEMON seeds no trust anchor at
+   # all and cannot establish a chain of trust. (The compiled-in root anchor is
+   # wired into `dog`, not into this daemon.) Validation is on by default —
+   # require_dnssec_validation defaults to true — so an unconfigured daemon
+   # validates against an empty anchor set.
+   #
+   # trust_anchor_ds:      ". IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"
+   # trust_anchor_dnskey:  ". IN DNSKEY 257 3 8 AwEAAaz/tAm8y..."
+   # trust-anchor-file:    /etc/tdns/root.key    # unbound-style, one DS/DNSKEY per line
+   #                                             # (note: hyphens, unlike the two above)
+
+   # require_dnssec_validation: true
+
+   # Stub / forward zones: answer these from the named servers instead of
+   # iterating from the root.
+   # stubs:
+   #    - zone:     internal.example.
+   #      servers:  [ 192.0.2.53, 2001:db8::53 ]
+
+   # Optional IMR debug log, separate from log.file below.
+   # logging:
+   #    enabled:  true
+   #    file:     /var/log/tdns/imr-debug.log    # this is the default when enabled
+
+   # Resolver tuning. Every key below is optional; the value shown IS the
+   # default. Inspect the effective values at runtime with `dump tuning`
+   # (interactive mode) or `tdns-cli agent imr dump-tuning`.
+   # tuning:
+   #    backoff:
+   #       first_failure:     15s    # first backoff after a server failure
+   #       max_failure:       1h     # ceiling (raised to first_failure if set lower)
+   #       multiplier:        3.0    # exponential growth factor
+   #       jitter_fraction:   0.25   # must be in [0,1); else reset to default
+   #       routing_failure:   1h     # backoff after an unreachable-network error
+   #       lame_delegation:   1h     # backoff after a lame delegation
+   #    address_family:
+   #       window_duration:   10m    # observation window for per-family failures
+   #       failure_threshold: 5      # distinct failures before a family is suspect
+   #       suspect_duration:  10m    # how long a family stays suspect
+   #       probe_interval:    30s    # how often a suspect family is re-probed
+   #    discovery:
+   #       retry_after_failure: 30s  # transport-signal discovery retry
+   #       max_failures:        3    # give up discovery after this many
+   #    query_budget:            8s  # total wall-clock budget for one query
+   #    upgrade_indirect_cache_hits: true   # left unset in code; treated as true
+
 # DNSSEC algorithm numbers whose DNSKEY/RRSIG payloads are large for UDP.
 # When a referral DS RRset contains any listed algorithm, the IMR fetches
 # the child zone's DNSKEY over TCP from the start (do53-tcp), not UDP with
@@ -26,8 +98,25 @@ imrengine:
 dnssec:
    large_algorithms: [ RSASHA512 ]
 
+# The HTTP management API. apikey is effectively required: SetupSimpleAPIRouter
+# returns an error when it is empty, and that aborts tdns-imr startup.
+# addresses, by contrast, is optional — omit it and the API simply does not
+# listen while the resolver keeps running.
+apiserver:
+   apikey:     "REPLACE-ME-with-a-long-random-string"
+   addresses:  [ 127.0.0.1:8080 ]
+   # usetls defaults to TRUE when not set. With usetls true you must also give
+   # certfile/keyfile, or the API listener fails to start (the resolver itself
+   # keeps running). Set it false for a plaintext API on loopback.
+   usetls:     false
+   # certfile:   /etc/tdns/certs/api.crt
+   # keyfile:    /etc/tdns/certs/api.key
+
 log:
    file:                /var/log/tdns/tdns-imr.log
    level:               info    # default level: debug|info|warn|error
 
-
+# Optional second config file, merged on top of this one. This is the only
+# `imr.`-prefixed key; it is read directly and is not part of `imrengine:`.
+# imr:
+#    localconfig:  /etc/tdns/tdns-imr-local.yaml

--- a/guide/README.md
+++ b/guide/README.md
@@ -18,6 +18,20 @@ companion [tdns-mp Guide](../../tdns-mp/guide/README.md).
   tdns-agent, tdns-imr, tdns-cli, dog) with links to
   detailed documentation for each.
 
+- [TDNS Configuration Guide](configuration.md)
+  -- How to configure each application, starting from a
+  minimal working example. Conventions common to all apps
+  (config file location, `include:`, unknown-key warnings,
+  zone quarantining), then per-application pages:
+  [tdns-auth](config-tdns-auth.md) (TSIG keys, the
+  `allow-notify:` / `downstreams:` ACLs, zone declarations
+  and options, the zone template system, the `dnsengine:`
+  block, DNSSEC policies including policy templates,
+  `split_algorithms` and `large_algorithms`),
+  [tdns-imr](config-tdns-imr.md) (trust anchors, stub zones,
+  the `imrengine.tuning.*` knobs) and
+  [tdns-agent](config-tdns-agent.md) (placeholder).
+
 - [TDNS Special Features and Extensions](special-features.md)
   -- Delegation sync (parent side, child side, and the
   agent-as-proxy path for DSYNC-unaware primaries, including

--- a/guide/app-dog.md
+++ b/guide/app-dog.md
@@ -1,13 +1,105 @@
 # DOG
 
-**DOG** is a trivial implementation of a DNS query tool, similar to the
-much more capable utility "*dig*" (from the BIND distribution). DOG has
-support for the new record types (i.e. DSYNC and DELEG) that TDNS-SERVER
-implements.
+**DOG** is a DNS query tool: an independent Go reimplementation of *dig* (from
+the BIND distribution), aiming to be as close to CLI-identical to dig as
+possible. It is not a fork of dig, nor of the Rust tool of the same name.
 
-The CLI in to **DOG** is as close to identical to *dig* as possible.
+dog has no configuration file.
+
+What dog adds over dig is support for the parts of DNS that TDNS implements and
+that dig does not know about:
+
+- the **experimental record types** TDNS defines (DSYNC, DELEG, HSYNC3,
+  HSYNCPARAM, CHUNK, JWK, and the obsolete HSYNC/HSYNC2/TSYNC/MSIGNER/NOTIFY),
+  usable as query types and printed in presentation format;
+- the **post-quantum DNSSEC algorithms** TDNS registers (codepoints 199–214:
+  ML-DSA, SLH-DSA, Falcon, MAYO, SNOVA, SQIsign, QR-UOV, CROSS), including
+  actually *validating* RRSIGs made with them;
+- **`+sigchase`**, a DNSSEC chain walk that reports a per-zone-cut verdict;
+- **encrypted transports** — DoT, DoH and DoQ — alongside Do53 UDP and TCP.
 
 On an error response, **DOG** reports the DNS rcode by name
 (REFUSED, SERVFAIL, NOTAUTH, ...) rather than a bare numeric code --
 for example, a transfer refused by a `downstreams:` ACL prints
 "server returned REFUSED" instead of "rcode 5".
+
+## dig compatibility
+
+Arguments are case-insensitive and may appear in any order:
+
+```console
+$ dog @ns1.example.com www.example.com AAAA +dnssec +multi
+```
+
+- **`@server`** accepts `@host`, `@host:port`, `@[ipv6]`, `@[ipv6]:port`, and
+  also URL forms — `dns://`, `tcp://`, `tls://`, `dot://`, `https://`, `doh://`,
+  `quic://`, `doq://` — which select the transport directly.
+- **The query type** is any name dog knows, including the experimental types
+  above. Default is `A`.
+- **`IXFR=<serial>`** requests an IXFR from that serial. `AXFR` and `IXFR` are
+  Do53-only.
+- **DNS classes are not supported.** There is no `IN`/`CH`/`HS` positional
+  argument; queries are always class IN.
+
+Flags: `-v`/`--verbose`, `-d`/`--debug`, `--version`, `--short`, `-p`/`--port`,
+`-k`/`--trust-anchor <file>`, and `-y [algorithm:]name:secret` for TSIG
+(dig-compatible; algorithm defaults to `hmac-sha256`, and TSIG works on Do53,
+Do53-TCP and DoT only).
+
+## `+options`
+
+| Option | Effect |
+|--------|--------|
+| `+DNSSEC`, `+DO` | Set the DO (DNSSEC OK) bit |
+| `+CD` | Set the CD (Checking Disabled) bit |
+| `+COMPACT`, `+CO` | Set the CO bit (compact denial of existence) |
+| `+DELEG`, `+DE` | Set the DE (Delegation Extension) EDNS bit |
+| `+PRIVACY`, `+PR` | Set the PR (Privacy Requested) EDNS bit |
+| `+MULTI` | Multi-line RR output |
+| `+WIDTH=N` | Right margin for `+MULTI` |
+| `+SHORT` | Print only the answer RDATA (same as `--short`) |
+| `+SIGCHASE`, `+SIGCHA`, `+SC` | Walk and validate the DNSSEC chain |
+| `+ALGCHASE`, `+ALGCHA`, `+AC` | As `+sigchase`, annotating each algorithm number with its name |
+| `+TCP` | Force Do53 over TCP |
+| `+TLS`, `+DOT` | DoT (default port 853) |
+| `+HTTPS`, `+DOH` | DoH (default port 443) |
+| `+QUIC`, `+DOQ` | DoQ (default port 853) |
+| `+OPCODE=QUERY\|NOTIFY\|UPDATE` | Set the opcode (numeric 0/4/5 also accepted) |
+| `+OTS`, `+OTS=opt_in\|opt_out` | EDNS(0) transport-signaling option |
+| `+ER=<agent.domain>` | EDNS(0) Error Reporting, RFC 9567 |
+
+Anything else is rejected as an unknown option. A truncated UDP response is
+retried over TCP automatically.
+
+## DNSSEC chain validation
+
+`+sigchase` bypasses the ordinary query path: dog resolves through a recursive
+resolver with DO=1, walks the delegation chain, and prints a per-link verdict of
+secure, insecure, indeterminate or bogus.
+
+```console
+$ dog www.iis.se A +sigchase
+$ dog www.iis.se A +algchase          # same, with alg=214 (CROSSRSDPG128SMALL)
+```
+
+Trust anchors are taken, in order of priority, from `--trust-anchor <file>`, the
+IMR config file, and finally the compiled-in root KSK DS.
+
+## Post-quantum algorithms
+
+dog is built with `CGO_ENABLED=1` so that the C-backed implementations
+(liboqs, sqisign, qruov) are linked in and RRSIGs across the full algorithm
+range can actually be verified, not merely displayed.
+
+`dog --version` prints the table of algorithms the binary supports, with their
+codepoints and whether each is usable for SIG(0), DNSSEC, KSK and ZSK.
+
+## Experimental record types
+
+The types dog can query and print are registered by the shared `tdns/v2/core`
+package; see [NEW-RRTYPES.md](../NEW-RRTYPES.md) for what each one means.
+Current types are **DSYNC** (RFC 9859 generalized notifications), **DELEG**,
+**HSYNC3** and **HSYNCPARAM** (multi-provider enrollment and policy), **CHUNK**
+(chunked payloads), and **JWK** (RFC 7517 keys). **HSYNC**, **HSYNC2**,
+**TSYNC**, **MSIGNER** and the old private **NOTIFY** type are obsolete but
+still registered, so dog will still parse and print them.

--- a/guide/app-tdns-imr.md
+++ b/guide/app-tdns-imr.md
@@ -2,6 +2,9 @@
 
 A simple DNS IMR (Iterative Mode Resolver, i.e. a recursive DNS nameserver).
 
+For the configuration file, see
+[tdns-imr configuration](config-tdns-imr.md).
+
 Features:
 
 - **tdns-imr** does recursive lookups, caches intermediate referrals and final
@@ -9,9 +12,6 @@ Features:
 
 - incoming queries are first matched against the cache before initiating
   lookup via external queries
-
-- if **tdns-imr** is started without arguments (the normal case) it will enter
-  a command loop (i.e. it provides an interactive CLI). 
 
 - supports modern DNS transports (DoT, DoH and DoQ) in addition to Do53 (UDP/TCP).
 
@@ -25,15 +25,118 @@ Features:
   alternative carrier. See section 2 of
   [TDNS Special Features](special-features.md) for the full picture.
 
-The **tdns-imr** interactive CLI has the following implemented or planned
-features:
+## Daemon mode and interactive mode
 
-- *query* qname qtype: issue a manual DNS query directly, without going via 
-  an external tool like "dig" (or "dog").
+**tdns-imr** runs in one of two modes, selected by the `--cli` flag.
 
-- *dump*: Dump the current contents of the recursive cache.
+```console
+$ tdns-imr                       # daemon mode (the default)
+tdns-imr: Starting in daemon mode, no CLI
 
-- *dump-only-suffix* *suffix*: Dump the part of the cache with owner names
-  ending in the suffix.
+$ tdns-imr --cli                 # interactive mode
+```
 
-- *flush*: Not yet implemented.
+Interactive mode is **not** a lightweight client. Startup is identical in both
+modes: the resolver binds `imrengine.addresses`, starts the validator and the
+HTTP management API, and begins answering queries. `--cli` merely layers a shell
+on top of that running resolver, so every command below inspects and manipulates
+the live in-process cache.
+
+The shell is a `go-prompt` REPL with completion. `exit` or `quit` terminates it
+— and with it the daemon. A bare `query` with no arguments is also treated as
+`quit`.
+
+Other flags: `--config`, `-d`/`--debug`, `-v`/`--verbose`, `--version`,
+`-H`/`--headers`, `-z`/`--zone`, `-Z`/`--pzone`. Sending `SIGHUP` triggers a
+zone reload.
+
+## Interactive commands
+
+**Querying**
+
+| Command | Effect |
+|---------|--------|
+| `query <name> <type>` | Resolve in-process and print the answer with its DNSSEC validation state. `-v` also prints the negative proof |
+
+**Cache inspection** — `dump` on its own lists the RRset cache.
+
+| Command | Effect |
+|---------|--------|
+| `dump suffix <suffix>` | Cached RRsets whose owner name ends in `<suffix>` |
+| `dump zones` | All cached zones, with secure-delegation status |
+| `dump zone servers <zone>` | Servers known for one zone |
+| `dump zone backoffs <zone>` | Lame-delegation backoffs for one zone |
+| `dump servers` | Servers, grouped by zone |
+| `dump auth-servers` | Authoritative-server table |
+| `dump auth-servers servers` | The server entries |
+| `dump auth-servers keys` | The cache keys |
+| `dump auth-servers errors` | Servers currently in backoff |
+| `dump keys` | Cache keys |
+| `dump dnskeys` | Trust anchors and cached DS, with validation state |
+| `dump tuning` | The effective `imrengine.tuning.*` values |
+| `dump discovery` | Transport-signal and TLSA discovery state |
+
+**Cache flushing**
+
+| Command | Effect |
+|---------|--------|
+| `flush common <domain>` | Flush non-structural RRsets at and below `<domain>` |
+| `flush all <domain>` | Flush all RRsets at and below `<domain>`. Refuses the root |
+
+**Statistics**
+
+| Command | Effect |
+|---------|--------|
+| `stats` | Large-KSK metrics, and lists the subcommands |
+| `stats large-ksk` | DNSKEY-over-TCP counters for large algorithms |
+| `stats auth-transports <zone>` | Per-transport counters |
+| `stats auth-servers <zone>` | Alias of the above |
+
+**Inspection and settings**
+
+| Command | Effect |
+|---------|--------|
+| `show config` | Listen addresses, cache-primed flag, trust anchors, stub zones |
+| `show options` | The configured `imrengine.options` |
+| `set linewidth <n>` | Output truncation width |
+| `set server transport --server <ns> --signal "doq:20,dot:100,do53:3"` | Override a server's transport signal at runtime (debug). `--reset` clears it |
+
+**Zones**
+
+`zone list` prints only, and `zone check <file>` is not yet implemented.
+
+There is no interactive command to add, remove or reload trust anchors, and no
+command to re-prime the cache. Trust anchors are display-only here (`show
+config`, `dump dnskeys`); a cache reset exists only over the API. IMR debug
+logging is configured with `imrengine.logging.enabled`, not toggled from the
+shell.
+
+## Relationship to `tdns-cli imr ...`
+
+Three surfaces exist, and they are easy to confuse.
+
+**The interactive shell** (above) acts on the tdns-imr process it is part of,
+through in-process channels.
+
+**`tdns-cli imr <cache-command>` does not work.** `tdns-cli` registers the same
+command objects under `imr`, but their implementations reach for an in-process
+resolver that `tdns-cli` does not have. `tdns-cli imr query` prints
+*"No active channel to RecursorEngine. Terminating."* The only `tdns-cli imr`
+subcommands that do anything are `imr ping`, `imr daemon ...` and
+`imr dsync-query`.
+
+**`tdns-cli agent imr ...` and `tdns-cli auth imr ...` are the real API-based
+cache commands.** They POST to the `/imr` endpoint of a running **tdns-agent**
+or **tdns-auth** — each of which embeds its own resolver — not to tdns-imr.
+
+| Command | Wire command |
+|---------|--------------|
+| `query <qname> <qtype>` | `imr-query` |
+| `flush <qname>` | `imr-flush` |
+| `reset` | `imr-reset` (flush and re-prime, preserving root NS) |
+| `show --id <agent>` | `imr-show` |
+| `dump-tuning` | `imr-dump-tuning` |
+| `dump-zone-backoffs [zone]` | `imr-dump-zone-backoffs` |
+
+tdns-imr does serve the `/imr` endpoint itself, but no shipped CLI command is
+wired to send these cache commands to it.

--- a/guide/config-tdns-agent.md
+++ b/guide/config-tdns-agent.md
@@ -1,0 +1,32 @@
+# tdns-agent configuration
+
+> **Placeholder.** This page is not yet written. The agent's proxy
+> configurations in particular still need documenting.
+
+`tdns-agent` is the single-provider agent for delegation synchronization. It
+shares most of its configuration surface with `tdns-auth` — the same `service:`,
+`dnsengine:`, `apiserver:`, `db:` and `log:` blocks, validated the same way — so
+[tdns-auth configuration](config-tdns-auth.md) is the right starting point
+today.
+
+Two differences are worth knowing now:
+
+- **The agent does not sign.** The `online-signing` and `inline-signing` zone
+  options are rejected for `tdns-agent`, and a zone template's `dnssecpolicy:`
+  is not inherited by agent zones.
+
+- **The agent can proxy delegation sync** on behalf of a DSYNC-unaware primary
+  (BIND, Knot, NSD) with the `delegation-sync-proxy` zone option. That path is
+  already documented, as an operator how-to, in
+  [Agent as a DSYNC proxy](agent-dsync-proxy.md).
+
+## Still to document
+
+- The `delegationsync:` block: `parent.schemes`, `parent.notify.*`,
+  `parent.update.*` (including `{ZONENAME}` target substitution and the
+  key-verification knobs), `child.schemes`, `child.update.keygen.*`.
+- The proxy configurations: which combinations of NOTIFY and signed DNS UPDATE
+  are supported toward the parent, and how the agent chooses between them.
+- `apiserver.agent` and `apiserver.combiner` sub-blocks for multi-app
+  deployments.
+- The `keystate.*` and `verifyengine.*` key-bootstrap knobs.

--- a/guide/config-tdns-auth.md
+++ b/guide/config-tdns-auth.md
@@ -1,0 +1,546 @@
+# tdns-auth configuration
+
+`tdns-auth` is the TDNS authoritative nameserver. This page starts from the
+smallest config that runs and then covers, in turn: TSIG keys, the two address
+ACLs, zone declarations and the template system, the `dnsengine:` block, and
+DNSSEC policies.
+
+Read [Configuration Guide](configuration.md) first for the conventions that
+apply to every TDNS application (config file location, `include:`, the
+"unknown config keys" warning, zone quarantining).
+
+- [Minimal working example](#minimal-working-example)
+- [TSIG configuration](#tsig-configuration)
+- [ACL configuration](#acl-configuration)
+- [Zone declarations](#zone-declarations)
+- [Zone templates](#zone-templates)
+- [The dnsengine block](#the-dnsengine-block)
+- [DNSSEC policies](#dnssec-policies)
+
+## Minimal working example
+
+`tdns-auth` validates five sections at startup and refuses to run if any
+required key in them is missing: `service`, `dnsengine`, `apiserver`, `db` and
+`log`. The following is the whole config for a server that listens on one IPv4
+and one IPv6 address and serves a single zone as primary.
+
+```yaml
+service:
+   name:  TDNS-AUTH               # required
+
+dnsengine:
+   addresses:   [ 127.0.0.1:5354, '[::1]:5354' ]   # required
+   transports:  [ do53 ]                           # required
+
+apiserver:
+   addresses:  [ 127.0.0.1:8080 ]                  # required
+   apikey:     "a-long-random-string"              # required
+   certfile:   /etc/tdns/certs/api.crt             # required, must exist
+   keyfile:    /etc/tdns/certs/api.key             # required, must exist
+   usetls:     false
+
+db:
+   file:  /var/lib/tdns/tdns-auth.db               # required; created on first run
+
+log:
+   file:   /var/log/tdns/tdns-auth.log             # required
+   level:  info
+
+zones:
+   - name:      example.com.
+     type:      primary
+     zonefile:  /etc/tdns/zones/example.com.zone
+     downstreams:                                  # who may AXFR from us
+        - prefix:  "127.0.0.0/8"
+          key:     NOKEY
+        - prefix:  "::1"
+          key:     NOKEY
+```
+
+Three things about this are easy to get wrong.
+
+**`apiserver.certfile` and `apiserver.keyfile` are required even when
+`usetls: false`.** They are validated as an existing, matching certificate/key
+pair regardless of whether TLS is switched on, so a server with no API TLS
+still needs a cert on disk. `apiserver.addresses` and `apiserver.apikey` are
+likewise required — there is no way to run tdns-auth without its management API
+being configured, though you may point it at loopback.
+
+**`transports: [ do53 ]` needs no certificate, but `dot`, `doh` and `doq` all
+need `dnsengine.certfile`/`keyfile`.** If those are missing, the encrypted
+listeners are quietly skipped while Do53 keeps working.
+
+**Without `downstreams:` no one can transfer the zone.** An empty or absent
+`downstreams:` ACL denies every AXFR/IXFR. This is deliberate — it closes the
+old open-by-default behaviour — but it means a freshly configured primary will
+refuse its own secondaries until you say otherwise. See
+[ACL configuration](#acl-configuration).
+
+Zones are usually kept in a separate file and pulled in with `include:`; see
+[`auth-zones.sample.yaml`](../cmdv2/auth/auth-zones.sample.yaml).
+
+## TSIG configuration
+
+TSIG keys may be declared statically in the config file, or added at runtime to
+the keystore. Both end up in the same place: the keystore lives in the SQLite
+database named by `db.file`, and there is no separate keystore path to
+configure.
+
+```yaml
+keys:
+   tsig:
+      - name:       xfr-key-2026.       # required
+        algorithm:  hmac-sha256         # required
+        secret:     "base64-secret=="   # required
+        owner:      rollover-2026       # optional label
+```
+
+Supported algorithms are `hmac-sha1`, `hmac-sha224`, `hmac-sha256`,
+`hmac-sha384` and `hmac-sha512`.
+
+Keys declared here are synchronised into the keystore at startup as
+`origin=config` rows, and the in-memory cache is then rebuilt from the
+database. Keys added at runtime are stored with `origin=keystore`:
+
+```console
+$ tdns-cli auth keystore tsig add --name xfr-key-2026. \
+      --algorithm hmac-sha256 --secret-file /root/newkey.b64
+```
+
+Prefer `--secret-file` over `--secret`: an inline secret is visible in your
+shell history and in the process list.
+
+`owner:` is a free-text provenance label shown by
+`tdns-cli auth keystore tsig list`. It does **not** scope the key to a zone and
+grants no authority of its own; it defaults to the key's origin.
+
+Two names are reserved and may not be used as key names: **`NOKEY`** and
+**`BLOCKED`**. Both are ACL sentinels, described next.
+
+A key name referenced from a zone's `primaries:`, `notify:`, `allow-notify:` or
+`downstreams:` must resolve, either here or in the keystore. If it does not,
+that zone is quarantined at config load:
+
+```
+Error[config]: downstreams: acl entry "192.0.2.0/24": unknown key "xfr-key-2026"
+```
+
+## ACL configuration
+
+Two zone-level keys are address ACLs. They share a grammar and differ only in
+what they guard:
+
+| Key | Side | Guards | Empty means |
+|-----|------|--------|-------------|
+| `downstreams:` | primary | who may AXFR/IXFR **from** us | **deny everyone** |
+| `allow-notify:` | secondary | who may send NOTIFY **to** us | accept unsigned NOTIFY from any configured primary's address |
+
+Both are ordered lists of `{prefix, key}` entries. Note that `notify:` and
+`primaries:` are *not* ACLs — they are lists of destinations and sources, and
+take `{addr, key}` entries where the address includes a port. Writing `addr:`
+inside a `downstreams:` entry is the single most common mistake; it decodes to
+an empty prefix and quarantines the zone with `bad ip-spec ""`.
+
+### The prefix field
+
+`prefix` is an ip-spec matched against the **source address** of the request:
+
+| Form | IPv4 | IPv6 |
+|------|------|------|
+| bare address | `192.0.2.1` | `::1` |
+| CIDR | `192.0.2.0/24` | `2001:db8::/32` |
+| netmask | `192.0.2.0&255.255.255.0` | — |
+| range | `192.0.2.10-192.0.2.20` | `2001:db8::10-2001:db8::20` |
+| any | `0.0.0.0/0` | `::/0` |
+
+`0.0.0.0/0` matches IPv4 sources only and `::/0` matches IPv6 sources only. To
+allow both address families you need both entries — this catches people out on
+dual-stack servers.
+
+### The key field
+
+`key` says what the matched source must present:
+
+- **a TSIG key name** — the request must carry a valid TSIG signed with that key.
+- **`NOKEY`** — the source is trusted by address alone. Unsigned requests are
+  accepted, and a TSIG that happens to be present is not enforced.
+- **`BLOCKED`** — deny. A matching `BLOCKED` entry supersedes every allow entry
+  in the list, wherever it appears (NSD semantics).
+
+### How matching works
+
+Matching collects **every** non-`BLOCKED` entry whose prefix matches the source,
+and the request is accepted if it satisfies **any one** of the collected keys.
+Two consequences follow, and both are load-bearing.
+
+**A `NOKEY` entry disables TSIG enforcement for every source it covers.** If
+one entry names a key and a broader entry says `NOKEY`, a source matching both
+is accepted unsigned. The `NOKEY` is checked first and wins:
+
+```yaml
+downstreams:
+   - prefix: "192.0.2.0/24"
+     key:    xfr-key-2026     # intended: TSIG required
+   - prefix: "0.0.0.0/0"
+     key:    NOKEY            # ...but this makes it optional for 192.0.2.0/24 too
+```
+
+If you want TSIG enforced, do not leave a `NOKEY` entry covering the same
+addresses.
+
+**Two named keys for one source accept either.** This is how you roll a TSIG key
+without downtime: add the new key alongside the old, migrate the secondary, then
+drop the old entry.
+
+```yaml
+downstreams:
+   - prefix: "2001:db8:1::/48"
+     key:    xfr-key-2026     # new key
+   - prefix: "2001:db8:1::/48"
+     key:    xfr-key-2025     # old key, still accepted during the overlap
+   - prefix: "192.0.2.66"
+     key:    BLOCKED          # denied even with a valid key
+```
+
+## Zone declarations
+
+A zone is one entry in the top-level `zones:` list.
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `name` | string | **required**, FQDN with trailing dot |
+| `type` | string | **required** unless inherited from a template: `primary` or `secondary` |
+| `zonefile` | path | required for primary; optional persistence for secondary |
+| `store` | string | `map` (default) or `xfr` |
+| `template` | string | name of an entry in `templates:` |
+| `primaries` | list of `{addr, key}` | required for `secondary` |
+| `notify` | list of `{addr, key}` | NOTIFY destinations |
+| `allow-notify` | list of `{prefix, key}` | inbound-NOTIFY ACL |
+| `downstreams` | list of `{prefix, key}` | provide-xfr ACL |
+| `options` | list of strings | see below |
+| `dnssecpolicy` | string | names an entry in `dnssec.policies:`; `none` == unset |
+| `multisigner` | string | names an entry in `multisigner:` |
+| `updatepolicy` | block | DNS UPDATE authorization |
+| `delegationbackend` | string | required if the zone accepts child updates |
+
+Note the spellings: **`dnssecpolicy`** and **`multisigner`**, each one word.
+`dnssec_policy`, `dnssec-policy` and `multi_signer` are not config keys; they
+decode to nothing and leave the zone without a policy, which then makes
+`online-signing` fail validation.
+
+### store
+
+Only two values are live. `map` is the general-purpose store and the default.
+`xfr` holds the zone for transfer in and out only — it does **not** answer
+normal queries. `slice` is deprecated: it logs a warning and falls back to
+`map`. Any other value, including the `reg` mentioned in some older comments,
+also falls back to `map`.
+
+### Zone options
+
+`options:` is a list of strings. An unrecognized option puts the zone in `ERROR`
+state with `unknown config option: "..."`.
+
+**Delegation synchronization**
+
+| Option | Effect |
+|--------|--------|
+| `delegation-sync-parent` | Provide delegation sync toward child zones (accept child DS/NS/A/AAAA updates) |
+| `delegation-sync-child` | Push this zone's DS/NS/A/AAAA changes to its parent |
+| `delegation-sync-proxy` | Agent secondary proxies CDS/CSYNC NOTIFYs upstream for a DSYNC-unaware primary |
+
+**Zone modification**
+
+| Option | Effect |
+|--------|--------|
+| `allow-updates` | Accept authenticated DNS UPDATE for any RRset |
+| `allow-child-updates` | Accept DNS UPDATE of child delegation data only. Forced off when the child update-policy type is `none` or unset; the zone must also set `delegationbackend:` |
+| `allow-edits` | Allow apex RRsets (NS, DNSKEY, CDS, CSYNC) to be modified dynamically |
+
+**DNSSEC**
+
+| Option | Effect |
+|--------|--------|
+| `online-signing` | Sign responses on the fly |
+| `inline-signing` | Maintain a signed copy of the zone |
+| `dont-publish-key` | Do not publish the zone's SIG(0) KEY record |
+
+Both signing options **require the zone to set `dnssecpolicy:`**. Without one,
+the option is dropped and the zone goes to `ERROR` with "... is ignored because
+the DNSSEC policy is not set". Neither is accepted by `tdns-agent`, which does
+not sign.
+
+**DNS behaviour**
+
+| Option | Effect |
+|--------|--------|
+| `fold-case` | Case-insensitive owner-name matching |
+| `black-lies` | Compact denial of existence: synthesize a minimally covering NSEC rather than serving precomputed NSEC records |
+| `add-transport-signal` | Synthesize SVCB transport-signal RRs into the Additional section |
+
+**Multi-provider and catalog**
+
+| Option | Effect |
+|--------|--------|
+| `multi-provider` | Zone is served by several providers (RFC 8901); changes signing and rollover behaviour |
+| `catalog-zone` | RFC 9432 catalog zone. Requires a `catalog:` config section |
+| `catalog-member-auto-create` | Auto-create member zones from this catalog. Only valid on a zone that also has `catalog-zone` |
+| `catalog-member-auto-delete` | Auto-delete member zones removed from this catalog. Same requirement |
+
+**Options you cannot set.** `dirty`, `frozen`, `automatic-zone`,
+`api-managed-zone`, `multi-signer` and `dont-publish-jwk` are real zone options,
+but the server sets them itself. Putting any of them in `options:` is rejected
+as an unknown option. You will see them in `tdns-cli auth zone list` output.
+
+## Zone templates
+
+Templates are declared in the top-level `templates:` list. A template is an
+ordinary zone declaration that carries a `name:` and is not itself served, so it
+accepts every key a zone accepts.
+
+```yaml
+templates:
+   - name:          signed-primary
+     type:          primary
+     store:         map
+     options:       [ delegation-sync-parent, online-signing ]
+     dnssecpolicy:  default
+     downstreams:
+        - prefix: "192.0.2.0/24"
+          key:    NOKEY
+
+zones:
+   - name:      example.com.
+     zonefile:  /etc/tdns/zones/example.com.zone
+     template:  signed-primary       # type, store, options, policy, ACL inherited
+```
+
+`templates:` is a **list**, not a map keyed by template name. A mapping shape
+fails the whole config load with `'templates': source data must be an array or
+slice, got map`. A zone naming a template that does not exist is quarantined
+with `template "..." does not exist`.
+
+The merge is a **gap fill**: the zone's own value always wins, and the template
+supplies only what the zone left unset. Four rules qualify that.
+
+1. **`options:` is a union, not a gap fill.** Template options are appended to
+   the zone's list. A zone can add options but cannot remove one the template
+   supplies.
+
+2. **`zonefile:` in a template is a `fmt.Sprintf` pattern**, `%`-substituted
+   with the zone name — which includes its trailing dot. So
+   `zonefile: /etc/tdns/zones/%szone` yields
+   `/etc/tdns/zones/example.com.zone` for zone `example.com.`. A pattern that
+   expands to a path containing `..` is rejected.
+
+3. **`dnssecpolicy:` is gap-filled for tdns-auth but never for tdns-agent**,
+   which does not sign.
+
+4. **A field counts as "set" only if it is non-zero.** A zone therefore cannot
+   override a template value back to an empty or zero value. If a template says
+   `store: xfr`, a zone cannot revert to the default by writing `store: ""` —
+   it must name the other value explicitly. The same applies to any `false`
+   the template set to `true`.
+
+`name:` and `template:` are never copied from a template. A template may itself
+set `template:` to inherit from another; cycles are detected and rejected.
+
+## The dnsengine block
+
+```yaml
+dnsengine:
+   addresses:   [ 127.0.0.1:5354, '[::1]:5354' ]
+   transports:  [ do53, dot, doh, doq ]
+   ports:
+      dot:   [ 853 ]
+      doh:   [ 443 ]
+      doq:   [ 853 ]
+   certfile:  /etc/tdns/certs/server.crt
+   keyfile:   /etc/tdns/certs/server.key
+   outbound_soa_serial:  keep
+   options:
+      - minimal-responses
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `addresses` | — | **required**. Do53 listen sockets, each `addr:port`. The host part is reused for the encrypted transports |
+| `transports` | — | **required**. Any of `do53`, `dot`, `doh`, `doq`. `do53` is added even if omitted |
+| `certfile` / `keyfile` | — | required for `dot`/`doh`/`doq`; if absent those listeners do not start |
+| `ports.dot` | `853` | listen ports for DoT |
+| `ports.doh` | `443` | listen ports for DoH |
+| `ports.doq` | `853` | listen ports for DoQ (only 853 is truly supported) |
+| `outbound_soa_serial` | `keep` | `keep`, `unixtime` or `persist` |
+| `options` | — | server-wide options, below |
+
+`ports.do53` is **not read**. Do53 always listens on the ports embedded in
+`addresses`.
+
+`outbound_soa_serial` controls the SOA serial advertised to secondaries.
+`keep` sends the inbound serial unchanged. `unixtime` uses the load time.
+`persist` remembers the last serial in the database, so a restart with no zone
+change does not regress the serial and does not provoke a needless AXFR — the
+right choice for a primary with BIND/Knot/NSD secondaries.
+
+Two `options:` values are recognized:
+
+- **`minimal-responses`** — omit the authority NS RRset and apex glue from
+  positive answers, BIND-style. Referrals and NXDOMAIN/NODATA are unaffected.
+  Absence means false; `minimal-responses:false` disables it explicitly.
+- **`parent-update:delta`** or **`parent-update:replace`** — how delegation
+  updates are applied to the parent. `delta` is the default and applies even
+  when no `options:` block is present.
+
+## DNSSEC policies
+
+All DNSSEC configuration lives under one top-level `dnssec:` block with six
+sub-keys: `completeness`, `large_algorithms`, `split_algorithms`, `templates`,
+`policies` and `kasp`.
+
+A zone selects one policy by name with `dnssecpolicy: <name>`. If the config
+defines no policies at all, a built-in `default` policy is injected (ED25519,
+`ksk-zsk` mode, `forever` key lifetimes, no rollover).
+
+### Policy keys
+
+```yaml
+dnssec:
+   policies:
+      example:
+         algorithm:  ED25519       # default algorithm for both roles
+         mode:       ksk-zsk       # ksk-zsk (default) | csk
+         ksk:
+            algorithm:  ED25519    # optional per-role override
+            lifetime:   90d
+         zsk:
+            lifetime:   30d
+         csk:
+            lifetime:   none
+         sigvalidity:              # per-RRTYPE, not per key role
+            default:  14d          # REQUIRED, must be > 0
+            dnskey:   30d          # defaults to `default`
+            ds:       14d          # defaults to `default`
+         rollover:
+            method:        multi-ds       # none (default) | multi-ds | double-signature
+            num-ds:        3
+            parent-agent:  127.0.0.1:5354 # required when method != none
+         ttls:
+            dnskey:      2h
+            # max_served: 5m
+         clamping:
+            enabled:  true
+            margin:   1h           # REQUIRED when enabled
+```
+
+`sigvalidity` is a **policy-level block keyed by RRtype**, with `default`
+required. It is not a per-key-role setting: there is no `sigvalidity` under
+`ksk:` or `zsk:`, and those sub-blocks carry only `lifetime` and `algorithm`.
+
+Durations accept Go duration strings plus a `d` (days) or `w` (weeks) suffix on
+a plain integer: `14d`, `2w`, `90m`. Key lifetimes additionally accept
+`forever` and `none`.
+
+### Policy templates
+
+`dnssec.templates:` holds partial policies. A policy sets `template: <name>` to
+inherit the fields it does not specify itself.
+
+```yaml
+dnssec:
+   templates:
+      base:
+         algorithm:  ED25519
+         sigvalidity:
+            default:  14d
+            dnskey:   30d
+         rollover:
+            method:        multi-ds
+            num-ds:        3
+            parent-agent:  127.0.0.1:5354
+   policies:
+      from-template:
+         template:  base
+         ksk:
+            lifetime:  90d
+         zsk:
+            lifetime:  30d
+```
+
+Unlike the *zone* template merge, which is shallow, the policy merge is a
+**deep** merge: a policy that sets only some leaves of a nested block (`ksk`,
+`zsk`, `rollover`, `ttls`, `sigvalidity`, `clamping`) inherits the remaining
+leaves of that block from the template. The policy's own values always win.
+
+The same zero-value caveat applies: a policy cannot override a template value
+back to `""`, `0` or `false`, because those read as "unset". A template that
+sets `clamping.enabled: true` cannot be switched off by a policy that inherits
+from it.
+
+Templates are not usable policies. A zone cannot reference one, and an unknown
+template name quarantines just that policy.
+
+### split_algorithms
+
+A policy whose KSK and ZSK algorithms differ is **rejected at config load**
+unless that exact pair is allowlisted. This fails closed, so an accidental
+mismatch is caught rather than silently deployed.
+
+```yaml
+dnssec:
+   split_algorithms:
+      RSASHA512: [ ED25519, ECDSAP256SHA256 ]
+```
+
+The map is keyed by **KSK** algorithm name; the value lists the ZSK algorithms
+that KSK may pair with. Policies using the same algorithm for both roles always
+work and need no entry. An algorithm name this binary does not know is skipped
+with a warning — which means the pair it would have permitted stays forbidden.
+
+### large_algorithms
+
+Algorithms whose DNSKEY and RRSIG payloads are large for UDP.
+
+```yaml
+dnssec:
+   large_algorithms: [ RSASHA512, MLDSA87, FALCON1024 ]
+```
+
+Listing an algorithm here makes the internal resolver fetch a child zone's
+DNSKEY over TCP from the outset — rather than trying UDP and retrying on
+truncation — whenever a referral's DS RRset uses it, and makes the signer emit
+bulk-signing warnings. Entries are algorithm **names**, not codepoints, because
+the non-standardized PQ codepoints are assigned per deployment.
+
+Names must match **exactly** (case-insensitively); an unknown name is a hard
+config error and the server refuses to start. The accepted post-quantum
+spellings are compact and uppercase — `MLDSA44`, `MLDSA65`, `MLDSA87`,
+`SLHDSA128S`, `FALCON512`, `FALCON1024`, `MAYO1`, `MAYO2`, `MAYO3`, `MAYO5`,
+`SNOVA24_5_4`, `SNOVA37_17_2`, `SNOVA25_8_3`, `SQISIGN1`, `QRUOV_Q31_L3`,
+`CROSSRSDPG128SMALL` — not the hyphenated spec forms (`ML-DSA-44`).
+
+> Name-prefix globs such as `MLDSA*` are **not** supported on this branch; they
+> are a hard "unknown algorithm" error. Prefix matching against the algorithm
+> metadata registry is implemented on `feature/large-alg-prefix-matching` and
+> this section will be updated when that lands.
+
+Which PQ names resolve depends on how the binary was built — an algorithm needs
+a real, linked implementation, not merely registered metadata.
+
+### completeness and kasp
+
+`dnssec.completeness:` is deployment-wide and takes `strict` (default) or
+`relaxed`. It governs whether a ZSK algorithm rollover keeps the old-algorithm
+key signing through the drain window. An unknown value is a hard config error.
+
+`dnssec.kasp:` configures the key-state worker:
+
+| Key | Default |
+|-----|---------|
+| `propagation_delay` | `1h` |
+| `check_interval` | `1m` |
+| `standby_zsk_count` | `1` |
+| `standby_ksk_count` | `0` |
+
+For the rollover machinery these policies drive, see
+[Automatic DNSSEC Rollovers](key-rollover.md) and
+[Rollover Timing Equations](rollover-timing-equations.md).

--- a/guide/config-tdns-imr.md
+++ b/guide/config-tdns-imr.md
@@ -164,10 +164,32 @@ accepted spellings, and inspect the counters with
 
 ## imr.localconfig
 
-The one `imr.`-prefixed key. It names a second config file that is merged on
-top of the main one; a missing file is skipped silently.
+The one `imr.`-prefixed key. It names a second config file, read after the main
+one; a missing file is skipped silently.
 
 ```yaml
 imr:
    localconfig:  /etc/tdns/tdns-imr-local.yaml
 ```
+
+**The overlay does not override the main config file.** It can only *supply*
+keys that the main file leaves unset. Any key the main file defines wins, even
+though the overlay is read later.
+
+```yaml
+# tdns-imr.yaml                  # tdns-imr-local.yaml
+imrengine:                       imrengine:
+   addresses: [ 127.0.0.1:53 ]      addresses: [ 127.0.0.1:5353 ]   # IGNORED
+   transports: [ do53 ]             active: false                   # APPLIED
+```
+
+The overlay's `addresses` is discarded, because the main file sets that key. Its
+`active` is honoured, because the main file does not — so this resolver ends up
+disabled, having never listened on either address.
+
+This holds for every key, hyphenated or not: `root-hints` and `trust_anchor_ds`
+are both picked up from the overlay when the main file omits them, and both
+ignored when it does not.
+
+So `imr.localconfig` is useful for adding local settings, not for overriding
+shared ones. If you need to override a key, change it in the main file.

--- a/guide/config-tdns-imr.md
+++ b/guide/config-tdns-imr.md
@@ -12,25 +12,6 @@ Almost all of the resolver's configuration lives under a top-level block called
 **`imrengine:`**, not `imr:`. The only `imr.`-prefixed key is
 `imr.localconfig`, described at the end of this page.
 
-> **`tdns-imr --config <path>` does not select the config file.** The named
-> file *is* read — it is validated, and its values are loaded — but the main
-> config decode then reads `/etc/tdns/tdns-imr.yaml` **on top of it**. The two
-> files are merged, and the default file wins:
->
-> - any key `/etc/tdns/tdns-imr.yaml` defines **overrides** your file;
-> - a key only your file defines **survives**;
-> - the `log:` block always comes from the default file, because logging is set
->   up before the parse;
-> - validation runs against *your* file, so a valid `--config` does not mean the
->   file that actually gets parsed is valid.
->
-> Concretely: `--config` with `imrengine.addresses: [127.0.0.1:15353]` still
-> binds the default file's addresses, while `imrengine.active: false` — a key
-> the default file happens not to set — does take effect.
->
-> Until this is fixed, put the config you want at `/etc/tdns/tdns-imr.yaml` and
-> do not pass `--config`. Other TDNS applications honour `--config` normally.
-
 ## Minimal working example
 
 Three keys are validated as required (`imrengine.addresses`,

--- a/guide/config-tdns-imr.md
+++ b/guide/config-tdns-imr.md
@@ -12,10 +12,24 @@ Almost all of the resolver's configuration lives under a top-level block called
 **`imrengine:`**, not `imr:`. The only `imr.`-prefixed key is
 `imr.localconfig`, described at the end of this page.
 
-> **`--config` is not fully honoured by tdns-imr.** The flag is read, and the
-> named file is used for validation, but the main config decode always reads
-> `/etc/tdns/tdns-imr.yaml`. Until that is fixed, install your config at the
-> default path. Other TDNS applications honour `--config` normally.
+> **`tdns-imr --config <path>` does not select the config file.** The named
+> file *is* read — it is validated, and its values are loaded — but the main
+> config decode then reads `/etc/tdns/tdns-imr.yaml` **on top of it**. The two
+> files are merged, and the default file wins:
+>
+> - any key `/etc/tdns/tdns-imr.yaml` defines **overrides** your file;
+> - a key only your file defines **survives**;
+> - the `log:` block always comes from the default file, because logging is set
+>   up before the parse;
+> - validation runs against *your* file, so a valid `--config` does not mean the
+>   file that actually gets parsed is valid.
+>
+> Concretely: `--config` with `imrengine.addresses: [127.0.0.1:15353]` still
+> binds the default file's addresses, while `imrengine.active: false` — a key
+> the default file happens not to set — does take effect.
+>
+> Until this is fixed, put the config you want at `/etc/tdns/tdns-imr.yaml` and
+> do not pass `--config`. Other TDNS applications honour `--config` normally.
 
 ## Minimal working example
 

--- a/guide/config-tdns-imr.md
+++ b/guide/config-tdns-imr.md
@@ -1,0 +1,178 @@
+# tdns-imr configuration
+
+`tdns-imr` is the TDNS iterative/recursive resolver. For how to run it — daemon
+mode versus the interactive shell — see [tdns-imr](app-tdns-imr.md).
+
+Read [Configuration Guide](configuration.md) first for the conventions common to
+every TDNS application.
+
+## The block is named `imrengine:`
+
+Almost all of the resolver's configuration lives under a top-level block called
+**`imrengine:`**, not `imr:`. The only `imr.`-prefixed key is
+`imr.localconfig`, described at the end of this page.
+
+> **`--config` is not fully honoured by tdns-imr.** The flag is read, and the
+> named file is used for validation, but the main config decode always reads
+> `/etc/tdns/tdns-imr.yaml`. Until that is fixed, install your config at the
+> default path. Other TDNS applications honour `--config` normally.
+
+## Minimal working example
+
+Three keys are validated as required (`imrengine.addresses`,
+`imrengine.transports`, `log.file`), and one more is required in practice:
+`apiserver.apikey`. The API router refuses to build without an API key, and
+that error aborts startup — even though the resolver would otherwise not need
+the API at all.
+
+```yaml
+imrengine:
+   addresses:   [ 127.0.0.1:53, '[::1]:53' ]   # required
+   transports:  [ do53 ]                       # required
+
+apiserver:
+   apikey:  "a-long-random-string"             # required in practice
+
+log:
+   file:   /var/log/tdns/tdns-imr.log          # required
+   level:  info
+```
+
+Everything else defaults. Two caveats:
+
+**`apiserver.addresses` is optional.** Omit it and the management API simply
+does not listen, while the resolver runs normally. If you do set it, note that
+`apiserver.usetls` defaults to **true**, which then requires `certfile` and
+`keyfile`; otherwise the API listener fails to start (the resolver keeps
+running).
+
+**No trust anchor is configured by default.** DNSSEC validation is on —
+`require_dnssec_validation` defaults to true — but the daemon seeds no root
+anchor unless you configure one. The compiled-in root anchor is wired into
+`dog`, not into `tdns-imr`. A resolver with no anchor cannot build a chain of
+trust. See below.
+
+## Trust anchors
+
+Exactly three forms exist. Note that two use underscores and the third uses
+hyphens.
+
+```yaml
+imrengine:
+   # inline DS record (preferred)
+   trust_anchor_ds:      ". IN DS 20326 8 2 E06D44B8...EC8D"
+
+   # or inline DNSKEY
+   trust_anchor_dnskey:  ". IN DNSKEY 257 3 8 AwEAAaz/tAm8y..."
+
+   # or an unbound-style file, one DS/DNSKEY per line
+   trust-anchor-file:    /etc/tdns/root.key
+```
+
+Inspect what the running resolver actually loaded with `show config` in the
+interactive shell.
+
+## Transports and listeners
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `addresses` | — | **required**. `addr:port` sockets to listen on |
+| `transports` | — | **required**. Any of `do53`, `dot`, `doh`, `doq` |
+| `certfile` / `keyfile` | — | required for `dot`/`doh`/`doq` |
+| `active` | `true` | set `false` to disable the resolver entirely |
+| `root-hints` | compiled-in | path to a root hints file |
+| `require_dnssec_validation` | `true` | — |
+
+`imrengine.options:` accepts `query-for-transport`,
+`always-query-for-transport`, `query-for-transport-tlsa` and
+`transport-signal-type`. Transport-signal *processing* is always on: signals
+that arrive in the Additional section are applied whether or not these options
+are set; the options control whether the resolver goes looking for them.
+
+## Stub zones
+
+Answer a zone from named servers instead of iterating from the root.
+
+```yaml
+imrengine:
+   stubs:
+      - zone:     internal.example.
+        servers:  [ 192.0.2.53, 2001:db8::53 ]
+```
+
+Both `zone` and `servers` are required in each entry.
+
+## Debug logging
+
+Separate from `log.file`, and off by default.
+
+```yaml
+imrengine:
+   logging:
+      enabled:  true
+      file:     /var/log/tdns/imr-debug.log   # this is the default when enabled
+```
+
+## Tuning
+
+Every key under `imrengine.tuning:` is optional. The values below **are** the
+defaults, so this block is only worth writing when you want to change one.
+Inspect the effective values on a running resolver with `dump tuning` in the
+interactive shell, or `tdns-cli agent imr dump-tuning` against an agent.
+
+```yaml
+imrengine:
+   tuning:
+      backoff:
+         first_failure:     15s   # first backoff after a server failure
+         max_failure:       1h    # ceiling; raised to first_failure if set lower
+         multiplier:        3.0   # exponential growth factor
+         jitter_fraction:   0.25  # must be in [0,1), else reset to the default
+         routing_failure:   1h    # backoff after an unreachable-network error
+         lame_delegation:   1h    # backoff after a lame delegation
+      address_family:
+         window_duration:   10m   # observation window for per-family failures
+         failure_threshold: 5     # distinct failures before a family is suspect
+         suspect_duration:  10m   # how long a family stays suspect
+         probe_interval:    30s   # how often a suspect family is re-probed
+      discovery:
+         retry_after_failure: 30s # transport-signal discovery retry
+         max_failures:        3   # give up discovery after this many
+      query_budget:              8s     # total wall-clock budget for one query
+      upgrade_indirect_cache_hits: true # left unset in code; treated as true
+```
+
+The `address_family` group is what demotes a broken IPv6 (or IPv4) path: once
+`failure_threshold` distinct failures are seen inside `window_duration`, that
+family is treated as suspect for `suspect_duration` and re-probed every
+`probe_interval`.
+
+## large_algorithms
+
+Not part of `imrengine:` — it lives in the shared top-level `dnssec:` block.
+
+```yaml
+dnssec:
+   large_algorithms: [ RSASHA512 ]
+```
+
+When a referral's DS RRset names one of these algorithms, the resolver fetches
+the child's DNSKEY over TCP from the outset rather than trying UDP and retrying
+on truncation.
+
+Entries are algorithm **names**, not codepoints — `[ 10, 8, 5 ]` is a decode
+error (`expected type 'string', got unconvertible type 'int'`) that prevents
+startup. A name this binary does not know is likewise a hard config error. See
+[DNSSEC policies](config-tdns-auth.md#large_algorithms) for the full list of
+accepted spellings, and inspect the counters with
+`tdns-cli imr stats large-ksk`.
+
+## imr.localconfig
+
+The one `imr.`-prefixed key. It names a second config file that is merged on
+top of the main one; a missing file is skipped silently.
+
+```yaml
+imr:
+   localconfig:  /etc/tdns/tdns-imr-local.yaml
+```

--- a/guide/configuration.md
+++ b/guide/configuration.md
@@ -1,0 +1,94 @@
+# TDNS Configuration Guide
+
+This is the operator-facing guide to configuring the TDNS applications. It is
+task-oriented: each page starts from a minimal working example and then works
+outwards through the blocks you are most likely to need.
+
+For an exhaustive per-key lookup, the annotated sample configs shipped next to
+each binary are the reference:
+
+| Application | Sample config |
+|-------------|---------------|
+| tdns-auth   | [`cmdv2/auth/tdns-auth.sample.yaml`](../cmdv2/auth/tdns-auth.sample.yaml), [`auth-zones.sample.yaml`](../cmdv2/auth/auth-zones.sample.yaml), [`auth-templates.sample.yaml`](../cmdv2/auth/auth-templates.sample.yaml) |
+| tdns-imr    | [`cmdv2/imr/tdns-imr.sample.yaml`](../cmdv2/imr/tdns-imr.sample.yaml) |
+
+For the command-line tools, see the generated [CLI reference](../reference/cli/).
+
+## Documents
+
+- [tdns-auth configuration](config-tdns-auth.md)
+  -- Minimal working example, TSIG keys, the `allow-notify:` and
+  `downstreams:` ACLs, zone declarations (every zone option, and the
+  template system), the `dnsengine:` block, and DNSSEC policies
+  (policy templates, `split_algorithms`, `large_algorithms`).
+
+- [tdns-imr configuration](config-tdns-imr.md)
+  -- Minimal working example, trust anchors, stub zones, and the
+  `imrengine.tuning.*` knobs with their defaults.
+
+- [tdns-agent configuration](config-tdns-agent.md)
+  -- Placeholder. The agent's proxy configurations are not yet documented
+  here; see [Agent as a DSYNC proxy](agent-dsync-proxy.md) meanwhile.
+
+`dog` has no configuration file — see [DOG](app-dog.md).
+
+## Conventions common to all TDNS applications
+
+**Config file location.** Each binary reads `/etc/tdns/<appname>.yaml` by
+default — `/etc/tdns/tdns-auth.yaml`, `/etc/tdns/tdns-imr.yaml` and so on.
+Override with `--config <path>`. No TDNS application reads configuration from
+environment variables.
+
+> `tdns-imr` currently honours `--config` only partially: the named file is
+> read for validation, but the main config decode still reads
+> `/etc/tdns/tdns-imr.yaml`. See [tdns-imr configuration](config-tdns-imr.md).
+
+**Includes.** A top-level `include:` list splices other YAML files into the
+main config before it is parsed. Includes may nest, to a depth of 10.
+
+```yaml
+include:
+   - auth-templates.yaml
+   - auth-zones.yaml
+   - /var/lib/tdns/dynamic-zones.yaml
+```
+
+**The `log:` block is special.** It is read directly out of the *main* config
+file, early, before includes are resolved. It must therefore appear at the top
+level of the file named by `--config`; putting it in an included file makes
+startup fail. `log.file` is required.
+
+**Unknown keys are warned about, not rejected.** The loader decodes the config
+into Go structs and then logs every key it did not consume:
+
+```
+[WARN/config] unknown config keys ignored (possible misspellings) keys=[zones[0].dnssec_polciy]
+```
+
+A misspelled key is therefore *silently inert* — the feature it was meant to
+enable simply never turns on. A small registry of keys that were renamed or
+moved by past restructures gets a louder, specific message instead:
+
+```
+[ERROR/config] deprecated config key (config lags the code) — `dnssecpolicies:` moved
+under `dnssec:` as `dnssec.policies:` (restructure 2026-06-16) key=dnssecpolicies
+```
+
+Both lines are worth grepping for after any config change.
+
+**Some blocks are read outside the struct decoder.** A handful of top-level
+blocks (`delegationsync:`, `childsync:`, `scanner:`, `server:`,
+`resignerengine:`, `common:`) are read key-by-key rather than decoded into the
+`Config` struct. They work, but because the struct decoder does not recognize
+them they also appear in that "unknown config keys" warning at startup. That is
+expected and not an error.
+
+**Zone errors are quarantined, not fatal.** A zone whose configuration is
+invalid — a bad ACL, an unknown TSIG key, a signing option with no DNSSEC
+policy, a template that does not exist — is put into `ERROR` state on its own
+while the rest of the server starts normally. Check for these with:
+
+```console
+$ tdns-cli auth zone list
+mldsa.pq.axfr.net.   ERROR   Error[config]: downstreams: acl entry "": bad ip-spec ""
+```

--- a/guide/configuration.md
+++ b/guide/configuration.md
@@ -39,9 +39,10 @@ default — `/etc/tdns/tdns-auth.yaml`, `/etc/tdns/tdns-imr.yaml` and so on.
 Override with `--config <path>`. No TDNS application reads configuration from
 environment variables.
 
-> `tdns-imr` currently honours `--config` only partially: the named file is
-> read for validation, but the main config decode still reads
-> `/etc/tdns/tdns-imr.yaml`. See [tdns-imr configuration](config-tdns-imr.md).
+> `tdns-imr` is the exception: `--config` does not select the config file. The
+> named file is read and validated, but `/etc/tdns/tdns-imr.yaml` is then
+> decoded on top of it, so the two are merged and the default file wins. See
+> [tdns-imr configuration](config-tdns-imr.md).
 
 **Includes.** A top-level `include:` list splices other YAML files into the
 main config before it is parsed. Includes may nest, to a depth of 10.

--- a/guide/configuration.md
+++ b/guide/configuration.md
@@ -39,11 +39,6 @@ default — `/etc/tdns/tdns-auth.yaml`, `/etc/tdns/tdns-imr.yaml` and so on.
 Override with `--config <path>`. No TDNS application reads configuration from
 environment variables.
 
-> `tdns-imr` is the exception: `--config` does not select the config file. The
-> named file is read and validated, but `/etc/tdns/tdns-imr.yaml` is then
-> decoded on top of it, so the two are merged and the default file wins. See
-> [tdns-imr configuration](config-tdns-imr.md).
-
 **Includes.** A top-level `include:` list splices other YAML files into the
 main config before it is parsed. Includes may nest, to a depth of 10.
 

--- a/guide/key-rollover.md
+++ b/guide/key-rollover.md
@@ -78,38 +78,50 @@ rollover settings.
 
 ```yaml
 zones:
-   example.com.:
-      dnssec-policy: production-weekly
+   - name:         example.com.
+     dnssecpolicy: production-weekly
 
-dnssecpolicies:
-   production-weekly:
-      algorithm: ecdsap256sha256
-      mode:      ksk-zsk
-      ksk:
-         lifetime:     7d
-         sig-validity: 14d
-      zsk:
-         lifetime:     30d
-         sig-validity: 14d
-      rollover:
-         method:                      multi-ds
-         num-ds:                      3
-         parent-agent:                parent.example.net:53
-         ds-publish-delay:            5m
-         max-attempts-before-backoff: 5
-         softfail-delay:              1h
-         dsync-scheme-preference:     auto
-      ttls:
-         dnskey:     1h
-         max_served: 8h
-      clamping:
-         enabled: true
-         margin:  15m
+dnssec:
+   policies:
+      production-weekly:
+         algorithm: ecdsap256sha256
+         mode:      ksk-zsk
+         ksk:
+            lifetime: 7d
+         zsk:
+            lifetime: 30d
+         sigvalidity:
+            default: 14d
+            dnskey:  14d
+         rollover:
+            method:                      multi-ds
+            num-ds:                      3
+            parent-agent:                parent.example.net:53
+            ds-publish-delay:            5m
+            max-attempts-before-backoff: 5
+            softfail-delay:              1h
+            dsync-scheme-preference:     auto
+         ttls:
+            dnskey:     1h
+            max_served: 8h
+         clamping:
+            enabled: true
+            margin:  15m
 ```
+
+Note the shapes: `zones:` is a **list** of entries each with a
+`name:`, the zone's policy reference is spelled
+**`dnssecpolicy:`** (one word), and policies live under
+**`dnssec.policies:`** — not a top-level `dnssecpolicies:`.
+
+Note also that signature validity is a **policy-level
+`sigvalidity:` block keyed by RRtype**, with `default`
+required. It is not a per-key-role setting: `ksk:` and
+`zsk:` carry only `lifetime` and `algorithm`.
 
 Most fields have sensible defaults. The minimal required
 set is `algorithm`, `mode`, `ksk.lifetime`,
-`ksk.sig-validity`, `rollover.method`, and
+`sigvalidity.default`, `rollover.method`, and
 `rollover.parent-agent`. Everything else is either
 derived from `ds-publish-delay` or carries an engine
 default.
@@ -171,9 +183,10 @@ Full reference of policy parameters:
 | `algorithm` | yes | -- | DNSSEC algorithm (e.g. `ECDSAP256SHA256`, `MLDSA44`) |
 | `mode` | no | `ksk-zsk` | `ksk-zsk` or `csk` |
 | `ksk.lifetime` | yes | -- | Rollover cadence (`next = active_at + lifetime`) |
-| `ksk.sig-validity` | yes | -- | RRSIG validity for DNSKEY signatures |
 | `zsk.lifetime` | yes | -- | ZSK cadence (out of scope today; engine does not auto-roll ZSKs) |
-| `zsk.sig-validity` | yes | -- | RRSIG validity for non-DNSKEY signatures |
+| `sigvalidity.default` | yes | -- | RRSIG validity for every RRset without a more specific setting |
+| `sigvalidity.dnskey` | no | `sigvalidity.default` | RRSIG validity for the DNSKEY RRset |
+| `sigvalidity.ds` | no | `sigvalidity.default` | RRSIG validity for DS RRsets this zone publishes |
 | `rollover.method` | yes | `none` | `multi-ds`, `double-signature`, or `none` |
 | `rollover.num-ds` | no | `3` (multi-ds) / `2` (double-sig) | DS pipeline depth |
 | `rollover.parent-agent` | yes if `method != none` | -- | Parent's address for DS queries, `host:port` |
@@ -570,27 +583,29 @@ long-weekend resilience because the testbed is on a local
 network with you watching it.
 
 ```yaml
-dnssecpolicies:
-   testbed-fast:
-      algorithm: ECDSAP256SHA256
-      mode: ksk-zsk
-      ksk:
-         lifetime: 10m
-         sig-validity: 30m
-      zsk:
-         lifetime: 24h
-         sig-validity: 1h
-      rollover:
-         method: multi-ds
-         num-ds: 3
-         parent-agent: 192.0.2.1:53
-         ds-publish-delay: 30s
-      ttls:
-         dnskey: 60s
-         max_served: 300s
-      clamping:
-         enabled: true
-         margin: 60s
+dnssec:
+   policies:
+      testbed-fast:
+         algorithm: ECDSAP256SHA256
+         mode: ksk-zsk
+         ksk:
+            lifetime: 10m
+         zsk:
+            lifetime: 24h
+         sigvalidity:
+            default: 1h      # non-DNSKEY RRsets
+            dnskey:  30m     # DNSKEY RRset
+         rollover:
+            method: multi-ds
+            num-ds: 3
+            parent-agent: 192.0.2.1:53
+            ds-publish-delay: 30s
+         ttls:
+            dnskey: 60s
+            max_served: 300s
+         clamping:
+            enabled: true
+            margin: 60s
 ```
 
 Notes:
@@ -598,7 +613,7 @@ Notes:
 - `ksk.lifetime: 10m` makes the next-scheduled rollover
   fire ten minutes after the current active key became
   active. Your testbed will roll continuously.
-- `ksk.sig-validity: 30m` is much shorter than production
+- `sigvalidity.dnskey: 30m` is much shorter than production
   but appropriate for a local testbed where outages are
   minutes, not days. The engine resigns DNSKEY RRSIGs as
   they approach expiry.
@@ -623,35 +638,37 @@ operational confidence in the rollover machinery, and
 need to survive long weekends without paging.
 
 ```yaml
-dnssecpolicies:
-   production-weekly:
-      algorithm: ECDSAP256SHA256
-      mode: ksk-zsk
-      ksk:
-         lifetime: 7d
-         sig-validity: 14d
-      zsk:
-         lifetime: 30d
-         sig-validity: 14d
-      rollover:
-         method: multi-ds
-         num-ds: 3
-         parent-agent: parent.example.net:53
-         ds-publish-delay: 5m
-         max-attempts-before-backoff: 5
-         softfail-delay: 1h
-      ttls:
-         dnskey: 1h
-         max_served: 8h
-      clamping:
-         enabled: true
-         margin: 15m
+dnssec:
+   policies:
+      production-weekly:
+         algorithm: ECDSAP256SHA256
+         mode: ksk-zsk
+         ksk:
+            lifetime: 7d
+         zsk:
+            lifetime: 30d
+         sigvalidity:
+            default: 14d
+            dnskey:  14d
+         rollover:
+            method: multi-ds
+            num-ds: 3
+            parent-agent: parent.example.net:53
+            ds-publish-delay: 5m
+            max-attempts-before-backoff: 5
+            softfail-delay: 1h
+         ttls:
+            dnskey: 1h
+            max_served: 8h
+         clamping:
+            enabled: true
+            margin: 15m
 ```
 
 Notes:
 
 - `ksk.lifetime: 7d` schedules a rollover every week.
-- `ksk.sig-validity: 14d` with engine-default
+- `sigvalidity.dnskey: 14d` with engine-default
   resign-at-half means RRSIGs always have at least 7
   days remaining. Friday-evening signing failure leaves
   you 7 days of validity in caches -- comfortably more
@@ -680,29 +697,31 @@ rollover rhythm -- perhaps to align with monthly
 maintenance windows.
 
 ```yaml
-dnssecpolicies:
-   production-monthly:
-      algorithm: ECDSAP256SHA256
-      mode: ksk-zsk
-      ksk:
-         lifetime: 30d
-         sig-validity: 14d
-      zsk:
-         lifetime: 90d
-         sig-validity: 14d
-      rollover:
-         method: multi-ds
-         num-ds: 3
-         parent-agent: parent.example.net:53
-         ds-publish-delay: 5m
-         max-attempts-before-backoff: 5
-         softfail-delay: 1h
-      ttls:
-         dnskey: 1h
-         max_served: 8h
-      clamping:
-         enabled: true
-         margin: 15m
+dnssec:
+   policies:
+      production-monthly:
+         algorithm: ECDSAP256SHA256
+         mode: ksk-zsk
+         ksk:
+            lifetime: 30d
+         zsk:
+            lifetime: 90d
+         sigvalidity:
+            default: 14d
+            dnskey:  14d
+         rollover:
+            method: multi-ds
+            num-ds: 3
+            parent-agent: parent.example.net:53
+            ds-publish-delay: 5m
+            max-attempts-before-backoff: 5
+            softfail-delay: 1h
+         ttls:
+            dnskey: 1h
+            max_served: 8h
+         clamping:
+            enabled: true
+            margin: 15m
 ```
 
 The only change from 7.2 is `ksk.lifetime` (30 days vs 7
@@ -712,7 +731,7 @@ expectations, safety margin. The orthogonality of the
 three knobs lets you change cadence without touching the
 rest.
 
-Some operators prefer to bump `ksk.sig-validity` higher
+Some operators prefer to bump `sigvalidity.dnskey` higher
 (to 30d) for monthly cadence as well, on the theory that
 "I'm only checking on this thing monthly so it should
 survive a long absence." That's reasonable but not
@@ -794,7 +813,7 @@ tdns-cli auth keystore dnssec policy validate \
    --file /etc/tdns/tdns-auth.yaml
 ```
 
-This parses every policy under `dnssecpolicies:` and
+This parses every policy under `dnssec.policies:` and
 reports configuration errors (invalid durations, missing
 required fields, cross-field constraint violations)
 without affecting the running daemon. The same validation
@@ -918,15 +937,19 @@ signed) the retired key is removed and its signatures are
 stripped. The engine keeps `standby-zsk-count` standbys
 ready so a roll never waits on key generation.
 
-**Configuration.** The ZSK lifetime and signature validity
-live in the same policy block as the KSK:
+**Configuration.** The ZSK lifetime lives in the same policy
+block as the KSK. Signature validity is not per key role: the
+RRsets a ZSK signs take `sigvalidity.default`.
 
 ```yaml
-   mypolicy:
-      algorithm:   ED25519
-      zsk:
-         lifetime:    2w      # roll cadence (forever = never)
-         sigvalidity: 2h
+dnssec:
+   policies:
+      mypolicy:
+         algorithm: ED25519
+         zsk:
+            lifetime: 2w      # roll cadence (forever = never)
+         sigvalidity:
+            default: 2h       # RRSIG validity for the RRsets the ZSK signs
 ```
 
 `zsk.lifetime: forever` disables the scheduled roll; you can

--- a/v2/deprecated_config_keys_test.go
+++ b/v2/deprecated_config_keys_test.go
@@ -17,6 +17,15 @@ func TestClassifyUnusedConfigKeys(t *testing.T) {
 		// with a parent path, must still match the ".sigvalidity" substring
 		"dnssec.policies[fastroll].KSK.sigvalidity",
 		"dnssec.policies[default].ZSK.sigvalidity",
+		// deprecated — the hyphenated spelling of the same key, which the
+		// guide used for a long time. Must NOT be shadowed by ".sigvalidity",
+		// which it does not contain.
+		"dnssec.policies[p1].KSK.sig-validity",
+		// deprecated — zone-level leaves whose misspelling silently disables
+		// signing rather than failing loudly
+		"zones[0].dnssec_policy",
+		"zones[1].dnssec-policy",
+		"zones[0].multi_signer",
 		// genuine typos — not deprecated, should land in unknown
 		"servce", // misspelled "service"
 		"dnsengine.adresses",
@@ -35,6 +44,10 @@ func TestClassifyUnusedConfigKeys(t *testing.T) {
 		"dnssecpolicies", "kasp",
 		"dnssec.policies[fastroll].KSK.sigvalidity",
 		"dnssec.policies[default].ZSK.sigvalidity",
+		"dnssec.policies[p1].KSK.sig-validity",
+		"zones[0].dnssec_policy",
+		"zones[1].dnssec-policy",
+		"zones[0].multi_signer",
 	} {
 		if !gotDep[want] {
 			t.Errorf("expected %q classified as deprecated, was not", want)
@@ -73,5 +86,44 @@ func TestClassifyUnusedConfigKeys_ExactVsSubstring(t *testing.T) {
 	}
 	if len(unknown) != 1 {
 		t.Errorf("expected the non-deprecated path in unknown, got %v", unknown)
+	}
+
+	// A non-exact entry names a deprecated LEAF and must match only at the END
+	// of the path. A typo INSIDE the valid `sigvalidity:` subtree produces a
+	// path that contains ".sigvalidity" but is really a misspelled `default`;
+	// reporting it as the deprecated per-key scalar would send the operator
+	// chasing the wrong migration.
+	dep, unknown = classifyUnusedConfigKeys([]string{"dnssec.policies[p1].SigValidity.defualt"})
+	if len(dep) != 0 {
+		t.Errorf("typo inside a valid sigvalidity: block wrongly reported as deprecated: %+v", dep)
+	}
+	if len(unknown) != 1 {
+		t.Errorf("expected the typo in unknown, got %v", unknown)
+	}
+
+	// Likewise the correctly-spelled keys, should one ever reach the classifier.
+	for _, valid := range []string{
+		"zones[0].dnssecpolicy",
+		"zones[0].multisigner",
+		"dnssec.policies[p1].SigValidity.default",
+	} {
+		dep, _ := classifyUnusedConfigKeys([]string{valid})
+		if len(dep) != 0 {
+			t.Errorf("valid key %q wrongly classified as deprecated: %+v", valid, dep)
+		}
+	}
+}
+
+// TestDeprecatedConfigKeysAdviceNamesReplacement is a cheap quality guard on the
+// registry itself: the whole point of an entry is to tell the operator what to
+// write instead, so every advice string must be non-trivial.
+func TestDeprecatedConfigKeysAdviceNamesReplacement(t *testing.T) {
+	for _, d := range deprecatedConfigKeys {
+		if d.match == "" {
+			t.Error("deprecated entry with empty match pattern")
+		}
+		if len(d.advice) < 20 {
+			t.Errorf("deprecated entry %q has uselessly short advice %q", d.match, d.advice)
+		}
 	}
 }

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -71,14 +71,15 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 			return fmt.Errorf("cannot determine default config file: Globals.App.Name is not set")
 		}
 	}
-	// Imr uses the default config file directly and is a Cobra app: it
-	// parses argv itself (cmdv2/imr/root.go) and registers its own
-	// --version there. MainInit must NOT parse flags for it — a second
-	// pflag.Parse() here runs against the global set (which lacks imr's
-	// Cobra-registered flags) and would reject --cli/--debug/etc. Every
-	// other app type is a plain-flag daemon: register the shared flags
-	// (including --version) and parse. This AppType inversion avoids
-	// enumerating downstream-defined types (tdns-mp, tdns-nm, tdns-es).
+	// Imr is a Cobra app: it parses argv itself (cmdv2/imr/root.go) and
+	// registers its own --config and --version there. MainInit must NOT
+	// parse flags for it — a second pflag.Parse() here runs against the
+	// global set (which lacks imr's Cobra-registered flags) and would
+	// reject --cli/--debug/etc. Because MainInit cannot see imr's --config,
+	// imr passes the file it already resolved in as defaultcfg; take it as
+	// given. Every other app type is a plain-flag daemon: register the
+	// shared flags (including --version) and parse. This AppType inversion
+	// avoids enumerating downstream-defined types (tdns-mp, tdns-nm, tdns-es).
 	if Globals.App.Type == AppTypeImr {
 		conf.Internal.CfgFile = defaultcfg
 	} else {

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -200,6 +200,9 @@ type deprecatedConfigKey struct {
 //   - Renamed/moved a LEAF that can appear under many parents
 //     (x: → y: under each policy)? Add
 //     {match: ".oldleaf", advice: "`oldleaf` moved to ...; see <doc>"}.
+//     A non-exact entry is matched against the END of the unused path, so it
+//     fires on the leaf itself and not on a valid block of the same name that
+//     merely happens to contain a typo'd child.
 //
 // Keep advice concrete: name the new location and, ideally, the change date
 // or doc so an operator can find the migration.
@@ -243,7 +246,13 @@ func classifyUnusedConfigKeys(unused []string) (deprecated []deprecatedConfigKey
 		for i := range deprecatedConfigKeys {
 			d := &deprecatedConfigKeys[i]
 			ml := strings.ToLower(d.match)
-			if (d.exact && lk == ml) || (!d.exact && strings.Contains(lk, ml)) {
+			// A non-exact entry names a deprecated LEAF (".oldleaf") that may sit
+			// under many parents, so it must match the END of the path. Matching
+			// anywhere in the path would also fire on a valid parent block: a typo
+			// inside the (valid) `sigvalidity:` subtree reports as
+			// "dnssec.policies[p].SigValidity.defualt", which contains
+			// ".sigvalidity" but is a misspelled `default`, not a deprecated key.
+			if (d.exact && lk == ml) || (!d.exact && strings.HasSuffix(lk, ml)) {
 				hit = d
 				break
 			}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -219,6 +219,17 @@ var deprecatedConfigKeys = []deprecatedConfigKey{
 	// with `default` required.
 	{match: ".sigvalidity",
 		advice: "per-key `sigvalidity:` is now a policy-level subtree `sigvalidity: { default, dnskey, ds }` (default required)"},
+	{match: ".sig-validity",
+		advice: "`sig-validity:` is spelled `sigvalidity:` and is a policy-level subtree `{ default, dnskey, ds }` (default required), not a key under ksk:/zsk:"},
+	// Zone-level leaves whose misspelling silently disables the feature: an
+	// unrecognized dnssec_policy/dnssec-policy leaves the zone with no policy,
+	// which then rejects online-signing/inline-signing at validation.
+	{match: ".dnssec_policy",
+		advice: "zone key is `dnssecpolicy:` (one word, no underscore); `dnssec_policy:` is ignored, leaving the zone unsigned"},
+	{match: ".dnssec-policy",
+		advice: "zone key is `dnssecpolicy:` (one word, no hyphen); `dnssec-policy:` is ignored, leaving the zone unsigned"},
+	{match: ".multi_signer",
+		advice: "zone key is `multisigner:` (one word, no underscore); `multi_signer:` is ignored"},
 }
 
 // classifyUnusedConfigKeys splits mapstructure's unused-key list into keys

--- a/v2/sample_config_test.go
+++ b/v2/sample_config_test.go
@@ -84,9 +84,13 @@ func checkZoneConf(t *testing.T, what string, z ZoneConf) {
 	for _, acl := range [][]AclEntry{z.Downstreams, z.AllowNotify} {
 		for _, e := range acl {
 			if e.Legacy != "" {
+				// A legacy entry carries the bare string and nothing else, so its
+				// Prefix and Key are both empty. Report the one real problem and
+				// move on, rather than also alleging a missing prefix and key.
 				t.Errorf("%s %s: legacy bare-string ACL entry %q (migrate to {prefix, key})", what, z.Name, e.Legacy)
+				continue
 			}
-			if e.Legacy == "" && e.Prefix == "" {
+			if e.Prefix == "" {
 				t.Errorf("%s %s: ACL entry with empty prefix (did you write `addr:` instead of `prefix:`?)", what, z.Name)
 			}
 			if e.Prefix != "" {

--- a/v2/sample_config_test.go
+++ b/v2/sample_config_test.go
@@ -2,73 +2,215 @@ package tdns
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v3"
 )
 
-// TestSampleZonesConfigDecodes guards the shipped auth-zones sample against
-// drifting out of sync with the PeerConf struct form. It runs the same
-// yaml -> map -> mapstructure(+hook) pipeline ParseConfig uses and asserts no
-// bare-string (Legacy) primaries/notify entries survive — a legacy entry would
-// quarantine the example zone, making the sample a broken example.
-func TestSampleZonesConfigDecodes(t *testing.T) {
-	data, err := os.ReadFile("../cmdv2/auth/auth-zones.sample.yaml")
+// The shipped sample configs are the config reference the guide points at, so
+// they must decode exactly the way ParseConfig decodes a real config file.
+// These tests run that same yaml -> map -> mapstructure(+hooks) pipeline.
+//
+// They exist because every one of the following shipped in a "working" sample
+// at some point, and none was caught by a YAML-syntax check:
+//   - templates: written as a map (Config.Templates is []ZoneConf) -> whole
+//     config load fails with "source data must be an array or slice, got map"
+//   - dnssec_policy: / multi_signer: instead of dnssecpolicy: / multisigner:
+//     -> silently dropped, so online-signing then fails validation
+//   - bare-string notify:/downstreams: entries -> zone quarantined to ERROR
+//   - an options: value that no longer parses -> zone quarantined to ERROR
+
+// decodeSample runs the shipped decode pipeline over one sample file and
+// returns the mapstructure metadata so a caller can assert on dropped keys.
+func decodeSample(t *testing.T, path string, result interface{}) mapstructure.Metadata {
+	t.Helper()
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("checked-in sample not found (%v)", err)
 	}
 	var raw map[string]interface{}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("sample is not valid YAML: %v", err)
+		t.Fatalf("%s is not valid YAML: %v", path, err)
 	}
-	var result struct {
-		Zones []ZoneConf `yaml:"zones"`
-	}
+	var md mapstructure.Metadata
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName:    "yaml",
-		Result:     &result,
-		DecodeHook: stringToPeerConfHook(),
+		TagName:  "yaml",
+		Result:   result,
+		Metadata: &md,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			stringToPeerConfHook(),
+			stringToAclEntryHook(),
+		),
 	})
 	if err != nil {
 		t.Fatalf("decoder: %v", err)
 	}
 	if err := decoder.Decode(raw); err != nil {
-		t.Fatalf("sample failed to decode: %v", err)
+		t.Fatalf("%s failed to decode: %v", path, err)
 	}
+	return md
+}
+
+// internalOnlyZoneOptions are valid ZoneOption values that are set
+// programmatically and REJECTED when they appear in a config file: they have no
+// case in the parseZoneOptions switch, so they fall to its default arm and put
+// the zone in ERROR state. Keep in sync with v2/parseoptions.go.
+var internalOnlyZoneOptions = map[string]bool{
+	"dirty":            true,
+	"frozen":           true,
+	"automatic-zone":   true,
+	"api-managed-zone": true,
+	"multi-signer":     true,
+	"dont-publish-jwk": true,
+}
+
+// checkZoneConf asserts one decoded zone/template entry is loadable: no legacy
+// bare-string peers or ACL entries, every ACL prefix parses, and every option is
+// one a config file may actually set.
+func checkZoneConf(t *testing.T, what string, z ZoneConf) {
+	t.Helper()
+	for _, p := range z.Primaries {
+		if p.Legacy != "" {
+			t.Errorf("%s %s: legacy bare-string primary %q (migrate to {addr, key})", what, z.Name, p.Legacy)
+		}
+	}
+	for _, n := range z.Notify {
+		if n.Legacy != "" {
+			t.Errorf("%s %s: legacy bare-string notify %q (migrate to {addr, key})", what, z.Name, n.Legacy)
+		}
+	}
+	for _, acl := range [][]AclEntry{z.Downstreams, z.AllowNotify} {
+		for _, e := range acl {
+			if e.Legacy != "" {
+				t.Errorf("%s %s: legacy bare-string ACL entry %q (migrate to {prefix, key})", what, z.Name, e.Legacy)
+			}
+			if e.Legacy == "" && e.Prefix == "" {
+				t.Errorf("%s %s: ACL entry with empty prefix (did you write `addr:` instead of `prefix:`?)", what, z.Name)
+			}
+			if e.Prefix != "" {
+				if err := ValidateIPSpec(e.Prefix); err != nil {
+					t.Errorf("%s %s: bad ACL prefix %q: %v", what, z.Name, e.Prefix, err)
+				}
+			}
+			if e.Key == "" {
+				t.Errorf("%s %s: ACL entry %q has no key (use a TSIG key name, NOKEY, or BLOCKED)", what, z.Name, e.Prefix)
+			}
+		}
+	}
+	for _, o := range z.OptionsStrs {
+		opt := strings.ToLower(strings.TrimSpace(o))
+		if _, ok := StringToZoneOption[opt]; !ok {
+			t.Errorf("%s %s: unknown zone option %q", what, z.Name, o)
+			continue
+		}
+		if internalOnlyZoneOptions[opt] {
+			t.Errorf("%s %s: option %q is set programmatically and is rejected from config", what, z.Name, o)
+		}
+	}
+	// A signing option without a policy is dropped and the zone goes to ERROR.
+	// Templates are exempt: a template may supply the option and let the zone
+	// supply the policy (or vice versa).
+	if what == "zone" {
+		signing := false
+		for _, o := range z.OptionsStrs {
+			switch strings.ToLower(strings.TrimSpace(o)) {
+			case "online-signing", "inline-signing":
+				signing = true
+			}
+		}
+		if signing && z.DnssecPolicy == "" && z.Template == "" {
+			t.Errorf("zone %s: has a signing option but no dnssecpolicy: and no template:", z.Name)
+		}
+	}
+}
+
+func TestSampleZonesConfigDecodes(t *testing.T) {
+	var result struct {
+		Zones []ZoneConf `yaml:"zones"`
+	}
+	md := decodeSample(t, "../cmdv2/auth/auth-zones.sample.yaml", &result)
+
 	if len(result.Zones) == 0 {
 		t.Fatal("no zones decoded from sample")
 	}
-	sawPrimaries := false
+	if len(md.Unused) > 0 {
+		t.Errorf("sample has config keys the loader silently drops: %v", md.Unused)
+	}
+	sawPrimaries, sawDownstreams, sawTsigAcl := false, false, false
 	for _, z := range result.Zones {
+		checkZoneConf(t, "zone", z)
 		if len(z.Primaries) > 0 {
 			sawPrimaries = true
 		}
-		for _, p := range z.Primaries {
-			if p.Legacy != "" {
-				t.Errorf("zone %s: legacy bare-string primary %q (migrate to {addr, key})", z.Name, p.Legacy)
-			}
-		}
-		for _, n := range z.Notify {
-			if n.Legacy != "" {
-				t.Errorf("zone %s: legacy bare-string notify %q (migrate to {addr, key})", z.Name, n.Legacy)
+		for _, e := range z.Downstreams {
+			sawDownstreams = true
+			if e.Key != NOKEY && e.Key != BLOCKED {
+				sawTsigAcl = true
 			}
 		}
 	}
 	if !sawPrimaries {
 		t.Error("expected at least one zone with a primaries: list in the sample")
 	}
+	if !sawDownstreams {
+		t.Error("expected at least one zone with a downstreams: ACL in the sample")
+	}
+	if !sawTsigAcl {
+		t.Error("expected at least one downstreams: entry naming a real TSIG key in the sample")
+	}
 }
 
-// TestSampleTemplatesConfigIsValidYAML is a syntactic guard for the templates
-// sample (its template entries are a map, decoded separately at runtime).
-func TestSampleTemplatesConfigIsValidYAML(t *testing.T) {
-	data, err := os.ReadFile("../cmdv2/auth/auth-templates.sample.yaml")
-	if err != nil {
-		t.Fatalf("checked-in sample not found (%v)", err)
+// TestSampleTemplatesConfigDecodes guards the templates sample against the
+// shape it shipped with for a long time: a map keyed by template name, which
+// cannot decode into Config.Templates ([]ZoneConf).
+func TestSampleTemplatesConfigDecodes(t *testing.T) {
+	var result struct {
+		Templates []ZoneConf `yaml:"templates"`
 	}
-	var raw map[string]interface{}
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("templates sample is not valid YAML: %v", err)
+	md := decodeSample(t, "../cmdv2/auth/auth-templates.sample.yaml", &result)
+
+	if len(result.Templates) == 0 {
+		t.Fatal("no templates decoded from sample (is templates: a list of {name: ...} entries?)")
+	}
+	if len(md.Unused) > 0 {
+		t.Errorf("templates sample has config keys the loader silently drops: %v", md.Unused)
+	}
+	seen := map[string]bool{}
+	for _, tmpl := range result.Templates {
+		if tmpl.Name == "" {
+			t.Error("template with no name: (buildTemplateMap requires one)")
+			continue
+		}
+		if seen[tmpl.Name] {
+			t.Errorf("duplicate template name %q", tmpl.Name)
+		}
+		seen[tmpl.Name] = true
+		checkZoneConf(t, "template", tmpl)
+	}
+}
+
+// TestSampleZonesReferenceDefinedTemplates ties the two samples together: every
+// template: named by a sample zone must exist in the templates sample, or the
+// zone is quarantined with "template %q does not exist".
+func TestSampleZonesReferenceDefinedTemplates(t *testing.T) {
+	var zres struct {
+		Zones []ZoneConf `yaml:"zones"`
+	}
+	decodeSample(t, "../cmdv2/auth/auth-zones.sample.yaml", &zres)
+	var tres struct {
+		Templates []ZoneConf `yaml:"templates"`
+	}
+	decodeSample(t, "../cmdv2/auth/auth-templates.sample.yaml", &tres)
+
+	defined := map[string]bool{}
+	for _, tmpl := range tres.Templates {
+		defined[tmpl.Name] = true
+	}
+	for _, z := range zres.Zones {
+		if z.Template != "" && !defined[z.Template] {
+			t.Errorf("zone %s references undefined template %q", z.Name, z.Template)
+		}
 	}
 }


### PR DESCRIPTION
## Why

The guide documented TDNS's distinctive features well, but had essentially no **configuration guide** — while the one page that *did* carry config examples used keys that do not exist.

Investigating that turned up something worse: **three of the four shipped sample configs could not load**, and one of them takes the whole config down with it.

## What changed

### New: a Configuration Guide

| Page | Contents |
|---|---|
| `guide/configuration.md` | Index + conventions shared by all apps: config file location, `include:`, the unknown-key warning, zone quarantining |
| `guide/config-tdns-auth.md` | MWE, TSIG keys, the `allow-notify:`/`downstreams:` ACLs, zone declarations and every zone option, the zone template system, the `dnsengine:` block, DNSSEC policies (policy templates, `split_algorithms`, `large_algorithms`) |
| `guide/config-tdns-imr.md` | MWE, trust anchors, stub zones, the `imrengine.tuning.*` knobs with defaults |
| `guide/config-tdns-agent.md` | Placeholder, with an explicit list of what remains to document |

`dog` gets no config page — it has no config file.

### Fixed: the sample configs

- **`auth-templates.sample.yaml` could not decode at all.** It declared `templates:` as a map keyed by template name, but `Config.Templates` is `[]ZoneConf`. Loading it fails with `'templates': source data must be an array or slice, got map` — and `tdns-auth.sample.yaml` `include:`s it. Rewritten as a list of `{name: ...}` entries.
- **`auth-zones.sample.yaml` documented `downstreams:` as "Alias for notify (same meaning)".** It is not: `notify:` entries are destinations (`{addr, key}`), `downstreams:` is the provide-xfr ACL (`{prefix, key}`). Writing `addr:` there produces the unhelpful `acl entry "": bad ip-spec ""`. The header now documents the ACL grammar, and there are worked examples for IPv4+IPv6 prefixes with `NOKEY`, prefix-restricted transfer, and transfer requiring a real TSIG key.
- **Both samples used `dnssec_policy:` and `multi_signer:`**, which are not config keys (`dnssecpolicy:`, `multisigner:`). mapstructure dropped them silently, so EXAMPLE 1 enabled `online-signing` with no policy and would have been quarantined at validation.
- **`tdns-auth.sample.yaml` had no `keys:`/`tsig:` block** despite zones needing named TSIG keys. Blocks the code never reads (`keybootstrap:`, `childsync.schemes`/`sync-on-boot`/`syncwithparent`, `resignerengine.keygen.*`, `dnsengine.ports.do53`, `common.servername`) are now marked as such instead of reading as working configuration.
- **`tdns-imr.sample.yaml` could not start**: `apiserver.apikey` is required by `SetupSimpleAPIRouter` and was absent.

### Fixed: wrong config keys in `key-rollover.md`

Four examples used keys that do not load: a zone **map** instead of the `zones:` list, `dnssec-policy:` for `dnssecpolicy:`, a top-level `dnssecpolicies:` instead of `dnssec.policies:`, and `sig-validity:` nested under `ksk:`/`zsk:`.

The last was a **conceptual** error too: signature validity is per-RRtype (`sigvalidity: {default, dnskey, ds}`, `default` required), not per key role. So those examples would have failed with `sigvalidity.default is required` *even after* the spelling was corrected.

### Corrected app pages

- `app-tdns-imr.md` claimed tdns-imr enters a command loop when started without arguments. It does not — the default is daemon mode; `--cli` selects the interactive shell, which is a full daemon with a shell layered on top. The old text also named a `dump-only-suffix` command that does not exist and called `flush` unimplemented, though it is not. Now documents both modes, the real interactive command set, and why `tdns-cli imr <cache-command>` is inert while `tdns-cli agent|auth imr` works.
- `app-dog.md` now records that dog is an independent reimplementation of dig, not a fork of it or of the Rust tool of the same name, with its `+options`, transports, PQ algorithms and TDNS-local RRtypes.

## Code changes

### `tdns-imr --config` now selects the config file (`94677a7`)

Found while writing the IMR page, fixed on this branch rather than documented as a limitation.

`tdns-imr --config <path>` silently **merged** the named file with `/etc/tdns/tdns-imr.yaml`, and the default file won. `initConfig()` resolved the path, validated it and unmarshalled it into `Conf` — then called `MainInit(appCtx, "")`, and `MainInit` derives `/etc/tdns/<appname>.yaml` when `defaultcfg` is empty, assigning it to `Internal.CfgFile` for `AppTypeImr`. `SetupLogging` therefore read `/etc`'s `log:` block, and `ParseConfig` decoded `/etc` over the already-populated struct. Keys present in `/etc` overrode the user's file; keys unique to the user's file survived. Validation ran against one file while the other was parsed.

The fix passes the resolved path in — `MainInit(appCtx, cfgFileUsed)`. The `AppTypeImr` special case stays; it is load-bearing (tdns-imr is a Cobra app, so `MainInit` must not run a second `pflag.Parse()`). This also removes the validate-one-file/parse-another asymmetry.

### Smaller code changes

1. **`v2/parseconfig.go`** — `deprecatedConfigKeys` gains `.dnssec_policy`, `.dnssec-policy`, `.multi_signer` and `.sig-validity`, so these silently-dropped keys produce the loud migration error the registry exists for. Writing tests for them exposed a latent bug in the neighbouring entry: non-exact entries matched with `strings.Contains`, so `.sigvalidity` also fired on a typo *inside* the valid `sigvalidity:` subtree (`...SigValidity.defualt`), giving confidently wrong advice. The registry's own doc comment says these entries name a deprecated **leaf**, so matching is now by suffix.
2. **`v2/sample_config_test.go`** — replaces a YAML-syntax-only check (whose comment asserted the *wrong* shape: "its template entries are a map") with decoding through the real `ParseConfig` pipeline. Asserts no keys are silently dropped, no legacy bare-string peer/ACL entries survive, every ACL prefix parses, every option is one a config file may actually set, and zone `template:` references resolve. **Verified to fail on each pre-existing defect above.**
3. **`cmdv2/dog/dog.go`** — `--help` advertised a `+DO_BIT` option the parser never accepted; the DO-bit line now reads `+DNSSEC or +DO`.

## Verification

Not just read — run.

- **The tdns-auth MWE was booted.** It binds one IPv4 and one IPv6 listener, answers `A` queries on both, and serves AXFR according to its `downstreams:` ACL.
- **The four ACL behaviours the guide documents were tested against that running server:**

| Configuration | Observed |
|---|---|
| `downstreams:` absent | AXFR refused (empty ⇒ DENY) |
| `key: testkey.` | unsigned refused, TSIG-signed succeeds |
| `testkey.` **and** `NOKEY` on the same prefix | unsigned **succeeds** — `NOKEY` is checked first and wins |
| `0.0.0.0/0` NOKEY + `127.0.0.1` BLOCKED | refused |

- **The tdns-imr MWE was booted too**, once `94677a7` made `--config` usable: it binds its own addresses, writes its own log file, and removing `apiserver.apikey` aborts startup with `Error setting up IMR API router: apiserver.apikey is not set`, exactly as the page claims.
- **Every corrected policy example passes** `tdns-cli auth keystore dnssec policy validate --file`. The validator was itself checked against bad input (it rejects a missing `sigvalidity.default` and a missing `rollover.parent-agent`, exit 1) so the pass is meaningful.
- Full `v2` test suite green; all relative links in `guide/` resolve.

## Reviewer notes

- **The change most worth a careful read is the `Contains` → `HasSuffix` fix** in `classifyUnusedConfigKeys` (`v2/parseconfig.go`). It is correct only because all five non-exact `deprecatedConfigKeys` entries are leaves; a future non-leaf entry would silently stop matching. It is also the only change here that alters what a running server logs.
- **`internalOnlyZoneOptions`** in `v2/sample_config_test.go` duplicates the `default` arm of the switch in `v2/parseoptions.go` and will drift if someone adds a zone option there. Noted in the code, not solved.
- **`imr.localconfig` does not override the main config file** — it only supplies keys the main file omits. The guide now says so. The behaviour is left as-is: fixing it means teaching `ParseConfig` about the overlay, which is a design change rather than a patch.
- **One related fix was deliberately kept off this branch**, because it changes runtime behaviour for existing deployments: `cmdv2/auth/auth-templates.yaml` (the real file, not the sample) has legacy bare-string `notify:` entries that now quarantine every zone using those templates, plus an invalid `multisigner` zone option.
- The `large_algorithms` section documents the **exact-name** syntax that works on `main`. Name-prefix globs (`MLDSA*`) live on `feature/large-alg-prefix-matching` and are called out as such, with a note to update when that lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified DNSSEC command-line help: `+DNSSEC` and `+DO` enable the DNSSEC OK bit.
  - Removed the obsolete `+DO_BIT` option from the help listing.
  - Improved guidance for migrating additional legacy or misspelled DNSSEC configuration keys.

- **Bug Fixes**
  - Improved configuration handling to avoid incorrectly flagging valid settings as deprecated.
  - IMR now reports and uses the resolved configuration file during startup and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->