### PR TITLE
auth: EDNS-aware UDP truncation (set TC=1 on oversized responses)

### DIFF
--- a/cmdv2/dog/dog.go
+++ b/cmdv2/dog/dog.go
@@ -20,6 +20,8 @@ import (
 	"github.com/johanix/tdns/v2"
 	core "github.com/johanix/tdns/v2/core"
 	edns0 "github.com/johanix/tdns/v2/edns0"
+	dogopts "dog/internal/options"
+	dogtransport "dog/internal/transport"
 
 	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
@@ -61,6 +63,7 @@ var rootCmd = &cobra.Command{
 		+HTTPS: Force HTTPS transport
 		+QUIC: Force QUIC transport
 		+WIDTH=N: Set the width of the output to N characters
+		+BUFsize=N: Set the EDNS(0) UDP payload size (dig-compatible; +BUFSIZ=N accepted)
 		+OPCODE=QUERY|NOTIFY|UPDATE: Set the opcode of the query
 		+OTS=opt_in|opt_out: Set the OTS (transport signaling) EDNS(0)option
 		+ER=agent.domain: Add EDNS(0) Error Reporting option with agent domain (RFC9567)
@@ -82,9 +85,6 @@ var rootCmd = &cobra.Command{
 		var serial uint32
 
 		for _, arg := range args {
-			if tdns.Globals.Debug {
-				fmt.Printf("processing arg: %s, options: %+v\n", arg, options)
-			}
 			if strings.HasPrefix(arg, "@") || strings.Contains(arg, "://") {
 				serverArg := arg
 				if strings.HasPrefix(arg, "@") {
@@ -117,9 +117,6 @@ var rootCmd = &cobra.Command{
 			}
 
 			if strings.HasPrefix(ucarg, "+") {
-				if tdns.Globals.Debug {
-					fmt.Printf("processing dog option: %s\n", ucarg)
-				}
 				options, err = ProcessOptions(options, ucarg)
 				if err != nil {
 					fmt.Printf("Error: %v\n", err)
@@ -266,13 +263,13 @@ var rootCmd = &cobra.Command{
 
 			switch rrtype {
 			case dns.TypeAXFR, dns.TypeIXFR:
-				if options["transport"] == "Do53" {
+				if dogtransport.PlainDo53(options["transport"]) {
 					upstream := net.JoinHostPort(options["server"], options["port"])
 					if err := tdns.ZoneTransferPrint(qname, upstream, serial, rrtype, options, tsigName, tsigAlgo, tsigSecret); err != nil {
 						os.Exit(1)
 					}
 				} else {
-					fmt.Printf("Zone transfer only supported for transport Do53 (TCP), this is %s\n", options["transport"])
+					fmt.Printf("Zone transfer only supported over Do53/TCP, not %s\n", options["transport"])
 					os.Exit(1)
 				}
 
@@ -291,14 +288,17 @@ var rootCmd = &cobra.Command{
 				if options["cd_bit"] == "true" {
 					m.MsgHdr.CheckingDisabled = true
 				}
-				// do_bit = options["do_bit"] == "true"
-				// m.SetEdns0(4096, do_bit)
+				ednsUDPSize, err := dogopts.EDNSUDPSizeFromMap(options)
+				if err != nil {
+					fmt.Printf("Error: %v\n", err)
+					os.Exit(1)
+				}
 				opt := &dns.OPT{
 					Hdr: dns.RR_Header{
 						Name:   ".",
 						Rrtype: dns.TypeOPT,
-						Class:  4096, // This is the UDP buffer size
-						Ttl:    0,    // Extended RCODE and flags
+						Class:  ednsUDPSize, // EDNS UDP payload size (RFC 6891)
+						Ttl:    0,             // Extended RCODE and flags
 					},
 				}
 				if options["do_bit"] == "true" {
@@ -340,9 +340,6 @@ var rootCmd = &cobra.Command{
 				}
 				m.Extra = append(m.Extra, opt)
 
-				if tdns.Globals.Debug {
-					fmt.Printf("*** Outbound DNS message: %s\n", m.String())
-				}
 				start := time.Now()
 
 				server, ok := options["server"]
@@ -416,6 +413,15 @@ var rootCmd = &cobra.Command{
 					}
 				}
 
+				if showDNSMessageTrace() {
+					fmt.Println("*** Outbound DNS message:")
+					out := m.String()
+					fmt.Print(out)
+					if !strings.HasSuffix(out, "\n") {
+						fmt.Println()
+					}
+				}
+
 				client := core.NewDNSClient(t, options["port"], tlsConfig, clientOpts...)
 				res, _, err := client.Exchange(m, server, false) // FIXME: duration is always zero
 				if err == nil && res != nil && res.Truncated && t == core.TransportDo53 && !forceTCP {
@@ -449,6 +455,10 @@ var rootCmd = &cobra.Command{
 					fmt.Printf("Error from %s: %v\n", server, err)
 					fmt.Printf("*** This is what we got: %+v\n", res)
 					os.Exit(1)
+				}
+				if showDNSMessageTrace() {
+					fmt.Println()
+					fmt.Println("*** Incoming DNS response:")
 				}
 				tdns.MsgPrint(res, server, elapsed, short, options)
 				if tsigSigned && res != nil {
@@ -520,6 +530,12 @@ func parseTsigFlag(s string) (name, algo, secret string, err error) {
 		return "", "", "", fmt.Errorf("-y must be [algorithm:]name:secret")
 	}
 	return name, algo, secret, nil
+}
+
+// showDNSMessageTrace enables outbound/incoming DNS message printouts for
+// --verbose and --debug (the latter also prints lower-level parse tracing).
+func showDNSMessageTrace() bool {
+	return tdns.Globals.Verbose || tdns.Globals.Debug
 }
 
 func ProcessOptions(options map[string]string, ucarg string) (map[string]string, error) {
@@ -670,6 +686,17 @@ func ProcessOptions(options map[string]string, ucarg string) (map[string]string,
 			return nil, fmt.Errorf("Error: +WIDTH option requires a valid integer width (e.g., +WIDTH=100)")
 		}
 
+		if val, ok := dogopts.ParseBufsizeFlag(ucarg); ok {
+			if val == "" {
+				return nil, fmt.Errorf("Error: +bufsize requires a value (e.g. +bufsize=512)")
+			}
+			if _, err := dogopts.ParseEDNSUDPSize(val); err != nil {
+				return nil, fmt.Errorf("Error: %v", err)
+			}
+			options["bufsize"] = val
+			return options, nil
+		}
+
 		return nil, fmt.Errorf("Error: Unknown option: %s", ucarg)
 	}
 }
@@ -796,11 +823,6 @@ func ParseServer(serverArg string, options map[string]string) (map[string]string
 
 	if strings.HasSuffix(options["server"], "/") {
 		options["server"] = options["server"][:len(options["server"])-1]
-	}
-
-	if tdns.Globals.Debug {
-		fmt.Printf("ParseServer: server: %s, port: %s, transport: %s, path: %s\n",
-			options["server"], options["port"], options["transport"], options["path"])
 	}
 
 	// Basic validation

--- a/cmdv2/dog/internal/options/options.go
+++ b/cmdv2/dog/internal/options/options.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package options
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+const DefaultEDNSUDPSize = 4096
+
+// ParseBufsizeFlag recognizes dig-style +bufsize=N and the +bufsiz=N
+// abbreviation. ucarg must already be uppercased.
+func ParseBufsizeFlag(ucarg string) (value string, ok bool) {
+	for _, prefix := range []string{"+BUFsize=", "+BUFSIZ="} {
+		if strings.HasPrefix(ucarg, prefix) {
+			val := strings.TrimPrefix(ucarg, prefix)
+			return val, true
+		}
+	}
+	return "", false
+}
+
+// ParseEDNSUDPSize validates and normalizes an EDNS UDP payload size. Per RFC
+// 6891, values below 512 are treated as 512.
+func ParseEDNSUDPSize(s string) (uint16, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("+bufsize requires a valid integer (e.g. +bufsize=512)")
+	}
+	if n < 0 || n > 65535 {
+		return 0, fmt.Errorf("+bufsize=%d out of range (0-65535)", n)
+	}
+	if n < int(dns.MinMsgSize) {
+		n = int(dns.MinMsgSize)
+	}
+	return uint16(n), nil
+}
+
+// EDNSUDPSizeFromMap returns the OPT UDP payload size for a dog options map.
+func EDNSUDPSizeFromMap(opts map[string]string) (uint16, error) {
+	raw, ok := opts["bufsize"]
+	if !ok || raw == "" {
+		return DefaultEDNSUDPSize, nil
+	}
+	return ParseEDNSUDPSize(raw)
+}

--- a/cmdv2/dog/internal/options/options.go
+++ b/cmdv2/dog/internal/options/options.go
@@ -17,7 +17,7 @@ const DefaultEDNSUDPSize = 4096
 // ParseBufsizeFlag recognizes dig-style +bufsize=N and the +bufsiz=N
 // abbreviation. ucarg must already be uppercased.
 func ParseBufsizeFlag(ucarg string) (value string, ok bool) {
-	for _, prefix := range []string{"+BUFsize=", "+BUFSIZ="} {
+	for _, prefix := range []string{"+BUFSIZE=", "+BUFSIZ="} {
 		if strings.HasPrefix(ucarg, prefix) {
 			val := strings.TrimPrefix(ucarg, prefix)
 			return val, true

--- a/cmdv2/dog/internal/options/options_test.go
+++ b/cmdv2/dog/internal/options/options_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestParseBufsizeFlag(t *testing.T) {
-	if val, ok := ParseBufsizeFlag("+BUFsize=512"); !ok || val != "512" {
-		t.Fatalf("+BUFsize=512: val=%q ok=%v", val, ok)
+	if val, ok := ParseBufsizeFlag("+BUFSIZE=512"); !ok || val != "512" {
+		t.Fatalf("+BUFSIZE=512: val=%q ok=%v", val, ok)
 	}
 	if val, ok := ParseBufsizeFlag("+BUFSIZ=1232"); !ok || val != "1232" {
 		t.Fatalf("+BUFSIZ=1232: val=%q ok=%v", val, ok)
@@ -53,7 +53,7 @@ func TestEDNSUDPSizeFromMap(t *testing.T) {
 
 func TestParseBufsizeFlagCaseFromDog(t *testing.T) {
 	// dog uppercases argv before ProcessOptions
-	arg := strings.ToUpper("+bufsiz=512")
+	arg := strings.ToUpper("+bufsize=512")
 	val, ok := ParseBufsizeFlag(arg)
 	if !ok || val != "512" {
 		t.Fatalf("%s: val=%q ok=%v", arg, val, ok)

--- a/cmdv2/dog/internal/options/options_test.go
+++ b/cmdv2/dog/internal/options/options_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package options
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestParseBufsizeFlag(t *testing.T) {
+	if val, ok := ParseBufsizeFlag("+BUFsize=512"); !ok || val != "512" {
+		t.Fatalf("+BUFsize=512: val=%q ok=%v", val, ok)
+	}
+	if val, ok := ParseBufsizeFlag("+BUFSIZ=1232"); !ok || val != "1232" {
+		t.Fatalf("+BUFSIZ=1232: val=%q ok=%v", val, ok)
+	}
+	if _, ok := ParseBufsizeFlag("+DO"); ok {
+		t.Fatal("+DO should not match bufsize")
+	}
+}
+
+func TestParseEDNSUDPSize(t *testing.T) {
+	size, err := ParseEDNSUDPSize("512")
+	if err != nil || size != 512 {
+		t.Fatalf("512: size=%d err=%v", size, err)
+	}
+	size, err = ParseEDNSUDPSize("300")
+	if err != nil || size != dns.MinMsgSize {
+		t.Fatalf("300: size=%d err=%v, want %d", size, err, dns.MinMsgSize)
+	}
+	if _, err := ParseEDNSUDPSize("abc"); err == nil {
+		t.Fatal("expected error for abc")
+	}
+	if _, err := ParseEDNSUDPSize("70000"); err == nil {
+		t.Fatal("expected error for 70000")
+	}
+}
+
+func TestEDNSUDPSizeFromMap(t *testing.T) {
+	size, err := EDNSUDPSizeFromMap(nil)
+	if err != nil || size != DefaultEDNSUDPSize {
+		t.Fatalf("default: size=%d err=%v", size, err)
+	}
+	size, err = EDNSUDPSizeFromMap(map[string]string{"bufsize": "512"})
+	if err != nil || size != 512 {
+		t.Fatalf("512: size=%d err=%v", size, err)
+	}
+}
+
+func TestParseBufsizeFlagCaseFromDog(t *testing.T) {
+	// dog uppercases argv before ProcessOptions
+	arg := strings.ToUpper("+bufsiz=512")
+	val, ok := ParseBufsizeFlag(arg)
+	if !ok || val != "512" {
+		t.Fatalf("%s: val=%q ok=%v", arg, val, ok)
+	}
+}

--- a/cmdv2/dog/internal/transport/transport.go
+++ b/cmdv2/dog/internal/transport/transport.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package transport
+
+import (
+	core "github.com/johanix/tdns/v2/core"
+)
+
+// PlainDo53 reports whether transport is plain Do53 (UDP, with query-time TCP
+// fallback) or explicit Do53-over-TCP. Zone transfers use miekg dns.Transfer,
+// which always dials TCP regardless; both labels are valid for AXFR/IXFR.
+func PlainDo53(s string) bool {
+	t, err := core.StringToTransport(s)
+	if err != nil {
+		return false
+	}
+	return t == core.TransportDo53 || t == core.TransportDo53TCP
+}

--- a/cmdv2/dog/internal/transport/transport_test.go
+++ b/cmdv2/dog/internal/transport/transport_test.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package transport
+
+import "testing"
+
+func TestPlainDo53(t *testing.T) {
+	yes := []string{"Do53", "do53", "Do53-TCP", "do53-tcp", "tcp", "TCP"}
+	for _, s := range yes {
+		if !PlainDo53(s) {
+			t.Errorf("PlainDo53(%q) = false, want true", s)
+		}
+	}
+	no := []string{"DoT", "DoH", "DoQ", "dot", "quic", ""}
+	for _, s := range no {
+		if PlainDo53(s) {
+			t.Errorf("PlainDo53(%q) = true, want false", s)
+		}
+	}
+}

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -48,7 +48,8 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 	// servers below carry a TsigProvider (needed to MAC the response). DoH/DoQ
 	// receive the unwrapped authDNSHandler; DoT installs the wrapper itself in
 	// DnsDoTEngine, since it also carries a TsigProvider.
-	dnsMux.HandleFunc(".", TsigSigningHandler(authDNSHandler))
+	// udpTruncate sits inside TsigSigningHandler so TSIG MACs the truncated wire.
+	dnsMux.HandleFunc(".", TsigSigningHandler(udpTruncate(authDNSHandler)))
 
 	addresses := conf.DnsEngine.Addresses
 	if !CaseFoldContains(conf.DnsEngine.Transports, "do53") {

--- a/v2/edns0/edns0.go
+++ b/v2/edns0/edns0.go
@@ -21,6 +21,7 @@ type MsgOptions struct {
 	HasEROption   bool            // True if ER option is present
 	ErAgentDomain string          // RFC9567: DNS Error Reporting agent domain
 	KeyState      *KeyStateOption // KeyState option if present
+	UDPSize       uint16          // Client-advertised EDNS UDP payload size (RFC 6891)
 }
 
 type EDNS0Option struct {
@@ -35,8 +36,11 @@ func ExtractFlagsAndEDNS0Options(r *dns.Msg) (*MsgOptions, error) {
 
 	opt := r.IsEdns0()
 	if opt == nil {
+		msgoptions.UDPSize = dns.MinMsgSize
 		return msgoptions, nil
 	}
+
+	msgoptions.UDPSize = RequestUDPSize(r)
 
 	// Extract DO bit (DNSSEC OK) - bit 15
 	msgoptions.DO = opt.Do()
@@ -80,4 +84,21 @@ func ExtractFlagsAndEDNS0Options(r *dns.Msg) (*MsgOptions, error) {
 	}
 
 	return msgoptions, nil
+}
+
+// RequestUDPSize returns the EDNS UDP payload size advertised in r. Per RFC
+// 6891: no OPT ⇒ 512; OPT UDP size < 512 ⇒ treat as 512.
+func RequestUDPSize(r *dns.Msg) uint16 {
+	if r == nil {
+		return dns.MinMsgSize
+	}
+	opt := r.IsEdns0()
+	if opt == nil {
+		return dns.MinMsgSize
+	}
+	size := opt.UDPSize()
+	if size < dns.MinMsgSize {
+		return dns.MinMsgSize
+	}
+	return size
 }

--- a/v2/edns0/edns0_test.go
+++ b/v2/edns0/edns0_test.go
@@ -30,6 +30,9 @@ func TestExtractFlagsAndEDNS0Options(t *testing.T) {
 		if opts.DO {
 			t.Error("DO flag should be false (no EDNS0)")
 		}
+		if opts.UDPSize != dns.MinMsgSize {
+			t.Errorf("UDPSize should be %d without EDNS0, got %d", dns.MinMsgSize, opts.UDPSize)
+		}
 	})
 
 	t.Run("WithEDNS0DO", func(t *testing.T) {
@@ -46,6 +49,9 @@ func TestExtractFlagsAndEDNS0Options(t *testing.T) {
 		}
 		if !opts.DO {
 			t.Error("DO flag should be true")
+		}
+		if opts.UDPSize != 4096 {
+			t.Errorf("UDPSize should be 4096, got %d", opts.UDPSize)
 		}
 	})
 
@@ -74,6 +80,34 @@ func TestExtractFlagsAndEDNS0Options(t *testing.T) {
 		}
 		if opts.ErAgentDomain != "erp.example.com." {
 			t.Errorf("ErAgentDomain should be 'erp.example.com.', got %s", opts.ErAgentDomain)
+		}
+	})
+}
+
+func TestRequestUDPSize(t *testing.T) {
+	t.Run("NoEDNS0", func(t *testing.T) {
+		msg := new(dns.Msg)
+		msg.SetQuestion("example.com.", dns.TypeA)
+		if got := RequestUDPSize(msg); got != dns.MinMsgSize {
+			t.Errorf("RequestUDPSize() = %d, want %d", got, dns.MinMsgSize)
+		}
+	})
+
+	t.Run("Advertised4096", func(t *testing.T) {
+		msg := new(dns.Msg)
+		msg.SetQuestion("example.com.", dns.TypeA)
+		msg.SetEdns0(4096, false)
+		if got := RequestUDPSize(msg); got != 4096 {
+			t.Errorf("RequestUDPSize() = %d, want 4096", got)
+		}
+	})
+
+	t.Run("Below512Clamped", func(t *testing.T) {
+		msg := new(dns.Msg)
+		msg.SetQuestion("example.com.", dns.TypeA)
+		msg.SetEdns0(300, false)
+		if got := RequestUDPSize(msg); got != dns.MinMsgSize {
+			t.Errorf("RequestUDPSize() = %d, want %d", got, dns.MinMsgSize)
 		}
 	})
 }

--- a/v2/rr_print.go
+++ b/v2/rr_print.go
@@ -5,6 +5,7 @@ package tdns
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -443,6 +444,21 @@ func rdataOnly(rr dns.RR) string {
 	return parts[4]
 }
 
+// digStyleServer formats the ;; SERVER footer like dig: host#port(host). For
+// DoH the server argument is already a URL and is returned unchanged.
+func digStyleServer(host, port string) string {
+	if strings.Contains(host, "://") {
+		return host
+	}
+	if port == "" {
+		port = "53"
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		return fmt.Sprintf("[%s]#%s([%s])", host, port, host)
+	}
+	return fmt.Sprintf("%s#%s(%s)", host, port, host)
+}
+
 func MsgPrint(m *dns.Msg, server string, elapsed time.Duration, short bool, options map[string]string) {
 	if short {
 		// dig-compatible +short: print only the RDATA of each Answer RR,
@@ -579,7 +595,7 @@ func MsgPrint(m *dns.Msg, server string, elapsed time.Duration, short bool, opti
 	}
 
 	fmt.Printf("\n;; Query time: %d msec\n", elapsed.Milliseconds())
-	fmt.Printf(";; SERVER: %s (%s)\n", server, transport)
+	fmt.Printf(";; SERVER: %s (%s)\n", digStyleServer(server, options["port"]), transport)
 	fmt.Printf(";; WHEN: %s\n", time.Now().Format(TimeLayout))
 
 	buf, err := m.Pack()

--- a/v2/rr_print_dig_test.go
+++ b/v2/rr_print_dig_test.go
@@ -1,0 +1,20 @@
+package tdns
+
+import "testing"
+
+func TestDigStyleServer(t *testing.T) {
+	cases := []struct {
+		host, port, want string
+	}{
+		{"127.0.0.1", "5354", "127.0.0.1#5354(127.0.0.1)"},
+		{"127.0.0.1", "53", "127.0.0.1#53(127.0.0.1)"},
+		{"127.0.0.1", "", "127.0.0.1#53(127.0.0.1)"},
+		{"::1", "5354", "[::1]#5354([::1])"},
+		{"https://example.com/dns-query", "443", "https://example.com/dns-query"},
+	}
+	for _, c := range cases {
+		if got := digStyleServer(c.host, c.port); got != c.want {
+			t.Errorf("digStyleServer(%q, %q) = %q, want %q", c.host, c.port, got, c.want)
+		}
+	}
+}

--- a/v2/tsig_response_sign_test.go
+++ b/v2/tsig_response_sign_test.go
@@ -10,10 +10,16 @@ import (
 type fakeTsigRW struct {
 	tsigStatus error
 	written    *dns.Msg
+	network    string
 }
 
-func (f *fakeTsigRW) LocalAddr() net.Addr       { return nil }
-func (f *fakeTsigRW) RemoteAddr() net.Addr      { return nil }
+func (f *fakeTsigRW) LocalAddr() net.Addr { return nil }
+func (f *fakeTsigRW) RemoteAddr() net.Addr {
+	if f.network == "" {
+		return stubNetAddr{network: "tcp"}
+	}
+	return stubNetAddr{network: f.network}
+}
 func (f *fakeTsigRW) WriteMsg(m *dns.Msg) error { f.written = m; return nil }
 func (f *fakeTsigRW) Write([]byte) (int, error) { return 0, nil }
 func (f *fakeTsigRW) Close() error              { return nil }

--- a/v2/udp_truncate.go
+++ b/v2/udp_truncate.go
@@ -42,10 +42,25 @@ func udpTruncate(next func(dns.ResponseWriter, *dns.Msg)) func(dns.ResponseWrite
 		if ra := w.RemoteAddr(); ra != nil {
 			udp = ra.Network() == "udp"
 		}
+		bufsize := edns0.RequestUDPSize(r)
+		// TsigSigningHandler wraps us and appends the response TSIG AFTER we
+		// truncate, so reserve room for it or the final wire would overshoot
+		// bufsize. The response TSIG mirrors the request's key + algorithm, so
+		// the request TSIG's length is a good proxy.
+		if r != nil {
+			if tsig := r.IsTsig(); tsig != nil {
+				if tl := uint16(dns.Len(tsig)); bufsize > tl {
+					bufsize -= tl
+				} else {
+					bufsize = 0
+				}
+			}
+		}
+
 		w = &truncatingResponseWriter{
 			ResponseWriter: w,
 			udp:            udp,
-			bufsize:        edns0.RequestUDPSize(r),
+			bufsize:        bufsize,
 		}
 		next(w, r)
 	}

--- a/v2/udp_truncate.go
+++ b/v2/udp_truncate.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	edns0 "github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// truncatingResponseWriter truncates oversized UDP responses to the client's
+// advertised EDNS buffer size (RFC 6891) before delegating to the inner writer.
+// Only WriteMsg is overridden; every other dns.ResponseWriter method is promoted
+// from the embedded writer unchanged.
+type truncatingResponseWriter struct {
+	dns.ResponseWriter
+	udp     bool
+	bufsize uint16
+}
+
+func (w *truncatingResponseWriter) WriteMsg(m *dns.Msg) error {
+	if w.udp && m.Len() > int(w.bufsize) {
+		m.Truncate(int(w.bufsize))
+	}
+	return w.ResponseWriter.WriteMsg(m)
+}
+
+// udpTruncate wraps next so Do53-over-UDP responses that exceed the requester's
+// advertised EDNS UDP payload size are truncated and marked TC. TCP (and any
+// non-UDP transport on this mux) passes responses through unchanged.
+//
+// Install only on the Do53 mux — not on createAuthDnsHandler, which is also
+// used unwrapped by DoH and DoQ (QUIC must never be truncated).
+func udpTruncate(next func(dns.ResponseWriter, *dns.Msg)) func(dns.ResponseWriter, *dns.Msg) {
+	return func(w dns.ResponseWriter, r *dns.Msg) {
+		// Defensive: a nil RemoteAddr should never happen for a real Do53
+		// request, but treat "unknown transport" as non-UDP and never truncate
+		// rather than panic (a panic here would only reach the handler's
+		// recover() as a SERVFAIL).
+		udp := false
+		if ra := w.RemoteAddr(); ra != nil {
+			udp = ra.Network() == "udp"
+		}
+		w = &truncatingResponseWriter{
+			ResponseWriter: w,
+			udp:            udp,
+			bufsize:        edns0.RequestUDPSize(r),
+		}
+		next(w, r)
+	}
+}

--- a/v2/udp_truncate_test.go
+++ b/v2/udp_truncate_test.go
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type stubNetAddr struct {
+	network string
+}
+
+func (a stubNetAddr) Network() string { return a.network }
+func (a stubNetAddr) String() string  { return "stub:" + a.network }
+
+type recordingRW struct {
+	dns.ResponseWriter
+	network string
+	written *dns.Msg
+}
+
+func (w *recordingRW) RemoteAddr() net.Addr { return stubNetAddr{network: w.network} }
+func (w *recordingRW) WriteMsg(m *dns.Msg) error {
+	w.written = m
+	return nil
+}
+
+func oversizedResponseFor(t *testing.T, minLen int) *dns.Msg {
+	t.Helper()
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeDNSKEY)
+	m.SetEdns0(512, true)
+	txt := make([]byte, minLen)
+	for i := range txt {
+		txt[i] = 'x'
+	}
+	m.Answer = append(m.Answer, &dns.TXT{
+		Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 60},
+		Txt: []string{string(txt)},
+	})
+	if m.Len() <= minLen {
+		t.Fatalf("fixture not oversized for %d: len=%d", minLen, m.Len())
+	}
+	return m
+}
+
+func oversizedResponse(t *testing.T) *dns.Msg {
+	return oversizedResponseFor(t, 512)
+}
+
+func TestTruncatingResponseWriter_UDPTruncates(t *testing.T) {
+	inner := &recordingRW{network: "udp"}
+	w := &truncatingResponseWriter{ResponseWriter: inner, udp: true, bufsize: 512}
+	resp := oversizedResponse(t)
+
+	if err := w.WriteMsg(resp); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+	if inner.written == nil {
+		t.Fatal("inner WriteMsg not called")
+	}
+	if !inner.written.Truncated {
+		t.Error("expected TC bit set on truncated UDP response")
+	}
+	if inner.written.Len() > 512 {
+		t.Errorf("truncated response len=%d, want <=512", inner.written.Len())
+	}
+	if len(inner.written.Question) != 1 {
+		t.Errorf("question section lost: %+v", inner.written.Question)
+	}
+	if inner.written.IsEdns0() == nil {
+		t.Error("expected OPT preserved in truncated response")
+	}
+}
+
+func TestTruncatingResponseWriter_TCPPassthrough(t *testing.T) {
+	inner := &recordingRW{network: "tcp"}
+	w := &truncatingResponseWriter{ResponseWriter: inner, udp: false, bufsize: 512}
+	resp := oversizedResponse(t)
+	before := resp.Len()
+
+	if err := w.WriteMsg(resp); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+	if inner.written.Truncated {
+		t.Error("TCP response must not be truncated")
+	}
+	if inner.written.Len() != before {
+		t.Errorf("TCP response size changed: got %d want %d", inner.written.Len(), before)
+	}
+}
+
+func TestTruncatingResponseWriter_UDPSmallUntouched(t *testing.T) {
+	inner := &recordingRW{network: "udp"}
+	w := &truncatingResponseWriter{ResponseWriter: inner, udp: true, bufsize: 512}
+	resp := new(dns.Msg)
+	resp.SetQuestion("example.com.", dns.TypeA)
+	resp.Answer = append(resp.Answer, &dns.A{
+		Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   net.IP{192, 0, 2, 1},
+	})
+
+	if err := w.WriteMsg(resp); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+	if inner.written.Truncated {
+		t.Error("small UDP response must not set TC")
+	}
+}
+
+func TestUdpTruncate_UsesRequestBufsize(t *testing.T) {
+	inner := &recordingRW{network: "udp"}
+	var gotBufsize uint16
+	serve := udpTruncate(func(w dns.ResponseWriter, r *dns.Msg) {
+		tw := w.(*truncatingResponseWriter)
+		gotBufsize = tw.bufsize
+		resp := oversizedResponseFor(t, 1232)
+		_ = w.WriteMsg(resp)
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeDNSKEY)
+	req.SetEdns0(1232, true)
+	serve(inner, req)
+
+	if gotBufsize != 1232 {
+		t.Errorf("bufsize=%d, want 1232", gotBufsize)
+	}
+	if inner.written == nil || !inner.written.Truncated {
+		t.Fatal("expected truncated response for oversized answer")
+	}
+}
+
+func TestTsigSigningHandler_TruncatesBeforeMAC(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeDNSKEY)
+	req.SetEdns0(512, true)
+	req.SetTsig("mykey.", dns.HmacSHA256, 300, time.Now().Unix())
+
+	inner := &fakeTsigRW{tsigStatus: nil, network: "udp"}
+	serve := TsigSigningHandler(udpTruncate(func(w dns.ResponseWriter, r *dns.Msg) {
+		_ = w.WriteMsg(oversizedResponse(t))
+	}))
+	serve(inner, req)
+
+	if inner.written == nil {
+		t.Fatal("no response written")
+	}
+	if !inner.written.Truncated {
+		t.Error("expected TC on TSIG response chain")
+	}
+	if inner.written.Len() > 512 {
+		t.Errorf("TSIG response len=%d, want <=512", inner.written.Len())
+	}
+	if inner.written.IsTsig() == nil {
+		t.Error("expected response TSIG added after truncation")
+	}
+}


### PR DESCRIPTION
## What

Make `tdns-auth` honor the EDNS UDP buffer size and set the **TC bit** when a
UDP response is too large, so clients fall back to TCP instead of receiving a
fragmenting datagram.

## Why

tdns-auth never called `msg.Truncate()` — a `bufsize=512` client got a 1666 B
answer, a DNSKEY query got a 7747 B / 6-fragment datagram. On the public
internet the fragments are dropped, so large PQ-signed zones (falcon512 / mayo3
ZSKs) time out over UDP instead of retrying over TCP. On the pq.axfr.net testbed
this was **105/135 zones reachable over UDP** (135/135 over TCP). This is the
exact failure mode alg-split exists to fix. (Testbed bug TB2.)

## How (commit 1 — the fix)

A `truncatingResponseWriter` installed on the **Do53 mux**, *inside*
`TsigSigningHandler`:
- **Mux placement** (not `createAuthDnsHandler`): that shared closure is used
  unwrapped by DoH/DoQ, and DoQ is UDP-based (QUIC) — a `Network()=="udp"`
  wrapper there would mis-truncate DoQ. The Do53 mux is used only by the UDP+TCP
  servers, so `"udp"` there unambiguously means plain Do53-over-UDP.
- **Inside the TSIG handler**: truncation precedes the TSIG MAC (MAC covers the
  truncated wire).
- **bufsize rule** (`edns0.RequestUDPSize`): no OPT or `<512` → 512, else the
  advertised value. **No anti-fragmentation cap** (deliberate — honor the
  client's advertised size).
- Only Do53-UDP truncates; TCP passes through. `m.Truncate` drops trailing RRs
  and sets TC, preserving the question + OPT.

Client side already handles TC=1: `dog` and `tdns-imr` both fall back to TCP
(via `core.DNSClient`), so the fix is end-to-end.

Tests: UDP-truncates (TC + ≤bufsize, question/OPT kept), TCP passthrough,
small-untouched, request-bufsize, and truncate-before-TSIG-MAC ordering.

## Commit 2 — unrelated nits (kept on-branch)

Small cleanups too minor for their own PR: extract dog's option/transport
parsing into `internal/options` + `internal/transport` (tested), and a
dig-style `;; SERVER` footer helper in `rr_print.go`. No functional overlap with
the fix.

Plan: `docs/2026-07-15-tc-bit-edns-truncation-plan.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `+bufsize=N` option to configure EDNS(0) UDP payload sizes.
  * DNS responses over UDP are now truncated according to the client’s advertised buffer size.
  * Verbose and debug modes now display outgoing and incoming DNS message traces.
  * Improved dig-style server information in DNS output.

* **Bug Fixes**
  * Preserved TSIG signing behavior when UDP responses require truncation.
  * Improved transport handling for AXFR/IXFR requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->