### PR TITLE
config: copy-on-write RuntimeConfig snapshot — fix reload data races

### DIFF
--- a/docs/2026-07-15-runtime-config-snapshot-plan.md
+++ b/docs/2026-07-15-runtime-config-snapshot-plan.md
@@ -1,0 +1,160 @@
+# Runtime config snapshot — copy-on-write for reloadable config
+
+**Status:** design for sign-off (no code yet).
+**Branch:** own PR off `main` (pre-existing bug; blocks #286).
+**Origin:** load-testing #286 surfaced `fatal error: concurrent map read and map
+write` crashes. Two hit so far — `NeedsResigning`→viper, and RefreshEngine→
+`conf.Internal.DnssecPolicies` — both the same class.
+
+## 1. Problem
+
+`config reload` rewrites shared config (the `conf.Internal.*` maps, and viper's
+map via `viper.ReadConfig`) while long-running reader goroutines — the
+RefreshEngine and the signer — read it **without synchronization**. Any such
+concurrent read vs the reload write is a Go runtime `fatal error` (unrecoverable).
+
+Guarding the *reads* is the wrong model here:
+- **Fragile:** every reader must remember to lock; the RefreshEngine forgot, and
+  so will the next one.
+- **Deadlock hazard:** the RefreshEngine reads these maps *inside* its
+  `zd.mu.Lock()` block (refreshengine.go:358–440), while reload takes
+  `confMu.Lock()` → `zdp.mu.Lock()`. Adding `confMu.RLock()` under `zd.mu` is a
+  lock-order inversion (`zd.mu→confMu` vs `confMu→zd.mu`) → deadlock.
+
+## 2. Principle — guard the write, not the reads
+
+Everything in scope is **written once per reload, read constantly otherwise.**
+That is the textbook copy-on-write case: build a new immutable config at reload,
+**atomically publish** it (one pointer swap); readers `Load()` and go, lock-free.
+Same model as the zone snapshot (#279). `confMu` shrinks to serializing reloads
+against each other — it stops gating readers, so the deadlock hazard disappears.
+
+## 3. Design
+
+```go
+// RuntimeConfig is an immutable snapshot of all config that is read at RUNTIME
+// and can change on reload. Never mutated after publish; reload builds a fresh
+// one and swaps the pointer.
+type RuntimeConfig struct {
+    DnssecPolicies map[string]DnssecPolicy      // copy of conf.Internal.DnssecPolicies
+    MultiSigner    map[string]MultiSignerConf   // copy of conf.MultiSigner
+
+    // Scalars currently read from viper at runtime (phase 1 = the racy/hot set):
+    MaxRefresh       uint32
+    MinRefresh       uint32
+    ResignerInterval int    // seconds; replaces the temporary atomic in #286
+    PeriodicResign   bool
+    ServiceDebug     bool
+    // …phase 2 folds in the long-tail viper runtime reads (see §6).
+}
+
+// Published pointer + accessor.
+var liveConfig atomic.Pointer[RuntimeConfig]
+
+// ConfLive returns the current snapshot, never nil (see §5 first-publish).
+func ConfLive() *RuntimeConfig { return liveConfig.Load() }
+```
+
+**Build + publish** — a single helper, called under `confMu` at the end of every
+reload path:
+
+```go
+// buildRuntimeConfig snapshots the just-parsed config into a fresh immutable
+// RuntimeConfig. Copies the maps (small) so the snapshot is independent of the
+// parse-scratch conf.Internal fields. Must run single-threaded (holds confMu).
+func (conf *Config) buildRuntimeConfig() *RuntimeConfig { … }
+
+func (conf *Config) publishRuntimeConfig() { liveConfig.Store(conf.buildRuntimeConfig()) }
+```
+
+Note: `conf.Internal.DnssecPolicies` / `conf.MultiSigner` **stay** as parse
+scratch (written during parse, read only by `buildRuntimeConfig`, both under
+`confMu`). Nothing at runtime reads the plain fields anymore — that keeps the
+parse code untouched and the change to readers only. (A later cleanup can delete
+the plain fields once no one references them.)
+
+## 4. Publish points
+
+All three reload entry points, plus startup, call `publishRuntimeConfig()` as the
+**last** step, under `confMu`:
+
+- **startup** — after the initial `ParseConfig(false)` + `parseDnssecConfig`,
+  **before** any engine goroutine starts (so `ConfLive()` is never nil).
+- `ReloadConfig` (config.go:564) — after `ParseConfig(true)`.
+- `ReloadZoneConfig` (config.go:602) — after `reloadDnssecFromFile` + `ParseZones`,
+  before the `confMu.Unlock()` at :662.
+- `ReloadZone` (zone_utils.go:1122) — after its `reloadDnssecFromFile`.
+
+Each publishes a fresh, fully-consistent snapshot (all fields from the same
+reload epoch — no cross-field skew).
+
+## 5. First-publish / nil-safety
+
+`ConfLive()` must never return nil. Publish an initial snapshot at startup before
+engines start. Belt-and-suspenders: a package `init` (or the accessor) seeds
+`liveConfig` with a zero-value `&RuntimeConfig{}` so an early reader gets safe
+defaults (empty maps, 0 scalars → existing clamps/fallbacks apply) rather than a
+nil deref.
+
+## 6. Reader migration
+
+### Phase 1 — crash-critical + hot (this PR)
+
+| Read today | → |
+|---|---|
+| `conf.Internal.DnssecPolicies[…]` — refreshengine `:274,:276,:414,:618,:621` | `ConfLive().DnssecPolicies[…]` |
+| `conf.Internal.DnssecPolicies[…]` — apihandler_zone `:373,:474` (drop `confMu.RLock`) | `ConfLive().DnssecPolicies[…]` |
+| `conf.MultiSigner[…]` — refreshengine `:283,:434,:628` | `ConfLive().MultiSigner[…]` |
+| `viper.GetInt("service.maxrefresh"/"minrefresh")` — refreshengine `:883,:891` | `ConfLive().MaxRefresh/MinRefresh` |
+| `viper.GetBool("service.debug")` — zone_utils `:331` | `ConfLive().ServiceDebug` |
+| `viper.GetInt("resignerengine.interval")` — sign.go `NeedsResigning` | `ConfLive().ResignerInterval` (removes the temp atomic from #286 23022bf) |
+| `viper.GetInt/GetBool` — resigner.go `:18,:35` | `ConfLive().ResignerInterval/PeriodicResign` |
+
+That set covers both confirmed crashes and the next-in-line (`FindSoaRefresh`).
+
+### Phase 2 — long tail (follow-up, same snapshot)
+
+The remaining runtime viper reads — `delegationsync.*` (`ops_dsync`,
+`delegation_utils`, `delegation_sync`, `childsync_utils`, `sig0_utils`,
+`zone_utils:793/813`), `keystate.*`, `verifyengine.*`, `scanner.*`,
+`validator.*`, `imrengine server.*`, `dnslookup dns.resolvers`,
+`dnsutils external.*` — fold into `RuntimeConfig` fields incrementally. They race
+too, but fire only during their specific operations, so they can land after the
+hot set. **Out of scope permanently:** `v2/cli/*` (separate process) and
+startup-only listener/cert reads (`do53/dot/doh/doq`, trust-anchor files).
+
+## 7. confMu
+
+Still serializes reloads and protects the parse. Readers of the snapshotted
+values **no longer take it** — which is what removes the RefreshEngine
+`zd.mu`↔`confMu` deadlock hazard entirely. API handlers drop their
+`confMu.RLock` around `DnssecPolicies` in favour of `ConfLive()`.
+
+## 8. Testing
+
+- **Race regression:** generalise the existing `-race` test — spawn readers doing
+  `ConfLive().DnssecPolicies[…]` / `.MaxRefresh` while a writer loops
+  `publishRuntimeConfig()`; must be clean under `-race`. (The current
+  viper-specific test folds in.)
+- **Live:** the exact combined stress that crashed twice (query flood +
+  reload-zones storm + config-reload storm, 60s) must **survive**, and a paced
+  reload must still advance RRSIG inception.
+
+## 9. Scope / sequencing
+
+One PR off `main` (**runtime-config-snapshot**, phase 1). It **subsumes** the
+earlier PR-A (viper sweep) + PR-B (map snapshot) split and folds in the temporary
+`NeedsResigning` atomic from #286 (23022bf). Phase-2 long-tail is follow-up PRs
+into the same snapshot — and each one deletes a live viper read, i.e. real
+progress toward removing viper. #286 waits for phase 1, then rebuilds and re-runs
+the load test.
+
+## 10. Open questions
+
+- **Map copy vs move:** phase 1 copies the maps into the snapshot (simple, keeps
+  parse code untouched). If the copy ever matters (it won't at these sizes), move
+  the freshly-built map straight into the snapshot and drop the plain field.
+- **`ReloadTsigConfig`** rewrites TSIG keys, not `RuntimeConfig` fields — no
+  publish needed there (confirm nothing runtime-read moved into scope).
+- Confirm `SplitAlgorithms`/other `conf.Internal` maps really are parse-only (grep
+  showed no engine reads) before relying on that.

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -365,13 +365,10 @@ func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) 
 	if policyName == "" {
 		return "", fmt.Errorf("policy-set: no policy specified")
 	}
-	// Snapshot the resolved policy under confMu: a concurrent config reload
-	// (ReloadZoneConfig / ReloadZone) replaces Conf.Internal.DnssecPolicies
-	// wholesale. pol is a value copy, so we can release the lock immediately
-	// and not hold it across the re-sign below.
-	confMu.RLock()
-	pol, ok := Conf.Internal.DnssecPolicies[policyName]
-	confMu.RUnlock()
+	// Read the resolved policy from the immutable runtime-config snapshot: a
+	// concurrent config reload publishes a new snapshot rather than mutating in
+	// place, so this is lock-free and pol is a stable value copy.
+	pol, ok := ConfLive().DnssecPolicies[policyName]
 	if !ok {
 		return "", fmt.Errorf("policy-set: DNSSEC policy %q does not exist", policyName)
 	}
@@ -470,9 +467,7 @@ func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, erro
 	if policyName == "" {
 		return "", fmt.Errorf("change-policy: no policy specified")
 	}
-	confMu.RLock()
-	pol, ok := Conf.Internal.DnssecPolicies[policyName]
-	confMu.RUnlock()
+	pol, ok := ConfLive().DnssecPolicies[policyName]
 	if !ok {
 		return "", fmt.Errorf("change-policy: DNSSEC policy %q does not exist", policyName)
 	}

--- a/v2/config.go
+++ b/v2/config.go
@@ -579,6 +579,11 @@ func (conf *Config) ReloadConfig() (string, error) {
 			lgConfig.Error("TSIG keys: config error on reload (affected keys skipped)", "err", kerr)
 		}
 	}
+	// Publish the new runtime-config snapshot on a successful reload (still under
+	// confMu); on a parse error keep the last-good snapshot.
+	if err == nil {
+		conf.publishRuntimeConfig()
+	}
 	Globals.App.ServerConfigTime = time.Now()
 	return "Config reloaded.", err
 }
@@ -658,6 +663,10 @@ func (conf *Config) ReloadZoneConfig(ctx context.Context) (string, error) {
 
 	lgConfig.Info("ReloadZones: zones after reloading", "zones", zonelist, "broken", brokenlist)
 	Globals.App.ServerConfigTime = time.Now()
+
+	// Publish the new runtime-config snapshot while still under confMu — the
+	// reloaded DnssecPolicies (via reloadDnssecFromFile above) are now final.
+	conf.publishRuntimeConfig()
 
 	// Capture hook reference before releasing lock to avoid deadlock
 	// if the hook re-enters config paths.

--- a/v2/main_initfuncs.go
+++ b/v2/main_initfuncs.go
@@ -126,6 +126,9 @@ func (conf *Config) MainInit(ctx context.Context, defaultcfg string) error {
 	if err != nil {
 		return fmt.Errorf("error parsing config %q: %w", conf.Internal.CfgFile, err)
 	}
+	// Publish the initial runtime-config snapshot before any engine starts, so
+	// the hot readers (RefreshEngine, signer) never Load() an unpopulated one.
+	conf.publishRuntimeConfig()
 	// KeyDB must exist before TSIG load so LoadTsigKeys can sync keys.tsig into
 	// TsigKeystore and populate the cache from the DB (Auth/Agent init KeyDB in
 	// ParseConfig; Scanner only here).

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/spf13/viper"
 
 	core "github.com/johanix/tdns/v2/core"
 )
@@ -271,16 +270,16 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							// not in the map (e.g. an override pointing to a removed
 							// policy) must not bind a zero-value policy — quarantine
 							// the zone instead.
-							dp := conf.Internal.DnssecPolicies[polName]
+							dp := ConfLive().DnssecPolicies[polName]
 							if polName != "" {
-								if _, exists := conf.Internal.DnssecPolicies[polName]; !exists {
+								if _, exists := ConfLive().DnssecPolicies[polName]; !exists {
 									lgEngine.Error("zone has unknown effective DNSSEC policy, will not be signed", "zone", zone, "policy", polName, "config_policy", zr.DnssecPolicy)
 									zd.SetError(DnssecError, "DNSSEC policy %q does not exist", polName)
 									dp = DnssecPolicy{}
 									polName = ""
 								}
 							}
-							msc := conf.MultiSigner[zr.MultiSigner]
+							msc := ConfLive().MultiSigner[zr.MultiSigner]
 
 							zd.mu.Lock()
 							zd.ZoneStore = zr.ZoneStore
@@ -411,7 +410,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							} else if overridden {
 								polName = eff
 							}
-							if dp, exists := conf.Internal.DnssecPolicies[polName]; exists {
+							if dp, exists := ConfLive().DnssecPolicies[polName]; exists {
 								// Rebind so a same-name policy whose internals changed
 								// on reload (lifetimes, sigvalidity, rollover, ttls, …)
 								// takes effect; the re-sign below converges the zone
@@ -431,7 +430,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							}
 						}
 						if zr.MultiSigner != "" {
-							if msc, exists := conf.MultiSigner[zr.MultiSigner]; exists {
+							if msc, exists := ConfLive().MultiSigner[zr.MultiSigner]; exists {
 								zd.MultiSigner = &msc
 							} else {
 								lgEngine.Warn("MultiSigner config not found, keeping existing", "multisigner", zr.MultiSigner, "zone", zone)
@@ -615,17 +614,17 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 					// A non-empty effective policy name that is not in the map
 					// (e.g. an override to a removed policy) must not bind a
 					// zero-value policy — quarantine the zone after creation.
-					dp := conf.Internal.DnssecPolicies[polName]
+					dp := ConfLive().DnssecPolicies[polName]
 					unknownPolicy := ""
 					if polName != "" {
-						if _, exists := conf.Internal.DnssecPolicies[polName]; !exists {
+						if _, exists := ConfLive().DnssecPolicies[polName]; !exists {
 							lgEngine.Error("dynamic zone has unknown effective DNSSEC policy, will not be signed", "zone", zone, "policy", polName, "config_policy", zr.DnssecPolicy)
 							unknownPolicy = polName
 							dp = DnssecPolicy{}
 							polName = ""
 						}
 					}
-					msc := conf.MultiSigner[zr.MultiSigner]
+					msc := ConfLive().MultiSigner[zr.MultiSigner]
 					// Resolution happens at every ingress path (parse/load/add/
 					// modify/catalog), so a config-bearing refresher always carries
 					// the resolved Primaries alongside the as-written PrimariesConf.
@@ -880,7 +879,7 @@ func FindSoaRefresh(zd *ZoneData) (uint32, error) {
 	// value in the config falls back to the default rather than
 	// wrapping to ~4 billion seconds via the uint32 cast.
 	maxrefresh := defaultMaxRefresh
-	if cfg := viper.GetInt("service.maxrefresh"); cfg > 0 {
+	if cfg := ConfLive().MaxRefresh; cfg > 0 {
 		maxrefresh = uint32(cfg)
 	}
 	if maxrefresh < refresh {
@@ -888,7 +887,7 @@ func FindSoaRefresh(zd *ZoneData) (uint32, error) {
 	}
 
 	minrefresh := defaultMinRefresh
-	if cfg := viper.GetInt("service.minrefresh"); cfg > 0 {
+	if cfg := ConfLive().MinRefresh; cfg > 0 {
 		minrefresh = uint32(cfg)
 	}
 	if minrefresh > refresh {

--- a/v2/resigner.go
+++ b/v2/resigner.go
@@ -6,8 +6,6 @@ package tdns
 import (
 	"context"
 	"time"
-
-	"github.com/spf13/viper"
 )
 
 // func ResignerEngine(zoneresignch chan ZoneRefresher, stopch chan struct{}) {
@@ -15,7 +13,7 @@ func ResignerEngine(ctx context.Context, zoneresignch chan *ZoneData) {
 
 	//	var zoneresignch = conf.Internal.ResignZoneCh
 
-	interval := viper.GetInt("resignerengine.interval")
+	interval := ConfLive().ResignerInterval
 	if interval < 60 {
 		interval = 60
 	}
@@ -32,7 +30,7 @@ func ResignerEngine(ctx context.Context, zoneresignch chan *ZoneData) {
 	// AtomicRollover or other key-state change) are always honored,
 	// regardless of this setting — otherwise rollovers can leave
 	// the DNSKEY RRset signed by a key that's no longer active.
-	periodic := viper.GetBool("service.resign")
+	periodic := ConfLive().PeriodicResign
 	if !periodic {
 		lgSigner.Info("ResignerEngine: periodic mode OFF; explicit triggerResign requests still honored")
 	} else {

--- a/v2/runtime_config.go
+++ b/v2/runtime_config.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package tdns
+
+import (
+	"sync/atomic"
+
+	"github.com/spf13/viper"
+)
+
+// RuntimeConfig is an immutable snapshot of config that is read at RUNTIME and
+// can change on reload. It is never mutated after publish: a reload builds a
+// fresh one and atomically swaps the pointer (copy-on-write). This lets the hot
+// reader paths (RefreshEngine, signer) read reloadable config lock-free instead
+// of racing config reload on shared maps ("fatal error: concurrent map read and
+// map write"). Same model as the zone snapshot. Only the ONE writer (reload) is
+// guarded; the many reads are free.
+//
+// See docs/2026-07-15-runtime-config-snapshot-plan.md.
+type RuntimeConfig struct {
+	// Reloadable maps read outside the parse/API paths. Copied from the
+	// parse-scratch conf fields at publish time so the snapshot is independent
+	// and immutable.
+	DnssecPolicies map[string]DnssecPolicy
+	MultiSigner    map[string]MultiSignerConf
+
+	// Scalars read at runtime (phase 1: the racy/hot set). Stored raw as viper
+	// returned them; readers keep their existing gate/clamp logic.
+	MaxRefresh       int  // service.maxrefresh
+	MinRefresh       int  // service.minrefresh
+	ResignerInterval int  // resignerengine.interval
+	PeriodicResign   bool // service.resign
+	ServiceDebug     bool // service.debug
+}
+
+// liveConfig holds the current published snapshot. Seeded with an empty snapshot
+// so ConfLive() never returns nil for a reader that runs before the first
+// publish (it gets safe zero-value defaults: empty maps, 0 scalars → the
+// readers' existing clamps/fallbacks apply).
+var liveConfig atomic.Pointer[RuntimeConfig]
+
+func init() { liveConfig.Store(&RuntimeConfig{}) }
+
+// ConfLive returns the current runtime-config snapshot. Never nil, lock-free.
+func ConfLive() *RuntimeConfig { return liveConfig.Load() }
+
+// buildRuntimeConfig snapshots the just-parsed config into a fresh immutable
+// RuntimeConfig. Copies the maps (small) so the snapshot does not alias the
+// parse-scratch conf fields. MUST be called single-threaded — the caller holds
+// confMu — after ParseConfig / reloadDnssecFromFile have finalized the config.
+func (conf *Config) buildRuntimeConfig() *RuntimeConfig {
+	pols := make(map[string]DnssecPolicy, len(conf.Internal.DnssecPolicies))
+	for k, v := range conf.Internal.DnssecPolicies {
+		pols[k] = v
+	}
+	ms := make(map[string]MultiSignerConf, len(conf.MultiSigner))
+	for k, v := range conf.MultiSigner {
+		ms[k] = v
+	}
+	return &RuntimeConfig{
+		DnssecPolicies:   pols,
+		MultiSigner:      ms,
+		MaxRefresh:       viper.GetInt("service.maxrefresh"),
+		MinRefresh:       viper.GetInt("service.minrefresh"),
+		ResignerInterval: viper.GetInt("resignerengine.interval"),
+		PeriodicResign:   viper.GetBool("service.resign"),
+		ServiceDebug:     viper.GetBool("service.debug"),
+	}
+}
+
+// publishRuntimeConfig builds a fresh snapshot and atomically publishes it. Call
+// as the last step of startup and of every reload path, while holding confMu.
+func (conf *Config) publishRuntimeConfig() {
+	liveConfig.Store(conf.buildRuntimeConfig())
+}

--- a/v2/runtime_config_race_test.go
+++ b/v2/runtime_config_race_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package tdns
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/spf13/viper"
+)
+
+// TestRuntimeConfigSnapshotNoRace is the regression guard for the
+// "fatal error: concurrent map read and map write" crashes found load-testing
+// the config-reload path. Runtime readers must go through the immutable
+// RuntimeConfig snapshot (ConfLive()), never the parse-scratch conf maps or the
+// global viper — those are rewritten on every reload.
+//
+// Under `-race`: the writer goroutine simulates a reload storm (rewrite viper,
+// rebuild the plain DnssecPolicies map, republish the snapshot) while readers
+// hammer ConfLive() reads and the signer hot path (NeedsResigning). If any
+// reader is reverted to read viper or the plain map, the detector trips.
+func TestRuntimeConfigSnapshotNoRace(t *testing.T) {
+	conf := &Config{}
+	conf.Internal.DnssecPolicies = map[string]DnssecPolicy{"default": {}}
+	conf.MultiSigner = map[string]MultiSignerConf{}
+	conf.publishRuntimeConfig()
+
+	rrsig := &dns.RRSIG{Expiration: uint32(time.Now().Add(time.Hour).Unix())}
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: reload storm — rewrite the global viper, rebuild the parse-scratch
+	// map, republish. All single-threaded within this goroutine (as a real
+	// reload is, under confMu).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		const cfg = "resignerengine:\n    interval: 300\nservice:\n    maxrefresh: 3600\n    minrefresh: 60\n"
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				viper.SetConfigType("yaml")
+				_ = viper.ReadConfig(strings.NewReader(cfg))
+				conf.Internal.DnssecPolicies = map[string]DnssecPolicy{"default": {}}
+				conf.publishRuntimeConfig()
+			}
+		}
+	}()
+
+	// Readers: snapshot reads + the signer hot path.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 5000; j++ {
+				rt := ConfLive()
+				_ = rt.DnssecPolicies["default"]
+				_ = rt.MultiSigner
+				_ = rt.MaxRefresh
+				_ = rt.MinRefresh
+				_ = NeedsResigning(rrsig, 3600)
+			}
+		}()
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -14,7 +14,6 @@ import (
 
 	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
-	"github.com/spf13/viper"
 )
 
 // sig0TTL is the TTL used for SIG(0) records in signed messages.
@@ -238,7 +237,7 @@ func NeedsResigning(rrsig *dns.RRSIG, servedTTL uint32) bool {
 	expirationTime := time.Unix(int64(rrsig.Expiration), 0)
 	remaining := time.Until(expirationTime)
 
-	scanInterval := time.Duration(viper.GetInt("resignerengine.interval")) * time.Second
+	scanInterval := time.Duration(ConfLive().ResignerInterval) * time.Second
 	if scanInterval < 60*time.Second {
 		scanInterval = 60 * time.Second
 	}

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -328,7 +328,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 		cb(zd)
 	}
 
-	if viper.GetBool("service.debug") {
+	if ConfLive().ServiceDebug {
 		fname, err := zd.ZoneFileName()
 		if err != nil {
 			lg.Error("ZoneFileName failed", "zone", zd.ZoneName, "err", err)
@@ -1133,6 +1133,7 @@ func (zd *ZoneData) ReloadZone(refreshCh chan<- ZoneRefresher, force bool, wait 
 	if err := Conf.reloadDnssecFromFile(); err != nil {
 		lg.Error("ReloadZone: failed to re-parse dnssec config, keeping previous policies", "zone", zd.ZoneName, "err", err)
 	}
+	Conf.publishRuntimeConfig()
 	confMu.Unlock()
 
 	var respch = make(chan RefresherResponse, 1)


### PR DESCRIPTION
Fixes a **pre-existing** config-reload data race — a Go `fatal error: concurrent map read and map write` that aborts the process — surfaced while load-testing #286.

## Problem

`config reload` rewrites shared config (`conf.Internal.DnssecPolicies` / `MultiSigner` and the global viper map) while the RefreshEngine and signer read them **without synchronization**. Two crashes were reproduced under a reload-under-load stress:

- signer: `NeedsResigning` → `viper.GetInt` vs reload's `viper.ReadConfig`
- RefreshEngine: `conf.Internal.DnssecPolicies[…]` (refreshengine.go:414) vs reload rebuilding the map

Guarding the *reads* is fragile (the RefreshEngine forgot; the API handlers didn't) and here has a **lock-order inversion** — the RefreshEngine reads under `zd.mu`, while reload takes `confMu`→`zd.mu`, so a `confMu.RLock` at the read would deadlock.

## Fix — guard the write, not the reads

These values are write-once-per-reload, read-constantly → copy-on-write, the same model as the zone snapshot:

- Immutable `RuntimeConfig` behind `atomic.Pointer`, read via `ConfLive()` (lock-free), holding the reloadable maps (`DnssecPolicies`, `MultiSigner`) + the hot runtime-read scalars (`max`/`minrefresh`, resigner interval, periodic-resign, `service.debug`).
- `publishRuntimeConfig()` builds a fresh snapshot and `Store()`s it as the **last step of startup + all three reload paths** (`ReloadConfig`, `ReloadZoneConfig`, `ReloadZone`), under `confMu`.
- Crash-critical/hot readers migrated off the plain maps and viper: RefreshEngine, `apihandler_zone` (**drops its `confMu.RLock`**), `NeedsResigning`, `ResignerEngine`, `zone_utils`.

`confMu` shrinks to serializing reloads against each other — so the RefreshEngine `zd.mu`↔`confMu` deadlock hazard is gone entirely.

## Scope

Phase 1 (design: `docs/2026-07-15-runtime-config-snapshot-plan.md`). The long-tail runtime viper reads (delegation/dsync/bootstrap/scanner/validator) fold into the **same** snapshot as follow-ups — each one deleting a live viper read, chipping toward getting viper out.

**Relation to #286:** pre-existing on `main`; #286 (async reload signing) doesn't cause it, but by making reloads fast it made the race easy to hit. #286 waits for this, then rebuilds and re-runs the load test.

## Verification

- `v2` builds + `go vet` clean; **full `v2` suite green with `-race`**.
- New regression test (`v2/runtime_config_race_test.go`) hammers `ConfLive()` readers + `NeedsResigning` against a reload-simulating (`viper.ReadConfig` + republish) writer under `-race`.
- **Live re-test pending:** rebuild tdns-auth from `main` + this + #286 and re-run the exact combined stress (query flood + reload-zones storm + config-reload storm) that crashed twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved configuration reload consistency by applying updated DNSSEC, refresh, signing, and debug settings atomically.
  * Reduced the risk of inconsistent behavior while zones are refreshed, signed, or reloaded.

* **Bug Fixes**
  * Ensured DNSSEC policy and MultiSigner settings use the latest active configuration.
  * Improved startup and reload handling so runtime settings are available before processing begins.

* **Tests**
  * Added coverage to verify configuration reads remain stable during concurrent reload activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->