### PR TITLE
Transactional DNSSEC-policy apply core + persistence (Plan B, PR 1 of 2)

### DIFF
--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -285,6 +285,11 @@ dnssec:
       # reference this template need only declare their own key lifetimes.
       base:
          algorithm:  ED25519
+         # mode selects the key scheme:
+         #   ksk-zsk  (default) — separate Key-Signing + Zone-Signing keys.
+         #   csk                — a single Combined-Signing Key does both roles.
+         # Omitted → ksk-zsk. An invalid value is rejected at config load.
+         mode:  ksk-zsk
          sigvalidity:
             default:  14d
             dnskey:   30d

--- a/docs/2026-07-15-transactional-policy-reload-decisions.md
+++ b/docs/2026-07-15-transactional-policy-reload-decisions.md
@@ -152,6 +152,19 @@ never fired) and is now unused by policy-reset, which uses
 general keystore-cache-invalidation hardening (all subcommands / external txs)
 remains a separate follow-up (G3).
 
+### D8 — policy-reset is a dry-run without --confirm
+**Decision:** running `zone dnssec policy-reset` WITHOUT `--confirm` is a DRY RUN
+(commit 39bf595): the server runs the guards + computes the per-role decision
+read-only and returns a preview of what the reset WOULD do (which roles would
+roll; whether the parent DS would break) — no key drop, no re-sign, no DB write.
+`--confirm` still gates the actual mutation; the CLI no longer refuses
+client-side, it sends the request so the server can produce the preview.
+**Motivation:** the old behaviour refused without `--confirm` with a generic
+danger lecture, so an operator had to add `--confirm` and re-run *just to discover
+the reset was a no-op*. The per-role decision is already cheap and read-only, so
+previewing it costs nothing and turns the safety gate into useful information
+(esp. "this would be a no-op" and "ZSK-only → DS intact").
+
 ---
 
 ## Deferred to PR-2 (gates)

--- a/docs/2026-07-15-transactional-policy-reload-decisions.md
+++ b/docs/2026-07-15-transactional-policy-reload-decisions.md
@@ -120,6 +120,11 @@ split↔CSK **mode change** is handled conservatively as a full reset with the D
 warning (chosen over trying to keep a former-CSK key as a KSK, whose mixed
 signer semantics aren't worth the risk in a break-glass tool). The no-op case
 (both roles already correct) still re-signs additively + records applied=config.
+The force op strips not only the dropped keys' orphaned RRSIGs but **every
+DNSKEY-covering RRSIG** — on a ZSK-only flip the DNSKEY RRset changed, so the
+kept KSK's DNSKEY RRSIG covers a stale key set (not an orphan; additive re-sign
+won't remove it) — letting the re-sign regenerate exactly one fresh RRSIG per
+active KSK.
 **Motivation:** the original unconditional drop+regenerate-all rolled the KSK
 even for a ZSK-only change → new KSK keytag → the parent DS went stale and the
 chain of trust broke for nothing (confirmed on hardware: MAYO5+MAYO2 →

--- a/docs/2026-07-15-transactional-policy-reload-decisions.md
+++ b/docs/2026-07-15-transactional-policy-reload-decisions.md
@@ -107,6 +107,33 @@ applied-policy DB writes are not ctx-aware anywhere in the tree, so full
 threading is a separate `SignZone`-ctx change; the parameter is carried now so
 that change is drop-in later.
 
+### D7 — policy-reset is surgical (per-role key handling)
+**Decision:** policy-reset forces the zone's active key set to match the config
+policy's algorithms **per role** — keep any key whose algorithm is already
+correct, drop+regenerate only the role(s) whose algorithm changed
+(`zoneActiveKeyRoleChanges` → `forceZoneKeysToPolicyRoles`). A ZSK-only change
+keeps the KSK, so the parent DS stays intact; the DS-break warning fires only
+when the KSK algorithm changed. A role is "changed" if it lacks a right-alg
+active key or carries a wrong-alg one (missing role or mid-rollover mix →
+changed, drop all of that role's keys across every state + regen one). A
+split↔CSK **mode change** is handled conservatively as a full reset with the DS
+warning (chosen over trying to keep a former-CSK key as a KSK, whose mixed
+signer semantics aren't worth the risk in a break-glass tool). The no-op case
+(both roles already correct) still re-signs additively + records applied=config.
+**Motivation:** the original unconditional drop+regenerate-all rolled the KSK
+even for a ZSK-only change → new KSK keytag → the parent DS went stale and the
+chain of trust broke for nothing (confirmed on hardware: MAYO5+MAYO2 →
+MAYO5+MAYO1 dropped the MAYO5 KSK). Surgical per-role handling is the correct
+abrupt hard-flip counterpart to change-policy's gradual roll, and because it
+pre-aligns keys before re-signing it works in strict completeness mode
+(reconcile has nothing to refuse). **Side effect:** removed the clear-only
+post-commit cache invalidation from `f81defa` — it was dead for the plain
+`keystore dnssec clear` CLI path (external tx, so the localtx-gated invalidation
+never fired) and is now unused by policy-reset, which uses
+`forceZoneKeysToPolicyRoles` with its own complete post-commit invalidation. The
+general keystore-cache-invalidation hardening (all subcommands / external txs)
+remains a separate follow-up (G3).
+
 ---
 
 ## Deferred to PR-2 (gates)
@@ -139,3 +166,17 @@ in-flight-ZSK-roll and §5.6 deleted-policy fallback branches, and retargets
 routing + escape hatch); wiring it into the live reload/restart paths is the
 behavioural change and carries the §9 live-matrix merge gate — kept separate so
 each PR is reviewable and independently testable.
+
+### G3 — Generic keystore cache-invalidation hardening (CodeRabbit) — follow-up
+**Decision:** the keystore's `DnssecKeyMgmt` cache invalidations are per-subcommand
+and mid-transaction; several are unlocked map mutations, and the pattern is
+vulnerable to the same uncommitted-window re-cache race across `add` / `generate`
+/ `setstate` / `delete`, and skips post-commit invalidation entirely for
+caller-supplied (external) transactions. Generalizing this — a single locked,
+post-commit invalidation hook that also works with external txs — is a deliberate
+refactor of shared DNSSEC-keystore code, deferred to its own pass.
+**Motivation:** these are pre-existing issues (PR-1 only touched the policy-reset
+path); a broad keystore-cache refactor doesn't belong in a policy-reload PR and
+carries real regression risk on the key store. D4/D7 fixed the one observed
+(policy-reset) path completely via the explicit `refreshActiveDnssecKeys` + the
+force op's own complete post-commit invalidation.

--- a/docs/2026-07-15-transactional-policy-reload-decisions.md
+++ b/docs/2026-07-15-transactional-policy-reload-decisions.md
@@ -125,6 +125,19 @@ DNSKEY-covering RRSIG** — on a ZSK-only flip the DNSKEY RRset changed, so the
 kept KSK's DNSKEY RRSIG covers a stale key set (not an orphan; additive re-sign
 won't remove it) — letting the re-sign regenerate exactly one fresh RRSIG per
 active KSK.
+
+**Review refinements (2c92b97):** (a) the RRSIG strip runs **after** the keystore
+commit, not inside the force op's tx — `forceZoneKeysToPolicyRoles` returns the
+surviving keytags and resetZonePolicy strips via `stripStaleRRSIGsForKeySet`
+post-commit — so a keystore commit failure can never leave the served zone
+published without its signatures. (b) A split↔CSK mode change is detected by
+comparing the reliable **`DnssecPolicy.Mode`** field (the zone's currently-bound
+policy Mode vs the config Mode) — NOT inferred from key shape, which misread a
+split zone transiently missing its ZSK as CSK and wrongly dropped the healthy
+KSK. `Mode` is a real, validated config field (`dnssec_policy.mode:`, default
+`ksk-zsk`), now also surfaced in the auth sample YAML (c2686ce). (c)
+`policyResetReport` takes the target Mode so a CSK replacement reads as "CSK
+algorithm rolled," not "KSK rolled, ZSK kept."
 **Motivation:** the original unconditional drop+regenerate-all rolled the KSK
 even for a ZSK-only change → new KSK keytag → the parent DS went stale and the
 chain of trust broke for nothing (confirmed on hardware: MAYO5+MAYO2 →

--- a/docs/2026-07-15-transactional-policy-reload-decisions.md
+++ b/docs/2026-07-15-transactional-policy-reload-decisions.md
@@ -1,0 +1,141 @@
+# Transactional DNSSEC policy-reload — decisions & motivations
+
+Companion to `2026-07-15-transactional-policy-reload-plan.md`. The plan records
+the *what*; this file records the *why* for the design decisions taken while
+implementing **PR-1** and the review + testbed round on top of it, so the
+motivation survives independently of the plan. PR references are to
+[johanix/tdns#288](https://github.com/johanix/tdns/pull/288).
+
+Each entry is **Decision** + **Motivation** (+ where it lives). This is a log,
+not a spec — when a decision changes, add a dated entry rather than rewriting.
+
+---
+
+## Foundational — Phase-0 design locks
+
+These gate the whole design and are stated in the plan (§5.1/§6.2); repeated
+here because everything below depends on them.
+
+- **① Classification is always applied (from DB) vs intent — never the current
+  in-memory binding.**
+  *Motivation:* on restart the binding is freshly loaded from config and equals
+  intent, so comparing the binding to intent returns "no change" and silently
+  misses a YAML edit. Comparing the *last-applied* record (persisted) to intent
+  detects it. `classifyPolicyChange` is therefore structurally unable to take
+  `zd.DnssecPolicy` as the "old" side.
+
+- **② Applied-missing → backfill `applied = intent` WITHOUT a forced re-sign**
+  when the zone is already signed under intent.
+  *Motivation:* the first reload after upgrade must not re-sign every
+  already-correct config-only zone (thundering herd). The backfill branch is
+  reachable independently of `intent == applied`.
+
+---
+
+## PR-1 decisions
+
+### D1 — No `BenignInternals` classifier class (plan Finding A)
+**Decision:** the classifier has three classes — `None`, `CompatibleName`,
+`IncompatibleAlg`. Same name + same effective algorithms → `None` (this includes
+internals-only edits: lifetimes/sigvalidity/ttls/rollover). Persist the policy
+**name only**, no fingerprint.
+**Motivation:** `resolvePolicyPair` resolves BOTH the applied and intent structs
+from the *same* `ConfLive()` snapshot *by name*, so a "same name, changed
+internals" delta is unreachable at classify time — both sides are the identical
+struct. Internals edits converge via the resigner on the normal cadence, so a
+separate class would be dead weight. (Removed the earlier `BenignInternals`
+value + its `suppressLoadWarnings`-normalized struct compare.)
+
+### D2 — Per-zone apply serialization via a dedicated `policyApplyMu`
+**Decision:** add `ZoneData.policyApplyMu` (distinct from `zd.mu`). The apply
+core acquires it as the OUTERMOST lock across rebind → re-sign → persist →
+revert. `applyZonePolicyTransactional` locks it and delegates to
+`applyZonePolicyTransactionalLocked`; `policy-reset` holds the mutex itself
+across its clear + re-sign and calls the `…Locked` variant.
+**Motivation:** two concurrent applies on one zone could interleave, and a
+failed revert could clobber a newer successful binding. The apply cannot hold
+`zd.mu` across the sign because `SignZone` takes `zd.mu` internally — and a lock
+held *across* `SignZone` is the shape that previously self-deadlocked here
+(`zd.mu` released before `SignZone`, so `policyApplyMu` as an outer lock has no
+ordering inversion). Chose **core-locks + locked-variant** over caller-held so
+the common CLI callers can't forget to lock, while `policy-reset` (which must
+serialize clear+apply as one unit) avoids a double-lock.
+
+### D3 — policy-reset clears persisted records only AFTER a successful re-sign
+**Decision:** order is rebind config → drop+regen keys (`clear`) → refresh key
+cache → `applyZonePolicyTransactionalLocked(source=config)` (writes
+`applied=config`) → clear the CLI override **last**. `applied` is never
+pre-cleared. On a `clear` failure, the in-memory rebind is reverted (its tx
+rolled back, original keys intact). Failure messages: post-key-regen → "run
+`resign`" (keys already correct); pre-regen → "re-run `policy-reset`".
+**Motivation:** the original order cleared the override + applied records and
+dropped keys *before* the fallible re-sign, so a re-sign failure left the zone
+unsigned (SERVFAIL) with its records already gone. Pre-clearing `applied` is
+specifically avoided because, on a failed re-sign, a restart would then see
+"applied missing" and the ② backfill would record `applied=config` on an
+*unsigned* zone — reopening the same SERVFAIL window. Letting the successful
+apply write `applied=config` keeps the record honest.
+
+### D4 — policy-reset stale active-key-cache fix
+**Decision:** `resetZonePolicy` calls `zd.refreshActiveDnssecKeys` after `clear`
+and before the re-sign; additionally `DnssecKeyMgmt` re-invalidates the zone's
+`KeystoreDnskeyCache` entries POST-COMMIT for the `clear` subcommand.
+**Motivation:** the keystore `clear` runs DELETE + regen in one transaction and
+invalidates the cache mid-tx (before commit). A `GetDnssecKeys` during that
+uncommitted window (separate DB connection) re-caches the OLD key set, so the
+in-line re-sign then read stale keys and refused on an algorithm mismatch
+(ED25519 → MAYO5), leaving the zone SERVFAIL until a manual `resign` — the
+testbed failure that triggered this round. The post-commit invalidation closes
+the latent bug for the plain `keystore dnssec clear` path too.
+
+### D5 — `ClearZonePolicyOverride` clears the override only (UPDATE, not DELETE)
+**Decision:** `UPDATE ZonePolicyOverride SET policy='', set_at=NULL WHERE
+zone=?` instead of deleting the row.
+**Motivation:** the override (`policy`/`set_at`, intent) and the last-applied
+record (`applied_*`) share one row but are independent (a config-only zone can
+carry `applied_*` with no override). A full-row DELETE wiped `applied_*` too,
+contradicting that independence. An empty `policy` already reads as "no
+override".
+
+### D6 — `ctx` threaded at the signature, inert at the leaf
+**Decision:** `applyZonePolicyTransactional` and its callers take
+`context.Context` as the first parameter (fed `r.Context()` from the API
+handler), but it is currently unused past the signature.
+**Motivation:** house convention + consistency with `resetZonePolicy` (which
+threads `ctx` into `DnssecKeyMgmt`). The leaf `SignZone(kdb, force)` and the
+applied-policy DB writes are not ctx-aware anywhere in the tree, so full
+threading is a separate `SignZone`-ctx change; the parameter is carried now so
+that change is drop-in later.
+
+---
+
+## Deferred to PR-2 (gates)
+
+### G1 — Backfill "actually signed" predicate (plan §5.5) — MUST close before backfill goes live
+**Decision:** PR-1 ships `backfillAppliedIfEligible` with a **keystore-only**
+predicate (active keys match intent's algorithms). Strengthening it to also
+require the zone to actually SERVE a signature by an active intent-algorithm key
+is deferred to PR-2. The exact recipe and the constraint are captured in the
+function's `⚠ PR-2 GATE` doc-comment.
+**Motivation:** algorithm-matched keys are necessary but not sufficient — a zone
+can hold the right active keys yet be unsigned (fresh keygen with no sign; a
+secondary whose stored RRSIGs are absent/stale). But the served-RRSIG check
+reads zone data (`zd.GetRRset` → needs `zd.Ready` + a populated snapshot), which
+couples it to the (PR-2) refresh-engine call site: that call MUST run *after* the
+zone snapshot is Ready, NOT the pre-`initialLoadZone` placement §5.5 line 516
+floats for a keystore-only predicate. Landing the stricter predicate now, in
+isolation, would be either untestable (needs a signed-snapshot fixture) or a
+trap — it fails closed when the snapshot isn't ready, forcing a re-sign of every
+config-only zone and defeating blocking-②. Safe to defer because backfill has no
+production caller in PR-1 (unit tests only).
+
+### G2 — Refresh-engine wiring (the rest of the plan)
+**Decision:** the three refresh-engine sites (reload / restart-first-bind /
+dynamic) are wired through `resolvePolicyPair → backfill → classify →
+apply/refuse` in PR-2, which also removes `applyReloadedPolicyLocked`, adds the
+in-flight-ZSK-roll and §5.6 deleted-policy fallback branches, and retargets
+`reload_policy_alg_guard_test.go` to applied-vs-intent.
+**Motivation:** PR-1 is the foundation (persistence + transactional core + CLI
+routing + escape hatch); wiring it into the live reload/restart paths is the
+behavioural change and carries the §9 live-matrix merge gate — kept separate so
+each PR is reviewable and independently testable.

--- a/guide/config-tdns-auth.md
+++ b/guide/config-tdns-auth.md
@@ -436,6 +436,10 @@ dnssec:
 required. It is not a per-key-role setting: there is no `sigvalidity` under
 `ksk:` or `zsk:`, and those sub-blocks carry only `lifetime` and `algorithm`.
 
+`mode` selects the key scheme: `ksk-zsk` (the default when omitted) uses
+separate Key-Signing and Zone-Signing keys; `csk` uses a single Combined-Signing
+Key for both roles. An invalid value is rejected at config load.
+
 Durations accept Go duration strings plus a `d` (days) or `w` (weeks) suffix on
 a plain integer: `14d`, `2w`, `90m`. Key lifetimes additionally accept
 `forever` and `none`.

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -608,34 +608,62 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 	lgApi.Warn("policy-reset: forcing a zone off its DNSSEC policy — DROPPING keys and BREAKING the chain of trust until the parent DS is re-published",
 		"zone", zd.ZoneName, "config_policy", configName)
 
-	// 1) Clear both persisted records so the zone falls back to its config base.
-	if err := ClearZonePolicyOverride(kdb, zd.ZoneName); err != nil {
-		return "", fmt.Errorf("policy-reset: clearing CLI override for zone %s: %w", zd.ZoneName, err)
-	}
-	if err := ClearZoneAppliedPolicy(kdb, zd.ZoneName); err != nil {
-		return "", fmt.Errorf("policy-reset: clearing applied-policy record for zone %s: %w", zd.ZoneName, err)
-	}
+	// Serialize the WHOLE reset (rebind → drop+regen keys → re-sign → clear
+	// override) against concurrent policy applies on this zone. We hold
+	// policyApplyMu ourselves and call the *Locked apply variant below to avoid a
+	// double-lock (applyZonePolicyTransactional would otherwise re-acquire it).
+	zd.policyApplyMu.Lock()
+	defer zd.policyApplyMu.Unlock()
 
-	// 2) Rebind to the config policy BEFORE dropping keys, so the keystore
+	// 1) Rebind to the config policy BEFORE dropping keys, so the keystore
 	// `clear` path regenerates fresh active keys under the CONFIG algorithm (it
-	// reads zd.DnssecPolicy from the live zone).
+	// reads zd.DnssecPolicy from the live zone). Snapshot the old binding so we
+	// can restore it if the key drop fails (its tx rolls back — see below).
 	zd.mu.Lock()
+	oldPol := zd.DnssecPolicy
+	oldName := zd.DnssecPolicyName
 	zd.DnssecPolicy = &pol
 	zd.DnssecPolicyName = configName
 	zd.mu.Unlock()
 
-	// 3) Drop the zone's DNSSEC keys and regenerate under the config policy,
+	// 2) Drop the zone's DNSSEC keys and regenerate under the config policy,
 	// stripping the old keys' now-orphaned RRSIGs. Reuse the keystore `clear`
 	// path (delete all keys → regen 1 active KSK + 1 active ZSK → strip orphans).
+	// It runs in its own transaction: on failure it rolls back, leaving the
+	// ORIGINAL keys and every persisted record untouched, so we just restore the
+	// in-memory binding and tell the operator to retry.
 	if _, err := kdb.DnssecKeyMgmt(ctx, nil, KeystorePost{Command: "dnssec", SubCommand: "clear", Zone: zd.ZoneName}); err != nil {
-		return "", fmt.Errorf("policy-reset: dropping/regenerating keys for zone %s FAILED — the CLI override and applied-policy records were ALREADY cleared (zone now falls back to config policy %q) and its keys may be partially dropped; re-run `zone dnssec policy-reset --confirm` or restart to converge: %w", zd.ZoneName, configName, err)
+		zd.mu.Lock()
+		zd.DnssecPolicy = oldPol
+		zd.DnssecPolicyName = oldName
+		zd.mu.Unlock()
+		return "", fmt.Errorf("policy-reset: dropping/regenerating keys for zone %s FAILED — no persisted records were changed and the original keys are intact; re-run `zone dnssec policy-reset --confirm`: %w", zd.ZoneName, err)
 	}
 
-	// 4) Re-sign under the config policy and record applied = config through the
-	// shared transactional core (source config → no CLI override written).
-	newrrsigs, err := applyZonePolicyTransactional(ctx, zd, kdb, &pol, configName, PolicyApplySourceConfig)
+	// 3) Force a fresh active-key read before re-signing. `clear` regenerated the
+	// keys inside its transaction and invalidated the active-key cache mid-tx; a
+	// read during that uncommitted window can re-cache the OLD set, which would
+	// make the re-sign refuse on an algorithm mismatch. Re-fetch from the now
+	// committed DB. From here on the new config-policy keys ARE committed, so any
+	// later failure means "run resign" — NOT re-run policy-reset.
+	if _, err := zd.refreshActiveDnssecKeys(kdb, "policy-reset: after key regen"); err != nil {
+		return "", fmt.Errorf("policy-reset: re-reading regenerated keys for zone %s FAILED — the new config-policy keys are already in the keystore but the zone is not yet re-signed; run `zone dnssec resign -z %s` to converge: %w", zd.ZoneName, zd.ZoneName, err)
+	}
+
+	// 4) Re-sign under the config policy and record applied=config through the
+	// shared core (source config → no CLI override written). We already hold
+	// policyApplyMu, so call the *Locked variant.
+	newrrsigs, err := applyZonePolicyTransactionalLocked(ctx, zd, kdb, &pol, configName, PolicyApplySourceConfig)
 	if err != nil {
-		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q FAILED — keys were dropped/regenerated and the override+applied records ALREADY cleared, so the zone is unsigned until it re-signs; re-run `zone dnssec policy-reset --confirm` or restart to converge: %w", zd.ZoneName, configName, err)
+		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q FAILED — the new config-policy keys are already in the keystore, so run `zone dnssec resign -z %s` to converge (do NOT re-run policy-reset): %w", zd.ZoneName, configName, zd.ZoneName, err)
+	}
+
+	// 5) Only now that the zone is signed under config and applied=config is
+	// recorded, clear any stale CLI override so intent matches reality. Done LAST
+	// so a failure here cannot strand an unsigned zone; it clears only the
+	// override (applied_* is preserved).
+	if err := ClearZonePolicyOverride(kdb, zd.ZoneName); err != nil {
+		return "", fmt.Errorf("policy-reset: zone %s is signed under config policy %q and applied=config recorded, but clearing the stale CLI override FAILED — the override still points at the old policy and a later reload may refuse it; bind the config policy explicitly with `zone dnssec policy-set -z %s -p %s`: %w", zd.ZoneName, configName, zd.ZoneName, configName, err)
 	}
 
 	var b strings.Builder

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -620,7 +620,17 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 	// whose active-key algorithm already matches config, roll only the one that
 	// changed. Computed under policyApplyMu so the decision and the key mutation
 	// are atomic w.r.t. other applies. kskChanged ⇒ the parent DS breaks.
-	kskChanged, zskChanged, err := zoneActiveKeyRoleChanges(kdb, zd.ZoneName, &pol)
+	// currentMode is the zone's currently-bound policy Mode, read BEFORE the
+	// rebind: a genuine split↔CSK mode change is detected from that reliable field,
+	// not inferred from key shape (which would misread a split zone missing its ZSK
+	// as CSK and wrongly drop the KSK).
+	currentMode := ""
+	zd.mu.Lock()
+	if zd.DnssecPolicy != nil {
+		currentMode = zd.DnssecPolicy.Mode
+	}
+	zd.mu.Unlock()
+	kskChanged, zskChanged, err := zoneActiveKeyRoleChanges(kdb, zd.ZoneName, &pol, currentMode)
 	if err != nil {
 		return "", fmt.Errorf("policy-reset: inspecting active keys for zone %s: %w", zd.ZoneName, err)
 	}
@@ -649,28 +659,37 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 
 	// 2) Surgically drop+regenerate only the changed role(s), keeping any key
 	// whose algorithm is already correct — so a ZSK-only change leaves the KSK
-	// (and the parent DS) untouched. Atomic; strips the dropped keys' orphaned
-	// RRSIGs. Skipped entirely when nothing changed. On failure the tx rolled back
-	// (original keys intact) → restore the binding and tell the operator to retry.
+	// (and the parent DS) untouched. Skipped entirely when nothing changed. The
+	// keystore mutation is atomic: on failure the tx rolled back (original keys
+	// intact) → restore the binding and tell the operator to retry.
 	if kskChanged || zskChanged {
-		if err := kdb.forceZoneKeysToPolicyRoles(ctx, zd, &pol, kskChanged, zskChanged); err != nil {
+		surviving, ferr := kdb.forceZoneKeysToPolicyRoles(zd, &pol, kskChanged, zskChanged)
+		if ferr != nil {
 			zd.mu.Lock()
 			zd.DnssecPolicy = oldPol
 			zd.DnssecPolicyName = oldName
 			zd.mu.Unlock()
-			return "", fmt.Errorf("policy-reset: dropping/regenerating the changed key role(s) for zone %s FAILED — no persisted records were changed and the original keys are intact; re-run `zone dnssec policy-reset --confirm`: %w", zd.ZoneName, err)
+			return "", fmt.Errorf("policy-reset: dropping/regenerating the changed key role(s) for zone %s FAILED — no persisted records were changed and the original keys are intact; re-run `zone dnssec policy-reset --confirm`: %w", zd.ZoneName, ferr)
+		}
+
+		// The new key set is now COMMITTED. Every failure from here means "run
+		// resign" — NOT re-run policy-reset.
+		//
+		// 2a) Force a fresh active-key read: the regen invalidated the cache, and a
+		// stale read would make the re-sign refuse on an algorithm mismatch.
+		if _, err := zd.refreshActiveDnssecKeys(kdb, "policy-reset: after key regen"); err != nil {
+			return "", fmt.Errorf("policy-reset: re-reading regenerated keys for zone %s FAILED — the new config-policy keys are already in the keystore but the zone is not yet re-signed; run `zone dnssec resign -z %s` to converge: %w", zd.ZoneName, zd.ZoneName, err)
+		}
+		// 2b) Strip the now-stale served signatures (orphans + every DNSKEY RRSIG)
+		// AFTER the keystore commit and BEFORE the re-sign regenerates fresh ones.
+		// Doing this post-commit is what makes the whole reset transactionally safe:
+		// a keystore commit failure can never leave the served zone unsigned.
+		if _, err := stripStaleRRSIGsForKeySet(ctx, zd, surviving); err != nil {
+			return "", fmt.Errorf("policy-reset: stripping stale signatures for zone %s FAILED — the new config-policy keys are already in the keystore but the zone is not yet re-signed; run `zone dnssec resign -z %s` to converge: %w", zd.ZoneName, zd.ZoneName, err)
 		}
 	}
 
-	// 3) Force a fresh active-key read before re-signing: the regen invalidated
-	// the active-key cache within its tx, and a stale read would make the re-sign
-	// refuse on an algorithm mismatch. From here on the new keys ARE committed, so
-	// any later failure means "run resign" — NOT re-run policy-reset.
-	if _, err := zd.refreshActiveDnssecKeys(kdb, "policy-reset: after key regen"); err != nil {
-		return "", fmt.Errorf("policy-reset: re-reading regenerated keys for zone %s FAILED — the new config-policy keys are already in the keystore but the zone is not yet re-signed; run `zone dnssec resign -z %s` to converge: %w", zd.ZoneName, zd.ZoneName, err)
-	}
-
-	// 4) Re-sign under the config policy and record applied=config through the
+	// 3) Re-sign under the config policy and record applied=config through the
 	// shared core (source config → no CLI override written). We already hold
 	// policyApplyMu, so call the *Locked variant.
 	newrrsigs, err := applyZonePolicyTransactionalLocked(ctx, zd, kdb, &pol, configName, PolicyApplySourceConfig)
@@ -678,7 +697,7 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q FAILED — the config-policy keys are already in the keystore, so run `zone dnssec resign -z %s` to converge (do NOT re-run policy-reset): %w", zd.ZoneName, configName, zd.ZoneName, err)
 	}
 
-	// 5) Only now that the zone is signed under config and applied=config is
+	// 4) Only now that the zone is signed under config and applied=config is
 	// recorded, clear any stale CLI override so intent matches reality. Done LAST
 	// so a failure here cannot strand an unsigned zone; it clears only the
 	// override (applied_* is preserved).
@@ -686,7 +705,7 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 		return "", fmt.Errorf("policy-reset: zone %s is signed under config policy %q and applied=config recorded, but clearing the stale CLI override FAILED — the override still points at the old policy and a later reload may refuse it; bind the config policy explicitly with `zone dnssec policy-set -z %s -p %s`: %w", zd.ZoneName, configName, zd.ZoneName, configName, err)
 	}
 
-	return policyResetReport(zd.ZoneName, configName, kskChanged, zskChanged, newrrsigs), nil
+	return policyResetReport(zd.ZoneName, configName, pol.Mode, kskChanged, zskChanged, newrrsigs), nil
 }
 
 func APIzoneDsync(ctx context.Context, app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w http.ResponseWriter, r *http.Request) {

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -560,20 +560,24 @@ func changeZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, policyName 
 	return b.String(), nil
 }
 
-// resetZonePolicy is the `zone dnssec policy-reset` escape hatch (test/lab;
-// DANGEROUS). An abrupt policy switch that changes a zone's KSK/ZSK ALGORITHM is
-// refused by design — it needs a key rollover that is not built — which is
-// correct for production but blocks iteration on test zones. policy-reset forces
-// it: DROP the zone's DNSSEC keys, clear BOTH persisted policy records (the CLI
-// override AND the last-applied record) so the zone falls back to its config
-// dnssec_policy, and re-sign from scratch under that config policy.
+// resetZonePolicy is the `zone dnssec policy-reset` escape hatch (test/lab). An
+// abrupt policy switch that changes a zone's KSK/ZSK ALGORITHM is refused by
+// design — it needs a key rollover that is not built — which is correct for
+// production but blocks iteration on test zones. policy-reset forces the zone's
+// active key set to match the config policy's algorithms per role, then re-signs
+// under config, records applied=config, and clears the CLI override.
 //
-// This BREAKS THE CHAIN OF TRUST: the parent DS no longer matches the freshly
-// generated KSK, so validators go BOGUS until the operator re-publishes the DS.
-// The only gates are --confirm and naming a single zone (same posture as rm -f).
+// It is SURGICAL: only the role(s) whose algorithm actually changed are dropped
+// and regenerated; a key whose algorithm is already correct is kept. So a
+// ZSK-only change keeps the KSK and the parent DS INTACT (no warning); only a KSK
+// algorithm change (or a CSK alg / mode change) breaks the chain of trust — the
+// parent DS no longer matches the new KSK and validators go BOGUS until the
+// operator re-publishes the DS. Because it pre-aligns the keys before re-signing,
+// it works even in strict completeness mode (reconcile has nothing to refuse).
+// The only gates are --confirm and naming a single zone.
 func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool) (string, error) {
 	if !confirm {
-		return "", fmt.Errorf("policy-reset: refusing without --confirm — this DROPS zone %s's DNSSEC keys and breaks the chain of trust until the parent DS is re-published", zd.ZoneName)
+		return "", fmt.Errorf("policy-reset: refusing without --confirm — this drops and regenerates zone %s's DNSSEC keys for any role whose algorithm changed, and breaks the chain of trust (until the parent DS is re-published) if the KSK algorithm changed", zd.ZoneName)
 	}
 
 	// Resolve the zone's CONFIG-base policy (its YAML dnssec_policy) — what the
@@ -605,20 +609,37 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 		return "", fmt.Errorf("policy-reset: zone %s is not signed (neither online-signing nor inline-signing)", zd.ZoneName)
 	}
 
-	lgApi.Warn("policy-reset: forcing a zone off its DNSSEC policy — DROPPING keys and BREAKING the chain of trust until the parent DS is re-published",
-		"zone", zd.ZoneName, "config_policy", configName)
-
-	// Serialize the WHOLE reset (rebind → drop+regen keys → re-sign → clear
-	// override) against concurrent policy applies on this zone. We hold
-	// policyApplyMu ourselves and call the *Locked apply variant below to avoid a
-	// double-lock (applyZonePolicyTransactional would otherwise re-acquire it).
+	// Serialize the WHOLE reset (per-role decision → drop/regen the changed
+	// role(s) → re-sign → clear override) against concurrent policy applies on
+	// this zone. We hold policyApplyMu ourselves and call the *Locked apply
+	// variant below to avoid a double-lock.
 	zd.policyApplyMu.Lock()
 	defer zd.policyApplyMu.Unlock()
 
-	// 1) Rebind to the config policy BEFORE dropping keys, so the keystore
-	// `clear` path regenerates fresh active keys under the CONFIG algorithm (it
-	// reads zd.DnssecPolicy from the live zone). Snapshot the old binding so we
-	// can restore it if the key drop fails (its tx rolls back — see below).
+	// Decide, per role, which key(s) must be dropped+regenerated: keep a role
+	// whose active-key algorithm already matches config, roll only the one that
+	// changed. Computed under policyApplyMu so the decision and the key mutation
+	// are atomic w.r.t. other applies. kskChanged ⇒ the parent DS breaks.
+	kskChanged, zskChanged, err := zoneActiveKeyRoleChanges(kdb, zd.ZoneName, &pol)
+	if err != nil {
+		return "", fmt.Errorf("policy-reset: inspecting active keys for zone %s: %w", zd.ZoneName, err)
+	}
+
+	switch {
+	case kskChanged:
+		lgApi.Warn("policy-reset: KSK algorithm changing — DROPPING the KSK and BREAKING the chain of trust until the parent DS is re-published",
+			"zone", zd.ZoneName, "config_policy", configName, "zsk_changed", zskChanged)
+	case zskChanged:
+		lgApi.Info("policy-reset: rolling the ZSK algorithm only (KSK and parent DS unchanged)",
+			"zone", zd.ZoneName, "config_policy", configName)
+	default:
+		lgApi.Info("policy-reset: active keys already match config — no key roll, re-signing only",
+			"zone", zd.ZoneName, "config_policy", configName)
+	}
+
+	// 1) Rebind to the config policy BEFORE mutating keys, so regeneration and the
+	// re-sign use the CONFIG algorithms. Snapshot the old binding to restore it if
+	// the key mutation fails (its tx rolls back, leaving the original keys intact).
 	zd.mu.Lock()
 	oldPol := zd.DnssecPolicy
 	oldName := zd.DnssecPolicyName
@@ -626,26 +647,25 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 	zd.DnssecPolicyName = configName
 	zd.mu.Unlock()
 
-	// 2) Drop the zone's DNSSEC keys and regenerate under the config policy,
-	// stripping the old keys' now-orphaned RRSIGs. Reuse the keystore `clear`
-	// path (delete all keys → regen 1 active KSK + 1 active ZSK → strip orphans).
-	// It runs in its own transaction: on failure it rolls back, leaving the
-	// ORIGINAL keys and every persisted record untouched, so we just restore the
-	// in-memory binding and tell the operator to retry.
-	if _, err := kdb.DnssecKeyMgmt(ctx, nil, KeystorePost{Command: "dnssec", SubCommand: "clear", Zone: zd.ZoneName}); err != nil {
-		zd.mu.Lock()
-		zd.DnssecPolicy = oldPol
-		zd.DnssecPolicyName = oldName
-		zd.mu.Unlock()
-		return "", fmt.Errorf("policy-reset: dropping/regenerating keys for zone %s FAILED — no persisted records were changed and the original keys are intact; re-run `zone dnssec policy-reset --confirm`: %w", zd.ZoneName, err)
+	// 2) Surgically drop+regenerate only the changed role(s), keeping any key
+	// whose algorithm is already correct — so a ZSK-only change leaves the KSK
+	// (and the parent DS) untouched. Atomic; strips the dropped keys' orphaned
+	// RRSIGs. Skipped entirely when nothing changed. On failure the tx rolled back
+	// (original keys intact) → restore the binding and tell the operator to retry.
+	if kskChanged || zskChanged {
+		if err := kdb.forceZoneKeysToPolicyRoles(ctx, zd, &pol, kskChanged, zskChanged); err != nil {
+			zd.mu.Lock()
+			zd.DnssecPolicy = oldPol
+			zd.DnssecPolicyName = oldName
+			zd.mu.Unlock()
+			return "", fmt.Errorf("policy-reset: dropping/regenerating the changed key role(s) for zone %s FAILED — no persisted records were changed and the original keys are intact; re-run `zone dnssec policy-reset --confirm`: %w", zd.ZoneName, err)
+		}
 	}
 
-	// 3) Force a fresh active-key read before re-signing. `clear` regenerated the
-	// keys inside its transaction and invalidated the active-key cache mid-tx; a
-	// read during that uncommitted window can re-cache the OLD set, which would
-	// make the re-sign refuse on an algorithm mismatch. Re-fetch from the now
-	// committed DB. From here on the new config-policy keys ARE committed, so any
-	// later failure means "run resign" — NOT re-run policy-reset.
+	// 3) Force a fresh active-key read before re-signing: the regen invalidated
+	// the active-key cache within its tx, and a stale read would make the re-sign
+	// refuse on an algorithm mismatch. From here on the new keys ARE committed, so
+	// any later failure means "run resign" — NOT re-run policy-reset.
 	if _, err := zd.refreshActiveDnssecKeys(kdb, "policy-reset: after key regen"); err != nil {
 		return "", fmt.Errorf("policy-reset: re-reading regenerated keys for zone %s FAILED — the new config-policy keys are already in the keystore but the zone is not yet re-signed; run `zone dnssec resign -z %s` to converge: %w", zd.ZoneName, zd.ZoneName, err)
 	}
@@ -655,7 +675,7 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 	// policyApplyMu, so call the *Locked variant.
 	newrrsigs, err := applyZonePolicyTransactionalLocked(ctx, zd, kdb, &pol, configName, PolicyApplySourceConfig)
 	if err != nil {
-		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q FAILED — the new config-policy keys are already in the keystore, so run `zone dnssec resign -z %s` to converge (do NOT re-run policy-reset): %w", zd.ZoneName, configName, zd.ZoneName, err)
+		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q FAILED — the config-policy keys are already in the keystore, so run `zone dnssec resign -z %s` to converge (do NOT re-run policy-reset): %w", zd.ZoneName, configName, zd.ZoneName, err)
 	}
 
 	// 5) Only now that the zone is signed under config and applied=config is
@@ -666,12 +686,7 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 		return "", fmt.Errorf("policy-reset: zone %s is signed under config policy %q and applied=config recorded, but clearing the stale CLI override FAILED — the override still points at the old policy and a later reload may refuse it; bind the config policy explicitly with `zone dnssec policy-set -z %s -p %s`: %w", zd.ZoneName, configName, zd.ZoneName, configName, err)
 	}
 
-	var b strings.Builder
-	fmt.Fprintf(&b, "Zone %s: DNSSEC policy RESET to config policy %q; dropped the old keys and generated fresh ones (%d new RRSIGs).\n",
-		zd.ZoneName, configName, newrrsigs)
-	b.WriteString("WARNING: this was an ABRUPT switch that BREAKS the chain of trust — the parent DS no longer matches the new KSK.\n")
-	b.WriteString("NOTE: validators will go BOGUS until the new DS is published at the parent (via the auto-rollover engine or a manual DS update).")
-	return b.String(), nil
+	return policyResetReport(zd.ZoneName, configName, kskChanged, zskChanged, newrrsigs), nil
 }
 
 func APIzoneDsync(ctx context.Context, app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w http.ResponseWriter, r *http.Request) {

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -113,6 +113,13 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 				resp.ErrorMsg = err.Error()
 			}
 
+		case "policy-reset":
+			resp.Msg, err = resetZonePolicy(r.Context(), zd, kdb, zp.Force)
+			if err != nil {
+				resp.Error = true
+				resp.ErrorMsg = err.Error()
+			}
+
 		case "proxy-key":
 			resp.Msg, err = zd.ProxyKeyStatus(context.Background(), kdb, Globals.ImrEngine)
 			if err != nil {
@@ -379,11 +386,12 @@ func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) 
 		return "", fmt.Errorf("policy-set: zone %s is not signed (neither online-signing nor inline-signing)", zd.ZoneName)
 	}
 
-	// Capture the current policy (pointer + name + algorithms) before rebinding,
-	// so we can report the transition, decide whether it double-signs, and
-	// restore it if the re-sign fails.
+	// Capture the current policy name + algorithms for the operator message
+	// (transition wording + whether the change transiently double-signs). This
+	// is for REPORTING ONLY — the transactional core snapshots its own state for
+	// revert-on-failure and must never be handed the in-memory binding to
+	// classify against (design lock ①).
 	zd.mu.Lock()
-	oldPol := zd.DnssecPolicy
 	oldName := zd.DnssecPolicyName
 	var oldKSKAlg, oldZSKAlg uint8
 	if zd.DnssecPolicy != nil {
@@ -394,31 +402,15 @@ func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) 
 	// alongside the retired old ones — the zone is transiently double-signed.
 	algChanged := oldKSKAlg != pol.KSKAlgorithm || oldZSKAlg != pol.ZSKAlgorithm
 
-	// Rebind and re-sign FIRST; only persist the durable override after the
-	// re-sign succeeds. Otherwise a sign failure would leave a persisted
-	// override (surviving restart) for a policy the zone was never actually
-	// signed under. On failure, restore the previous in-memory binding.
-	zd.mu.Lock()
-	zd.DnssecPolicy = &pol
-	zd.DnssecPolicyName = policyName
-	zd.mu.Unlock()
-
-	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm, false)
-
-	// Additive sign: reconcile (retire wrong-alg, generate new) + add new-key
-	// RRSIGs, leaving the retired keys' RRSIGs in place for a graceful
+	// Rebind → re-sign → persist applied + CLI override, transactionally: on a
+	// sign failure the shared core reverts the in-memory binding and persists
+	// nothing, so the zone is never left bound to a policy it was not signed
+	// under. The additive sign reconciles (retire wrong-alg, generate new) and
+	// adds new-key RRSIGs, leaving retired keys' RRSIGs in place for a graceful
 	// transition.
-	newrrsigs, err := zd.SignZone(kdb, true)
+	newrrsigs, err := applyZonePolicyTransactional(zd, kdb, &pol, policyName, PolicyApplySourceCommand)
 	if err != nil {
-		zd.mu.Lock()
-		zd.DnssecPolicy = oldPol
-		zd.DnssecPolicyName = oldName
-		zd.mu.Unlock()
-		return "", fmt.Errorf("policy-set: re-sign zone %s: %w", zd.ZoneName, err)
-	}
-
-	if err := SetZonePolicyOverride(kdb, zd.ZoneName, policyName); err != nil {
-		return "", fmt.Errorf("policy-set: zone re-signed but persisting the override failed (the change will not survive restart): %w", err)
+		return "", fmt.Errorf("policy-set: %w", err)
 	}
 
 	// Build an explicit, multi-line message: a live DNSSEC policy change is
@@ -537,29 +529,17 @@ func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, erro
 			zd.ZoneName, dns.AlgorithmToString[curZSKAlg], dns.AlgorithmToString[pol.ZSKAlgorithm])
 	}
 
-	// --- Bind the target: reuse set-policy's override-write + rebind + sign.
-	// In relaxed mode the reconcile no-ops the synchronous swap, so SignZone
-	// here only adds RRSIGs by the (unchanged) active keys + re-stages the
-	// pipeline; no old-alg active ZSK is retired. ---
+	// --- Bind the target via the shared transactional core (rebind → re-sign →
+	// persist applied + CLI override, revert on failure). In relaxed mode the
+	// reconcile no-ops the synchronous swap, so SignZone here only adds RRSIGs by
+	// the (unchanged) active keys + re-stages the pipeline; no old-alg active ZSK
+	// is retired. ---
 	zd.mu.Lock()
-	oldPol := zd.DnssecPolicy
 	oldName := zd.DnssecPolicyName
-	zd.DnssecPolicy = &pol
-	zd.DnssecPolicyName = policyName
 	zd.mu.Unlock()
 
-	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm, false)
-
-	if _, err := zd.SignZone(kdb, true); err != nil {
-		zd.mu.Lock()
-		zd.DnssecPolicy = oldPol
-		zd.DnssecPolicyName = oldName
-		zd.mu.Unlock()
-		return "", fmt.Errorf("change-policy: re-sign zone %s: %w", zd.ZoneName, err)
-	}
-
-	if err := SetZonePolicyOverride(kdb, zd.ZoneName, policyName); err != nil {
-		return "", fmt.Errorf("change-policy: zone bound but persisting the override failed (the change will not survive restart): %w", err)
+	if _, err := applyZonePolicyTransactional(zd, kdb, &pol, policyName, PolicyApplySourceCommand); err != nil {
+		return "", fmt.Errorf("change-policy: %w", err)
 	}
 
 	var b strings.Builder
@@ -577,6 +557,88 @@ func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, erro
 	}
 	b.WriteString("WARNING: the policy change is stored in the keystore, not the zone config.\n")
 	fmt.Fprintf(&b, "NOTE: update the zone's dnssec_policy in YAML to make %q the permanent policy.", policyName)
+	return b.String(), nil
+}
+
+// resetZonePolicy is the `zone dnssec policy-reset` escape hatch (test/lab;
+// DANGEROUS). An abrupt policy switch that changes a zone's KSK/ZSK ALGORITHM is
+// refused by design — it needs a key rollover that is not built — which is
+// correct for production but blocks iteration on test zones. policy-reset forces
+// it: DROP the zone's DNSSEC keys, clear BOTH persisted policy records (the CLI
+// override AND the last-applied record) so the zone falls back to its config
+// dnssec_policy, and re-sign from scratch under that config policy.
+//
+// This BREAKS THE CHAIN OF TRUST: the parent DS no longer matches the freshly
+// generated KSK, so validators go BOGUS until the operator re-publishes the DS.
+// The only gates are --confirm and naming a single zone (same posture as rm -f).
+func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool) (string, error) {
+	if !confirm {
+		return "", fmt.Errorf("policy-reset: refusing without --confirm — this DROPS zone %s's DNSSEC keys and breaks the chain of trust until the parent DS is re-published", zd.ZoneName)
+	}
+
+	// Resolve the zone's CONFIG-base policy (its YAML dnssec_policy) — what the
+	// zone falls back to once the override + applied records are cleared. Read
+	// the name from Conf.Zones (as the list-zones handler does) and the struct
+	// from the ConfLive() snapshot (lock-free).
+	var configName string
+	for i := range Conf.Zones {
+		if dns.Fqdn(Conf.Zones[i].Name) == zd.ZoneName {
+			configName = strings.TrimSpace(Conf.Zones[i].DnssecPolicy)
+			break
+		}
+	}
+	if configName == "" {
+		return "", fmt.Errorf("policy-reset: zone %s has no config-base dnssec_policy to reset to (dynamic/API-managed zones are not supported)", zd.ZoneName)
+	}
+	pol, ok := ConfLive().DnssecPolicies[configName]
+	if !ok {
+		return "", fmt.Errorf("policy-reset: config dnssec_policy %q for zone %s does not exist", configName, zd.ZoneName)
+	}
+	if pol.Error != "" {
+		return "", fmt.Errorf("policy-reset: config dnssec_policy %q for zone %s is broken: %s", configName, zd.ZoneName, pol.Error)
+	}
+	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+		return "", fmt.Errorf("policy-reset: zone %s is not signed (neither online-signing nor inline-signing)", zd.ZoneName)
+	}
+
+	lgApi.Warn("policy-reset: forcing a zone off its DNSSEC policy — DROPPING keys and BREAKING the chain of trust until the parent DS is re-published",
+		"zone", zd.ZoneName, "config_policy", configName)
+
+	// 1) Clear both persisted records so the zone falls back to its config base.
+	if err := ClearZonePolicyOverride(kdb, zd.ZoneName); err != nil {
+		return "", fmt.Errorf("policy-reset: clearing CLI override for zone %s: %w", zd.ZoneName, err)
+	}
+	if err := ClearZoneAppliedPolicy(kdb, zd.ZoneName); err != nil {
+		return "", fmt.Errorf("policy-reset: clearing applied-policy record for zone %s: %w", zd.ZoneName, err)
+	}
+
+	// 2) Rebind to the config policy BEFORE dropping keys, so the keystore
+	// `clear` path regenerates fresh active keys under the CONFIG algorithm (it
+	// reads zd.DnssecPolicy from the live zone).
+	zd.mu.Lock()
+	zd.DnssecPolicy = &pol
+	zd.DnssecPolicyName = configName
+	zd.mu.Unlock()
+
+	// 3) Drop the zone's DNSSEC keys and regenerate under the config policy,
+	// stripping the old keys' now-orphaned RRSIGs. Reuse the keystore `clear`
+	// path (delete all keys → regen 1 active KSK + 1 active ZSK → strip orphans).
+	if _, err := kdb.DnssecKeyMgmt(ctx, nil, KeystorePost{Command: "dnssec", SubCommand: "clear", Zone: zd.ZoneName}); err != nil {
+		return "", fmt.Errorf("policy-reset: dropping/regenerating keys for zone %s: %w", zd.ZoneName, err)
+	}
+
+	// 4) Re-sign under the config policy and record applied = config through the
+	// shared transactional core (source config → no CLI override written).
+	newrrsigs, err := applyZonePolicyTransactional(zd, kdb, &pol, configName, PolicyApplySourceConfig)
+	if err != nil {
+		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q: %w", zd.ZoneName, configName, err)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Zone %s: DNSSEC policy RESET to config policy %q; dropped the old keys and generated fresh ones (%d new RRSIGs).\n",
+		zd.ZoneName, configName, newrrsigs)
+	b.WriteString("WARNING: this was an ABRUPT switch that BREAKS the chain of trust — the parent DS no longer matches the new KSK.\n")
+	b.WriteString("NOTE: validators will go BOGUS until the new DS is published at the parent (via the auto-rollover engine or a manual DS update).")
 	return b.String(), nil
 }
 

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -100,14 +100,14 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			resp.Msg = fmt.Sprintf("Zone %s: resigned, %d RRSIGs written by currently-active keys", zd.ZoneName, newrrsigs)
 
 		case "policy-set":
-			resp.Msg, err = setZonePolicy(zd, kdb, zp.Policy)
+			resp.Msg, err = setZonePolicy(r.Context(), zd, kdb, zp.Policy)
 			if err != nil {
 				resp.Error = true
 				resp.ErrorMsg = err.Error()
 			}
 
 		case "change-policy":
-			resp.Msg, err = changeZonePolicy(zd, kdb, zp.Policy)
+			resp.Msg, err = changeZonePolicy(r.Context(), zd, kdb, zp.Policy)
 			if err != nil {
 				resp.Error = true
 				resp.ErrorMsg = err.Error()
@@ -367,7 +367,7 @@ func zoneOptionsFromStrings(strs []string) map[ZoneOption]bool {
 // retired key's existing RRSIGs stay in place. The zone is therefore briefly
 // double-signed and stays validatable; the KeyStateWorker removes the retired
 // keys and strips their RRSIGs after propagation_delay.
-func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) {
+func setZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, policyName string) (string, error) {
 	policyName = strings.TrimSpace(policyName)
 	if policyName == "" {
 		return "", fmt.Errorf("policy-set: no policy specified")
@@ -408,7 +408,7 @@ func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) 
 	// under. The additive sign reconciles (retire wrong-alg, generate new) and
 	// adds new-key RRSIGs, leaving retired keys' RRSIGs in place for a graceful
 	// transition.
-	newrrsigs, err := applyZonePolicyTransactional(zd, kdb, &pol, policyName, PolicyApplySourceCommand)
+	newrrsigs, err := applyZonePolicyTransactional(ctx, zd, kdb, &pol, policyName, PolicyApplySourceCommand)
 	if err != nil {
 		return "", fmt.Errorf("policy-set: %w", err)
 	}
@@ -454,7 +454,7 @@ func setZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) 
 //     predicate): refused.
 //   - KSK-only alg target / strict mode: deferred to the reconcile, which
 //     refuses (defensive backstop) — but we surface a clean error here too.
-func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, error) {
+func changeZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, policyName string) (string, error) {
 	policyName = strings.TrimSpace(policyName)
 	if policyName == "" {
 		return "", fmt.Errorf("change-policy: no policy specified")
@@ -538,7 +538,7 @@ func changeZonePolicy(zd *ZoneData, kdb *KeyDB, policyName string) (string, erro
 	oldName := zd.DnssecPolicyName
 	zd.mu.Unlock()
 
-	if _, err := applyZonePolicyTransactional(zd, kdb, &pol, policyName, PolicyApplySourceCommand); err != nil {
+	if _, err := applyZonePolicyTransactional(ctx, zd, kdb, &pol, policyName, PolicyApplySourceCommand); err != nil {
 		return "", fmt.Errorf("change-policy: %w", err)
 	}
 
@@ -580,13 +580,17 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 	// zone falls back to once the override + applied records are cleared. Read
 	// the name from Conf.Zones (as the list-zones handler does) and the struct
 	// from the ConfLive() snapshot (lock-free).
+	// Conf.Zones is replaced wholesale by a config reload; guard the scan with
+	// confMu (read lock), matching the list-zones handler above.
 	var configName string
+	confMu.RLock()
 	for i := range Conf.Zones {
 		if dns.Fqdn(Conf.Zones[i].Name) == zd.ZoneName {
 			configName = strings.TrimSpace(Conf.Zones[i].DnssecPolicy)
 			break
 		}
 	}
+	confMu.RUnlock()
 	if configName == "" {
 		return "", fmt.Errorf("policy-reset: zone %s has no config-base dnssec_policy to reset to (dynamic/API-managed zones are not supported)", zd.ZoneName)
 	}
@@ -624,14 +628,14 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 	// stripping the old keys' now-orphaned RRSIGs. Reuse the keystore `clear`
 	// path (delete all keys → regen 1 active KSK + 1 active ZSK → strip orphans).
 	if _, err := kdb.DnssecKeyMgmt(ctx, nil, KeystorePost{Command: "dnssec", SubCommand: "clear", Zone: zd.ZoneName}); err != nil {
-		return "", fmt.Errorf("policy-reset: dropping/regenerating keys for zone %s: %w", zd.ZoneName, err)
+		return "", fmt.Errorf("policy-reset: dropping/regenerating keys for zone %s FAILED — the CLI override and applied-policy records were ALREADY cleared (zone now falls back to config policy %q) and its keys may be partially dropped; re-run `zone dnssec policy-reset --confirm` or restart to converge: %w", zd.ZoneName, configName, err)
 	}
 
 	// 4) Re-sign under the config policy and record applied = config through the
 	// shared transactional core (source config → no CLI override written).
-	newrrsigs, err := applyZonePolicyTransactional(zd, kdb, &pol, configName, PolicyApplySourceConfig)
+	newrrsigs, err := applyZonePolicyTransactional(ctx, zd, kdb, &pol, configName, PolicyApplySourceConfig)
 	if err != nil {
-		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q: %w", zd.ZoneName, configName, err)
+		return "", fmt.Errorf("policy-reset: re-signing zone %s under config policy %q FAILED — keys were dropped/regenerated and the override+applied records ALREADY cleared, so the zone is unsigned until it re-signs; re-run `zone dnssec policy-reset --confirm` or restart to converge: %w", zd.ZoneName, configName, err)
 	}
 
 	var b strings.Builder

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -574,16 +574,28 @@ func changeZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, policyName 
 // parent DS no longer matches the new KSK and validators go BOGUS until the
 // operator re-publishes the DS. Because it pre-aligns the keys before re-signing,
 // it works even in strict completeness mode (reconcile has nothing to refuse).
-// The only gates are --confirm and naming a single zone.
-func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool) (string, error) {
-	if !confirm {
-		return "", fmt.Errorf("policy-reset: refusing without --confirm — this drops and regenerates zone %s's DNSSEC keys for any role whose algorithm changed, and breaks the chain of trust (until the parent DS is re-published) if the KSK algorithm changed", zd.ZoneName)
-	}
+//
+// Without --confirm it is a DRY RUN: it reports what it WOULD do (which roles
+// would roll, and whether the parent DS would break) and changes nothing.
+// --confirm performs the reset. The only gates are --confirm and a single zone.
 
+// boundPolicyMode returns the zone's currently-bound DNSSEC policy Mode
+// ("ksk-zsk" | "csk"), or "" when unbound. Read under zd.mu.
+func boundPolicyMode(zd *ZoneData) string {
+	zd.mu.Lock()
+	defer zd.mu.Unlock()
+	if zd.DnssecPolicy == nil {
+		return ""
+	}
+	return zd.DnssecPolicy.Mode
+}
+
+func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool) (string, error) {
 	// Resolve the zone's CONFIG-base policy (its YAML dnssec_policy) — what the
 	// zone falls back to once the override + applied records are cleared. Read
 	// the name from Conf.Zones (as the list-zones handler does) and the struct
-	// from the ConfLive() snapshot (lock-free).
+	// from the ConfLive() snapshot (lock-free). These guards run for the dry-run
+	// too, so a preview also surfaces a missing/broken config policy.
 	// Conf.Zones is replaced wholesale by a config reload; guard the scan with
 	// confMu (read lock), matching the list-zones handler above.
 	var configName string
@@ -609,6 +621,19 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 		return "", fmt.Errorf("policy-reset: zone %s is not signed (neither online-signing nor inline-signing)", zd.ZoneName)
 	}
 
+	// DRY RUN (no --confirm): compute the per-role decision READ-ONLY and report
+	// what WOULD happen — no key drop, no re-sign, no DB write. This is the
+	// preview an operator gets before committing; the destructive run needs
+	// --confirm. currentMode is the zone's currently-bound policy Mode, so a
+	// genuine split↔CSK mode change is detected from that reliable field.
+	if !confirm {
+		kskChanged, zskChanged, err := zoneActiveKeyRoleChanges(kdb, zd.ZoneName, &pol, boundPolicyMode(zd))
+		if err != nil {
+			return "", fmt.Errorf("policy-reset: inspecting active keys for zone %s: %w", zd.ZoneName, err)
+		}
+		return policyResetDryRunReport(zd.ZoneName, configName, pol.Mode, kskChanged, zskChanged), nil
+	}
+
 	// Serialize the WHOLE reset (per-role decision → drop/regen the changed
 	// role(s) → re-sign → clear override) against concurrent policy applies on
 	// this zone. We hold policyApplyMu ourselves and call the *Locked apply
@@ -616,21 +641,11 @@ func resetZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, confirm bool
 	zd.policyApplyMu.Lock()
 	defer zd.policyApplyMu.Unlock()
 
-	// Decide, per role, which key(s) must be dropped+regenerated: keep a role
-	// whose active-key algorithm already matches config, roll only the one that
-	// changed. Computed under policyApplyMu so the decision and the key mutation
-	// are atomic w.r.t. other applies. kskChanged ⇒ the parent DS breaks.
-	// currentMode is the zone's currently-bound policy Mode, read BEFORE the
-	// rebind: a genuine split↔CSK mode change is detected from that reliable field,
-	// not inferred from key shape (which would misread a split zone missing its ZSK
-	// as CSK and wrongly drop the KSK).
-	currentMode := ""
-	zd.mu.Lock()
-	if zd.DnssecPolicy != nil {
-		currentMode = zd.DnssecPolicy.Mode
-	}
-	zd.mu.Unlock()
-	kskChanged, zskChanged, err := zoneActiveKeyRoleChanges(kdb, zd.ZoneName, &pol, currentMode)
+	// Recompute the per-role decision UNDER policyApplyMu so the decision and the
+	// key mutation are atomic w.r.t. other applies (the dry-run's read above was
+	// advisory). currentMode is read (before the rebind) from the reliable Mode
+	// field, not inferred from key shape. kskChanged ⇒ the parent DS breaks.
+	kskChanged, zskChanged, err := zoneActiveKeyRoleChanges(kdb, zd.ZoneName, &pol, boundPolicyMode(zd))
 	if err != nil {
 		return "", fmt.Errorf("policy-reset: inspecting active keys for zone %s: %w", zd.ZoneName, err)
 	}

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -358,15 +358,19 @@ func zoneOptionsFromStrings(strs []string) map[ZoneOption]bool {
 	return opts
 }
 
-// setZonePolicy applies a DNSSEC policy to a zone at runtime: it validates the
-// named policy, persists a per-zone override (so the change survives restart
-// without rewriting the operator's YAML), rebinds the zone to the new policy,
-// and re-signs. The re-sign is ADDITIVE (SignZone, not ResignZone): the
-// algorithm reconcile in EnsureActiveDnssecKeys retires any wrong-algorithm
-// active key and generates one of the new policy's algorithm, while the
-// retired key's existing RRSIGs stay in place. The zone is therefore briefly
-// double-signed and stays validatable; the KeyStateWorker removes the retired
-// keys and strips their RRSIGs after propagation_delay.
+// setZonePolicy binds a zone to a named (config-defined) DNSSEC policy at
+// runtime, persisting it as a per-zone override (so the change survives restart
+// without rewriting the operator's YAML) and re-signing under it. It is the
+// everyday "rebind this zone's policy" command; its intended use is switching to
+// a differently-named but SAME-algorithm policy (a change of sig-validity, TTLs
+// or key lifetimes).
+//
+// An abrupt ALGORITHM change is not applied here: the reconcile backstop in
+// SignZone refuses a KSK algorithm change (always) and a ZSK algorithm change in
+// strict mode, and the transactional core then reverts, persisting nothing. So
+// set-policy either applies a same-algorithm change immediately or refuses; it
+// never performs the legacy synchronous key-swap. (Route a gradual ZSK algorithm
+// roll via change-policy; force an abrupt switch via policy-reset.)
 func setZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, policyName string) (string, error) {
 	policyName = strings.TrimSpace(policyName)
 	if policyName == "" {
@@ -436,8 +440,8 @@ func setZonePolicy(ctx context.Context, zd *ZoneData, kdb *KeyDB, policyName str
 }
 
 // changeZonePolicy binds a zone toward a new DNSSEC policy for a gradual,
-// relaxed-mode ZSK ALGORITHM rollover. Unlike set-policy (which retires the
-// old-alg key synchronously — the unsafe §2 swap for an algorithm change),
+// relaxed-mode ZSK ALGORITHM rollover. Unlike set-policy (which refuses an
+// abrupt algorithm change: the reconcile backstop rejects the synchronous swap),
 // change-policy only sets the algorithm of FUTURE-generated keys: it writes the
 // ZonePolicyOverride target + rebinds zd.DnssecPolicy, then the existing FIFO
 // ZSK pipeline drains in order. `auto-rollover asap -z <zone> --zsk` is the

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -119,6 +119,28 @@ throughout.`,
 	setPolicy.MarkFlagRequired("zone")
 	setPolicy.MarkFlagRequired("policy")
 
+	var policyResetConfirm bool
+	policyReset := &cobra.Command{
+		Use:   "policy-reset",
+		Short: "DANGER (test/lab): drop a zone's DNSSEC keys and re-sign under its config policy",
+		Long: `Force a zone back onto its config dnssec_policy by DROPPING its current DNSSEC
+keys, clearing both the runtime override and the last-applied record, and
+re-signing from scratch under the YAML config policy.
+
+This is a break-glass tool for test/lab zones. It exists because an abrupt
+policy switch that changes the KSK/ZSK algorithm is otherwise refused (that
+needs a key rollover that is not built). It BREAKS THE CHAIN OF TRUST: the
+parent DS will not match the freshly generated KSK until you re-publish it, so
+validators go BOGUS until the parent DS is updated. NOT for production.
+Requires --confirm and a single --zone (no wildcards, no bulk).`,
+		Run: func(cmd *cobra.Command, args []string) {
+			RunZoneResetPolicy(role, policyResetConfirm)
+		},
+	}
+	policyReset.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to reset the DNSSEC policy for")
+	policyReset.Flags().BoolVar(&policyResetConfirm, "confirm", false, "Confirm this dangerous operation (drops keys, breaks the chain of trust)")
+	policyReset.MarkFlagRequired("zone")
+
 	proxyKey := &cobra.Command{
 		Use:   "proxy-key",
 		Short: "Show the delegation-sync-proxy UPDATE state and the KEY to publish at the primary",
@@ -222,7 +244,7 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 		Use:   "dnssec",
 		Short: "Zone DNSSEC operations: signing, policy, and automated rollover",
 	}
-	dnssecCmd.AddCommand(setPolicy, newAutoRolloverPolicyChangeCmd(), newAutoRolloverCmd(role),
+	dnssecCmd.AddCommand(setPolicy, policyReset, newAutoRolloverPolicyChangeCmd(), newAutoRolloverCmd(role),
 		sign, resign, nsec)
 
 	c.AddCommand(list, dnssecCmd, reload, bump, write, freeze, thaw, proxyKey, add, del, modify, listDynamic)
@@ -353,6 +375,37 @@ func RunZoneSetPolicy(parent, policy string) {
 		Command: "policy-set",
 		Zone:    dns.Fqdn(tdns.Globals.Zonename),
 		Policy:  policy,
+	})
+	if err != nil {
+		fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+		os.Exit(1)
+	}
+
+	if cr.Msg != "" {
+		fmt.Printf("%s\n", cr.Msg)
+	}
+}
+
+// RunZoneResetPolicy drives the `zone dnssec policy-reset` escape hatch: it
+// forwards --confirm as ZonePost.Force. The server refuses without it.
+func RunZoneResetPolicy(parent string, confirm bool) {
+	if tdns.Globals.Zonename == "" {
+		fmt.Println("Error: zone name not specified")
+		os.Exit(1)
+	}
+	if !confirm {
+		fmt.Println("Error: policy-reset is destructive (drops the zone's DNSSEC keys and breaks the chain of trust); re-run with --confirm")
+		os.Exit(1)
+	}
+	api, err := GetApiClient(parent, true)
+	if err != nil {
+		log.Fatalf("Error getting API client for %s: %v", parent, err)
+	}
+
+	cr, err := SendZoneCommand(api, tdns.ZonePost{
+		Command: "policy-reset",
+		Zone:    dns.Fqdn(tdns.Globals.Zonename),
+		Force:   confirm,
 	})
 	if err != nil {
 		fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -122,23 +122,27 @@ throughout.`,
 	var policyResetConfirm bool
 	policyReset := &cobra.Command{
 		Use:   "policy-reset",
-		Short: "DANGER (test/lab): drop a zone's DNSSEC keys and re-sign under its config policy",
-		Long: `Force a zone back onto its config dnssec_policy by DROPPING its current DNSSEC
-keys, clearing both the runtime override and the last-applied record, and
-re-signing from scratch under the YAML config policy.
+		Short: "Reset a zone's DNSSEC keys to its config policy, per role (dry-run without --confirm)",
+		Long: `Force a zone onto its config dnssec_policy: for each key role whose algorithm no
+longer matches config, drop and regenerate that role's keys and re-sign; any
+role whose algorithm is already correct is kept. It also clears the runtime
+override and records the config policy as applied.
 
 This is a break-glass tool for test/lab zones. It exists because an abrupt
-policy switch that changes the KSK/ZSK algorithm is otherwise refused (that
-needs a key rollover that is not built). It BREAKS THE CHAIN OF TRUST: the
-parent DS will not match the freshly generated KSK until you re-publish it, so
-validators go BOGUS until the parent DS is updated. NOT for production.
-Requires --confirm and a single --zone (no wildcards, no bulk).`,
+policy switch that changes a KSK/ZSK algorithm is otherwise refused (that needs
+a key rollover that is not built). If the KSK algorithm changes it BREAKS THE
+CHAIN OF TRUST: the parent DS will not match the new KSK until you re-publish it
+(a ZSK-only change keeps the KSK and the DS). NOT for production.
+
+Run WITHOUT --confirm for a DRY RUN that previews what it would do (which roles
+would roll, whether the parent DS would break) and changes nothing; add
+--confirm to apply. A single --zone only (no wildcards, no bulk).`,
 		Run: func(cmd *cobra.Command, args []string) {
 			RunZoneResetPolicy(role, policyResetConfirm)
 		},
 	}
 	policyReset.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to reset the DNSSEC policy for")
-	policyReset.Flags().BoolVar(&policyResetConfirm, "confirm", false, "Confirm this dangerous operation (drops keys, breaks the chain of trust)")
+	policyReset.Flags().BoolVar(&policyResetConfirm, "confirm", false, "Apply the reset; without it the command is a dry-run that only previews what would happen")
 	policyReset.MarkFlagRequired("zone")
 
 	proxyKey := &cobra.Command{
@@ -386,15 +390,13 @@ func RunZoneSetPolicy(parent, policy string) {
 	}
 }
 
-// RunZoneResetPolicy drives the `zone dnssec policy-reset` escape hatch: it
-// forwards --confirm as ZonePost.Force. The server refuses without it.
+// RunZoneResetPolicy drives the `zone dnssec policy-reset` command: it forwards
+// --confirm as ZonePost.Force. Without --confirm the server returns a DRY-RUN
+// preview (what the reset would do) instead of applying it, so we always send
+// the request rather than refusing client-side.
 func RunZoneResetPolicy(parent string, confirm bool) {
 	if tdns.Globals.Zonename == "" {
 		fmt.Println("Error: zone name not specified")
-		os.Exit(1)
-	}
-	if !confirm {
-		fmt.Println("Error: policy-reset is destructive (drops the zone's DNSSEC keys and breaks the chain of trust); re-run with --confirm")
 		os.Exit(1)
 	}
 	api, err := GetApiClient(parent, true)

--- a/v2/db.go
+++ b/v2/db.go
@@ -168,6 +168,28 @@ WHERE state = 'standby' AND (CAST(flags AS INTEGER) & 1) = 1
 	if err != nil {
 		lgConfig.Error("data migration: rename old standby SEP keys to published failed", "err", err)
 	}
+
+	// Transactional policy reload (P0-2 / Plan B): seed applied_* from existing
+	// CLI overrides. A row with a non-empty `policy` was written by set-policy /
+	// change-policy AFTER a successful sign, so the zone is known to have been
+	// signed under that policy — copy it into the new last-applied columns
+	// (source 'command', applied_at = the override's set_at). Config-only zones
+	// have no override row and are backfilled at runtime by the refresh engine
+	// (§5.5), which can check that the zone is actually signed under intent.
+	//
+	// Idempotence: gated on applied_policy being unset, so a re-run (or a later
+	// applied_* write) is never overwritten.
+	if dbColumnExists(db, "ZonePolicyOverride", "applied_policy") {
+		_, err := db.Exec(`UPDATE ZonePolicyOverride
+SET applied_policy = policy,
+    applied_source = 'command',
+    applied_at = set_at
+WHERE policy IS NOT NULL AND policy != ''
+  AND (applied_policy IS NULL OR applied_policy = '')`)
+		if err != nil {
+			lgConfig.Error("data migration: seed applied_policy from CLI overrides failed", "err", err)
+		}
+	}
 }
 
 // dbMigrateSchema adds columns that may be missing from tables created by older schema versions.
@@ -235,6 +257,17 @@ func dbMigrateSchema(db *sql.DB) {
 		// would mix DDL-style migrations (idempotent column adds) with
 		// data-shape migrations (one-shot state transitions).
 		{"RolloverKeyState", "published_at", "ALTER TABLE RolloverKeyState ADD COLUMN published_at TEXT"},
+		// Transactional policy reload (P0-2 / Plan B): last-applied DNSSEC
+		// policy per zone, distinct from the sparse CLI `policy` override.
+		// applied_policy is the policy NAME the zone was last successfully
+		// signed under; applied_source is 'config' | 'command'; applied_at is
+		// the ISO timestamp of that apply. All nullable so existing rows (and
+		// config-only zones with no CLI override) migrate without a value —
+		// the CLI-row backfill below and the refresh-engine runtime backfill
+		// fill them in.
+		{"ZonePolicyOverride", "applied_policy", "ALTER TABLE ZonePolicyOverride ADD COLUMN applied_policy TEXT"},
+		{"ZonePolicyOverride", "applied_source", "ALTER TABLE ZonePolicyOverride ADD COLUMN applied_source TEXT"},
+		{"ZonePolicyOverride", "applied_at", "ALTER TABLE ZonePolicyOverride ADD COLUMN applied_at TEXT"},
 	}
 
 	for _, m := range migrations {

--- a/v2/db_schema.go
+++ b/v2/db_schema.go
@@ -179,12 +179,24 @@ UNIQUE (keyname)
 		updated_at        TEXT
 	)`,
 
-	// ZonePolicyOverride records a per-zone DNSSEC policy set dynamically at
-	// runtime (via `zone set-policy`), overriding the policy named in the
-	// zone's YAML config. Sparse — only zones whose policy was changed live
-	// appear here. The effective policy for a zone is the override if present,
-	// else the config base. This lets a live policy change survive restart
-	// without the server rewriting the operator's YAML.
+	// ZonePolicyOverride records per-zone DNSSEC policy state.
+	//
+	// `policy` / `set_at` are the sparse CLI OVERRIDE (INTENT): a policy set
+	// dynamically via `zone dnssec policy-set`, overriding the policy named in
+	// the zone's YAML config. Only zones whose policy was changed live have a
+	// non-empty `policy`. The effective policy for a zone is the override if
+	// present, else the config base — this lets a live policy change survive
+	// restart without the server rewriting the operator's YAML.
+	//
+	// `applied_policy` / `applied_source` / `applied_at` are the LAST-APPLIED
+	// record (P0-2 / Plan B): the policy the zone was last successfully SIGNED
+	// under, so intent vs reality is always comparable on reload and restart.
+	// applied_source is 'config' | 'command'. These three columns are added by
+	// dbMigrateSchema (ALTER TABLE), not this CREATE, so an existing database
+	// gains them on upgrade; they are nullable and filled by the CLI-row data
+	// migration (dbMigrateData) and the refresh-engine runtime backfill. A row
+	// may therefore have applied_* set with an empty `policy` (config-only
+	// zone, no CLI override) or vice versa — the two concerns are independent.
 	"ZonePolicyOverride": `CREATE TABLE IF NOT EXISTS 'ZonePolicyOverride' (
 		zone    TEXT NOT NULL PRIMARY KEY,
 		policy  TEXT NOT NULL,

--- a/v2/db_zone_policy_override.go
+++ b/v2/db_zone_policy_override.go
@@ -39,15 +39,21 @@ ON CONFLICT(zone) DO UPDATE SET
 	return err
 }
 
-// ClearZonePolicyOverride removes a zone's dynamic policy override (if any),
-// so the zone falls back to its config-base policy. Removing a non-existent
-// override is not an error.
+// ClearZonePolicyOverride removes a zone's dynamic policy override (if any), so
+// the zone falls back to its config-base policy. It clears ONLY the override
+// (intent) columns — `policy` and `set_at` — and leaves the last-applied record
+// (applied_*) in the same row intact: the override and the applied record are
+// independent (a config-only zone can carry applied_* with no override). It
+// therefore UPDATEs the row to an empty override rather than DELETEing it, so an
+// applied_* record is never collaterally erased. An empty `policy` reads as "no
+// override" via GetZonePolicyOverride. Clearing a non-existent override (no row)
+// is not an error.
 func ClearZonePolicyOverride(kdb *KeyDB, zone string) error {
 	if kdb == nil || kdb.DB == nil {
 		return fmt.Errorf("ClearZonePolicyOverride: nil keystore")
 	}
 	zone = dns.Fqdn(strings.TrimSpace(zone))
-	_, err := kdb.DB.Exec(`DELETE FROM ZonePolicyOverride WHERE zone = ?`, zone)
+	_, err := kdb.DB.Exec(`UPDATE ZonePolicyOverride SET policy = '', set_at = NULL WHERE zone = ?`, zone)
 	return err
 }
 

--- a/v2/db_zone_policy_override.go
+++ b/v2/db_zone_policy_override.go
@@ -90,3 +90,82 @@ func EffectiveDnssecPolicyName(kdb *KeyDB, zone, configName string) (effective s
 	}
 	return configName, false, nil
 }
+
+// --- Last-applied policy (P0-2 / Plan B) ---------------------------------
+//
+// The applied_* columns record what a zone was LAST SUCCESSFULLY SIGNED under,
+// independent of the CLI `policy` override (INTENT). They live in the same
+// ZonePolicyOverride row so a single lookup covers both, but the two are
+// semantically distinct: a config-only zone can have applied_* set with an
+// empty `policy` (no override), and clearing the override does not erase the
+// last-applied record.
+
+// SetZoneAppliedPolicy records the policy a zone was last successfully signed
+// under (source 'config' | 'command'), stamping applied_at. It never touches
+// the CLI override `policy`: a fresh row is inserted with an empty override
+// (config-only zone), and an existing row keeps whatever override it had.
+func SetZoneAppliedPolicy(kdb *KeyDB, zone, policy, source string) error {
+	if kdb == nil || kdb.DB == nil {
+		return fmt.Errorf("SetZoneAppliedPolicy: nil keystore")
+	}
+	zone = dns.Fqdn(strings.TrimSpace(zone))
+	policy = strings.TrimSpace(policy)
+	source = strings.TrimSpace(source)
+	if zone == "." || policy == "" {
+		return fmt.Errorf("SetZoneAppliedPolicy: empty zone or policy")
+	}
+	if source != "config" && source != "command" {
+		return fmt.Errorf("SetZoneAppliedPolicy: invalid source %q (want 'config' or 'command')", source)
+	}
+	// On INSERT the override column is '' (this zone has no CLI override); on
+	// CONFLICT we update ONLY the applied_* columns, leaving `policy` intact.
+	const q = `
+INSERT INTO ZonePolicyOverride (zone, policy, applied_policy, applied_source, applied_at)
+VALUES (?, '', ?, ?, datetime('now'))
+ON CONFLICT(zone) DO UPDATE SET
+  applied_policy = excluded.applied_policy,
+  applied_source = excluded.applied_source,
+  applied_at     = excluded.applied_at`
+	_, err := kdb.DB.Exec(q, zone, policy, source)
+	return err
+}
+
+// GetZoneAppliedPolicy returns the last-applied policy name and source for a
+// zone. ok is false (and name/source "") when the zone has no applied record,
+// whether because it has no row at all or the applied_policy column is unset.
+func GetZoneAppliedPolicy(kdb *KeyDB, zone string) (name string, source string, ok bool, err error) {
+	if kdb == nil || kdb.DB == nil {
+		return "", "", false, fmt.Errorf("GetZoneAppliedPolicy: nil keystore")
+	}
+	zone = dns.Fqdn(strings.TrimSpace(zone))
+	var p, s sql.NullString
+	err = kdb.DB.QueryRow(
+		`SELECT applied_policy, applied_source FROM ZonePolicyOverride WHERE zone = ?`, zone,
+	).Scan(&p, &s)
+	if err == sql.ErrNoRows {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, err
+	}
+	if !p.Valid || strings.TrimSpace(p.String) == "" {
+		return "", "", false, nil
+	}
+	return strings.TrimSpace(p.String), strings.TrimSpace(s.String), true, nil
+}
+
+// ClearZoneAppliedPolicy clears a zone's last-applied record (applied_* → NULL)
+// while leaving the CLI override row intact. Used by the `policy-reset` escape
+// hatch (§6.7) so a forced re-sign starts from a clean last-applied slate.
+// Clearing a zone with no row is not an error.
+func ClearZoneAppliedPolicy(kdb *KeyDB, zone string) error {
+	if kdb == nil || kdb.DB == nil {
+		return fmt.Errorf("ClearZoneAppliedPolicy: nil keystore")
+	}
+	zone = dns.Fqdn(strings.TrimSpace(zone))
+	_, err := kdb.DB.Exec(
+		`UPDATE ZonePolicyOverride
+SET applied_policy = NULL, applied_source = NULL, applied_at = NULL
+WHERE zone = ?`, zone)
+	return err
+}

--- a/v2/db_zone_policy_override_test.go
+++ b/v2/db_zone_policy_override_test.go
@@ -2,6 +2,109 @@ package tdns
 
 import "testing"
 
+// TestZoneAppliedPolicy exercises the last-applied CRUD and, crucially, that it
+// is INDEPENDENT of the CLI `policy` override: a config-only zone gets an
+// applied record with no override, and setting one never clobbers the other.
+func TestZoneAppliedPolicy(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// No applied record yet.
+	if _, _, ok, err := GetZoneAppliedPolicy(kdb, "example."); err != nil || ok {
+		t.Fatalf("no applied yet: got (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+
+	// Record a config-source applied policy for a zone with NO CLI override
+	// (the config-only case). FQDN normalization: set non-FQDN, read FQDN.
+	if err := SetZoneAppliedPolicy(kdb, "example", "pq-mayo", "config"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy: %v", err)
+	}
+	name, source, ok, err := GetZoneAppliedPolicy(kdb, "example.")
+	if err != nil || !ok || name != "pq-mayo" || source != "config" {
+		t.Fatalf("applied round-trip: got (%q, %q, %v, err=%v), want (\"pq-mayo\", \"config\", true, nil)", name, source, ok, err)
+	}
+	// applied is NOT an override: effective policy still falls back to config,
+	// and there is no override row content.
+	if eff, overridden, err := EffectiveDnssecPolicyName(kdb, "example.", "default"); err != nil || eff != "default" || overridden {
+		t.Fatalf("applied must not act as override: got (%q, %v, err=%v), want (\"default\", false, nil)", eff, overridden, err)
+	}
+	if _, ovOK, err := GetZonePolicyOverride(kdb, "example."); err != nil || ovOK {
+		t.Fatalf("applied write must not create an override (ovOK=%v err=%v)", ovOK, err)
+	}
+
+	// Now add a CLI override on the SAME zone: it must not disturb applied.
+	if err := SetZonePolicyOverride(kdb, "example.", "fastroll"); err != nil {
+		t.Fatalf("SetZonePolicyOverride: %v", err)
+	}
+	if name, source, ok, err := GetZoneAppliedPolicy(kdb, "example."); err != nil || !ok || name != "pq-mayo" || source != "config" {
+		t.Fatalf("applied after override set: got (%q, %q, %v, err=%v), want (\"pq-mayo\", \"config\", true, nil)", name, source, ok, err)
+	}
+	// And updating applied must not disturb the override.
+	if err := SetZoneAppliedPolicy(kdb, "example.", "fastroll", "command"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy update: %v", err)
+	}
+	if n, ovOK, err := GetZonePolicyOverride(kdb, "example."); err != nil || !ovOK || n != "fastroll" {
+		t.Fatalf("override after applied update: got (%q, %v, err=%v), want (\"fastroll\", true, nil)", n, ovOK, err)
+	}
+	if name, source, _, _ := GetZoneAppliedPolicy(kdb, "example."); name != "fastroll" || source != "command" {
+		t.Fatalf("applied after update: got (%q, %q), want (\"fastroll\", \"command\")", name, source)
+	}
+
+	// Clear applied: record gone, override retained.
+	if err := ClearZoneAppliedPolicy(kdb, "example."); err != nil {
+		t.Fatalf("ClearZoneAppliedPolicy: %v", err)
+	}
+	if _, _, ok, err := GetZoneAppliedPolicy(kdb, "example."); err != nil || ok {
+		t.Fatalf("after clear applied: got (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+	if n, ovOK, err := GetZonePolicyOverride(kdb, "example."); err != nil || !ovOK || n != "fastroll" {
+		t.Fatalf("override survives applied clear: got (%q, %v, err=%v), want (\"fastroll\", true, nil)", n, ovOK, err)
+	}
+	// Clearing applied on a zone with no row is not an error.
+	if err := ClearZoneAppliedPolicy(kdb, "nosuch."); err != nil {
+		t.Fatalf("ClearZoneAppliedPolicy (absent): %v", err)
+	}
+
+	// Validation: empty policy and bad source are rejected.
+	if err := SetZoneAppliedPolicy(kdb, "example.", "", "config"); err == nil {
+		t.Fatalf("SetZoneAppliedPolicy with empty policy should fail")
+	}
+	if err := SetZoneAppliedPolicy(kdb, "example.", "pq-mayo", "bogus"); err == nil {
+		t.Fatalf("SetZoneAppliedPolicy with invalid source should fail")
+	}
+}
+
+// TestZoneAppliedPolicyDataMigration verifies the dbMigrateData backfill that
+// seeds applied_* from a pre-existing CLI override row (which was written by
+// set-policy AFTER a successful sign), and that the backfill is idempotent.
+func TestZoneAppliedPolicyDataMigration(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// Simulate a pre-upgrade CLI override row: policy set, applied_* still unset.
+	if err := SetZonePolicyOverride(kdb, "legacy.", "pq-mayo"); err != nil {
+		t.Fatalf("SetZonePolicyOverride: %v", err)
+	}
+	if _, _, ok, err := GetZoneAppliedPolicy(kdb, "legacy."); err != nil || ok {
+		t.Fatalf("pre-migration applied should be absent (ok=%v err=%v)", ok, err)
+	}
+
+	// Run the data migration: applied_* seeded from the override, source command.
+	dbMigrateData(kdb.DB)
+	name, source, ok, err := GetZoneAppliedPolicy(kdb, "legacy.")
+	if err != nil || !ok || name != "pq-mayo" || source != "command" {
+		t.Fatalf("post-migration applied: got (%q, %q, %v, err=%v), want (\"pq-mayo\", \"command\", true, nil)", name, source, ok, err)
+	}
+
+	// Idempotent: a second run must not change or duplicate anything, and must
+	// not overwrite a later applied value that diverged from the override.
+	if err := SetZoneAppliedPolicy(kdb, "legacy.", "fastroll", "command"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy diverge: %v", err)
+	}
+	dbMigrateData(kdb.DB)
+	if name, _, _, _ := GetZoneAppliedPolicy(kdb, "legacy."); name != "fastroll" {
+		t.Fatalf("migration must not clobber a set applied_policy: got %q, want \"fastroll\"", name)
+	}
+}
+
 func TestZonePolicyOverride(t *testing.T) {
 	kdb := newTestKeyDB(t)
 

--- a/v2/db_zone_policy_override_test.go
+++ b/v2/db_zone_policy_override_test.go
@@ -154,3 +154,33 @@ func TestZonePolicyOverride(t *testing.T) {
 		t.Fatalf("ClearZonePolicyOverride (absent): %v", err)
 	}
 }
+
+// TestClearOverridePreservesApplied is the applied⊥override independence
+// regression: ClearZonePolicyOverride must clear only the override (intent) and
+// leave the last-applied record intact — it UPDATEs policy=” rather than
+// DELETEing the whole row, which previously wiped applied_* too.
+func TestClearOverridePreservesApplied(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// Zone carries BOTH an override and an applied record.
+	if err := SetZonePolicyOverride(kdb, "example.", "override-pol"); err != nil {
+		t.Fatalf("SetZonePolicyOverride: %v", err)
+	}
+	if err := SetZoneAppliedPolicy(kdb, "example.", "applied-pol", "config"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy: %v", err)
+	}
+
+	if err := ClearZonePolicyOverride(kdb, "example."); err != nil {
+		t.Fatalf("ClearZonePolicyOverride: %v", err)
+	}
+
+	// Override gone...
+	if _, ok, err := GetZonePolicyOverride(kdb, "example."); err != nil || ok {
+		t.Fatalf("override should be cleared after ClearZonePolicyOverride (ok=%v err=%v)", ok, err)
+	}
+	// ...applied record preserved (the independence guarantee).
+	name, source, ok, err := GetZoneAppliedPolicy(kdb, "example.")
+	if err != nil || !ok || name != "applied-pol" || source != "config" {
+		t.Fatalf("applied must survive an override clear: got (%q,%q,%v,err=%v), want (applied-pol,config,true,nil)", name, source, ok, err)
+	}
+}

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -695,30 +695,32 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 // forceZoneKeysToPolicyRoles is the surgical per-role counterpart to the keystore
 // `clear` operation, used by policy-reset. For each role flagged changed it drops
 // ALL of that role's keys (every state) and generates one fresh active key of the
-// config algorithm; the unchanged role's keys are left untouched. Orphaned RRSIGs
-// (those made by a dropped key) are stripped so only signatures by surviving keys
-// remain — the additive re-sign that follows re-signs under the new keys.
-// Everything runs in one transaction that rolls back on any failure; on success
-// the zone's key cache is invalidated post-commit (the DELETE+regen changed the
+// config algorithm; the unchanged role's keys are left untouched. It runs the key
+// mutation in one transaction that rolls back on any failure, and on success
+// invalidates the zone's key cache post-commit (the DELETE+regen changed the
 // active set, and this method owns its transaction, so the invalidation is
-// complete — unlike a mid-tx wipe that a read in the uncommitted window can
-// undo).
+// complete — unlike a mid-tx wipe that a read in the uncommitted window can undo).
+//
+// It returns the SURVIVING keytags (the kept role's keys + the regenerated ones);
+// the caller strips the now-stale served RRSIGs via stripStaleRRSIGsForKeySet
+// AFTER this returns — never before commit — so a keystore commit failure can
+// never leave the served zone published without its signatures.
 //
 // For a CSK policy a single SEP "CSK" key covers both roles: dropKSK true drops
 // every key and regenerates one CSK (dropZSK is ignored). For a split policy the
 // SEP bit selects the role (KSK = flags&1==1, ZSK = flags&1==0).
-func (kdb *KeyDB) forceZoneKeysToPolicyRoles(ctx context.Context, zd *ZoneData, pol *DnssecPolicy, dropKSK, dropZSK bool) error {
+func (kdb *KeyDB) forceZoneKeysToPolicyRoles(zd *ZoneData, pol *DnssecPolicy, dropKSK, dropZSK bool) (map[uint16]bool, error) {
 	if pol == nil {
-		return fmt.Errorf("forceZoneKeysToPolicyRoles: nil policy for zone %s", zd.ZoneName)
+		return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: nil policy for zone %s", zd.ZoneName)
 	}
 	if !dropKSK && !dropZSK {
-		return nil // nothing to roll
+		return nil, nil // nothing to roll
 	}
 	zone := zd.ZoneName
 
 	tx, err := kdb.Begin("forceZoneKeysToPolicyRoles")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	committed := false
 	defer func() {
@@ -730,26 +732,26 @@ func (kdb *KeyDB) forceZoneKeysToPolicyRoles(ctx context.Context, zd *ZoneData, 
 	if pol.Mode == DnssecPolicyModeCSK {
 		// Collapse to a single CSK: drop every key, regenerate one active CSK.
 		if _, err := tx.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=?`, zone); err != nil {
-			return fmt.Errorf("forceZoneKeysToPolicyRoles: delete keys for %s: %w", zone, err)
+			return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: delete keys for %s: %w", zone, err)
 		}
 		if _, _, err := kdb.GenerateKeypair(zone, "policy-reset-regen", DnskeyStateActive, dns.TypeDNSKEY, pol.Algorithm, "CSK", tx); err != nil {
-			return fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate CSK for %s: %w", zone, err)
+			return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate CSK for %s: %w", zone, err)
 		}
 	} else {
 		if dropKSK {
 			if _, err := tx.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=? AND (CAST(flags AS INTEGER) & 1) = 1`, zone); err != nil {
-				return fmt.Errorf("forceZoneKeysToPolicyRoles: delete KSK keys for %s: %w", zone, err)
+				return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: delete KSK keys for %s: %w", zone, err)
 			}
 			if _, _, err := kdb.GenerateKeypair(zone, "policy-reset-regen", DnskeyStateActive, dns.TypeDNSKEY, pol.KSKAlgorithm, "KSK", tx); err != nil {
-				return fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate KSK for %s: %w", zone, err)
+				return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate KSK for %s: %w", zone, err)
 			}
 		}
 		if dropZSK {
 			if _, err := tx.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=? AND (CAST(flags AS INTEGER) & 1) = 0`, zone); err != nil {
-				return fmt.Errorf("forceZoneKeysToPolicyRoles: delete ZSK keys for %s: %w", zone, err)
+				return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: delete ZSK keys for %s: %w", zone, err)
 			}
 			if _, _, err := kdb.GenerateKeypair(zone, "policy-reset-regen", DnskeyStateActive, dns.TypeDNSKEY, pol.ZSKAlgorithm, "ZSK", tx); err != nil {
-				return fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate ZSK for %s: %w", zone, err)
+				return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate ZSK for %s: %w", zone, err)
 			}
 		}
 	}
@@ -758,23 +760,11 @@ func (kdb *KeyDB) forceZoneKeysToPolicyRoles(ctx context.Context, zd *ZoneData, 
 	// active key(s), visible within this tx.
 	surviving, err := txZoneKeytags(tx, zone)
 	if err != nil {
-		return fmt.Errorf("forceZoneKeysToPolicyRoles: list surviving keys for %s: %w", zone, err)
-	}
-	// Strip (a) orphaned RRSIGs — those made by a dropped key — AND (b) ALL RRSIGs
-	// over the DNSKEY RRset. The DNSKEY RRset content always changes when the key
-	// set changes (a DNSKEY comes or goes), so even the KEPT KSK's DNSKEY RRSIG now
-	// covers a stale key set; it is not an orphan (its key is still active) and the
-	// additive re-sign would leave it in place as bogus cruft. Stripping every
-	// DNSKEY RRSIG here lets the re-sign regenerate exactly one fresh RRSIG per
-	// active KSK. (This method only runs when a role changed, so the key set did.)
-	if _, err := zd.StripZoneRRSIGs(ctx, func(rrsig *dns.RRSIG) bool {
-		return !surviving[rrsig.KeyTag] || rrsig.TypeCovered == dns.TypeDNSKEY
-	}); err != nil {
-		return fmt.Errorf("forceZoneKeysToPolicyRoles: strip stale/orphaned RRSIGs for %s: %w", zone, err)
+		return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: list surviving keys for %s: %w", zone, err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("forceZoneKeysToPolicyRoles: commit for %s: %w", zone, err)
+		return nil, fmt.Errorf("forceZoneKeysToPolicyRoles: commit for %s: %w", zone, err)
 	}
 	committed = true
 
@@ -786,7 +776,25 @@ func (kdb *KeyDB) forceZoneKeysToPolicyRoles(ctx context.Context, zd *ZoneData, 
 		}
 	}
 	kdb.mu.Unlock()
-	return nil
+	return surviving, nil
+}
+
+// stripStaleRRSIGsForKeySet removes served RRSIGs that a key-set change made
+// stale: (a) orphans — those made by a dropped key (keytag no longer in
+// `surviving`) — AND (b) EVERY DNSKEY-covering RRSIG. The DNSKEY RRset content
+// always changes when the key set changes (a DNSKEY comes or goes), so even a
+// KEPT KSK's DNSKEY RRSIG now covers a stale key set; it is not an orphan and the
+// additive re-sign would leave it in place as bogus cruft. The re-sign that
+// follows regenerates exactly one fresh RRSIG per active KSK.
+//
+// Call this AFTER the keystore mutation has committed (see
+// forceZoneKeysToPolicyRoles): running it before commit would publish the
+// stripped zone, and a subsequent commit failure would then leave the served
+// zone without its signatures.
+func stripStaleRRSIGsForKeySet(ctx context.Context, zd *ZoneData, surviving map[uint16]bool) (int, error) {
+	return zd.StripZoneRRSIGs(ctx, func(rrsig *dns.RRSIG) bool {
+		return !surviving[rrsig.KeyTag] || rrsig.TypeCovered == dns.TypeDNSKEY
+	})
 }
 
 // txZoneKeytags returns the set of keytags currently present in the keystore for

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -328,23 +328,6 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 			if txSuccess {
 				if err := tx.Commit(); err != nil {
 					lgSigner.Error("DnssecKeyMgmt commit failed", "err", err)
-					return
-				}
-				// Post-commit cache invalidation. `clear` DELETEs+regenerates
-				// all of a zone's keys inside this tx and invalidates the cache
-				// mid-tx (before commit); a GetDnssecKeys during the uncommitted
-				// window (separate DB connection) can re-cache the OLD set, so
-				// that mid-tx wipe is not enough. Drop the zone's cache entries
-				// again now that the new set is committed, so the next read is
-				// served from the committed DB rather than a stale cache.
-				if kp.SubCommand == "clear" && kp.Zone != "" {
-					kdb.mu.Lock()
-					for key := range kdb.KeystoreDnskeyCache {
-						if strings.HasPrefix(key, kp.Zone+"+") {
-							delete(kdb.KeystoreDnskeyCache, key)
-						}
-					}
-					kdb.mu.Unlock()
 				}
 			} else {
 				lgSigner.Debug("DnssecKeyMgmt rollback")
@@ -707,6 +690,115 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 
 	txSuccess = true
 	return &resp, nil
+}
+
+// forceZoneKeysToPolicyRoles is the surgical per-role counterpart to the keystore
+// `clear` operation, used by policy-reset. For each role flagged changed it drops
+// ALL of that role's keys (every state) and generates one fresh active key of the
+// config algorithm; the unchanged role's keys are left untouched. Orphaned RRSIGs
+// (those made by a dropped key) are stripped so only signatures by surviving keys
+// remain — the additive re-sign that follows re-signs under the new keys.
+// Everything runs in one transaction that rolls back on any failure; on success
+// the zone's key cache is invalidated post-commit (the DELETE+regen changed the
+// active set, and this method owns its transaction, so the invalidation is
+// complete — unlike a mid-tx wipe that a read in the uncommitted window can
+// undo).
+//
+// For a CSK policy a single SEP "CSK" key covers both roles: dropKSK true drops
+// every key and regenerates one CSK (dropZSK is ignored). For a split policy the
+// SEP bit selects the role (KSK = flags&1==1, ZSK = flags&1==0).
+func (kdb *KeyDB) forceZoneKeysToPolicyRoles(ctx context.Context, zd *ZoneData, pol *DnssecPolicy, dropKSK, dropZSK bool) error {
+	if pol == nil {
+		return fmt.Errorf("forceZoneKeysToPolicyRoles: nil policy for zone %s", zd.ZoneName)
+	}
+	if !dropKSK && !dropZSK {
+		return nil // nothing to roll
+	}
+	zone := zd.ZoneName
+
+	tx, err := kdb.Begin("forceZoneKeysToPolicyRoles")
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			tx.Rollback()
+		}
+	}()
+
+	if pol.Mode == DnssecPolicyModeCSK {
+		// Collapse to a single CSK: drop every key, regenerate one active CSK.
+		if _, err := tx.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=?`, zone); err != nil {
+			return fmt.Errorf("forceZoneKeysToPolicyRoles: delete keys for %s: %w", zone, err)
+		}
+		if _, _, err := kdb.GenerateKeypair(zone, "policy-reset-regen", DnskeyStateActive, dns.TypeDNSKEY, pol.Algorithm, "CSK", tx); err != nil {
+			return fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate CSK for %s: %w", zone, err)
+		}
+	} else {
+		if dropKSK {
+			if _, err := tx.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=? AND (CAST(flags AS INTEGER) & 1) = 1`, zone); err != nil {
+				return fmt.Errorf("forceZoneKeysToPolicyRoles: delete KSK keys for %s: %w", zone, err)
+			}
+			if _, _, err := kdb.GenerateKeypair(zone, "policy-reset-regen", DnskeyStateActive, dns.TypeDNSKEY, pol.KSKAlgorithm, "KSK", tx); err != nil {
+				return fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate KSK for %s: %w", zone, err)
+			}
+		}
+		if dropZSK {
+			if _, err := tx.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=? AND (CAST(flags AS INTEGER) & 1) = 0`, zone); err != nil {
+				return fmt.Errorf("forceZoneKeysToPolicyRoles: delete ZSK keys for %s: %w", zone, err)
+			}
+			if _, _, err := kdb.GenerateKeypair(zone, "policy-reset-regen", DnskeyStateActive, dns.TypeDNSKEY, pol.ZSKAlgorithm, "ZSK", tx); err != nil {
+				return fmt.Errorf("forceZoneKeysToPolicyRoles: regenerate ZSK for %s: %w", zone, err)
+			}
+		}
+	}
+
+	// Surviving keytags = the kept role's keys (all states) + the just-generated
+	// active key(s), visible within this tx. Strip any RRSIG whose key is gone.
+	surviving, err := txZoneKeytags(tx, zone)
+	if err != nil {
+		return fmt.Errorf("forceZoneKeysToPolicyRoles: list surviving keys for %s: %w", zone, err)
+	}
+	if _, err := zd.StripZoneRRSIGs(ctx, func(rrsig *dns.RRSIG) bool {
+		return !surviving[rrsig.KeyTag]
+	}); err != nil {
+		return fmt.Errorf("forceZoneKeysToPolicyRoles: strip orphaned RRSIGs for %s: %w", zone, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("forceZoneKeysToPolicyRoles: commit for %s: %w", zone, err)
+	}
+	committed = true
+
+	// Post-commit cache invalidation (locked against concurrent map access).
+	kdb.mu.Lock()
+	for key := range kdb.KeystoreDnskeyCache {
+		if strings.HasPrefix(key, zone+"+") {
+			delete(kdb.KeystoreDnskeyCache, key)
+		}
+	}
+	kdb.mu.Unlock()
+	return nil
+}
+
+// txZoneKeytags returns the set of keytags currently present in the keystore for
+// a zone, read within tx (so it sees this transaction's own deletes and inserts).
+func txZoneKeytags(tx *Tx, zone string) (map[uint16]bool, error) {
+	rows, err := tx.Query(`SELECT keyid FROM DnssecKeyStore WHERE zonename=?`, zone)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[uint16]bool{}
+	for rows.Next() {
+		var keyid int
+		if err := rows.Scan(&keyid); err != nil {
+			return nil, err
+		}
+		out[uint16(keyid)] = true
+	}
+	return out, rows.Err()
 }
 
 // dnssecKeyPurge deletes DNSKEY keystore rows in state 'removed', keeping

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -328,6 +328,23 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 			if txSuccess {
 				if err := tx.Commit(); err != nil {
 					lgSigner.Error("DnssecKeyMgmt commit failed", "err", err)
+					return
+				}
+				// Post-commit cache invalidation. `clear` DELETEs+regenerates
+				// all of a zone's keys inside this tx and invalidates the cache
+				// mid-tx (before commit); a GetDnssecKeys during the uncommitted
+				// window (separate DB connection) can re-cache the OLD set, so
+				// that mid-tx wipe is not enough. Drop the zone's cache entries
+				// again now that the new set is committed, so the next read is
+				// served from the committed DB rather than a stale cache.
+				if kp.SubCommand == "clear" && kp.Zone != "" {
+					kdb.mu.Lock()
+					for key := range kdb.KeystoreDnskeyCache {
+						if strings.HasPrefix(key, kp.Zone+"+") {
+							delete(kdb.KeystoreDnskeyCache, key)
+						}
+					}
+					kdb.mu.Unlock()
 				}
 			} else {
 				lgSigner.Debug("DnssecKeyMgmt rollback")

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -755,15 +755,22 @@ func (kdb *KeyDB) forceZoneKeysToPolicyRoles(ctx context.Context, zd *ZoneData, 
 	}
 
 	// Surviving keytags = the kept role's keys (all states) + the just-generated
-	// active key(s), visible within this tx. Strip any RRSIG whose key is gone.
+	// active key(s), visible within this tx.
 	surviving, err := txZoneKeytags(tx, zone)
 	if err != nil {
 		return fmt.Errorf("forceZoneKeysToPolicyRoles: list surviving keys for %s: %w", zone, err)
 	}
+	// Strip (a) orphaned RRSIGs — those made by a dropped key — AND (b) ALL RRSIGs
+	// over the DNSKEY RRset. The DNSKEY RRset content always changes when the key
+	// set changes (a DNSKEY comes or goes), so even the KEPT KSK's DNSKEY RRSIG now
+	// covers a stale key set; it is not an orphan (its key is still active) and the
+	// additive re-sign would leave it in place as bogus cruft. Stripping every
+	// DNSKEY RRSIG here lets the re-sign regenerate exactly one fresh RRSIG per
+	// active KSK. (This method only runs when a role changed, so the key set did.)
 	if _, err := zd.StripZoneRRSIGs(ctx, func(rrsig *dns.RRSIG) bool {
-		return !surviving[rrsig.KeyTag]
+		return !surviving[rrsig.KeyTag] || rrsig.TypeCovered == dns.TypeDNSKEY
 	}); err != nil {
-		return fmt.Errorf("forceZoneKeysToPolicyRoles: strip orphaned RRSIGs for %s: %w", zone, err)
+		return fmt.Errorf("forceZoneKeysToPolicyRoles: strip stale/orphaned RRSIGs for %s: %w", zone, err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/v2/policy_reset_cache_test.go
+++ b/v2/policy_reset_cache_test.go
@@ -1,0 +1,59 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestRefreshActiveDnssecKeysBypassesStaleCache is the regression for the
+// policy-reset stale active-key cache. The active-key cache can hold a STALE set
+// after the keystore changes underneath it (the uncommitted-window re-cache the
+// keystore `clear` path hits: a GetDnssecKeys during the DELETE+regen tx
+// re-caches the OLD keys). Once the DB has changed without a cache invalidation,
+// GetDnssecKeys keeps serving the old set; refreshActiveDnssecKeys must
+// invalidate + re-read from the committed DB so the subsequent re-sign sees the
+// real active keys (else policy-reset re-signs against stale keys and refuses on
+// an algorithm mismatch — the SERVFAIL the testbed hit).
+func TestRefreshActiveDnssecKeysBypassesStaleCache(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+
+	// Prime the active-key cache.
+	primed, err := kdb.GetDnssecKeys(algZone, DnskeyStateActive)
+	if err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+	if len(primed.KSKs)+len(primed.ZSKs) == 0 {
+		t.Fatal("expected primed active keys")
+	}
+
+	// Drop all keys DIRECTLY (bypassing the keystore's cache invalidation), so
+	// the active-key cache is now stale — the shape of the clear-window re-cache.
+	if _, err := kdb.DB.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=?`, algZone); err != nil {
+		t.Fatalf("direct delete: %v", err)
+	}
+
+	// The cache still serves the deleted keys...
+	stale, err := kdb.GetDnssecKeys(algZone, DnskeyStateActive)
+	if err != nil {
+		t.Fatalf("stale read: %v", err)
+	}
+	if len(stale.KSKs)+len(stale.ZSKs) == 0 {
+		t.Skip("GetDnssecKeys did not serve from cache here; nothing to regress")
+	}
+
+	// ...but refreshActiveDnssecKeys invalidates and re-reads the committed DB.
+	fresh, err := zd.refreshActiveDnssecKeys(kdb, "test")
+	if err != nil {
+		t.Fatalf("refreshActiveDnssecKeys: %v", err)
+	}
+	if len(fresh.KSKs)+len(fresh.ZSKs) != 0 {
+		t.Fatalf("refresh returned stale keys: KSKs=%d ZSKs=%d, want 0 (DB was emptied)", len(fresh.KSKs), len(fresh.ZSKs))
+	}
+}

--- a/v2/policy_reset_roles_test.go
+++ b/v2/policy_reset_roles_test.go
@@ -224,3 +224,60 @@ func TestForceZoneKeysToPolicyRoles(t *testing.T) {
 		}
 	})
 }
+
+// TestForceZoneKeysDNSKEYRRSIGStrip covers the ZSK-only flip's subtle case: the
+// DNSKEY RRset content changes (old ZSK's DNSKEY out, new ZSK's in), so the KEPT
+// KSK's DNSKEY RRSIG now covers a stale key set. It is NOT an orphan (its key is
+// still active), so the orphan strip alone would leave it as bogus cruft. The
+// force op must strip ALL DNSKEY RRSIGs; the kept KSK's non-DNSKEY (SOA) RRSIG
+// must survive, and the dropped ZSK's orphans must go.
+func TestForceZoneKeysDNSKEYRRSIGStrip(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	kskTag := genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+	zskTag := genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+
+	zone := `zsk-alg.example.	3600	IN	SOA	ns.zsk-alg.example. hostmaster.zsk-alg.example. 1 7200 1800 604800 7200
+zsk-alg.example.	3600	IN	NS	ns.zsk-alg.example.
+`
+	zd := testZone(t, algZone, zone)
+	registerZones(t, zd)
+
+	mkSig := func(covered, keytag uint16) *dns.RRSIG {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: algZone, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: covered,
+			KeyTag:      keytag,
+			SignerName:  algZone,
+		}
+	}
+	apex, ok := zd.Data.Get(algZone)
+	if !ok {
+		t.Fatal("apex owner missing from zd.Data")
+	}
+	// DNSKEY RRset signed by BOTH the kept KSK and the dropped ZSK.
+	dk := apex.RRtypes.GetOnlyRRSet(dns.TypeDNSKEY)
+	dk.Name = algZone
+	dk.RRtype = dns.TypeDNSKEY
+	dk.RRSIGs = []dns.RR{mkSig(dns.TypeDNSKEY, kskTag), mkSig(dns.TypeDNSKEY, zskTag)}
+	apex.RRtypes.Set(dns.TypeDNSKEY, dk)
+	// SOA RRset signed by both roles.
+	soa := apex.RRtypes.GetOnlyRRSet(dns.TypeSOA)
+	soa.RRSIGs = []dns.RR{mkSig(dns.TypeSOA, kskTag), mkSig(dns.TypeSOA, zskTag)}
+	apex.RRtypes.Set(dns.TypeSOA, soa)
+	zd.InstallInitialSnapshot()
+
+	// ZSK-only flip: keep KSK (algA), drop+regen ZSK (→ algC).
+	if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algA, algC), false, true); err != nil {
+		t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
+	}
+
+	// DNSKEY RRSIGs: ALL stripped — the kept KSK's stale one AND the ZSK orphan.
+	if tags := zd.mustRRSIGKeytags(t, algZone, dns.TypeDNSKEY); len(tags) != 0 {
+		t.Fatalf("DNSKEY RRSIGs after ZSK flip = %v, want none (incl. the kept KSK's stale one)", tags)
+	}
+	// SOA RRSIGs: kept KSK's survives (not DNSKEY-covered, key still active); the
+	// dropped ZSK's orphan is stripped.
+	if tags := zd.mustRRSIGKeytags(t, algZone, dns.TypeSOA); len(tags) != 1 || tags[0] != kskTag {
+		t.Fatalf("SOA RRSIGs after ZSK flip = %v, want [%d] (kept KSK only)", tags, kskTag)
+	}
+}

--- a/v2/policy_reset_roles_test.go
+++ b/v2/policy_reset_roles_test.go
@@ -52,58 +52,68 @@ func activeRoleKeys(t *testing.T, kdb *KeyDB) (seps, zsks []DnssecKeyWithTimesta
 // TestZoneActiveKeyRoleChanges covers the per-role keep/drop decision across the
 // four split cases, CSK, mode changes, missing roles, and a mid-rollover mix.
 func TestZoneActiveKeyRoleChanges(t *testing.T) {
+	// currentMode is the zone's currently-bound policy Mode ("ksk-zsk" | "csk");
+	// the mode-change cases set it to differ from the target pol.Mode.
 	cases := []struct {
 		name             string
+		currentMode      string
 		setup            func(t *testing.T, kdb *KeyDB)
 		pol              *DnssecPolicy
 		wantKSK, wantZSK bool
 	}{
-		{"split no-op", func(t *testing.T, kdb *KeyDB) {
+		{"split no-op", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 		}, splitPol(algA, algB), false, false},
 
-		{"split zsk-only", func(t *testing.T, kdb *KeyDB) {
+		{"split zsk-only", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 		}, splitPol(algA, algC), false, true},
 
-		{"split ksk-only", func(t *testing.T, kdb *KeyDB) {
+		{"split ksk-only", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 		}, splitPol(algC, algB), true, false},
 
-		{"split both", func(t *testing.T, kdb *KeyDB) {
+		{"split both", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 		}, splitPol(algC, algD), true, true},
 
-		{"no active keys", func(t *testing.T, kdb *KeyDB) {}, splitPol(algA, algB), true, true},
+		{"no active keys", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {}, splitPol(algA, algB), true, true},
 
-		{"ksk role missing", func(t *testing.T, kdb *KeyDB) {
+		{"ksk role missing", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 		}, splitPol(algA, algB), true, false},
 
-		{"zsk mid-rollover mix", func(t *testing.T, kdb *KeyDB) {
+		// The Finding-② regression: a split zone with a healthy KSK but a missing
+		// ZSK must roll only the ZSK and KEEP the KSK — NOT be misread as a CSK
+		// mode change that drops the KSK and breaks the DS.
+		{"zsk role missing (keep KSK)", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+		}, splitPol(algA, algB), false, true},
+
+		{"zsk mid-rollover mix", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK") // right alg
 			genRoleKey(t, kdb, DnskeyStateActive, algC, "ZSK") // wrong alg (in flight)
 		}, splitPol(algA, algB), false, true},
 
-		{"csk no-op", func(t *testing.T, kdb *KeyDB) {
+		{"csk no-op", DnssecPolicyModeCSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "CSK")
 		}, cskPol(algA), false, false},
 
-		{"csk alg change", func(t *testing.T, kdb *KeyDB) {
+		{"csk alg change", DnssecPolicyModeCSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "CSK")
 		}, cskPol(algB), true, false},
 
-		{"mode change split->csk", func(t *testing.T, kdb *KeyDB) {
+		{"mode change split->csk", DnssecPolicyModeKSKZSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 		}, cskPol(algA), true, true},
 
-		{"mode change csk->split", func(t *testing.T, kdb *KeyDB) {
+		{"mode change csk->split", DnssecPolicyModeCSK, func(t *testing.T, kdb *KeyDB) {
 			genRoleKey(t, kdb, DnskeyStateActive, algA, "CSK")
 		}, splitPol(algA, algB), true, true},
 	}
@@ -111,7 +121,7 @@ func TestZoneActiveKeyRoleChanges(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			kdb := newTestKeyDB(t)
 			c.setup(t, kdb)
-			ksk, zsk, err := zoneActiveKeyRoleChanges(kdb, algZone, c.pol)
+			ksk, zsk, err := zoneActiveKeyRoleChanges(kdb, algZone, c.pol, c.currentMode)
 			if err != nil {
 				t.Fatalf("zoneActiveKeyRoleChanges: %v", err)
 			}
@@ -122,33 +132,45 @@ func TestZoneActiveKeyRoleChanges(t *testing.T) {
 	}
 }
 
-// TestPolicyResetReport asserts the DS-break warning fires iff the KSK changed.
+// TestPolicyResetReport asserts the DS-break warning fires iff the KSK changed,
+// and that a CSK replacement is reported as CSK (not "KSK rolled, ZSK kept").
 func TestPolicyResetReport(t *testing.T) {
 	cases := []struct {
-		ksk, zsk bool
-		wantWarn bool
-		phrase   string
+		name      string
+		mode      string
+		ksk, zsk  bool
+		wantWarn  bool
+		phrase    string
+		notPhrase string
 	}{
-		{false, false, false, "KSK and parent DS unchanged"},
-		{false, true, false, "KSK and parent DS unchanged"},
-		{true, false, true, "BREAKS the chain of trust"},
-		{true, true, true, "BREAKS the chain of trust"},
+		{"split no-op", DnssecPolicyModeKSKZSK, false, false, false, "KSK and parent DS unchanged", ""},
+		{"split zsk-only", DnssecPolicyModeKSKZSK, false, true, false, "KSK and parent DS unchanged", ""},
+		{"split ksk-only", DnssecPolicyModeKSKZSK, true, false, true, "BREAKS the chain of trust", ""},
+		{"split both", DnssecPolicyModeKSKZSK, true, true, true, "BREAKS the chain of trust", ""},
+		{"csk no-op", DnssecPolicyModeCSK, false, false, false, "KSK and parent DS unchanged", ""},
+		// CSK replacement: DS warning, "CSK algorithm rolled", and NOT the split
+		// "ZSK kept" wording.
+		{"csk replacement", DnssecPolicyModeCSK, true, false, true, "CSK algorithm rolled", "ZSK kept"},
 	}
 	for _, c := range cases {
-		msg := policyResetReport("z.example.", "pol", c.ksk, c.zsk, 42)
+		msg := policyResetReport("z.example.", "pol", c.mode, c.ksk, c.zsk, 42)
 		hasWarn := strings.Contains(msg, "BREAKS the chain of trust")
 		if hasWarn != c.wantWarn {
-			t.Fatalf("ksk=%v zsk=%v: DS warning present=%v, want %v\nmsg: %s", c.ksk, c.zsk, hasWarn, c.wantWarn, msg)
+			t.Fatalf("%s: DS warning present=%v, want %v\nmsg: %s", c.name, hasWarn, c.wantWarn, msg)
 		}
 		if !strings.Contains(msg, c.phrase) {
-			t.Fatalf("ksk=%v zsk=%v: message missing %q\nmsg: %s", c.ksk, c.zsk, c.phrase, msg)
+			t.Fatalf("%s: message missing %q\nmsg: %s", c.name, c.phrase, msg)
+		}
+		if c.notPhrase != "" && strings.Contains(msg, c.notPhrase) {
+			t.Fatalf("%s: message unexpectedly contains %q\nmsg: %s", c.name, c.notPhrase, msg)
 		}
 	}
 }
 
-// TestForceZoneKeysToPolicyRoles verifies the surgical drop/regen: the kept
-// role's keytag is preserved, the dropped role gets a fresh key of the config
-// algorithm. StripZoneRRSIGs no-ops on the data-less test zone.
+// TestForceZoneKeysToPolicyRoles verifies the surgical drop/regen in the
+// keystore: the kept role's keytag is preserved, the dropped role gets a fresh
+// key of the config algorithm. (The RRSIG strip is a separate step, tested in
+// TestForceZoneKeysDNSKEYRRSIGStrip.)
 func TestForceZoneKeysToPolicyRoles(t *testing.T) {
 	t.Run("zsk-only keeps KSK keytag", func(t *testing.T) {
 		kdb := newTestKeyDB(t)
@@ -156,7 +178,7 @@ func TestForceZoneKeysToPolicyRoles(t *testing.T) {
 		kskTag := genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 		zskTag := genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 
-		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algA, algC), false, true); err != nil {
+		if _, err := kdb.forceZoneKeysToPolicyRoles(zd, splitPol(algA, algC), false, true); err != nil {
 			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
 		}
 		seps, zsks := activeRoleKeys(t, kdb)
@@ -174,7 +196,7 @@ func TestForceZoneKeysToPolicyRoles(t *testing.T) {
 		kskTag := genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 		zskTag := genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 
-		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algC, algB), true, false); err != nil {
+		if _, err := kdb.forceZoneKeysToPolicyRoles(zd, splitPol(algC, algB), true, false); err != nil {
 			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
 		}
 		seps, zsks := activeRoleKeys(t, kdb)
@@ -192,7 +214,7 @@ func TestForceZoneKeysToPolicyRoles(t *testing.T) {
 		genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 		genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 
-		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algC, algD), true, true); err != nil {
+		if _, err := kdb.forceZoneKeysToPolicyRoles(zd, splitPol(algC, algD), true, true); err != nil {
 			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
 		}
 		seps, zsks := activeRoleKeys(t, kdb)
@@ -212,7 +234,7 @@ func TestForceZoneKeysToPolicyRoles(t *testing.T) {
 		genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
 		genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
 
-		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, cskPol(algC), true, false); err != nil {
+		if _, err := kdb.forceZoneKeysToPolicyRoles(zd, cskPol(algC), true, false); err != nil {
 			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
 		}
 		seps, zsks := activeRoleKeys(t, kdb)
@@ -266,9 +288,15 @@ zsk-alg.example.	3600	IN	NS	ns.zsk-alg.example.
 	apex.RRtypes.Set(dns.TypeSOA, soa)
 	zd.InstallInitialSnapshot()
 
-	// ZSK-only flip: keep KSK (algA), drop+regen ZSK (→ algC).
-	if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algA, algC), false, true); err != nil {
+	// ZSK-only flip: keep KSK (algA), drop+regen ZSK (→ algC). The force op only
+	// mutates keys now; the strip happens after via stripStaleRRSIGsForKeySet
+	// (mirroring resetZonePolicy: strip post-commit, before the re-sign).
+	surviving, err := kdb.forceZoneKeysToPolicyRoles(zd, splitPol(algA, algC), false, true)
+	if err != nil {
 		t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
+	}
+	if _, err := stripStaleRRSIGsForKeySet(context.Background(), zd, surviving); err != nil {
+		t.Fatalf("stripStaleRRSIGsForKeySet: %v", err)
 	}
 
 	// DNSKEY RRSIGs: ALL stripped — the kept KSK's stale one AND the ZSK orphan.

--- a/v2/policy_reset_roles_test.go
+++ b/v2/policy_reset_roles_test.go
@@ -1,0 +1,226 @@
+package tdns
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Algorithms used across the per-role tests (all built-in; no liboqs needed).
+const (
+	algA = dns.ED25519
+	algB = dns.RSASHA256
+	algC = dns.RSASHA512
+	algD = dns.ECDSAP256SHA256
+)
+
+func genRoleKey(t *testing.T, kdb *KeyDB, state string, alg uint8, role string) uint16 {
+	t.Helper()
+	pkc, _, err := kdb.GenerateKeypair(algZone, "test", state, dns.TypeDNSKEY, alg, role, nil)
+	if err != nil {
+		t.Fatalf("GenerateKeypair(%s,%s,%s): %v", state, dns.AlgorithmToString[alg], role, err)
+	}
+	return pkc.KeyId
+}
+
+func splitPol(ksk, zsk uint8) *DnssecPolicy {
+	return &DnssecPolicy{Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: ksk, ZSKAlgorithm: zsk}
+}
+func cskPol(alg uint8) *DnssecPolicy {
+	return &DnssecPolicy{Mode: DnssecPolicyModeCSK, Algorithm: alg, KSKAlgorithm: alg, ZSKAlgorithm: alg}
+}
+
+// activeRoleKeys splits the zone's active keys into KSK/CSK (SEP) and ZSK (non-SEP).
+func activeRoleKeys(t *testing.T, kdb *KeyDB) (seps, zsks []DnssecKeyWithTimestamps) {
+	t.Helper()
+	active, err := GetDnssecKeysByState(kdb, algZone, DnskeyStateActive)
+	if err != nil {
+		t.Fatalf("GetDnssecKeysByState: %v", err)
+	}
+	for _, k := range active {
+		if k.Flags&0x0001 == 0x0001 {
+			seps = append(seps, k)
+		} else {
+			zsks = append(zsks, k)
+		}
+	}
+	return seps, zsks
+}
+
+// TestZoneActiveKeyRoleChanges covers the per-role keep/drop decision across the
+// four split cases, CSK, mode changes, missing roles, and a mid-rollover mix.
+func TestZoneActiveKeyRoleChanges(t *testing.T) {
+	cases := []struct {
+		name             string
+		setup            func(t *testing.T, kdb *KeyDB)
+		pol              *DnssecPolicy
+		wantKSK, wantZSK bool
+	}{
+		{"split no-op", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+		}, splitPol(algA, algB), false, false},
+
+		{"split zsk-only", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+		}, splitPol(algA, algC), false, true},
+
+		{"split ksk-only", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+		}, splitPol(algC, algB), true, false},
+
+		{"split both", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+		}, splitPol(algC, algD), true, true},
+
+		{"no active keys", func(t *testing.T, kdb *KeyDB) {}, splitPol(algA, algB), true, true},
+
+		{"ksk role missing", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+		}, splitPol(algA, algB), true, false},
+
+		{"zsk mid-rollover mix", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK") // right alg
+			genRoleKey(t, kdb, DnskeyStateActive, algC, "ZSK") // wrong alg (in flight)
+		}, splitPol(algA, algB), false, true},
+
+		{"csk no-op", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "CSK")
+		}, cskPol(algA), false, false},
+
+		{"csk alg change", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "CSK")
+		}, cskPol(algB), true, false},
+
+		{"mode change split->csk", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+			genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+		}, cskPol(algA), true, true},
+
+		{"mode change csk->split", func(t *testing.T, kdb *KeyDB) {
+			genRoleKey(t, kdb, DnskeyStateActive, algA, "CSK")
+		}, splitPol(algA, algB), true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			kdb := newTestKeyDB(t)
+			c.setup(t, kdb)
+			ksk, zsk, err := zoneActiveKeyRoleChanges(kdb, algZone, c.pol)
+			if err != nil {
+				t.Fatalf("zoneActiveKeyRoleChanges: %v", err)
+			}
+			if ksk != c.wantKSK || zsk != c.wantZSK {
+				t.Fatalf("got (kskChanged=%v, zskChanged=%v), want (%v, %v)", ksk, zsk, c.wantKSK, c.wantZSK)
+			}
+		})
+	}
+}
+
+// TestPolicyResetReport asserts the DS-break warning fires iff the KSK changed.
+func TestPolicyResetReport(t *testing.T) {
+	cases := []struct {
+		ksk, zsk bool
+		wantWarn bool
+		phrase   string
+	}{
+		{false, false, false, "KSK and parent DS unchanged"},
+		{false, true, false, "KSK and parent DS unchanged"},
+		{true, false, true, "BREAKS the chain of trust"},
+		{true, true, true, "BREAKS the chain of trust"},
+	}
+	for _, c := range cases {
+		msg := policyResetReport("z.example.", "pol", c.ksk, c.zsk, 42)
+		hasWarn := strings.Contains(msg, "BREAKS the chain of trust")
+		if hasWarn != c.wantWarn {
+			t.Fatalf("ksk=%v zsk=%v: DS warning present=%v, want %v\nmsg: %s", c.ksk, c.zsk, hasWarn, c.wantWarn, msg)
+		}
+		if !strings.Contains(msg, c.phrase) {
+			t.Fatalf("ksk=%v zsk=%v: message missing %q\nmsg: %s", c.ksk, c.zsk, c.phrase, msg)
+		}
+	}
+}
+
+// TestForceZoneKeysToPolicyRoles verifies the surgical drop/regen: the kept
+// role's keytag is preserved, the dropped role gets a fresh key of the config
+// algorithm. StripZoneRRSIGs no-ops on the data-less test zone.
+func TestForceZoneKeysToPolicyRoles(t *testing.T) {
+	t.Run("zsk-only keeps KSK keytag", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(algA, algB)
+		kskTag := genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+		zskTag := genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+
+		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algA, algC), false, true); err != nil {
+			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
+		}
+		seps, zsks := activeRoleKeys(t, kdb)
+		if len(seps) != 1 || seps[0].KeyTag != kskTag || seps[0].Algorithm != algA {
+			t.Fatalf("KSK not preserved: got %+v, want 1 KSK keytag %d alg %s", seps, kskTag, dns.AlgorithmToString[algA])
+		}
+		if len(zsks) != 1 || zsks[0].Algorithm != algC || zsks[0].KeyTag == zskTag {
+			t.Fatalf("ZSK not rolled to new alg: got %+v, want 1 ZSK alg %s with a new keytag (old %d)", zsks, dns.AlgorithmToString[algC], zskTag)
+		}
+	})
+
+	t.Run("ksk-only keeps ZSK keytag", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(algA, algB)
+		kskTag := genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+		zskTag := genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+
+		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algC, algB), true, false); err != nil {
+			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
+		}
+		seps, zsks := activeRoleKeys(t, kdb)
+		if len(seps) != 1 || seps[0].Algorithm != algC || seps[0].KeyTag == kskTag {
+			t.Fatalf("KSK not rolled: got %+v, want 1 KSK alg %s new keytag (old %d)", seps, dns.AlgorithmToString[algC], kskTag)
+		}
+		if len(zsks) != 1 || zsks[0].KeyTag != zskTag || zsks[0].Algorithm != algB {
+			t.Fatalf("ZSK not preserved: got %+v, want 1 ZSK keytag %d alg %s", zsks, zskTag, dns.AlgorithmToString[algB])
+		}
+	})
+
+	t.Run("both rolls both roles", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(algA, algB)
+		genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+		genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+
+		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, splitPol(algC, algD), true, true); err != nil {
+			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
+		}
+		seps, zsks := activeRoleKeys(t, kdb)
+		if len(seps) != 1 || seps[0].Algorithm != algC {
+			t.Fatalf("KSK: got %+v, want 1 KSK alg %s", seps, dns.AlgorithmToString[algC])
+		}
+		if len(zsks) != 1 || zsks[0].Algorithm != algD {
+			t.Fatalf("ZSK: got %+v, want 1 ZSK alg %s", zsks, dns.AlgorithmToString[algD])
+		}
+	})
+
+	t.Run("csk collapses to a single CSK", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(algA, algA)
+		zd.DnssecPolicy.Mode = DnssecPolicyModeCSK
+		// A split starting set (KSK+ZSK) to prove the leftover ZSK is removed.
+		genRoleKey(t, kdb, DnskeyStateActive, algA, "KSK")
+		genRoleKey(t, kdb, DnskeyStateActive, algB, "ZSK")
+
+		if err := kdb.forceZoneKeysToPolicyRoles(context.Background(), zd, cskPol(algC), true, false); err != nil {
+			t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
+		}
+		seps, zsks := activeRoleKeys(t, kdb)
+		if len(zsks) != 0 {
+			t.Fatalf("CSK reset should leave no separate ZSK, got %+v", zsks)
+		}
+		if len(seps) != 1 || seps[0].Algorithm != algC {
+			t.Fatalf("CSK: got %+v, want 1 SEP key alg %s", seps, dns.AlgorithmToString[algC])
+		}
+	})
+}

--- a/v2/policy_reset_roles_test.go
+++ b/v2/policy_reset_roles_test.go
@@ -167,6 +167,41 @@ func TestPolicyResetReport(t *testing.T) {
 	}
 }
 
+// TestPolicyResetDryRunReport asserts the no-confirm preview labels itself a DRY
+// RUN, always prompts for --confirm, and warns about a DS break only when the
+// KSK (or CSK) would roll.
+func TestPolicyResetDryRunReport(t *testing.T) {
+	cases := []struct {
+		name        string
+		mode        string
+		ksk, zsk    bool
+		wantDSBreak bool
+		phrase      string
+	}{
+		{"split no-op", DnssecPolicyModeKSKZSK, false, false, false, "roll NO keys"},
+		{"split zsk-only", DnssecPolicyModeKSKZSK, false, true, false, "keeping the KSK"},
+		{"split ksk-only", DnssecPolicyModeKSKZSK, true, false, true, "roll the KSK"},
+		{"split both", DnssecPolicyModeKSKZSK, true, true, true, "roll BOTH"},
+		{"csk replacement", DnssecPolicyModeCSK, true, false, true, "regenerate the CSK"},
+	}
+	for _, c := range cases {
+		msg := policyResetDryRunReport("z.example.", "pol", c.mode, c.ksk, c.zsk)
+		if !strings.Contains(msg, "DRY RUN") {
+			t.Fatalf("%s: missing DRY RUN header\nmsg: %s", c.name, msg)
+		}
+		if !strings.Contains(msg, "--confirm") {
+			t.Fatalf("%s: missing --confirm prompt\nmsg: %s", c.name, msg)
+		}
+		dsBreak := strings.Contains(msg, "BREAK the chain of trust")
+		if dsBreak != c.wantDSBreak {
+			t.Fatalf("%s: DS-break present=%v, want %v\nmsg: %s", c.name, dsBreak, c.wantDSBreak, msg)
+		}
+		if !strings.Contains(msg, c.phrase) {
+			t.Fatalf("%s: missing %q\nmsg: %s", c.name, c.phrase, msg)
+		}
+	}
+}
+
 // TestForceZoneKeysToPolicyRoles verifies the surgical drop/regen in the
 // keystore: the kept role's keytag is preserved, the dropped role gets a fresh
 // key of the config algorithm. (The RRSIG strip is a separate step, tested in

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -104,6 +104,15 @@ type ZoneRefreshAnalysis struct {
 
 type ZoneData struct {
 	mu sync.Mutex
+	// policyApplyMu serializes a full DNSSEC-policy apply (rebind → re-sign →
+	// persist → revert) for this zone. It is the OUTERMOST lock of that
+	// operation and is distinct from mu: SignZone takes mu internally, so the
+	// apply cannot hold mu across the sign; without a separate lock two
+	// concurrent applies could interleave and a failed revert could clobber a
+	// newer binding. Acquired by applyZonePolicyTransactional; policy-reset
+	// holds it across its clear+re-sign via the *Locked variant. Never held
+	// while mu is held, so there is no lock-order inversion with SignZone.
+	policyApplyMu sync.Mutex
 	// generation is bumped on every removal/replacement of this zone
 	// (RemoveDynamicZone, ModifyDynamicZone, config-reload Zones.Remove). A
 	// refresh goroutine snapshots it at dispatch; the pre-persist guard (B5b)

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -419,7 +419,7 @@ const policyResetDryRunConfirm = "Re-run with --confirm to apply."
 
 // policyResetDryRunDSBreak is the DS-break line for a dry-run preview whose
 // apply would roll the KSK (or CSK), plus the confirm prompt.
-const policyResetDryRunDSBreak = "  • ⚠ BREAK the chain of trust: the parent DS would no longer match the new KSK, and validators would go BOGUS until you re-publish the DS.\n" +
+const policyResetDryRunDSBreak = "  * !! BREAK the chain of trust: the parent DS would no longer match the new KSK, and validators would go BOGUS until you re-publish the DS.\n" +
 	policyResetDryRunConfirm
 
 // policyResetDryRunReport describes what a policy-reset WOULD do, WITHOUT making
@@ -432,21 +432,21 @@ func policyResetDryRunReport(zone, configName, mode string, kskChanged, zskChang
 	fmt.Fprintf(&b, "DRY RUN — policy-reset of zone %s to config policy %q would:\n", zone, configName)
 	switch {
 	case !kskChanged && !zskChanged:
-		b.WriteString("  • roll NO keys — the active keys already match config; it would only re-sign and record applied=config.\n")
-		b.WriteString("  • leave the KSK and parent DS UNCHANGED.\n")
+		b.WriteString("  * roll NO keys — the active keys already match config; it would only re-sign and record applied=config.\n")
+		b.WriteString("  * leave the KSK and parent DS UNCHANGED.\n")
 		b.WriteString("This is safe (a no-op key-wise). " + policyResetDryRunConfirm)
 	case mode == DnssecPolicyModeCSK:
-		b.WriteString("  • drop and regenerate the CSK (the single combined-signing key).\n")
+		b.WriteString("  * drop and regenerate the CSK (the single combined-signing key).\n")
 		b.WriteString(policyResetDryRunDSBreak)
 	case !kskChanged && zskChanged:
-		b.WriteString("  • roll the ZSK algorithm (drop and regenerate the ZSK), keeping the KSK.\n")
-		b.WriteString("  • leave the KSK and parent DS UNCHANGED — no DS update needed.\n")
+		b.WriteString("  * roll the ZSK algorithm (drop and regenerate the ZSK), keeping the KSK.\n")
+		b.WriteString("  * leave the KSK and parent DS UNCHANGED — no DS update needed.\n")
 		b.WriteString(policyResetDryRunConfirm)
 	case kskChanged && !zskChanged:
-		b.WriteString("  • roll the KSK algorithm (drop and regenerate the KSK), keeping the ZSK.\n")
+		b.WriteString("  * roll the KSK algorithm (drop and regenerate the KSK), keeping the ZSK.\n")
 		b.WriteString(policyResetDryRunDSBreak)
 	default: // both roles changed
-		b.WriteString("  • roll BOTH the KSK and ZSK algorithms (drop and regenerate both).\n")
+		b.WriteString("  * roll BOTH the KSK and ZSK algorithms (drop and regenerate both).\n")
 		b.WriteString(policyResetDryRunDSBreak)
 	}
 	return b.String()

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -20,7 +20,10 @@
 
 package tdns
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // PolicyApplySource records why a policy was applied, and is persisted as
 // applied_source. 'command' additionally persists a CLI override (intent);
@@ -158,13 +161,19 @@ func resolvePolicyPair(kdb *KeyDB, zone, configPolicyName string) (
 // The old binding is snapshotted for REVERT ONLY; it is never used to classify
 // the change (blocking ①). Caller is responsible for having classified/refused
 // before calling this.
+//
+// ctx is threaded as the first parameter per the house convention and to carry
+// cancellation once SignZone and the applied-policy DB writes become ctx-aware;
+// those downstream calls do not yet consume it.
 func applyZonePolicyTransactional(
+	ctx context.Context,
 	zd *ZoneData,
 	kdb *KeyDB,
 	newPol *DnssecPolicy,
 	newName string,
 	source PolicyApplySource,
 ) (newRRSIGs int, err error) {
+	_ = ctx // reserved: no ctx-aware downstream call yet (see doc comment)
 	if newPol == nil {
 		return 0, fmt.Errorf("applyZonePolicyTransactional: nil policy %q for zone %s", newName, zd.ZoneName)
 	}

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -412,3 +412,42 @@ func policyResetReport(zone, configName, mode string, kskChanged, zskChanged boo
 	}
 	return b.String()
 }
+
+// policyResetDryRunConfirm is the suffix for a dry-run preview whose apply is
+// destructive (a key roll): tells the operator how to actually run it.
+const policyResetDryRunConfirm = "Re-run with --confirm to apply."
+
+// policyResetDryRunDSBreak is the DS-break line for a dry-run preview whose
+// apply would roll the KSK (or CSK), plus the confirm prompt.
+const policyResetDryRunDSBreak = "  • ⚠ BREAK the chain of trust: the parent DS would no longer match the new KSK, and validators would go BOGUS until you re-publish the DS.\n" +
+	policyResetDryRunConfirm
+
+// policyResetDryRunReport describes what a policy-reset WOULD do, WITHOUT making
+// any change — the preview shown when --confirm is absent. It mirrors
+// policyResetReport's per-role classification in the conditional tense, states
+// whether the parent DS would break, and tells the operator to add --confirm to
+// proceed. mode is the config policy's Mode ("ksk-zsk" | "csk").
+func policyResetDryRunReport(zone, configName, mode string, kskChanged, zskChanged bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "DRY RUN — policy-reset of zone %s to config policy %q would:\n", zone, configName)
+	switch {
+	case !kskChanged && !zskChanged:
+		b.WriteString("  • roll NO keys — the active keys already match config; it would only re-sign and record applied=config.\n")
+		b.WriteString("  • leave the KSK and parent DS UNCHANGED.\n")
+		b.WriteString("This is safe (a no-op key-wise). " + policyResetDryRunConfirm)
+	case mode == DnssecPolicyModeCSK:
+		b.WriteString("  • drop and regenerate the CSK (the single combined-signing key).\n")
+		b.WriteString(policyResetDryRunDSBreak)
+	case !kskChanged && zskChanged:
+		b.WriteString("  • roll the ZSK algorithm (drop and regenerate the ZSK), keeping the KSK.\n")
+		b.WriteString("  • leave the KSK and parent DS UNCHANGED — no DS update needed.\n")
+		b.WriteString(policyResetDryRunConfirm)
+	case kskChanged && !zskChanged:
+		b.WriteString("  • roll the KSK algorithm (drop and regenerate the KSK), keeping the ZSK.\n")
+		b.WriteString(policyResetDryRunDSBreak)
+	default: // both roles changed
+		b.WriteString("  • roll BOTH the KSK and ZSK algorithms (drop and regenerate both).\n")
+		b.WriteString(policyResetDryRunDSBreak)
+	}
+	return b.String()
+}

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -40,12 +40,13 @@ const (
 type PolicyChangeClass int
 
 const (
-	// PolicyChangeNone: same name, same effective algorithms, identical policy
-	// internals — nothing to do.
+	// PolicyChangeNone: same name, same effective algorithms — nothing to do.
+	// An internals-only edit (lifetimes/sigvalidity/ttls/rollover) under the
+	// same name also lands here and converges via the resigner; there is no
+	// separate "benign internals" class. Finding A: resolvePolicyPair resolves
+	// applied and intent from the SAME ConfLive() snapshot by NAME, so a
+	// "same name, changed internals" delta is unreachable at classify time.
 	PolicyChangeNone PolicyChangeClass = iota
-	// PolicyChangeBenignInternals: same name, same effective algorithms, but
-	// lifetimes/sigvalidity/ttls/rollover internals changed — cheap re-sign.
-	PolicyChangeBenignInternals
 	// PolicyChangeCompatibleName: different name, same KSK+ZSK algorithms —
 	// apply transactionally.
 	PolicyChangeCompatibleName
@@ -58,8 +59,6 @@ func (c PolicyChangeClass) String() string {
 	switch c {
 	case PolicyChangeNone:
 		return "none"
-	case PolicyChangeBenignInternals:
-		return "benign-internals"
 	case PolicyChangeCompatibleName:
 		return "compatible-name"
 	case PolicyChangeIncompatibleAlg:
@@ -97,16 +96,10 @@ func classifyPolicyChange(
 	if appliedName != intentName {
 		return PolicyChangeCompatibleName
 	}
-	// Same name, same effective algorithms: distinguish an identical policy from
-	// an internals-only edit so the caller can pick the cheap re-sign path.
-	// suppressLoadWarnings is a non-semantic parse flag — normalize it out.
-	a, b := *appliedPol, *intentPol
-	a.suppressLoadWarnings = false
-	b.suppressLoadWarnings = false
-	if a == b {
-		return PolicyChangeNone
-	}
-	return PolicyChangeBenignInternals
+	// Same name, same effective algorithms → nothing to do. Any internals-only
+	// edit under the same name converges via the resigner (Finding A), so there
+	// is deliberately no separate class for it.
+	return PolicyChangeNone
 }
 
 // resolvePolicyPair loads a zone's intent (via EffectiveDnssecPolicyName: CLI
@@ -162,10 +155,33 @@ func resolvePolicyPair(kdb *KeyDB, zone, configPolicyName string) (
 // the change (blocking ①). Caller is responsible for having classified/refused
 // before calling this.
 //
+// It serializes concurrent applies on the same zone via zd.policyApplyMu.
+// Callers that must serialize extra steps together with the apply — policy-reset
+// drops and regenerates the zone's keys before the re-sign — hold
+// zd.policyApplyMu themselves and call applyZonePolicyTransactionalLocked.
+//
 // ctx is threaded as the first parameter per the house convention and to carry
 // cancellation once SignZone and the applied-policy DB writes become ctx-aware;
 // those downstream calls do not yet consume it.
 func applyZonePolicyTransactional(
+	ctx context.Context,
+	zd *ZoneData,
+	kdb *KeyDB,
+	newPol *DnssecPolicy,
+	newName string,
+	source PolicyApplySource,
+) (newRRSIGs int, err error) {
+	zd.policyApplyMu.Lock()
+	defer zd.policyApplyMu.Unlock()
+	return applyZonePolicyTransactionalLocked(ctx, zd, kdb, newPol, newName, source)
+}
+
+// applyZonePolicyTransactionalLocked is applyZonePolicyTransactional WITHOUT
+// acquiring zd.policyApplyMu. The caller MUST already hold zd.policyApplyMu for
+// this zone; use it only when the apply is one step of a larger critical
+// section that already holds the mutex (policy-reset). Otherwise call
+// applyZonePolicyTransactional.
+func applyZonePolicyTransactionalLocked(
 	ctx context.Context,
 	zd *ZoneData,
 	kdb *KeyDB,
@@ -192,7 +208,7 @@ func applyZonePolicyTransactional(
 	zd.DnssecPolicyName = newName
 	zd.mu.Unlock()
 
-	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm, false)
+	UpdateSigValidityFloor(zd, newPol, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm, false)
 
 	newRRSIGs, err = zd.SignZone(kdb, true)
 	if err != nil {

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -247,6 +247,28 @@ func applyZonePolicyTransactionalLocked(
 // (unsigned, no intent, or active-key algorithms differ from intent); the
 // caller then drives a genuine transactional apply toward intent, whose
 // SignZone algorithm backstop refuses an unsafe swap.
+//
+// ⚠ PR-2 GATE (plan §5.5) — MUST be closed before this is called from any live
+// refresh-engine path. The eligibility predicate is CURRENTLY keystore-only: it
+// checks that the zone's ACTIVE keys match intent's algorithms
+// (zoneActiveKeysMatchAlgs). That is NECESSARY but NOT SUFFICIENT — a zone can
+// hold the right active keys yet not actually be signed (fresh keygen with no
+// sign; a secondary whose stored RRSIGs are absent or stale, §5.5 line 79).
+// Recording applied=intent for such a zone marks it "signed under intent" when
+// it is not. Before going live, additionally require the zone to actually SERVE
+// a signature by an active intent-algorithm key, e.g.:
+//
+//	soa, err := zd.GetRRset(zd.ZoneName, dns.TypeSOA) // needs zd.Ready + MapZone
+//	// eligible only if err==nil, soa!=nil, and some rr in soa.RRSIGs is a
+//	// *dns.RRSIG with Algorithm == intentPol.ZSKAlgorithm (CSK: KSKAlgorithm).
+//
+// That check reads served zone data, so the call site MUST run AFTER the zone
+// snapshot is Ready — NOT the pre-initialLoadZone placement §5.5 line 516
+// contemplates for a keystore-only predicate. Otherwise the served-RRSIG check
+// fails closed and every config-only zone falls through to a forced re-sign,
+// defeating blocking-② (the thundering-herd avoidance this function exists for).
+// Left keystore-only in PR-1 because backfill is not called by any production
+// path here (unit tests only).
 func backfillAppliedIfEligible(kdb *KeyDB, zd *ZoneData, intentName string, intentPol *DnssecPolicy) (backfilled bool, err error) {
 	if intentPol == nil || intentName == "" {
 		return false, nil
@@ -273,6 +295,10 @@ func backfillAppliedIfEligible(kdb *KeyDB, zd *ZoneData, intentName string, inte
 // single active SEP key of pol.KSKAlgorithm (which equals pol.ZSKAlgorithm). The
 // SEP bit (flags & 1) distinguishes a KSK/CSK from a ZSK — the same convention
 // the signer and the standby→published migration use.
+//
+// NOTE (§5.5): this proves the KEYSTORE holds matching active keys, NOT that the
+// zone is actually signed under them. It is a necessary-not-sufficient input to
+// backfill eligibility — see the PR-2 GATE note on backfillAppliedIfEligible.
 func zoneActiveKeysMatchAlgs(kdb *KeyDB, zone string, pol *DnssecPolicy) (bool, error) {
 	active, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
 	if err != nil {

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -381,7 +381,7 @@ func zoneActiveKeyRoleChanges(kdb *KeyDB, zone string, pol *DnssecPolicy, curren
 
 // policyResetDSWarning is the chain-of-trust break notice, emitted only when the
 // KSK algorithm actually changed (the parent DS no longer matches the new KSK).
-const policyResetDSWarning = "WARNING: this was an ABRUPT switch that BREAKS the chain of trust — the parent DS no longer matches the new KSK.\n" +
+const policyResetDSWarning = "WARNING: this was an ABRUPT switch that BREAKS the chain of trust - the parent DS no longer matches the new KSK.\n" +
 	"NOTE: validators will go BOGUS until the new DS is published at the parent (via the auto-rollover engine or a manual DS update)."
 
 // policyResetReport builds the operator-facing message for a completed
@@ -393,7 +393,7 @@ func policyResetReport(zone, configName, mode string, kskChanged, zskChanged boo
 	var b strings.Builder
 	switch {
 	case !kskChanged && !zskChanged:
-		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; active keys already matched — no key roll. Re-signed (%d RRSIGs) and recorded applied=config.\n", zone, configName, newRRSIGs)
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; active keys already matched - no key roll. Re-signed (%d RRSIGs) and recorded applied=config.\n", zone, configName, newRRSIGs)
 		b.WriteString("KSK and parent DS unchanged.")
 	case mode == DnssecPolicyModeCSK:
 		// CSK: a single key does both roles, so a change is a CSK replacement
@@ -402,7 +402,7 @@ func policyResetReport(zone, configName, mode string, kskChanged, zskChanged boo
 		b.WriteString(policyResetDSWarning)
 	case !kskChanged && zskChanged:
 		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; ZSK algorithm rolled (dropped and regenerated the ZSK), KSK kept. Re-signed under the new ZSK (%d RRSIGs).\n", zone, configName, newRRSIGs)
-		b.WriteString("KSK and parent DS unchanged — no DS update needed.")
+		b.WriteString("KSK and parent DS unchanged - no DS update needed.")
 	case kskChanged && !zskChanged:
 		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; KSK algorithm rolled (dropped and regenerated the KSK), ZSK kept. Re-signed (%d RRSIGs).\n", zone, configName, newRRSIGs)
 		b.WriteString(policyResetDSWarning)
@@ -429,10 +429,10 @@ const policyResetDryRunDSBreak = "  * !! BREAK the chain of trust: the parent DS
 // proceed. mode is the config policy's Mode ("ksk-zsk" | "csk").
 func policyResetDryRunReport(zone, configName, mode string, kskChanged, zskChanged bool) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "DRY RUN — policy-reset of zone %s to config policy %q would:\n", zone, configName)
+	fmt.Fprintf(&b, "DRY RUN - policy-reset of zone %s to config policy %q would:\n", zone, configName)
 	switch {
 	case !kskChanged && !zskChanged:
-		b.WriteString("  * roll NO keys — the active keys already match config; it would only re-sign and record applied=config.\n")
+		b.WriteString("  * roll NO keys - the active keys already match config; it would only re-sign and record applied=config.\n")
 		b.WriteString("  * leave the KSK and parent DS UNCHANGED.\n")
 		b.WriteString("This is safe (a no-op key-wise). " + policyResetDryRunConfirm)
 	case mode == DnssecPolicyModeCSK:
@@ -440,7 +440,7 @@ func policyResetDryRunReport(zone, configName, mode string, kskChanged, zskChang
 		b.WriteString(policyResetDryRunDSBreak)
 	case !kskChanged && zskChanged:
 		b.WriteString("  * roll the ZSK algorithm (drop and regenerate the ZSK), keeping the KSK.\n")
-		b.WriteString("  * leave the KSK and parent DS UNCHANGED — no DS update needed.\n")
+		b.WriteString("  * leave the KSK and parent DS UNCHANGED - no DS update needed.\n")
 		b.WriteString(policyResetDryRunConfirm)
 	case kskChanged && !zskChanged:
 		b.WriteString("  * roll the KSK algorithm (drop and regenerate the KSK), keeping the ZSK.\n")

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -336,39 +336,38 @@ func zoneActiveKeysMatchAlgs(kdb *KeyDB, zone string, pol *DnssecPolicy) (bool, 
 // and regenerates one clean active key). `kskChanged` implies the parent DS
 // breaks (the KSK keytag changes); `zskChanged` alone keeps the DS intact.
 //
-// Mode handling: a split↔CSK mode change (the zone's active keys are CSK-shaped —
-// only SEP keys — while pol is split, or vice versa) is treated conservatively as
-// a full reset: both roles changed (DS break implied by kskChanged). In CSK mode
-// the single SEP key is the only role and zskChanged is always false.
-func zoneActiveKeyRoleChanges(kdb *KeyDB, zone string, pol *DnssecPolicy) (kskChanged, zskChanged bool, err error) {
+// Mode handling: a genuine split↔CSK mode change is a conservative FULL reset
+// (both roles). It is detected by comparing the RELIABLE policy Mode fields —
+// currentMode (the zone's currently-bound policy Mode) vs pol.Mode (the config
+// target) — NOT by inferring mode from key shape. Inferring "only SEP keys ⇒
+// CSK" would misread a split zone transiently missing its ZSK as a mode change
+// and wrongly drop the healthy KSK, breaking the parent DS. currentMode is
+// always "ksk-zsk" or "csk" for a bound policy (FinishDnssecPolicy normalizes
+// it); "" means unknown → skip the mode check. In CSK mode the single SEP key is
+// the only role and zskChanged is always false.
+func zoneActiveKeyRoleChanges(kdb *KeyDB, zone string, pol *DnssecPolicy, currentMode string) (kskChanged, zskChanged bool, err error) {
+	if currentMode != "" && currentMode != pol.Mode {
+		return true, true, nil
+	}
+
 	active, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
 	if err != nil {
 		return false, false, err
 	}
-	var sepAny, sepGood, sepBad bool // SEP bit set = KSK/CSK role
-	var zskAny, zskGood, zskBad bool // SEP bit clear = ZSK role
+	var sepGood, sepBad bool // SEP bit set = KSK/CSK role
+	var zskGood, zskBad bool // SEP bit clear = ZSK role
 	for _, k := range active {
 		if k.Flags&0x0001 == 0x0001 {
-			sepAny = true
 			if k.Algorithm == pol.KSKAlgorithm {
 				sepGood = true
 			} else {
 				sepBad = true
 			}
+		} else if k.Algorithm == pol.ZSKAlgorithm {
+			zskGood = true
 		} else {
-			zskAny = true
-			if k.Algorithm == pol.ZSKAlgorithm {
-				zskGood = true
-			} else {
-				zskBad = true
-			}
+			zskBad = true
 		}
-	}
-
-	// Mode change: the zone's current key shape (CSK = only SEP active keys)
-	// differs from pol's mode. Conservative full reset, DS break.
-	if (sepAny || zskAny) && (sepAny && !zskAny) != (pol.Mode == DnssecPolicyModeCSK) {
-		return true, true, nil
 	}
 
 	if pol.Mode == DnssecPolicyModeCSK {
@@ -376,7 +375,7 @@ func zoneActiveKeyRoleChanges(kdb *KeyDB, zone string, pol *DnssecPolicy) (kskCh
 		return !sepGood || sepBad, false, nil
 	}
 	// Split: each role changed iff it lacks a right-alg active key or carries a
-	// wrong-alg one.
+	// wrong-alg one. A missing role (no active key) → changed → regenerate.
 	return !sepGood || sepBad, !zskGood || zskBad, nil
 }
 
@@ -386,22 +385,28 @@ const policyResetDSWarning = "WARNING: this was an ABRUPT switch that BREAKS the
 	"NOTE: validators will go BOGUS until the new DS is published at the parent (via the auto-rollover engine or a manual DS update)."
 
 // policyResetReport builds the operator-facing message for a completed
-// policy-reset. The DS-break warning fires ONLY when the KSK algorithm changed
-// (kskChanged); when the KSK is untouched the report states the parent DS is
-// unchanged.
-func policyResetReport(zone, configName string, kskChanged, zskChanged bool, newRRSIGs int) string {
+// policy-reset. mode is the config policy's Mode ("ksk-zsk" | "csk"), used to
+// report a CSK replacement as such rather than as a KSK/ZSK split roll. The
+// DS-break warning fires ONLY when the KSK algorithm changed (kskChanged); when
+// the KSK is untouched the report states the parent DS is unchanged.
+func policyResetReport(zone, configName, mode string, kskChanged, zskChanged bool, newRRSIGs int) string {
 	var b strings.Builder
 	switch {
 	case !kskChanged && !zskChanged:
 		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; active keys already matched — no key roll. Re-signed (%d RRSIGs) and recorded applied=config.\n", zone, configName, newRRSIGs)
 		b.WriteString("KSK and parent DS unchanged.")
+	case mode == DnssecPolicyModeCSK:
+		// CSK: a single key does both roles, so a change is a CSK replacement
+		// (KSK-level → DS breaks), never a "ZSK kept" split roll.
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; CSK algorithm rolled (dropped and regenerated the CSK). Re-signed (%d RRSIGs).\n", zone, configName, newRRSIGs)
+		b.WriteString(policyResetDSWarning)
 	case !kskChanged && zskChanged:
 		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; ZSK algorithm rolled (dropped and regenerated the ZSK), KSK kept. Re-signed under the new ZSK (%d RRSIGs).\n", zone, configName, newRRSIGs)
 		b.WriteString("KSK and parent DS unchanged — no DS update needed.")
 	case kskChanged && !zskChanged:
 		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; KSK algorithm rolled (dropped and regenerated the KSK), ZSK kept. Re-signed (%d RRSIGs).\n", zone, configName, newRRSIGs)
 		b.WriteString(policyResetDSWarning)
-	default: // both roles changed (incl. a mode change / CSK alg change)
+	default: // split: both roles changed (incl. a csk→split full reset)
 		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; both KSK and ZSK algorithms rolled (dropped and regenerated both). Re-signed (%d RRSIGs).\n", zone, configName, newRRSIGs)
 		b.WriteString(policyResetDSWarning)
 	}

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -23,6 +23,7 @@ package tdns
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // PolicyApplySource records why a policy was applied, and is persisted as
@@ -323,4 +324,86 @@ func zoneActiveKeysMatchAlgs(kdb *KeyDB, zone string, pol *DnssecPolicy) (bool, 
 		}
 	}
 	return haveKSK && haveZSK, nil
+}
+
+// zoneActiveKeyRoleChanges reports, per role, whether the zone's ACTIVE keys must
+// be dropped and regenerated to match pol's algorithms — the per-role decision
+// that lets policy-reset be surgical (keep the role whose algorithm is already
+// correct; roll only the one that changed). A role is UNCHANGED only when it has
+// at least one active key of the target algorithm AND no active key of a wrong
+// algorithm; otherwise it is CHANGED (missing the right algorithm, or carrying a
+// wrong-alg key mid-rollover — both need the abrupt hard-flip that drops the role
+// and regenerates one clean active key). `kskChanged` implies the parent DS
+// breaks (the KSK keytag changes); `zskChanged` alone keeps the DS intact.
+//
+// Mode handling: a split↔CSK mode change (the zone's active keys are CSK-shaped —
+// only SEP keys — while pol is split, or vice versa) is treated conservatively as
+// a full reset: both roles changed (DS break implied by kskChanged). In CSK mode
+// the single SEP key is the only role and zskChanged is always false.
+func zoneActiveKeyRoleChanges(kdb *KeyDB, zone string, pol *DnssecPolicy) (kskChanged, zskChanged bool, err error) {
+	active, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
+	if err != nil {
+		return false, false, err
+	}
+	var sepAny, sepGood, sepBad bool // SEP bit set = KSK/CSK role
+	var zskAny, zskGood, zskBad bool // SEP bit clear = ZSK role
+	for _, k := range active {
+		if k.Flags&0x0001 == 0x0001 {
+			sepAny = true
+			if k.Algorithm == pol.KSKAlgorithm {
+				sepGood = true
+			} else {
+				sepBad = true
+			}
+		} else {
+			zskAny = true
+			if k.Algorithm == pol.ZSKAlgorithm {
+				zskGood = true
+			} else {
+				zskBad = true
+			}
+		}
+	}
+
+	// Mode change: the zone's current key shape (CSK = only SEP active keys)
+	// differs from pol's mode. Conservative full reset, DS break.
+	if (sepAny || zskAny) && (sepAny && !zskAny) != (pol.Mode == DnssecPolicyModeCSK) {
+		return true, true, nil
+	}
+
+	if pol.Mode == DnssecPolicyModeCSK {
+		// Single SEP (CSK) role; wrong-alg or missing CSK key → changed.
+		return !sepGood || sepBad, false, nil
+	}
+	// Split: each role changed iff it lacks a right-alg active key or carries a
+	// wrong-alg one.
+	return !sepGood || sepBad, !zskGood || zskBad, nil
+}
+
+// policyResetDSWarning is the chain-of-trust break notice, emitted only when the
+// KSK algorithm actually changed (the parent DS no longer matches the new KSK).
+const policyResetDSWarning = "WARNING: this was an ABRUPT switch that BREAKS the chain of trust — the parent DS no longer matches the new KSK.\n" +
+	"NOTE: validators will go BOGUS until the new DS is published at the parent (via the auto-rollover engine or a manual DS update)."
+
+// policyResetReport builds the operator-facing message for a completed
+// policy-reset. The DS-break warning fires ONLY when the KSK algorithm changed
+// (kskChanged); when the KSK is untouched the report states the parent DS is
+// unchanged.
+func policyResetReport(zone, configName string, kskChanged, zskChanged bool, newRRSIGs int) string {
+	var b strings.Builder
+	switch {
+	case !kskChanged && !zskChanged:
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; active keys already matched — no key roll. Re-signed (%d RRSIGs) and recorded applied=config.\n", zone, configName, newRRSIGs)
+		b.WriteString("KSK and parent DS unchanged.")
+	case !kskChanged && zskChanged:
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; ZSK algorithm rolled (dropped and regenerated the ZSK), KSK kept. Re-signed under the new ZSK (%d RRSIGs).\n", zone, configName, newRRSIGs)
+		b.WriteString("KSK and parent DS unchanged — no DS update needed.")
+	case kskChanged && !zskChanged:
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; KSK algorithm rolled (dropped and regenerated the KSK), ZSK kept. Re-signed (%d RRSIGs).\n", zone, configName, newRRSIGs)
+		b.WriteString(policyResetDSWarning)
+	default: // both roles changed (incl. a mode change / CSK alg change)
+		fmt.Fprintf(&b, "Zone %s: DNSSEC policy reset to config policy %q; both KSK and ZSK algorithms rolled (dropped and regenerated both). Re-signed (%d RRSIGs).\n", zone, configName, newRRSIGs)
+		b.WriteString(policyResetDSWarning)
+	}
+	return b.String()
 }

--- a/v2/zone_policy_apply.go
+++ b/v2/zone_policy_apply.go
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Transactional DNSSEC-policy apply core (P0-2 / Plan B).
+ *
+ * A single place that rebinds a zone to a DNSSEC policy, re-signs, and — only
+ * on success — persists the last-applied record, reverting the in-memory
+ * binding if the re-sign fails. The CLI path (policy-set / change-policy) and
+ * the config reload/restart path both call this so they cannot drift.
+ *
+ * Design lock (see docs/2026-07-15-transactional-policy-reload-plan.md):
+ *   ① Classification is ALWAYS applied-from-DB vs intent, never the current
+ *      in-memory binding: on restart the binding is freshly loaded from config
+ *      and equals intent, which would hide a pending change.
+ *   ② When no applied record exists yet (first post-upgrade reload of a
+ *      config-only zone), backfill applied = intent WITHOUT a forced re-sign
+ *      when the zone is already signed under intent — avoiding a thundering-herd
+ *      re-sign. The backfill branch is reachable independently of intent==applied.
+ */
+
+package tdns
+
+import "fmt"
+
+// PolicyApplySource records why a policy was applied, and is persisted as
+// applied_source. 'command' additionally persists a CLI override (intent);
+// 'config' does not.
+type PolicyApplySource string
+
+const (
+	PolicyApplySourceConfig  PolicyApplySource = "config"
+	PolicyApplySourceCommand PolicyApplySource = "command"
+)
+
+// PolicyChangeClass is the result of comparing a zone's last-applied policy
+// against its intent (operator-desired) policy.
+type PolicyChangeClass int
+
+const (
+	// PolicyChangeNone: same name, same effective algorithms, identical policy
+	// internals — nothing to do.
+	PolicyChangeNone PolicyChangeClass = iota
+	// PolicyChangeBenignInternals: same name, same effective algorithms, but
+	// lifetimes/sigvalidity/ttls/rollover internals changed — cheap re-sign.
+	PolicyChangeBenignInternals
+	// PolicyChangeCompatibleName: different name, same KSK+ZSK algorithms —
+	// apply transactionally.
+	PolicyChangeCompatibleName
+	// PolicyChangeIncompatibleAlg: KSK or ZSK effective algorithm differs — a
+	// key rollover that is not built (v1 refuses on the config path).
+	PolicyChangeIncompatibleAlg
+)
+
+func (c PolicyChangeClass) String() string {
+	switch c {
+	case PolicyChangeNone:
+		return "none"
+	case PolicyChangeBenignInternals:
+		return "benign-internals"
+	case PolicyChangeCompatibleName:
+		return "compatible-name"
+	case PolicyChangeIncompatibleAlg:
+		return "incompatible-alg"
+	default:
+		return fmt.Sprintf("PolicyChangeClass(%d)", int(c))
+	}
+}
+
+// classifyPolicyChange compares the LAST-APPLIED policy (from the DB, resolved
+// to a struct via ConfLive().DnssecPolicies) against INTENT (what the operator
+// wants). It MUST NOT be called with the zone's current in-memory binding as
+// the "applied" side — on restart the binding equals intent and the change is
+// hidden (blocking ①). Precondition: both structs non-nil; the applied-missing
+// case is resolved by backfillAppliedIfEligible / a first apply BEFORE the
+// classifier runs.
+//
+// The effective algorithms are DnssecPolicy.KSKAlgorithm / .ZSKAlgorithm — the
+// same fields SignZone, set-policy, and the old applyReloadedPolicyLocked guard
+// compare against the active keys.
+func classifyPolicyChange(
+	appliedPol *DnssecPolicy, appliedName string,
+	intentPol *DnssecPolicy, intentName string,
+) PolicyChangeClass {
+	// Defensive: a nil on either side means we cannot prove sameness — treat it
+	// as a name change so the caller drives a transactional apply toward intent
+	// (the SignZone algorithm backstop still refuses an unsafe swap).
+	if appliedPol == nil || intentPol == nil {
+		return PolicyChangeCompatibleName
+	}
+	if appliedPol.KSKAlgorithm != intentPol.KSKAlgorithm ||
+		appliedPol.ZSKAlgorithm != intentPol.ZSKAlgorithm {
+		return PolicyChangeIncompatibleAlg
+	}
+	if appliedName != intentName {
+		return PolicyChangeCompatibleName
+	}
+	// Same name, same effective algorithms: distinguish an identical policy from
+	// an internals-only edit so the caller can pick the cheap re-sign path.
+	// suppressLoadWarnings is a non-semantic parse flag — normalize it out.
+	a, b := *appliedPol, *intentPol
+	a.suppressLoadWarnings = false
+	b.suppressLoadWarnings = false
+	if a == b {
+		return PolicyChangeNone
+	}
+	return PolicyChangeBenignInternals
+}
+
+// resolvePolicyPair loads a zone's intent (via EffectiveDnssecPolicyName: CLI
+// override if set, else the config base) and its last-applied record (via
+// GetZoneAppliedPolicy), then resolves both policy structs from the ConfLive()
+// snapshot (lock-free — no confMu).
+//
+// appliedOK reports whether a last-applied record exists in the DB. appliedPol
+// may be nil even when appliedOK is true if the applied policy name is no longer
+// defined in config (§5.6 deleted-policy case) — callers handle that before
+// dereferencing. Likewise intentPol is nil when intent names a policy absent
+// from config.
+func resolvePolicyPair(kdb *KeyDB, zone, configPolicyName string) (
+	intentName string, intentPol *DnssecPolicy,
+	appliedName string, appliedPol *DnssecPolicy, appliedOK bool,
+	err error,
+) {
+	intentName, _, err = EffectiveDnssecPolicyName(kdb, zone, configPolicyName)
+	if err != nil {
+		// EffectiveDnssecPolicyName still returns a usable config-base name on a
+		// DB error; surface the error but keep resolving what we can.
+		return intentName, nil, "", nil, false, err
+	}
+	an, _, ok, gerr := GetZoneAppliedPolicy(kdb, zone)
+	if gerr != nil {
+		return intentName, nil, "", nil, false, gerr
+	}
+	appliedName, appliedOK = an, ok
+
+	live := ConfLive()
+	if intentName != "" {
+		if p, exists := live.DnssecPolicies[intentName]; exists {
+			ip := p
+			intentPol = &ip
+		}
+	}
+	if appliedOK && appliedName != "" {
+		if p, exists := live.DnssecPolicies[appliedName]; exists {
+			ap := p
+			appliedPol = &ap
+		}
+	}
+	return intentName, intentPol, appliedName, appliedPol, appliedOK, nil
+}
+
+// applyZonePolicyTransactional rebinds a signed zone to newPol, re-signs, and —
+// only on success — persists the last-applied record. On SignZone failure it
+// reverts the in-memory binding and returns an error without touching applied_*.
+// When source is PolicyApplySourceCommand it also persists a CLI override
+// (intent) on success.
+//
+// The old binding is snapshotted for REVERT ONLY; it is never used to classify
+// the change (blocking ①). Caller is responsible for having classified/refused
+// before calling this.
+func applyZonePolicyTransactional(
+	zd *ZoneData,
+	kdb *KeyDB,
+	newPol *DnssecPolicy,
+	newName string,
+	source PolicyApplySource,
+) (newRRSIGs int, err error) {
+	if newPol == nil {
+		return 0, fmt.Errorf("applyZonePolicyTransactional: nil policy %q for zone %s", newName, zd.ZoneName)
+	}
+	if newPol.Error != "" {
+		return 0, fmt.Errorf("applyZonePolicyTransactional: DNSSEC policy %q is broken: %s", newName, newPol.Error)
+	}
+	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+		return 0, fmt.Errorf("applyZonePolicyTransactional: zone %s is not signed (neither online-signing nor inline-signing)", zd.ZoneName)
+	}
+
+	// Snapshot the current binding for revert-on-failure ONLY.
+	zd.mu.Lock()
+	oldPol := zd.DnssecPolicy
+	oldName := zd.DnssecPolicyName
+	zd.DnssecPolicy = newPol
+	zd.DnssecPolicyName = newName
+	zd.mu.Unlock()
+
+	UpdateSigValidityFloor(zd, zd.DnssecPolicy, Conf.KaspPropagationDelay(), 0, false, Conf.IsLargeAlgorithm, false)
+
+	newRRSIGs, err = zd.SignZone(kdb, true)
+	if err != nil {
+		zd.mu.Lock()
+		zd.DnssecPolicy = oldPol
+		zd.DnssecPolicyName = oldName
+		zd.mu.Unlock()
+		return 0, fmt.Errorf("re-sign zone %s under policy %q: %w", zd.ZoneName, newName, err)
+	}
+
+	// Zone is now signed under newPol. Persist the last-applied record. A
+	// persistence failure does NOT revert the binding (the zone IS correctly
+	// signed); it is surfaced so the caller logs it. On restart the zone
+	// re-derives intent and re-converges.
+	if perr := SetZoneAppliedPolicy(kdb, zd.ZoneName, newName, string(source)); perr != nil {
+		return newRRSIGs, fmt.Errorf("zone %s re-signed under %q but persisting applied policy failed: %w", zd.ZoneName, newName, perr)
+	}
+
+	if source == PolicyApplySourceCommand {
+		if perr := SetZonePolicyOverride(kdb, zd.ZoneName, newName); perr != nil {
+			return newRRSIGs, fmt.Errorf("zone %s re-signed under %q but persisting the CLI override failed (the change will not survive restart): %w", zd.ZoneName, newName, perr)
+		}
+	}
+	return newRRSIGs, nil
+}
+
+// backfillAppliedIfEligible records applied = intent WITHOUT a forced re-sign
+// when a zone has no applied record yet but is ALREADY correctly signed under
+// intent — its active keys' algorithms match intent's KSK/ZSK algorithms
+// (blocking ②). This is the first-post-upgrade path for config-only signed
+// zones; it avoids re-signing every already-correct zone.
+//
+// Precondition: caller has established that no applied record exists. Returns
+// true when a backfill was written (caller then skips the re-sign for policy
+// purposes). Returns false — without error — when the zone is not eligible
+// (unsigned, no intent, or active-key algorithms differ from intent); the
+// caller then drives a genuine transactional apply toward intent, whose
+// SignZone algorithm backstop refuses an unsafe swap.
+func backfillAppliedIfEligible(kdb *KeyDB, zd *ZoneData, intentName string, intentPol *DnssecPolicy) (backfilled bool, err error) {
+	if intentPol == nil || intentName == "" {
+		return false, nil
+	}
+	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
+		return false, nil
+	}
+	match, err := zoneActiveKeysMatchAlgs(kdb, zd.ZoneName, intentPol)
+	if err != nil {
+		return false, err
+	}
+	if !match {
+		return false, nil
+	}
+	if err := SetZoneAppliedPolicy(kdb, zd.ZoneName, intentName, string(PolicyApplySourceConfig)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// zoneActiveKeysMatchAlgs reports whether the zone's ACTIVE keys already provide
+// the algorithms pol requires: for a split policy, an active KSK of
+// pol.KSKAlgorithm AND an active ZSK of pol.ZSKAlgorithm; for a CSK policy, a
+// single active SEP key of pol.KSKAlgorithm (which equals pol.ZSKAlgorithm). The
+// SEP bit (flags & 1) distinguishes a KSK/CSK from a ZSK — the same convention
+// the signer and the standby→published migration use.
+func zoneActiveKeysMatchAlgs(kdb *KeyDB, zone string, pol *DnssecPolicy) (bool, error) {
+	active, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
+	if err != nil {
+		return false, err
+	}
+	if pol.Mode == DnssecPolicyModeCSK {
+		for _, k := range active {
+			if k.Flags&0x0001 == 0x0001 && k.Algorithm == pol.KSKAlgorithm {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	var haveKSK, haveZSK bool
+	for _, k := range active {
+		if k.Flags&0x0001 == 0x0001 {
+			if k.Algorithm == pol.KSKAlgorithm {
+				haveKSK = true
+			}
+		} else if k.Algorithm == pol.ZSKAlgorithm {
+			haveZSK = true
+		}
+	}
+	return haveKSK && haveZSK, nil
+}

--- a/v2/zone_policy_apply_test.go
+++ b/v2/zone_policy_apply_test.go
@@ -109,6 +109,10 @@ func TestResolvePolicyPairRestartDetectsChange(t *testing.T) {
 // WITHOUT a re-sign; a zone whose active-key algorithms differ from intent is
 // NOT eligible (the caller then drives a real apply).
 func TestBackfillAppliedIfEligible(t *testing.T) {
+	// NOTE: this asserts PR-1's keystore-only predicate. Per the §5.5 PR-2 GATE
+	// on backfillAppliedIfEligible, going live additionally requires the zone to
+	// actually SERVE a signature; this positive case will then also need a
+	// signed-snapshot fixture (or move to the live matrix).
 	t.Run("eligible: keys match intent -> backfill, no sign", func(t *testing.T) {
 		kdb := newTestKeyDB(t)
 		zd := algTestZone(dns.ED25519, dns.ED25519)

--- a/v2/zone_policy_apply_test.go
+++ b/v2/zone_policy_apply_test.go
@@ -1,0 +1,204 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// withLivePolicies publishes a runtime-config snapshot whose DnssecPolicies map
+// is exactly `policies`, so ConfLive() (which the apply core reads, lock-free)
+// returns them. Restores the previous snapshot on cleanup. This is distinct
+// from withPolicies (zsk_alg_rollover_test.go), which sets the parse-scratch
+// Conf.Internal.DnssecPolicies but does NOT publish.
+func withLivePolicies(t *testing.T, policies map[string]DnssecPolicy) {
+	t.Helper()
+	prev := liveConfig.Load()
+	liveConfig.Store(&RuntimeConfig{DnssecPolicies: policies})
+	t.Cleanup(func() { liveConfig.Store(prev) })
+}
+
+func kskzsk(ksk, zsk uint8) DnssecPolicy {
+	return DnssecPolicy{Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: ksk, ZSKAlgorithm: zsk}
+}
+
+// TestClassifyPolicyChange covers the four change classes. The design lock ①
+// case is the CompatibleName row: a DIFFERENT applied name with the SAME
+// algorithms must classify as a change, which is only detectable because the
+// classifier compares applied-name vs intent-name, not a binding.
+func TestClassifyPolicyChange(t *testing.T) {
+	polA := kskzsk(dns.ED25519, dns.ED25519)
+	polB := kskzsk(dns.ED25519, dns.ED25519) // same algs, different name
+	polBenign := kskzsk(dns.ED25519, dns.ED25519)
+	polBenign.SigValidity.Default = 1234 // same name+algs, internals differ
+	polAlg := kskzsk(dns.RSASHA256, dns.ED25519)
+
+	cases := []struct {
+		name        string
+		appliedPol  DnssecPolicy
+		appliedName string
+		intentPol   DnssecPolicy
+		intentName  string
+		want        PolicyChangeClass
+	}{
+		{"identical", polA, "a", polA, "a", PolicyChangeNone},
+		{"benign-internals", polA, "a", polBenign, "a", PolicyChangeBenignInternals},
+		{"compatible-rename", polA, "a", polB, "b", PolicyChangeCompatibleName},
+		{"incompatible-ksk-alg", polA, "a", polAlg, "b", PolicyChangeIncompatibleAlg},
+		// An alg change even under the SAME name is still incompatible.
+		{"incompatible-same-name", polA, "a", polAlg, "a", PolicyChangeIncompatibleAlg},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ap, ip := c.appliedPol, c.intentPol
+			got := classifyPolicyChange(&ap, c.appliedName, &ip, c.intentName)
+			if got != c.want {
+				t.Fatalf("classify: got %s, want %s", got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolvePolicyPairRestartDetectsChange is the ① regression: on restart the
+// zone's in-memory binding is freshly loaded from config and EQUALS intent, so
+// classifying the binding against intent would return None and silently miss the
+// YAML edit. resolvePolicyPair + classifyPolicyChange compare the DB last-applied
+// against intent instead, and correctly detect the compatible rename.
+func TestResolvePolicyPairRestartDetectsChange(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	// Two same-algorithm policies with different names.
+	withLivePolicies(t, map[string]DnssecPolicy{
+		"polA": kskzsk(dns.ED25519, dns.ED25519),
+		"polB": kskzsk(dns.ED25519, dns.ED25519),
+	})
+	// DB records the zone was last signed under polA; the YAML now says polB
+	// (intent), with no CLI override.
+	if err := SetZoneAppliedPolicy(kdb, algZone, "polA", "config"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy: %v", err)
+	}
+
+	intentName, intentPol, appliedName, appliedPol, appliedOK, err := resolvePolicyPair(kdb, algZone, "polB")
+	if err != nil {
+		t.Fatalf("resolvePolicyPair: %v", err)
+	}
+	if intentName != "polB" || appliedName != "polA" || !appliedOK {
+		t.Fatalf("resolve: got intent=%q applied=%q ok=%v, want intent=polB applied=polA ok=true", intentName, appliedName, appliedOK)
+	}
+	if intentPol == nil || appliedPol == nil {
+		t.Fatalf("resolve: both structs must be non-nil (intent=%v applied=%v)", intentPol, appliedPol)
+	}
+
+	// Correct: applied (polA) vs intent (polB) → a change is detected.
+	if got := classifyPolicyChange(appliedPol, appliedName, intentPol, intentName); got != PolicyChangeCompatibleName {
+		t.Fatalf("applied-vs-intent classify: got %s, want compatible-name", got)
+	}
+
+	// The trap ① avoids: on restart the binding == intent (polB). Classifying the
+	// binding against intent would hide the change.
+	binding := intentPol // fresh restart binding equals intent
+	if got := classifyPolicyChange(binding, intentName, intentPol, intentName); got != PolicyChangeNone {
+		t.Fatalf("sanity: binding-vs-intent should read None (the ① trap), got %s", got)
+	}
+}
+
+// TestBackfillAppliedIfEligible covers blocking ②: a config-only signed zone
+// with no applied record but active keys already matching intent is backfilled
+// WITHOUT a re-sign; a zone whose active-key algorithms differ from intent is
+// NOT eligible (the caller then drives a real apply).
+func TestBackfillAppliedIfEligible(t *testing.T) {
+	t.Run("eligible: keys match intent -> backfill, no sign", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(dns.ED25519, dns.ED25519)
+		// Active KSK + ZSK of ED25519 — already signed under the intent alg.
+		if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+			t.Fatalf("KSK: %v", err)
+		}
+		genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+
+		intent := kskzsk(dns.ED25519, dns.ED25519)
+		backfilled, err := backfillAppliedIfEligible(kdb, zd, "intentpol", &intent)
+		if err != nil {
+			t.Fatalf("backfill: %v", err)
+		}
+		if !backfilled {
+			t.Fatal("zone already signed under intent must be eligible for backfill")
+		}
+		// Applied is recorded as config-source; nothing signed (a data-less zone
+		// would have errored in SignZone — proving backfill did not re-sign).
+		name, source, ok, err := GetZoneAppliedPolicy(kdb, algZone)
+		if err != nil || !ok || name != "intentpol" || source != "config" {
+			t.Fatalf("applied after backfill: got (%q,%q,%v,err=%v), want (intentpol,config,true,nil)", name, source, ok, err)
+		}
+	})
+
+	t.Run("ineligible: keys differ from intent -> no backfill", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(dns.ED25519, dns.ED25519)
+		// Active keys are ED25519, but intent wants an RSASHA256 KSK.
+		if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+			t.Fatalf("KSK: %v", err)
+		}
+		genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+
+		intent := kskzsk(dns.RSASHA256, dns.ED25519)
+		backfilled, err := backfillAppliedIfEligible(kdb, zd, "intentpol", &intent)
+		if err != nil {
+			t.Fatalf("backfill: %v", err)
+		}
+		if backfilled {
+			t.Fatal("keys whose algorithm differs from intent must NOT be backfilled")
+		}
+		if _, _, ok, _ := GetZoneAppliedPolicy(kdb, algZone); ok {
+			t.Fatal("ineligible zone must not get an applied record")
+		}
+	})
+
+	t.Run("unsigned zone -> no backfill", func(t *testing.T) {
+		kdb := newTestKeyDB(t)
+		zd := algTestZone(dns.ED25519, dns.ED25519)
+		zd.Options = map[ZoneOption]bool{} // not signed
+		intent := kskzsk(dns.ED25519, dns.ED25519)
+		if backfilled, err := backfillAppliedIfEligible(kdb, zd, "intentpol", &intent); err != nil || backfilled {
+			t.Fatalf("unsigned zone must not backfill (backfilled=%v err=%v)", backfilled, err)
+		}
+	})
+}
+
+// TestApplyZonePolicyTransactionalRevertOnSignFailure asserts the transactional
+// contract: when SignZone fails (here via an incompatible KSK algorithm change,
+// which reconcileActiveKeyAlgorithms refuses), the in-memory binding is reverted
+// to the prior policy and NOTHING is persisted (no applied record, no override).
+func TestApplyZonePolicyTransactionalRevertOnSignFailure(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.DnssecPolicyName = "polA"
+	// Active KSK is ED25519 — a switch to a policy wanting an RSASHA256 KSK will
+	// be refused inside SignZone (KSK alg rollover not implemented).
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+
+	polB := kskzsk(dns.RSASHA256, dns.ED25519) // KSK alg change → SignZone refuses
+	withLivePolicies(t, map[string]DnssecPolicy{"polB": polB})
+
+	if _, err := applyZonePolicyTransactional(zd, kdb, &polB, "polB", PolicyApplySourceCommand); err == nil {
+		t.Fatal("expected SignZone failure on incompatible KSK algorithm change")
+	}
+
+	// Binding reverted to polA.
+	zd.mu.Lock()
+	gotName := zd.DnssecPolicyName
+	gotKSK := zd.DnssecPolicy.KSKAlgorithm
+	zd.mu.Unlock()
+	if gotName != "polA" || gotKSK != dns.ED25519 {
+		t.Fatalf("binding not reverted: got (%q, ksk=%s), want (polA, ED25519)", gotName, dns.AlgorithmToString[gotKSK])
+	}
+	// Nothing persisted.
+	if _, _, ok, _ := GetZoneAppliedPolicy(kdb, algZone); ok {
+		t.Fatal("failed apply must not write an applied record")
+	}
+	if _, ok, _ := GetZonePolicyOverride(kdb, algZone); ok {
+		t.Fatal("failed apply must not write a CLI override")
+	}
+}

--- a/v2/zone_policy_apply_test.go
+++ b/v2/zone_policy_apply_test.go
@@ -23,15 +23,15 @@ func kskzsk(ksk, zsk uint8) DnssecPolicy {
 	return DnssecPolicy{Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: ksk, ZSKAlgorithm: zsk}
 }
 
-// TestClassifyPolicyChange covers the four change classes. The design lock ①
+// TestClassifyPolicyChange covers the three change classes. The design lock ①
 // case is the CompatibleName row: a DIFFERENT applied name with the SAME
 // algorithms must classify as a change, which is only detectable because the
 // classifier compares applied-name vs intent-name, not a binding.
 func TestClassifyPolicyChange(t *testing.T) {
 	polA := kskzsk(dns.ED25519, dns.ED25519)
 	polB := kskzsk(dns.ED25519, dns.ED25519) // same algs, different name
-	polBenign := kskzsk(dns.ED25519, dns.ED25519)
-	polBenign.SigValidity.Default = 1234 // same name+algs, internals differ
+	polInternals := kskzsk(dns.ED25519, dns.ED25519)
+	polInternals.SigValidity.Default = 1234 // same name+algs, internals differ
 	polAlg := kskzsk(dns.RSASHA256, dns.ED25519)
 
 	cases := []struct {
@@ -43,7 +43,9 @@ func TestClassifyPolicyChange(t *testing.T) {
 		want        PolicyChangeClass
 	}{
 		{"identical", polA, "a", polA, "a", PolicyChangeNone},
-		{"benign-internals", polA, "a", polBenign, "a", PolicyChangeBenignInternals},
+		// Finding A: same name, same algs, internals differ → None (no separate
+		// benign class; internals converge via the resigner).
+		{"same-name-internals-differ", polA, "a", polInternals, "a", PolicyChangeNone},
 		{"compatible-rename", polA, "a", polB, "b", PolicyChangeCompatibleName},
 		{"incompatible-ksk-alg", polA, "a", polAlg, "b", PolicyChangeIncompatibleAlg},
 		// An alg change even under the SAME name is still incompatible.

--- a/v2/zone_policy_apply_test.go
+++ b/v2/zone_policy_apply_test.go
@@ -1,6 +1,7 @@
 package tdns
 
 import (
+	"context"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -182,7 +183,7 @@ func TestApplyZonePolicyTransactionalRevertOnSignFailure(t *testing.T) {
 	polB := kskzsk(dns.RSASHA256, dns.ED25519) // KSK alg change → SignZone refuses
 	withLivePolicies(t, map[string]DnssecPolicy{"polB": polB})
 
-	if _, err := applyZonePolicyTransactional(zd, kdb, &polB, "polB", PolicyApplySourceCommand); err == nil {
+	if _, err := applyZonePolicyTransactional(context.Background(), zd, kdb, &polB, "polB", PolicyApplySourceCommand); err == nil {
 		t.Fatal("expected SignZone failure on incompatible KSK algorithm change")
 	}
 

--- a/v2/zsk_alg_rollover_test.go
+++ b/v2/zsk_alg_rollover_test.go
@@ -1,6 +1,7 @@
 package tdns
 
 import (
+	"context"
 	"log"
 	"os"
 	"strings"
@@ -425,7 +426,7 @@ func TestT2StrictModeZskAlgChangeRefused(t *testing.T) {
 	withPolicies(t, map[string]DnssecPolicy{
 		"target": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
 	})
-	_, err := changeZonePolicy(zd, kdb, "target")
+	_, err := changeZonePolicy(context.Background(), zd, kdb, "target")
 	if err == nil {
 		t.Fatal("strict-mode ZSK alg change must be refused")
 	}
@@ -445,7 +446,7 @@ func TestT2bKskAndCskAlgChangeRefused(t *testing.T) {
 	withPolicies(t, map[string]DnssecPolicy{
 		"kskroll": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.RSASHA256},
 	})
-	if _, err := changeZonePolicy(zd, kdb, "kskroll"); err == nil {
+	if _, err := changeZonePolicy(context.Background(), zd, kdb, "kskroll"); err == nil {
 		t.Fatal("KSK-only alg change must be refused")
 	}
 	if _, ok, _ := GetZonePolicyOverride(kdb, algZone); ok {
@@ -457,7 +458,7 @@ func TestT2bKskAndCskAlgChangeRefused(t *testing.T) {
 	withPolicies(t, map[string]DnssecPolicy{
 		"csk": {Mode: DnssecPolicyModeCSK, Algorithm: dns.RSASHA256, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.RSASHA256},
 	})
-	if _, err := changeZonePolicy(zdCsk, kdb, "csk"); err == nil {
+	if _, err := changeZonePolicy(context.Background(), zdCsk, kdb, "csk"); err == nil {
 		t.Fatal("CSK alg change must be refused")
 	}
 }
@@ -470,7 +471,7 @@ func TestT2cBothRoleChangeRejected(t *testing.T) {
 	withPolicies(t, map[string]DnssecPolicy{
 		"both": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.RSASHA256},
 	})
-	_, err := changeZonePolicy(zd, kdb, "both")
+	_, err := changeZonePolicy(context.Background(), zd, kdb, "both")
 	if err == nil {
 		t.Fatal("both-role alg change must be rejected")
 	}
@@ -497,7 +498,7 @@ func TestT2dReentrancyRefused(t *testing.T) {
 		withPolicies(t, map[string]DnssecPolicy{
 			"target": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
 		})
-		if _, err := changeZonePolicy(zd, kdb, "target"); err == nil {
+		if _, err := changeZonePolicy(context.Background(), zd, kdb, "target"); err == nil {
 			t.Fatal("re-entrant change-policy (pre-promotion) must be refused")
 		}
 	})
@@ -516,7 +517,7 @@ func TestT2dReentrancyRefused(t *testing.T) {
 		withPolicies(t, map[string]DnssecPolicy{
 			"target": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
 		})
-		if _, err := changeZonePolicy(zd, kdb, "target"); err == nil {
+		if _, err := changeZonePolicy(context.Background(), zd, kdb, "target"); err == nil {
 			t.Fatal("re-entrant change-policy (drain window) must be refused")
 		}
 	})
@@ -590,7 +591,7 @@ func TestChangePolicyFreshZonePassesReentrancyGuard(t *testing.T) {
 	withPolicies(t, map[string]DnssecPolicy{
 		"mayoish": {Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
 	})
-	_, err := changeZonePolicy(zd, kdb, "mayoish")
+	_, err := changeZonePolicy(context.Background(), zd, kdb, "mayoish")
 	// It will likely error in SignZone (no real zone data), but NOT with the
 	// re-entrancy refusal.
 	if err != nil && strings.Contains(err.Error(), "already in progress") {


### PR DESCRIPTION
Foundation for **P0-2 / Plan B** (transactional DNSSEC-policy reload), per `docs/2026-07-15-transactional-policy-reload-plan.md`. This is **PR 1 of 2** — Phases 1–2 (schema + persistence + shared transactional core + CLI refactor + escape hatch). **No config-reload/restart behaviour changes here**; the refresh-engine wiring is PR 2.

## What this does

**Phase 1 — persist last-applied policy** (`db.go`, `db_schema.go`, `db_zone_policy_override.go`)
- Extend `ZonePolicyOverride` with `applied_policy` / `applied_source` / `applied_at`: the policy a zone was last successfully **signed** under, distinct from the sparse CLI `policy` **override** (intent). This makes intent-vs-reality comparable on reload and across restart.
- `dbMigrateSchema` adds the columns (idempotent `ALTER`); `dbMigrateData` seeds `applied_*` from existing CLI override rows (source `command`) — set-policy only ever wrote after a successful sign, so the override is a valid seed. Idempotent.
- `Get`/`Set`/`ClearZoneAppliedPolicy`, independent of the override (config-only zones get `applied_*` with an empty override; clearing one never erases the other).

**Phase 2 — shared transactional core** (`zone_policy_apply.go`) + CLI refactor (`apihandler_zone.go`, `cli/zone_cmds.go`)
- One core (`applyZonePolicyTransactional`) does rebind → re-sign → persist-on-success, reverting the in-memory binding on a `SignZone` failure. `setZonePolicy` / `changeZonePolicy` now call it (entry guards + operator messaging unchanged; behaviour preserved).

### Design-lock invariants (gating PR 2), enforced in code + tests here
- **① classify applied (DB) vs intent, never the in-memory binding.** `classifyPolicyChange(appliedPol, appliedName, intentPol, intentName)` is structurally incapable of reading `zd.DnssecPolicy`. On restart the binding is freshly loaded from config and equals intent — comparing it would hide a pending YAML change. `resolvePolicyPair` resolves both sides from the lock-free `ConfLive()` snapshot.
- **② applied-missing → backfill `applied=intent` without a re-sign** when the zone is already signed under intent (active-key algorithms match). Avoids a thundering-herd re-sign of every already-correct zone on the first post-upgrade reload; reachable independently of `intent==applied`.

**Escape hatch — `zone dnssec policy-reset --confirm`** (§6.7, test/lab; **DANGEROUS**)
- An abrupt KSK/ZSK algorithm switch is refused by design (needs an unbuilt rollover). `policy-reset` forces it for test zones: drops the zone's keys (reusing the keystore `clear` path), clears the override **and** applied records, and re-signs from scratch under the config policy via the core (records `applied=config`). **Breaks the chain of trust** until the parent DS is re-published. Requires `--confirm`; not for production.

## Tests
- `go build ./...`, `go vet ./...`, `go test -race ./...` — all green.
- `zone_policy_apply_test.go`: classifier over all four classes; **① restart regression** (applied `polA` vs intent `polB` detected while a binding would equal intent); **② backfill eligibility** (match → backfill no-sign; alg mismatch / unsigned → no backfill); revert-on-sign-failure leaves binding restored and `applied_*`/override untouched.
- `db_zone_policy_override_test.go`: applied CRUD, applied⊥override independence, data-migration backfill idempotence.
- Existing set-policy/change-policy tests pass unchanged.

## Scope / follow-up
- **PR 2** wires the refresh engine (reload/restart/dynamic) through `resolvePolicyPair` → backfill → classify → apply/refuse, removes `applyReloadedPolicyLocked`, and retargets the reload guard tests to applied-vs-intent.
- The **§9 live-test matrix** (edit `dnssec_policy` in YAML → `config reload` / `reload-zones` → verify signing + the DB `applied_*` row) is the **PR-2 merge gate**, run against a live `tdns-auth`. PR 1 has no reload behaviour to live-test.

**Please do not merge yet** — merge decisions are the maintainer's; this is the low-risk foundation for PR 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `zone dnssec policy-reset` to revert a zone to its configured DNSSEC policy, with `--confirm` controlling whether the reset is applied or shown as a preview.
  * Improved DNSSEC policy application to track “last applied” policy state and handle config-vs-command application consistently.
* **Bug Fixes**
  * Prevented incomplete policy/key updates from persisting when signing fails.
  * Enhanced detection of policy changes (including compatible rename across restarts) and clearer operator reporting.
  * Fixed active DNSSEC key refresh after cache staleness and preserved applied-policy data when clearing CLI overrides.
* **Warnings**
  * Policy reset clears/rebuilds keys and may temporarily break the chain of trust until parent DS records are republished.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->