### PR TITLE
Replace KeystoreDnskeyCache with per-zone signing-keys snapshot (G3)

### DIFF
--- a/docs/2026-07-16-signing-keys-snapshot-design.md
+++ b/docs/2026-07-16-signing-keys-snapshot-design.md
@@ -1,0 +1,479 @@
+# Design proposal — per-zone signing-keys snapshot (G3)
+
+**Status:** architecture approved; M1–M3 / R1–R4 incorporated — ready to implement.
+**Defaults:** D1 = N-caller discipline + R4 freshness matrix; D2 = big-bang delete
+(grep-clean). §16: active-only yes; lazy = CAS-if-unbuilt (not plain Store);
+clear mid-tx strip = out of G3 (follow-up ticket).
+**Branch / worktree:** `feature/signing-keys-snapshot` @
+`/Users/johani/src/git/tdns-project/tdns-signing-keys-snapshot` (cut from
+`main` @ `bdc6450`).
+**Origin:** G3 in
+`docs/2026-07-15-transactional-policy-reload-decisions.md`; sketch in
+`docs/2026-07-14-snapshot-branch-signing-findings.md` §Signing pipeline item 2;
+CodeRabbit on #288 (keystore post-commit invalidation). Same race class as the
+config-map crashes fixed by the RuntimeConfig snapshot (#287).
+**Sequencing:** lands **before** Plan B PR-2 (refresh-engine wiring), which will
+read keys lock-free on the reload path via this accessor.
+
+Line numbers below are anchors as of `bdc6450` and drift — re-locate by symbol.
+
+---
+
+## 1. Problem
+
+`KeyDB.KeystoreDnskeyCache` (`structs.go:820`) is a plain
+`map[string]*DnssecKeys` keyed `zone+"+"+state`. It is read and written from many
+goroutines — signer hot path, config reload, key mutations — with **inconsistent
+locking**:
+
+| Access | Locked? |
+|--------|---------|
+| Cache hit / fill in `GetDnssecKeys` (`keystore.go:1071–1155`) | **No** |
+| Most invalidations (`add`/`generate`/`setstate`/`delete`, `PromoteDnssecKey`, `UpdateDnssecKeyStateTx`, `RolloverKey`, `sign.go` deletes) | **No** |
+| Prefix wipe in `clear` / `purge` / `forceZoneKeysToPolicyRoles` | Yes (`kdb.mu`) — and `clear` still wipes **mid-tx** |
+
+`kdb.mu` is a **single-tx context gate** (`Begin`/`Commit`), not a cache lock.
+Unlocked concurrent map read vs write is a Go runtime `fatal error`. Rare
+(exact-timing), but real — the same class as the #287 config races.
+
+**Decision (locked — do not re-litigate):**
+
+- Do **not** fix by sprinkling locks on every reader.
+- Do **not** fold keys into the zone-data snapshot (#279).
+- Give each zone its own **copy-on-write signing-keys snapshot** — a `zd`-held
+  `atomic.Pointer` — separate from the zone-data snapshot (#279) and the
+  runtime-config snapshot (#287). Same "guard the rare writer, not the many hot
+  readers" model.
+
+**Why this shape (recap):**
+
+1. Keys change rarely → reads are lock-free ~always.
+2. A mass re-sign (10⁴–10⁵ zones) rewrites RRSIGs but **not** keys → keys
+   snapshots do not republish → **zero cross-zone contention** (vs a global lock
+   serializing every signer).
+3. The snapshot is **keystore-derived**, not served-data-derived → **no
+   zone-Ready ordering dependency** (unlike the zone-data snapshot).
+
+---
+
+## 2. Principle — mirror #279 / #287
+
+| Precedent | Pattern |
+|-----------|---------|
+| Zone-data snapshot (#279) | `zd.snapshot atomic.Pointer[zoneSnapshot]`; writers build immutable copy under `zd.mu`, `Store`; readers `Load()` lock-free |
+| RuntimeConfig (#287) | `liveConfig atomic.Pointer[RuntimeConfig]`; `ConfLive()` never nil (seeded empty in `init`); publish under `confMu` at reload end |
+
+G3 applies the same pattern to **per-zone active signing keys**:
+
+- One rare writer path: **build from DB after keystore commit → atomic Store**.
+- Many hot readers: `Load()` and sign, no lock.
+- Nil-safe accessor (seeded empty sentinel), cf. `ConfLive()`.
+
+---
+
+## 3. Type + placement
+
+### 3.1 Snapshot struct (M2 — `built` distinguishes keyless vs unbuilt)
+
+```go
+// signingKeysSnapshot is an immutable, keystore-derived view of the keys a
+// zone signs with. Published snapshots are never mutated in place; a key-set
+// change builds a fresh one and swaps the pointer.
+type signingKeysSnapshot struct {
+    // built is true iff this snapshot was produced by a successful DB build
+    // (eager republish or CAS-if-unbuilt lazy fill). false means unbuilt —
+    // either the package sentinel or a post-failed-republish marker.
+    // Keyless-but-loaded zones have built=true with empty Active slices
+    // (negative-cached; no per-call DB re-query).
+    built  bool
+    Active *DnssecKeys // never nil; slices may be empty when built && keyless
+}
+```
+
+Reuse `DnssecKeys` / `PrivateKeyCache` (`structs.go:792–811`). After `Store`,
+neither the snapshot nor its `DnssecKeys` / slices / `PrivateKeyCache` entries
+are mutated. `PrepareKeyCache` sets `CS` eagerly (`readkey.go:330`); `SignRRset`
+only reads `CS`/`DnskeyRR` — sharing `*DnssecKeys` lock-free is race-free.
+
+### 3.2 Placement on `ZoneData`
+
+```go
+signingKeys atomic.Pointer[signingKeysSnapshot] // NOT on KeyDB
+```
+
+### 3.3 Lock-free accessors (never nil)
+
+```go
+// Package sentinel: built=false. Returned when Load() is nil. NEVER Store this
+// shared instance onto a zone (ABA hazard with CAS-if-unbuilt — M3).
+var emptySigningKeys = &signingKeysSnapshot{built: false, Active: &DnssecKeys{}}
+
+func (zd *ZoneData) SigningKeys() *signingKeysSnapshot { /* Load or emptySigningKeys */ }
+func (zd *ZoneData) ActiveDnssecKeys() *DnssecKeys     { /* SigningKeys().Active */ }
+```
+
+Never `Store(emptySigningKeys)`. On republish failure, `Store` a **fresh**
+allocation `{built:false, Active:&DnssecKeys{}}` so CAS expected-values stay unique.
+
+---
+
+## 4. Which key states go in the snapshot
+
+### Decision (signed off): **active only**
+
+| State | Today | Proposal |
+|-------|-------|----------|
+| **Active** | Cached in `KeystoreDnskeyCache` (only state that *reads* the cache) | **In snapshot** — every signer / QR / updater / `EnsureActiveDnssecKeys` |
+| Published / standby / retired / created / removed | `GetDnssecKeysByState` → **DB-direct** (no cache read); occasional `GetDnssecKeys(Published)` in Ensure bootstrap | **Stay DB-direct** via `GetDnssecKeysByState` / a thin DB loader |
+
+**Justification:**
+
+1. `GetDnssecKeys` only **hits** the cache for `state == Active`
+   (`keystore.go:1071`). Non-active fills are write-only noise.
+2. Rollover / KeyStateWorker already use `GetDnssecKeysByState` (metadata, no
+   private keys) — cold, infrequent, correct without a snapshot.
+3. Snapshotting every state would enlarge the republish surface (every
+   published→standby tick would republish) for no hot-path win.
+4. Favor the smaller change that eliminates the crash class and the global map.
+
+**Consequence for Ensure's published lookup** (`sign.go:463`): keep a DB-direct
+load (extract today's SQL path into `loadDnssecKeysFromDB`). Do not put
+published keys in the snapshot.
+
+If a later rollover-path race appears on cold states, that is a separate
+follow-up — not G3.
+
+---
+
+## 5. Build + republish
+
+### 5.1 Build (DB → immutable snapshot)
+
+```go
+// Always returns built=true on success (including keyless empty Active).
+func buildSigningKeysSnapshot(kdb *KeyDB, zone string) (*signingKeysSnapshot, error)
+```
+
+### 5.2 Republish — post-commit only + M3 loud failure / self-heal
+
+```go
+// Call ONLY after the keystore tx that changed this zone's keys has COMMITTED.
+func (zd *ZoneData) republishSigningKeys(kdb *KeyDB) error {
+    snap, err := buildSigningKeysSnapshot(kdb, zd.ZoneName)
+    if err != nil {
+        lgSigner.Error("republishSigningKeys: build failed, retrying", "zone", zd.ZoneName, "err", err)
+        snap, err = buildSigningKeysSnapshot(kdb, zd.ZoneName) // one retry
+    }
+    if err != nil {
+        // M3: do NOT leave the old built snapshot installed silently.
+        // Invalidate with a FRESH unbuilt marker (never the shared sentinel —
+        // ABA with CAS-if-unbuilt). Next reader rebuilds via CAS.
+        zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
+        lgSigner.Error("republishSigningKeys: failed after retry; marked unbuilt",
+            "zone", zd.ZoneName, "err", err)
+        return err
+    }
+    zd.signingKeys.Store(snap) // snap.built == true
+    return nil
+}
+
+// R3: always FQDN via Zones.Get(dns.Fqdn(zone)) — never keyname-shaped strings.
+func republishSigningKeysForZone(kdb *KeyDB, zone string) error {
+    zone = dns.Fqdn(strings.TrimSpace(zone))
+    if zone == "." { return nil }
+    zd, ok := Zones.Get(zone)
+    if !ok || zd == nil { return nil }
+    return zd.republishSigningKeys(kdb)
+}
+```
+
+`delete(map)` could not fail; a DB-build republish can. Returning the error keeps
+failures loud (callers / logs); the unbuilt marker prevents silent signing with
+removed keys via a stale `built=true` snapshot.
+
+### 5.3 Own-tx vs external-tx (R1)
+
+| Mutator | Owns commit? | Republish |
+|---------|--------------|-----------|
+| `DnssecKeyMgmt` (local tx) | yes | **Once** post-commit in defer, keyed by `dns.Fqdn(kp.Zone)` (R2) — not per-subcommand |
+| `PromoteDnssecKey` | yes | self-republish after Commit |
+| `UpdateDnssecKeyState` | yes | self-republish after Commit |
+| `RolloverKey` (tx==nil) | yes | self-republish after Commit |
+| `GenerateKeypair` (tx==nil, DNSKEY) | yes | self-republish after Commit |
+| `forceZoneKeysToPolicyRoles` | yes | `zd.republishSigningKeys` after Commit |
+| `GenerateKeypair` (external tx) | no | delete any cache op; **caller** republishes post-commit |
+| `UpdateDnssecKeyStateTx` | no | no inline cache/republish; **caller** republishes |
+| `RolloverKey` (external tx) | no | no inline cache/republish; **caller** republishes |
+
+**External-tx callers that must republish after their Commit (enumerate):**
+
+- `DnssecKeyMgmt` (covers generate/rollover/policy-cleanup/clear/purge via R2 once)
+- `AtomicRollover` (`ksk_rollover_atomic.go` after `tx.Commit`)
+- KSK observe advance that uses `UpdateDnssecKeyStateTx` (created→ds-published — active set unchanged; republish optional/harmless; still call for uniformity if cheap)
+- Any future helper that passes a non-nil `*Tx` into the three external-tx mutators
+
+**KeyStateWorker / reconcile / most rollover pipeline** call `UpdateDnssecKeyState`
+(own-tx) — covered by self-republish. `EnsureActiveDnssecKeys` calls
+`PromoteDnssecKey` / `GenerateKeypair(nil)` — covered by those self-republish paths;
+`refreshActiveDnssecKeys` becomes an explicit `republishSigningKeys`.
+
+### 5.4 Mid-tx ban
+
+NEVER republish (or invalidate) mid-tx. Same D4 window as the old mid-tx map wipe.
+
+## 6. Republish sites## 6. Republish sites (complete list)
+
+Every keystore mutation that can change a zone's **active** set must republish
+**after commit**. Sites today that touch `KeystoreDnskeyCache` (replace each
+delete/wipe with `republishSigningKeys` / `republishSigningKeysForZone`):
+
+| Site | Symbol / path | Trigger |
+|------|---------------|---------|
+| Keystore CLI/API add | `DnssecKeyMgmt` `add` | post-commit republish |
+| Keystore generate | `DnssecKeyMgmt` `generate` (after `GenerateKeypair`) | post-commit |
+| setstate | `DnssecKeyMgmt` `setstate` | post-commit (active set may change) |
+| delete | `DnssecKeyMgmt` `delete` | post-commit |
+| clear | `DnssecKeyMgmt` `clear` | **move** invalidate to post-commit; then republish (fixes mid-tx wipe) |
+| purge | `dnssecKeyPurge` | post-commit republish per affected zone |
+| policy-reset force | `forceZoneKeysToPolicyRoles` | replace cache wipe with `zd.republishSigningKeys` post-commit (zd already in hand) |
+| Promote | `PromoteDnssecKey` | after *that* tx commits |
+| State transitions | `UpdateDnssecKeyState` / `UpdateDnssecKeyStateTx` | after owning tx commits — covers **KeyStateWorker**, KSK/ZSK rollover promotions, reconcile retires |
+| ZSK roll | `RolloverKey` | post-commit |
+| Ensure bootstrap gen | `EnsureActiveDnssecKeys` after `GenerateKeypair` / `PromoteDnssecKey` | republish on zd after those commits (today's explicit cache deletes at `sign.go:507,537`) |
+| refresh after mutation | `refreshActiveDnssecKeys` | becomes `zd.republishSigningKeys` (or Load after publish) — not a blind cache delete |
+| ZSK active_at heal | `zsk_rollover.go` cache delete | metadata-only (`GetDnssecKeysByState`); **drop** the cache line — no snapshot republish |
+| KSK pipeline create | `GenerateKskRolloverCreated` | created-only → **no** active republish required; skip unless it also touches active |
+
+**`GenerateKeypair`:** own-tx (nil) self-republishes for DNSKEY after Commit;
+external-tx does not — caller republishes (R1).
+
+**Mass re-sign must NOT republish:** `SignZone`, `SetupZoneSigning`, resigner
+ticks, QR online-sign, zone-updater signing — these rewrite RRSIGs only. They
+**read** `zd.ActiveDnssecKeys()` and leave the pointer alone. That is the
+scalability property this design exists for.
+
+---
+
+## 7. Accessor resolution — `GetDnssecKeys` after G3 (M1 + M2)
+
+**M1 — never plain `Store` from the read path.** A lazy `Store(built)` can
+clobber a concurrent post-commit republish (reader builds during a wide
+`PrepareKeyCache` window; mutator republishes `{new}`; reader's Store lands
+last with `{old}` → silent stale until next mutation). Use **CAS-if-unbuilt**:
+
+```
+loaded := zd.signingKeys.Load()
+if loaded != nil && loaded.built {
+    return loaded.Active, nil          // includes built&&keyless (M2 negative cache)
+}
+built, err := buildSigningKeysSnapshot(kdb, zone)   // built=true always on success
+if err != nil { return nil, err }
+if zd.signingKeys.CompareAndSwap(loaded, built) {   // loaded may be nil
+    return built.Active, nil
+}
+return zd.signingKeys.Load().Active, nil            // lost the race — take winner
+```
+
+`GetDnssecKeys` resolution:
+
+```
+if state != Active:
+    return loadDnssecKeysFromDB(...)                 // cold; no snapshot
+
+zone = dns.Fqdn(zone)
+if zd, ok := Zones.Get(zone); ok && zd != nil:
+    return zd.activeKeysCAS(kdb)                     // § above
+
+return loadDnssecKeysFromDB(kdb, zone, Active)       // unloaded — no zd
+```
+
+Hot callers with `*ZoneData` prefer `zd.ActiveDnssecKeys()` when `built`
+(Ensure still generates when empty). Pre-Ready OK — no Ready dependency.
+
+---
+
+## 8. Bootstrap — eager + lazy (CAS-if-unbuilt)
+
+| When | What |
+|------|------|
+| `ZoneData` created | Leave pointer nil (accessor falls back to `emptySigningKeys`); **do not** Store the shared sentinel |
+| First successful `EnsureActiveDnssecKeys` / `SetupZoneSigning` | **Eager** `republishSigningKeys` → `Store({built:true, ...})` |
+| First read while `!built` | **Lazy CAS-if-unbuilt** (§7) — never plain Store |
+| Package sentinel | Return-only when `Load()==nil`; `built=false` |
+
+Keyless zones: eager/lazy build succeeds with empty slices and `built=true` —
+subsequent reads do not re-query the DB (M2; matches today's non-negative-cache
+gap at keystore.go:1136/:1142 which returned before fill — we now negative-cache
+correctly via `built`).
+
+---
+
+## 9. Removal of the global cache
+
+**Confirm:** this PR **deletes** `KeyDB.KeystoreDnskeyCache` and every access:
+
+- Field on `KeyDB` (`structs.go:820`)
+- Init in `NewKeyDB` (`db.go:359`)
+- All `delete(...)` / range-wipe sites listed in §6
+- Cache hit + fill in `GetDnssecKeys` (`keystore.go:1071–1155`)
+- Test `policy_reset_cache_test.go` — rewrite to assert **snapshot** freshness
+  after clear/force (stale global cache scenario goes away; new assertion:
+  post-commit snapshot matches DB active set)
+
+**No residual global map.** No "compat shim" that keeps a map behind the
+snapshot. Grep-clean for `KeystoreDnskeyCache` at PR end.
+
+---
+
+## 10. Consistency note — keys vs RRSIG snapshots
+
+Keys and RRSIGs live in **separate** snapshots (`signingKeys` vs
+`zoneSnapshot`). They are **not** published atomically together.
+
+**Existing discipline (unchanged, still required):**
+
+```
+keystore Commit
+  → republishSigningKeys          // new G3 step (was: cache invalidate)
+  → stripStaleRRSIGsForKeySet     // stages + publishes zone-data snapshot
+  → SignZone / apply transactional // adds RRSIGs; publishes zone-data again
+```
+
+Canonical reference: `forceZoneKeysToPolicyRoles` + `resetZonePolicy`
+(`apihandler_zone.go` after force) and D7 in the policy-reload decisions doc.
+
+**Torn-state window:** between keystore commit+keys-republish and the later
+zone-data publish, a reader can see **new keys + old RRSIGs** (or, during strip,
+briefly fewer RRSIGs). That window **already exists today** (decoupled
+`KeystoreDnskeyCache` vs zone snapshot). G3 does **not** widen it:
+
+- Readers never see a half-updated Go map (the crash class).
+- They see one immutable keys snapshot XOR the next — same as #279/#287.
+- Orphan/DNSKEY RRSIG correctness still rests on strip-after-commit → re-sign,
+  not on atomic co-publication of keys+RRSIGs.
+
+**Mass re-sign:** zone-data snapshot republishes many times; keys snapshot stays
+put → no cross-zone keys contention, and no extra torn windows from keys.
+
+---
+
+## 11. Call-site migration (implementation sketch)
+
+| Phase | Work |
+|-------|------|
+| A | Add type, field, accessors, `build`/`republish`, seed sentinel |
+| B | Wire post-commit republish at every §6 site; delete cache ops |
+| C | Rewrite `GetDnssecKeys` per §7; extract `loadDnssecKeysFromDB` |
+| D | Hot callers with `*ZoneData` → `zd.ActiveDnssecKeys()` (+ Ensure still generates) |
+| E | Delete `KeystoreDnskeyCache` field + init; grep-clean |
+| F | Tests (§12) |
+
+PR-2 (refresh-engine) then consumes `zd.ActiveDnssecKeys()` / `SigningKeys()` on
+reload without touching any global map.
+
+---
+
+## 12. Test plan (freshness matrix — R4)
+
+### 12.1 `-race` regression (mandatory)
+
+`TestSigningKeysSnapshotNoRace` — mirror `runtime_config_race_test.go`:
+many readers on `ActiveDnssecKeys` / `SigningKeys` vs one mutator that commits +
+republishes. Must stay clean under `-race`
+(`GOROOT=/opt/local/lib/go CGO_ENABLED=1`).
+
+### 12.2 Mass re-sign does not Store
+
+Publish keys snapshot; record pointer; `SignZone` without key mutation → same
+pointer. Contrast: real key mutation → pointer changes.
+
+### 12.3 Freshness matrix (per mutation path)
+
+For each path, after successful commit assert
+`zd.ActiveDnssecKeys()` keyids match DB active keyids (`GetDnssecKeysByState`
+or direct SQL):
+
+| Path | Test |
+|------|------|
+| setstate | DnssecKeyMgmt setstate → active |
+| generate | DnssecKeyMgmt generate / GenerateKeypair(nil) |
+| delete | DnssecKeyMgmt delete (active → removed) |
+| rollover | RolloverKey(nil) / ZSK roll |
+| promote | PromoteDnssecKey |
+| clear | DnssecKeyMgmt clear (+ regen) |
+| force | forceZoneKeysToPolicyRoles |
+
+Plus:
+
+- **M1:** concurrent lazy-read (force unbuilt) + mutation → ends with **fresh**
+  (new) keys, never the pre-mutation set.
+- **M3:** force republish build failure (inject / close DB) → error returned /
+  logged; snapshot `!built` (or next read rebuilds); never silently serve the
+  pre-failure built snapshot as if current.
+
+Rewrite `policy_reset_cache_test.go` into this matrix (stale global-cache
+scenario is gone).
+
+### 12.4 Nil-safety / built semantics
+
+- Fresh `ZoneData`: `SigningKeys()` non-nil, `built==false`.
+- Keyless zone after build: `built==true`, empty slices; second read no DB
+  round-trip (optional: count queries).
+
+### 12.5 Full suite gate
+
+`build` / `vet` / full `v2 -race` green before each commit.
+
+## 13. Non-goals## 13. Non-goals / out of scope
+
+- Folding keys into `zoneSnapshot` or `RuntimeConfig`.
+- Snapshotting published/standby/retired (see §4).
+- Per-zone sign coalescing / worker pool (findings doc items 1 and 3) — separate.
+- SIG0 key caches (`KeystoreSig0Cache`) — separate race class if any.
+- Widening `kdb.mu` into a general cache lock.
+
+---
+
+## 14. Implementation rules (when signed off)
+
+- Work only in the `tdns-signing-keys-snapshot` worktree on
+  `feature/signing-keys-snapshot`.
+- GPG-sign every commit (**never** `--no-gpg-sign`).
+- No `Co-Authored-By` / AI bylines.
+- Implement → commit → push → open PR → **stop** (do not merge).
+- `build` / `vet` / full `v2 -race` green before each commit.
+
+---
+
+## 15. Success criteria
+
+- Zero remaining references to `KeystoreDnskeyCache`.
+- Hot signer / QR path reads `zd.ActiveDnssecKeys()` lock-free.
+- Every active-set mutation republishes **post-commit** only.
+- Mass re-sign does not `Store` a new keys snapshot.
+- `-race` regression in §12.1 clean; freshness matrix §12.3 green (incl. M1/M3).
+- No wider torn-state window than today's cache vs zone-snapshot decoupling.
+- Ready for Plan B PR-2 to consume the accessor on reload.
+
+---
+
+## 16. Sign-off answers + method defaults
+
+| Item | Decision |
+|------|----------|
+| Active-only (§4) | **Yes** |
+| Lazy fill | **CAS-if-unbuilt** (M1) — not plain Store; return-without-store also acceptable |
+| clear mid-tx RRSIG strip | **Out of G3** — follow-up ticket (D7-ordering violation) |
+| **D1** choke-point vs N-caller | **N-caller (R1) + freshness matrix (R4)** unless Johan overrides |
+| **D2** shadow-map vs big-bang | **Big-bang**, grep-clean at PR end |
+
+## 17. References## 17. References
+
+- `docs/2026-07-15-transactional-policy-reload-decisions.md` — G3, D4, D7
+- `docs/2026-07-14-snapshot-branch-signing-findings.md` — per-`zd` active-key cache sketch
+- `docs/2026-07-15-runtime-config-snapshot-plan.md` — #287 pattern to mirror
+- `v2/runtime_config.go` — `ConfLive` / seed / publish
+- `v2/zone_snapshot.go` / `zone_mutation.go` — #279 publish path
+- `v2/keystore.go` — `GetDnssecKeys`, `forceZoneKeysToPolicyRoles` post-commit
+- `v2/policy_reset_cache_test.go` — stale-cache regression to retarget
+- `v2/runtime_config_race_test.go` — race-test template

--- a/docs/2026-07-16-signing-keys-snapshot-design.md
+++ b/docs/2026-07-16-signing-keys-snapshot-design.md
@@ -215,10 +215,16 @@ removed keys via a stale `built=true` snapshot.
 
 **External-tx callers that must republish after their Commit (enumerate):**
 
-- `DnssecKeyMgmt` (covers generate/rollover/policy-cleanup/clear/purge via R2 once)
+- **`APIkeystore` (`apihandler_funcs.go`)** — the production caller of `DnssecKeyMgmt`; always
+  passes a non-nil (external) tx. After a successful Commit, if
+  `resp.NeedsSigningKeysRepublish`, call `republishSigningKeysForZone` **before**
+  `triggerResign`. The `DnssecKeyMgmt` localtx/R2 republish path is never taken here.
 - `AtomicRollover` (`ksk_rollover_atomic.go` after `tx.Commit`)
 - KSK observe advance that uses `UpdateDnssecKeyStateTx` (created→ds-published — active set unchanged; republish optional/harmless; still call for uniformity if cheap)
-- Any future helper that passes a non-nil `*Tx` into the three external-tx mutators
+- Any future helper that passes a non-nil `*Tx` into `DnssecKeyMgmt` or the three external-tx mutators
+
+`DnssecKeyMgmt` with `tx==nil` (local tx) still self-republishes once post-commit (R2).
+That path is for direct/own-tx callers only — not the API.
 
 **KeyStateWorker / reconcile / most rollover pipeline** call `UpdateDnssecKeyState`
 (own-tx) — covered by self-republish. `EnsureActiveDnssecKeys` calls
@@ -472,7 +478,7 @@ scenario is gone).
 | Active-only (§4) | **Yes** |
 | Lazy fill | **CAS-if-unbuilt** (M1) — not plain Store; return-without-store also acceptable |
 | clear mid-tx RRSIG strip | **Out of G3** — follow-up ticket (D7-ordering violation) |
-| **D1** choke-point vs N-caller | **N-caller (R1) + freshness matrix (R4)** unless Johan overrides |
+| **D1** choke-point vs N-caller | **N-caller (R1) + freshness matrix (R4)** unless Johan overrides. Note: the APIkeystore external-tx gap showed N-caller still misses real callers; a tx-registered deferred republish remains an optional structural alternative. |
 | **D2** shadow-map vs big-bang | **Big-bang**, grep-clean at PR end |
 
 ## 17. References## 17. References

--- a/docs/2026-07-16-signing-keys-snapshot-design.md
+++ b/docs/2026-07-16-signing-keys-snapshot-design.md
@@ -158,7 +158,11 @@ func buildSigningKeysSnapshot(kdb *KeyDB, zone string) (*signingKeysSnapshot, er
 
 ```go
 // Call ONLY after the keystore tx that changed this zone's keys has COMMITTED.
+// Generation-gated: bump signingKeysGen at entry; Store (success or unbuilt
+// marker) only if that generation is still current — prevents an older
+// overlapping republish from clobbering a newer snapshot.
 func (zd *ZoneData) republishSigningKeys(kdb *KeyDB) error {
+    gen := zd.signingKeysGen.Add(1)
     snap, err := buildSigningKeysSnapshot(kdb, zd.ZoneName)
     if err != nil {
         lgSigner.Error("republishSigningKeys: build failed, retrying", "zone", zd.ZoneName, "err", err)
@@ -168,12 +172,16 @@ func (zd *ZoneData) republishSigningKeys(kdb *KeyDB) error {
         // M3: do NOT leave the old built snapshot installed silently.
         // Invalidate with a FRESH unbuilt marker (never the shared sentinel —
         // ABA with CAS-if-unbuilt). Next reader rebuilds via CAS.
-        zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
+        if zd.signingKeysGen.Load() == gen {
+            zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
+        }
         lgSigner.Error("republishSigningKeys: failed after retry; marked unbuilt",
             "zone", zd.ZoneName, "err", err)
         return err
     }
-    zd.signingKeys.Store(snap) // snap.built == true
+    if zd.signingKeysGen.Load() == gen {
+        zd.signingKeys.Store(snap) // snap.built == true
+    }
     return nil
 }
 

--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -82,6 +82,10 @@ type KeystoreResponse struct {
 	Error          bool
 	ErrorMsg       string
 	TsigCacheDelta *TsigCacheDelta `json:"-"`
+	// NeedsSigningKeysRepublish is set by DnssecKeyMgmt when the operation can
+	// change the zone's active signing-key set. External-tx callers (APIkeystore)
+	// must call republishSigningKeysForZone after their Commit (R1).
+	NeedsSigningKeysRepublish bool `json:"-"`
 }
 
 // TsigKeyExport carries a TSIG key's secret back to the caller for the explicit

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -37,6 +37,9 @@ func (kdb *KeyDB) APIkeystore(conf *Config) func(w http.ResponseWriter, r *http.
 			confMu.Lock()
 		}
 
+		var dnssecRepublishZone string
+		var dnssecResignZone string
+
 		tx, err := kdb.Begin("APIkeystore")
 
 		defer func() {
@@ -50,20 +53,34 @@ func (kdb *KeyDB) APIkeystore(conf *Config) func(w http.ResponseWriter, r *http.
 							resp.Error = true
 							resp.ErrorMsg = commitErr.Error()
 						}
-					} else if tsigCacheDelta != nil {
-						if !tsigMgmt {
-							confMu.Lock()
-						}
-						if applyErr := ApplyTsigCacheDelta(conf.Internal.TsigKeyStore, kdb, tsigCacheDelta); applyErr != nil {
-							lgApi.Error("ApplyTsigCacheDelta failed", "err", applyErr)
-							if resp == nil {
-								resp = &KeystoreResponse{Time: time.Now()}
+					} else {
+						// R1: DnssecKeyMgmt always receives this external tx, so its
+						// localtx republish path never runs. Republish here after
+						// Commit, before triggerResign, so SignZone sees the new set.
+						if dnssecRepublishZone != "" {
+							if rerr := republishSigningKeysForZone(kdb, dnssecRepublishZone); rerr != nil {
+								lgApi.Error("APIkeystore: post-commit signing-keys republish failed",
+									"zone", dnssecRepublishZone, "err", rerr)
 							}
-							resp.Error = true
-							resp.ErrorMsg = fmt.Sprintf("TSIG keystore committed, but runtime cache refresh failed: %v", applyErr)
 						}
-						if !tsigMgmt {
-							confMu.Unlock()
+						if dnssecResignZone != "" {
+							triggerResign(conf, dnssecResignZone)
+						}
+						if tsigCacheDelta != nil {
+							if !tsigMgmt {
+								confMu.Lock()
+							}
+							if applyErr := ApplyTsigCacheDelta(conf.Internal.TsigKeyStore, kdb, tsigCacheDelta); applyErr != nil {
+								lgApi.Error("ApplyTsigCacheDelta failed", "err", applyErr)
+								if resp == nil {
+									resp = &KeystoreResponse{Time: time.Now()}
+								}
+								resp.Error = true
+								resp.ErrorMsg = fmt.Sprintf("TSIG keystore committed, but runtime cache refresh failed: %v", applyErr)
+							}
+							if !tsigMgmt {
+								confMu.Unlock()
+							}
 						}
 					}
 				}
@@ -103,10 +120,13 @@ func (kdb *KeyDB) APIkeystore(conf *Config) func(w http.ResponseWriter, r *http.
 					Error:    true,
 					ErrorMsg: err.Error(),
 				}
+			} else if resp != nil && resp.NeedsSigningKeysRepublish {
+				dnssecRepublishZone = kp.Zone
 			}
-			// Trigger re-sign and inventory push after state-changing operations
+			// Re-sign after state-changing ops — deferred until post-commit
+			// (alongside snapshot republish) so the resigner does not race the tx.
 			if err == nil && (kp.SubCommand == "rollover" || kp.SubCommand == "delete" || kp.SubCommand == "setstate" || kp.SubCommand == "clear" || kp.SubCommand == "policy-cleanup") {
-				triggerResign(conf, kp.Zone)
+				dnssecResignZone = kp.Zone
 			}
 
 		case "tsig-mgmt":

--- a/v2/db.go
+++ b/v2/db.go
@@ -356,7 +356,6 @@ func NewKeyDB(dbfile string, force bool, options map[AuthOption]string) (*KeyDB,
 		DBFile:              dbfile,
 		KeystoreSig0Cache:   make(map[string]*Sig0ActiveKeys),
 		TruststoreSig0Cache: NewSig0StoreT(),
-		KeystoreDnskeyCache: make(map[string]*DnssecKeys),
 		UpdateQ:             make(chan UpdateRequest),
 		KeyBootstrapperQ:    make(chan KeyBootstrapperRequest, 10),
 	}

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -315,6 +315,7 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 	var localtx = false
 	var err error
 	var txSuccess bool
+	var needsRepublish bool // R2: one post-commit republish for the zone
 
 	if tx == nil {
 		tx, err = kdb.Begin("DnssecKeyMgmt")
@@ -328,11 +329,22 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 			if txSuccess {
 				if err := tx.Commit(); err != nil {
 					lgSigner.Error("DnssecKeyMgmt commit failed", "err", err)
+					return
+				}
+				if needsRepublish {
+					if rerr := republishSigningKeysForZone(kdb, kp.Zone); rerr != nil {
+						lgSigner.Error("DnssecKeyMgmt: post-commit signing-keys republish failed",
+							"zone", kp.Zone, "err", rerr)
+					}
 				}
 			} else {
 				lgSigner.Debug("DnssecKeyMgmt rollback")
 				tx.Rollback()
 			}
+		} else if txSuccess && needsRepublish {
+			// External tx: caller must republish after their Commit (R1).
+			lgSigner.Debug("DnssecKeyMgmt: external tx; caller must republishSigningKeysForZone post-commit",
+				"zone", kp.Zone)
 		}
 	}()
 
@@ -417,7 +429,7 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 			rows, _ := res.RowsAffected()
 			resp.Msg = fmt.Sprintf("Updated %d rows", rows)
 		}
-		delete(kdb.KeystoreDnskeyCache, kp.Keyname+"+"+kp.State)
+		needsRepublish = true
 
 	case "generate":
 		_, msg, err := kdb.GenerateKeypair(kp.Zone, "api-request", kp.State, dns.TypeDNSKEY, kp.Algorithm, kp.KeyType, tx)
@@ -427,8 +439,8 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 			resp.ErrorMsg = err.Error()
 		}
 		resp.Msg = msg
-		delete(kdb.KeystoreDnskeyCache, kp.Keyname+"+"+kp.State)
 		if err == nil {
+			needsRepublish = true
 			txSuccess = true
 		}
 		return &resp, err
@@ -455,7 +467,7 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 				resp.Msg = fmt.Sprintf("Key with name \"%s\" and keyid %d not found.", kp.Keyname, kp.Keyid)
 			}
 		}
-		delete(kdb.KeystoreDnskeyCache, kp.Keyname+"+"+kp.State)
+		needsRepublish = true
 
 	case "rollover":
 		keytype := kp.KeyType
@@ -469,6 +481,7 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 			return &resp, err
 		}
 		resp.Msg = fmt.Sprintf("%s rollover for zone %s: active key %d retired, standby key %d now active", keytype, kp.Zone, oldKeyid, newKeyid)
+		needsRepublish = true
 
 	case "export":
 		const getDnskeySql = `
@@ -538,8 +551,7 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 			return &resp, err
 		}
 		resp.Msg = fmt.Sprintf("Key %s (keyid %d) transitioned to %s", kp.Keyname, kp.Keyid, targetState)
-		delete(kdb.KeystoreDnskeyCache, kp.Keyname+"+"+state)
-		delete(kdb.KeystoreDnskeyCache, kp.Keyname+"+"+targetState)
+		needsRepublish = true
 
 	case "clear":
 		if kp.Zone == "" {
@@ -554,14 +566,7 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 			return &resp, err
 		}
 		count, _ := result.RowsAffected()
-		// Invalidate all caches for this zone (mutex protects iteration during concurrent access)
-		kdb.mu.Lock()
-		for key := range kdb.KeystoreDnskeyCache {
-			if strings.HasPrefix(key, kp.Zone+"+") {
-				delete(kdb.KeystoreDnskeyCache, key)
-			}
-		}
-		kdb.mu.Unlock()
+		needsRepublish = true // post-commit via defer (R2); never mid-tx
 		lgSigner.Info("all DNSSEC keys cleared", "zone", kp.Zone, "count", count)
 
 		// Immediately generate 1 active ZSK + 1 active KSK so the zone can be signed.
@@ -672,6 +677,7 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 		} else {
 			resp.Msg = fmt.Sprintf("Zone %s: removed %d retired key(s) %v and stripped their RRSIGs; active keys retained.",
 				kp.Zone, len(removedTags), removedTags)
+			needsRepublish = true
 		}
 
 	case "purge":
@@ -680,6 +686,7 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 			return purgeResp, err
 		}
 		resp = *purgeResp
+		needsRepublish = true
 
 	default:
 		resp.Msg = fmt.Sprintf("Unknown keystore dnssec sub-command: %s", kp.SubCommand)
@@ -697,8 +704,8 @@ SELECT zonename, state, keyid, flags, algorithm, privatekey, keyrr FROM DnssecKe
 // ALL of that role's keys (every state) and generates one fresh active key of the
 // config algorithm; the unchanged role's keys are left untouched. It runs the key
 // mutation in one transaction that rolls back on any failure, and on success
-// invalidates the zone's key cache post-commit (the DELETE+regen changed the
-// active set, and this method owns its transaction, so the invalidation is
+// republishes the zone's signing-keys snapshot post-commit (the DELETE+regen
+// changed the active set; this method owns its transaction, so the republish is
 // complete — unlike a mid-tx wipe that a read in the uncommitted window can undo).
 //
 // It returns the SURVIVING keytags (the kept role's keys + the regenerated ones);
@@ -768,14 +775,10 @@ func (kdb *KeyDB) forceZoneKeysToPolicyRoles(zd *ZoneData, pol *DnssecPolicy, dr
 	}
 	committed = true
 
-	// Post-commit cache invalidation (locked against concurrent map access).
-	kdb.mu.Lock()
-	for key := range kdb.KeystoreDnskeyCache {
-		if strings.HasPrefix(key, zone+"+") {
-			delete(kdb.KeystoreDnskeyCache, key)
-		}
+	// Post-commit signing-keys snapshot republish (G3).
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		return surviving, fmt.Errorf("forceZoneKeysToPolicyRoles: republish signing keys for %s: %w", zone, err)
 	}
-	kdb.mu.Unlock()
 	return surviving, nil
 }
 
@@ -929,7 +932,8 @@ func (kdb *KeyDB) dnssecKeyPurge(tx *Tx, kp KeystorePost) (*KeystoreResponse, er
 			continue // dry-run: don't actually delete
 		}
 
-		// Commit path: delete the rows + invalidate caches for this zone.
+		// Commit path: delete the rows. Active signing-keys snapshot is unchanged
+		// (only 'removed' rows are purged); DnssecKeyMgmt may still republish.
 		delSQL := `DELETE FROM DnssecKeyStore WHERE zonename=? AND state=?` + notInClause
 		res, err := tx.Exec(delSQL, args...)
 		if err != nil {
@@ -937,14 +941,6 @@ func (kdb *KeyDB) dnssecKeyPurge(tx *Tx, kp KeystorePost) (*KeystoreResponse, er
 		}
 		n, _ := res.RowsAffected()
 		deletedCount += int(n)
-
-		kdb.mu.Lock()
-		for cacheKey := range kdb.KeystoreDnskeyCache {
-			if strings.HasPrefix(cacheKey, zone+"+") {
-				delete(kdb.KeystoreDnskeyCache, cacheKey)
-			}
-		}
-		kdb.mu.Unlock()
 	}
 
 	resp.Dnskeys = purged
@@ -1061,100 +1057,18 @@ func (kdb *KeyDB) GetSig0KeyRaw(zonename, state string) (algorithm, privatekey, 
 	return "", "", "", false, nil
 }
 
+// GetDnssecKeys returns DNSSEC keys for zonename in the given state.
+// Active keys for a loaded zone are served from the per-zone signing-keys
+// snapshot (CAS-if-unbuilt on first access). Cold states are always DB-direct.
 func (kdb *KeyDB) GetDnssecKeys(zonename, state string) (*DnssecKeys, error) {
-	const (
-		fetchDnssecPrivKeySql = `
-SELECT keyid, flags, algorithm, privatekey, keyrr FROM DnssecKeyStore WHERE zonename=? AND state=?`
-	)
-
-	// XXX: Should use this once we've found all the bugs in the sqlite code
-	if state == DnskeyStateActive {
-		if dak, ok := kdb.KeystoreDnskeyCache[zonename+"+"+state]; ok {
-			return dak, nil
-		}
+	zonename = dns.Fqdn(strings.TrimSpace(zonename))
+	if state != DnskeyStateActive {
+		return loadDnssecKeysFromDB(kdb, zonename, state)
 	}
-
-	var dk DnssecKeys
-
-	rows, err := kdb.Query(fetchDnssecPrivKeySql, zonename, state)
-	if err != nil {
-		lgSigner.Error("failed to query DNSSEC keys", "sql", fetchDnssecPrivKeySql, "zone", zonename, "err", err)
-		return nil, err
+	if zd, ok := Zones.Get(zonename); ok && zd != nil {
+		return zd.activeKeysCAS(kdb)
 	}
-	defer rows.Close()
-
-	var algorithm, privatekey, keyrrstr, logmsg string
-	var flags, keyid int
-
-	var keysfound bool
-
-	for rows.Next() {
-		err := rows.Scan(&keyid, &flags, &algorithm, &privatekey, &keyrrstr)
-		if err != nil {
-			if err == sql.ErrNoRows {
-				lgSigner.Debug("no active DNSSEC key found", "zone", zonename)
-				return &dk, nil
-			}
-			lgSigner.Error("rows.Scan failed", "err", err)
-			return nil, err
-		}
-
-		keysfound = true
-
-		// Parse private key, detecting old BIND format or new PEM format
-		_, alg, bindFormat, err := ParsePrivateKeyFromDB(privatekey, algorithm, keyrrstr)
-		if err != nil {
-			lgSigner.Error("ParsePrivateKeyFromDB failed", "err", err)
-			return nil, err
-		}
-
-		// Use PrepareKeyCache with the BIND format (it handles both old and new keys this way)
-		pkc, err := PrepareKeyCache(bindFormat, keyrrstr)
-		if err != nil {
-			lgSigner.Error("PrepareKeyCache failed", "err", err)
-			return nil, err
-		}
-
-		// Ensure the parsed algorithm matches
-		if pkc.Algorithm != alg {
-			lgSigner.Warn("algorithm mismatch", "stored", alg, "parsed", pkc.Algorithm)
-			return nil, fmt.Errorf("error: algorithm mismatch for key %s: stored=%d, parsed=%d", keyrrstr, alg, pkc.Algorithm)
-		}
-
-		if (flags & 0x0001) != 0 {
-			dk.KSKs = append(dk.KSKs, pkc)
-			//log.Printf("Adding KSK to DAK: flags: %d key: %s", flags, pkc.DnskeyRR.String())
-			logmsg += fmt.Sprintf("%d (KSK) ", keyid)
-		} else {
-			dk.ZSKs = append(dk.ZSKs, pkc)
-			// log.Printf("Adding ZSK to DAK: flags: %d key: %s", flags, pkc.DnskeyRR.String())
-			logmsg += fmt.Sprintf("%d (ZSK) ", keyid)
-		}
-	}
-
-	// No keys found is not an error
-	if !keysfound {
-		lgSigner.Debug("no DNSSEC keys found", "state", state, "zone", zonename)
-		return &dk, nil
-	}
-
-	// No KSK found is a hard error
-	if len(dk.KSKs) == 0 {
-		lgSigner.Warn("no DNSSEC KSK found", "state", state, "zone", zonename)
-		return &dk, nil
-	}
-
-	// When using a CSK it will have the flags = 257, but also be used as a ZSK.
-	if len(dk.ZSKs) == 0 {
-		lgSigner.Info("no DNSSEC ZSK found, reusing KSK as CSK", "state", state, "zone", zonename)
-		dk.ZSKs = append(dk.ZSKs, dk.KSKs[0])
-	}
-
-	lgSigner.Debug("GetDnssecKeys returned keys", "zone", zonename, "state", state, "keys", logmsg)
-
-	kdb.KeystoreDnskeyCache[zonename+"+"+state] = &dk
-
-	return &dk, err
+	return loadDnssecKeysFromDB(kdb, zonename, DnskeyStateActive)
 }
 
 func (kdb *KeyDB) PromoteDnssecKey(zonename string, keyid uint16, oldstate, newstate string) (err error) {
@@ -1167,14 +1081,10 @@ func (kdb *KeyDB) PromoteDnssecKey(zonename string, keyid uint16, oldstate, news
 	if err != nil {
 		return fmt.Errorf("error beginning transaction: %v", err)
 	}
-
+	committed := false
 	defer func() {
-		if err != nil {
+		if !committed {
 			tx.Rollback()
-		} else {
-			if commitErr := tx.Commit(); commitErr != nil {
-				err = fmt.Errorf("commit failed: %w", commitErr)
-			}
 		}
 	}()
 
@@ -1213,9 +1123,15 @@ func (kdb *KeyDB) PromoteDnssecKey(zonename string, keyid uint16, oldstate, news
 		return fmt.Errorf("no rows updated, key with keyid %d in zone %s might not be in state %s", keyid, zonename, oldstate)
 	}
 
-	delete(kdb.KeystoreDnskeyCache, zonename+"+"+oldstate)
-	delete(kdb.KeystoreDnskeyCache, zonename+"+"+newstate)
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit failed: %w", err)
+	}
+	committed = true
 
+	// Post-commit signing-keys republish (own-tx; R1).
+	if rerr := republishSigningKeysForZone(kdb, zonename); rerr != nil {
+		return fmt.Errorf("PromoteDnssecKey: republish signing keys: %w", rerr)
+	}
 	return nil
 }
 
@@ -1390,29 +1306,40 @@ func GetDnssecKeysByState(kdb *KeyDB, zone string, state string) ([]DnssecKeyWit
 // UpdateDnssecKeyState transitions a DNSSEC key to a new state and sets the
 // appropriate lifecycle timestamp. When transitioning to "published", sets
 // published_at. When transitioning to "retired", sets retired_at.
-// Invalidates the cache for both old and new states.
+// Owns its transaction and republishes the zone's signing-keys snapshot
+// post-commit (R1).
 func UpdateDnssecKeyState(kdb *KeyDB, zonename string, keyid uint16, newstate string) (err error) {
 	tx, err := kdb.Begin("UpdateDnssecKeyState")
 	if err != nil {
 		return fmt.Errorf("error beginning transaction: %v", err)
 	}
-
+	committed := false
 	defer func() {
-		if err != nil {
+		if !committed {
 			tx.Rollback()
-		} else {
-			if commitErr := tx.Commit(); commitErr != nil {
-				err = fmt.Errorf("commit failed: %w", commitErr)
-			}
 		}
 	}()
 
-	return UpdateDnssecKeyStateTx(tx, kdb, zonename, keyid, newstate)
+	if err := UpdateDnssecKeyStateTx(tx, kdb, zonename, keyid, newstate); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit failed: %w", err)
+	}
+	committed = true
+	if rerr := republishSigningKeysForZone(kdb, zonename); rerr != nil {
+		return fmt.Errorf("UpdateDnssecKeyState: republish signing keys: %w", rerr)
+	}
+	return nil
 }
 
 // UpdateDnssecKeyStateTx updates a DNSKEY's state on an existing transaction.
 // Used by callers that need to wrap the state change together with other
 // rollover bookkeeping in a single TX (§9.4 two-store consistency).
+//
+// Does NOT republish the signing-keys snapshot — the caller must call
+// republishSigningKeysForZone after their Commit (R1). Callers today:
+// DnssecKeyMgmt (policy-cleanup; R2 defer), AtomicRollover, KSK observe-advance.
 func UpdateDnssecKeyStateTx(tx *Tx, kdb *KeyDB, zonename string, keyid uint16, newstate string) error {
 	var oldstate string
 	err := tx.QueryRow(`SELECT state FROM DnssecKeyStore WHERE zonename=? AND keyid=?`, zonename, keyid).Scan(&oldstate)
@@ -1449,10 +1376,6 @@ func UpdateDnssecKeyStateTx(tx *Tx, kdb *KeyDB, zonename string, keyid uint16, n
 	if rowsAffected == 0 {
 		return fmt.Errorf("no rows updated for key %d in zone %s", keyid, zonename)
 	}
-
-	// Invalidate caches for both old and new states
-	delete(kdb.KeystoreDnskeyCache, zonename+"+"+oldstate)
-	delete(kdb.KeystoreDnskeyCache, zonename+"+"+newstate)
 
 	lgSigner.Info("DNSKEY state updated", "zone", zonename, "keyid", keyid, "oldstate", oldstate, "newstate", newstate)
 	return nil
@@ -1507,7 +1430,9 @@ func (kdb *KeyDB) RolloverKey(zonename string, keytype string, tx *Tx) (uint16, 
 		return 0, 0, fmt.Errorf("no standby %s available for rollover in zone %s", keytype, zonename)
 	}
 
-	// Use existing transaction or begin a new one
+	// Use existing transaction or begin a new one.
+	// When tx != nil (external), the caller must republishSigningKeysForZone
+	// after their Commit (R1). When tx == nil we own the commit and republish.
 	localtx := false
 	if tx == nil {
 		tx, err = kdb.Begin("RolloverKey")
@@ -1519,14 +1444,10 @@ func (kdb *KeyDB) RolloverKey(zonename string, keytype string, tx *Tx) (uint16, 
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	var txErr error
-
+	committed := false
 	defer func() {
-		if localtx {
-			if txErr != nil {
-				tx.Rollback()
-			} else {
-				tx.Commit()
-			}
+		if localtx && !committed {
+			tx.Rollback()
 		}
 	}()
 
@@ -1560,10 +1481,16 @@ func (kdb *KeyDB) RolloverKey(zonename string, keytype string, tx *Tx) (uint16, 
 		return 0, 0, fmt.Errorf("active→retired transition failed: %w", txErr)
 	}
 
-	// Invalidate all relevant caches
-	delete(kdb.KeystoreDnskeyCache, zonename+"+"+DnskeyStateActive)
-	delete(kdb.KeystoreDnskeyCache, zonename+"+"+DnskeyStateStandby)
-	delete(kdb.KeystoreDnskeyCache, zonename+"+"+DnskeyStateRetired)
+	if localtx {
+		if err := tx.Commit(); err != nil {
+			txErr = err
+			return 0, 0, fmt.Errorf("commit failed: %w", err)
+		}
+		committed = true
+		if rerr := republishSigningKeysForZone(kdb, zonename); rerr != nil {
+			return 0, 0, fmt.Errorf("RolloverKey: republish signing keys: %w", rerr)
+		}
+	}
 
 	lgSigner.Info("key rollover completed", "zone", zonename, "keytype", keytype,
 		"old_active", activeKey.KeyTag, "new_active", standbyKey.KeyTag)

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -299,7 +299,7 @@ SELECT zonename, state, keyid, algorithm, privatekey, keyrr FROM Sig0KeyStore WH
 	return &resp, nil
 }
 
-func (kdb *KeyDB) DnssecKeyMgmt(ctx context.Context, tx *Tx, kp KeystorePost) (*KeystoreResponse, error) {
+func (kdb *KeyDB) DnssecKeyMgmt(ctx context.Context, tx *Tx, kp KeystorePost) (out *KeystoreResponse, err error) {
 	// dump.P(kp)
 
 	const (
@@ -313,7 +313,6 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 	)
 
 	var localtx = false
-	var err error
 	var txSuccess bool
 	var needsRepublish bool // R2: one post-commit republish for the zone
 
@@ -327,8 +326,9 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 	defer func() {
 		if localtx {
 			if txSuccess {
-				if err := tx.Commit(); err != nil {
-					lgSigner.Error("DnssecKeyMgmt commit failed", "err", err)
+				if cerr := tx.Commit(); cerr != nil {
+					lgSigner.Error("DnssecKeyMgmt commit failed", "err", cerr)
+					err = cerr
 					return
 				}
 				if needsRepublish {

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -324,6 +324,9 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 		localtx = true
 	}
 	defer func() {
+		if out != nil && needsRepublish && err == nil {
+			out.NeedsSigningKeysRepublish = true
+		}
 		if localtx {
 			if txSuccess {
 				if cerr := tx.Commit(); cerr != nil {
@@ -342,8 +345,8 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 				tx.Rollback()
 			}
 		} else if txSuccess && needsRepublish {
-			// External tx: caller must republish after their Commit (R1).
-			lgSigner.Debug("DnssecKeyMgmt: external tx; caller must republishSigningKeysForZone post-commit",
+			// External tx (APIkeystore): caller must republish after Commit (R1).
+			lgSigner.Debug("DnssecKeyMgmt: external tx; APIkeystore must republishSigningKeysForZone post-commit",
 				"zone", kp.Zone)
 		}
 	}()

--- a/v2/ksk_rollover_atomic.go
+++ b/v2/ksk_rollover_atomic.go
@@ -138,6 +138,11 @@ func AtomicRollover(conf *Config, kdb *KeyDB, zone string) (oldKid, newKid uint1
 	}
 	commit = true
 
+	// Post-commit signing-keys republish (UpdateDnssecKeyStateTx is external-tx; R1).
+	if rerr := republishSigningKeysForZone(kdb, zone); rerr != nil {
+		return 0, 0, fmt.Errorf("AtomicRollover: republish signing keys: %w", rerr)
+	}
+
 	lgSigner.Info("rollover: atomic_rollover committed",
 		"zone", zone, "old_keyid", oldKid, "new_keyid", newKid,
 		"phase", rolloverPhasePendingChildPublish)

--- a/v2/ksk_rollover_pipeline.go
+++ b/v2/ksk_rollover_pipeline.go
@@ -38,8 +38,8 @@ func GenerateKskRolloverCreated(kdb *KeyDB, zone, creator string, alg uint8, met
 		return 0, 0, fmt.Errorf("GenerateKskRolloverCreated: rollover state: %w", err)
 	}
 
-	delete(kdb.KeystoreDnskeyCache, zone+"+"+DnskeyStateCreated)
-
+	// Created-state key does not affect the active signing-keys snapshot; the
+	// caller republishes only if a later transition changes the active set (R1).
 	return pkc.KeyId, ri, nil
 }
 

--- a/v2/policy_reset_cache_test.go
+++ b/v2/policy_reset_cache_test.go
@@ -6,49 +6,39 @@ import (
 	"github.com/miekg/dns"
 )
 
-// TestRefreshActiveDnssecKeysBypassesStaleCache is the regression for the
-// policy-reset stale active-key cache. The active-key cache can hold a STALE set
-// after the keystore changes underneath it (the uncommitted-window re-cache the
-// keystore `clear` path hits: a GetDnssecKeys during the DELETE+regen tx
-// re-caches the OLD keys). Once the DB has changed without a cache invalidation,
-// GetDnssecKeys keeps serving the old set; refreshActiveDnssecKeys must
-// invalidate + re-read from the committed DB so the subsequent re-sign sees the
-// real active keys (else policy-reset re-signs against stale keys and refuses on
-// an algorithm mismatch — the SERVFAIL the testbed hit).
-func TestRefreshActiveDnssecKeysBypassesStaleCache(t *testing.T) {
+// TestRefreshActiveDnssecKeysRepublishesFromDB is the G3 replacement for the
+// stale KeystoreDnskeyCache regression: after the keystore changes underneath
+// a published snapshot, refreshActiveDnssecKeys must republish from the
+// committed DB so the subsequent re-sign sees the real active keys.
+func TestRefreshActiveDnssecKeysRepublishesFromDB(t *testing.T) {
 	kdb := newTestKeyDB(t)
 	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
 
 	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
 		t.Fatalf("KSK: %v", err)
 	}
 	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
-
-	// Prime the active-key cache.
-	primed, err := kdb.GetDnssecKeys(algZone, DnskeyStateActive)
-	if err != nil {
-		t.Fatalf("prime cache: %v", err)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("prime snapshot: %v", err)
 	}
-	if len(primed.KSKs)+len(primed.ZSKs) == 0 {
+	if len(zd.ActiveDnssecKeys().KSKs)+len(zd.ActiveDnssecKeys().ZSKs) == 0 {
 		t.Fatal("expected primed active keys")
 	}
 
-	// Drop all keys DIRECTLY (bypassing the keystore's cache invalidation), so
-	// the active-key cache is now stale — the shape of the clear-window re-cache.
+	// Drop all keys DIRECTLY (bypassing republish), so the snapshot is stale.
 	if _, err := kdb.DB.Exec(`DELETE FROM DnssecKeyStore WHERE zonename=?`, algZone); err != nil {
 		t.Fatalf("direct delete: %v", err)
 	}
 
-	// The cache still serves the deleted keys...
-	stale, err := kdb.GetDnssecKeys(algZone, DnskeyStateActive)
-	if err != nil {
-		t.Fatalf("stale read: %v", err)
-	}
+	// Snapshot still serves the deleted keys...
+	stale := zd.ActiveDnssecKeys()
 	if len(stale.KSKs)+len(stale.ZSKs) == 0 {
-		t.Skip("GetDnssecKeys did not serve from cache here; nothing to regress")
+		t.Fatal("expected stale snapshot to still hold keys before refresh")
 	}
 
-	// ...but refreshActiveDnssecKeys invalidates and re-reads the committed DB.
+	// ...but refreshActiveDnssecKeys republishes from the committed DB.
 	fresh, err := zd.refreshActiveDnssecKeys(kdb, "test")
 	if err != nil {
 		t.Fatalf("refreshActiveDnssecKeys: %v", err)
@@ -56,4 +46,5 @@ func TestRefreshActiveDnssecKeysBypassesStaleCache(t *testing.T) {
 	if len(fresh.KSKs)+len(fresh.ZSKs) != 0 {
 		t.Fatalf("refresh returned stale keys: KSKs=%d ZSKs=%d, want 0 (DB was emptied)", len(fresh.KSKs), len(fresh.ZSKs))
 	}
+	assertSnapMatchesDB(t, kdb, zd)
 }

--- a/v2/sig0_utils.go
+++ b/v2/sig0_utils.go
@@ -266,6 +266,9 @@ INSERT OR REPLACE INTO Sig0KeyStore (zonename, state, keyid, algorithm, creator,
 INSERT OR REPLACE INTO DnssecKeyStore (zonename, state, keyid, algorithm, flags, creator, privatekey, keyrr) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 	)
 
+	// When tx != nil (external), the caller must republishSigningKeysForZone
+	// after their Commit if the active set may have changed (R1). When tx == nil
+	// we own the commit and republish for DNSKEY inserts.
 	localtx := false
 	if tx == nil {
 		tx, err = kdb.Begin("GenerateKeypair")
@@ -274,13 +277,10 @@ INSERT OR REPLACE INTO DnssecKeyStore (zonename, state, keyid, algorithm, flags,
 		}
 		localtx = true
 	}
+	committed := false
 	defer func() {
-		if localtx {
-			if err != nil {
-				tx.Rollback()
-			} else {
-				tx.Commit()
-			}
+		if localtx && !committed {
+			tx.Rollback()
 		}
 	}()
 
@@ -313,9 +313,20 @@ INSERT OR REPLACE INTO DnssecKeyStore (zonename, state, keyid, algorithm, flags,
 		return nil, "", err
 	}
 
-	// log.Printf("Success storing generated SIG(0) key in keystore.")
+	msg := fmt.Sprintf("Generated new %s %s with keyid %d (initial state: %s)", owner, dns.TypeToString[rrtype], pkc.KeyId, state)
+	if localtx {
+		if err = tx.Commit(); err != nil {
+			return nil, "", err
+		}
+		committed = true
+		if rrtype == dns.TypeDNSKEY {
+			if rerr := republishSigningKeysForZone(kdb, owner); rerr != nil {
+				return pkc, msg, fmt.Errorf("GenerateKeypair: republish signing keys: %w", rerr)
+			}
+		}
+	}
 
-	return pkc, fmt.Sprintf("Generated new %s %s with keyid %d (initial state: %s)", owner, dns.TypeToString[rrtype], pkc.KeyId, state), nil
+	return pkc, msg, nil
 }
 
 func LoadSig0SigningKey(keyfile string) (*PrivateKeyCache, error) {

--- a/v2/sign.go
+++ b/v2/sign.go
@@ -264,16 +264,15 @@ func NeedsResigning(rrsig *dns.RRSIG, servedTTL uint32) bool {
 	return false
 }
 
-// refreshActiveDnssecKeys invalidates the cache and re-fetches active DNSSEC keys.
-// context is used in error messages to indicate when/why the refresh occurred.
+// refreshActiveDnssecKeys rebuilds the per-zone signing-keys snapshot from the
+// committed keystore and returns the active set. context is used in error
+// messages to indicate when/why the refresh occurred.
 func (zd *ZoneData) refreshActiveDnssecKeys(kdb *KeyDB, context string) (*DnssecKeys, error) {
-	delete(kdb.KeystoreDnskeyCache, zd.ZoneName+"+"+DnskeyStateActive)
-	dak, err := kdb.GetDnssecKeys(zd.ZoneName, DnskeyStateActive)
-	if err != nil {
-		lgSigner.Error("failed to get DNSSEC active keys", "zone", zd.ZoneName, "context", context, "err", err)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		lgSigner.Error("failed to republish DNSSEC active keys", "zone", zd.ZoneName, "context", context, "err", err)
 		return nil, err
 	}
-	return dak, nil
+	return zd.ActiveDnssecKeys(), nil
 }
 
 // reconcileActiveKeyAlgorithms reconciles active keys against the zone's policy
@@ -503,8 +502,6 @@ func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB, zdLocked bool) (*DnssecKe
 
 	// Generate KSK if still missing
 	if len(dak.KSKs) == 0 {
-		// Invalidate cache before generating to ensure fresh data
-		delete(kdb.KeystoreDnskeyCache, zd.ZoneName+"+"+DnskeyStateActive)
 		pkc, msg, err := kdb.GenerateKeypair(zd.ZoneName, "ensure-active-keys", DnskeyStateActive, dns.TypeDNSKEY, zd.DnssecPolicy.KSKAlgorithm, "KSK", nil)
 		if err != nil {
 			return nil, fmt.Errorf("EnsureActiveDnssecKeys: failed to generate KSK for zone %s: %v", zd.ZoneName, err)
@@ -533,8 +530,6 @@ func (zd *ZoneData) EnsureActiveDnssecKeys(kdb *KeyDB, zdLocked bool) (*DnssecKe
 
 	// Generate ZSK only if we have zero real ZSKs
 	if realZSKCount == 0 {
-		// Invalidate cache before generating to ensure fresh data
-		delete(kdb.KeystoreDnskeyCache, zd.ZoneName+"+"+DnskeyStateActive)
 		_, msg, err := kdb.GenerateKeypair(zd.ZoneName, "ensure-active-keys", DnskeyStateActive, dns.TypeDNSKEY, zd.DnssecPolicy.ZSKAlgorithm, "ZSK", nil)
 		if err != nil {
 			return nil, fmt.Errorf("EnsureActiveDnssecKeys: failed to generate ZSK for zone %s: %v", zd.ZoneName, err)

--- a/v2/signing_keys_snapshot.go
+++ b/v2/signing_keys_snapshot.go
@@ -68,22 +68,31 @@ func buildSigningKeysSnapshot(kdb *KeyDB, zone string) (*signingKeysSnapshot, er
 // Call ONLY after the keystore transaction that changed this zone's keys has
 // COMMITTED. On persistent build failure: loud Error, mark unbuilt with a
 // fresh allocation (never the shared sentinel), return err (M3).
+//
+// Overlapping republishes are generation-gated: each call takes a new
+// signingKeysGen; Store (success or unbuilt marker) runs only if that
+// generation is still current, so an older build cannot clobber a newer one.
 func (zd *ZoneData) republishSigningKeys(kdb *KeyDB) error {
 	if zd == nil {
 		return fmt.Errorf("republishSigningKeys: nil ZoneData")
 	}
+	gen := zd.signingKeysGen.Add(1)
 	snap, err := buildSigningKeysSnapshot(kdb, zd.ZoneName)
 	if err != nil {
 		lgSigner.Error("republishSigningKeys: build failed, retrying", "zone", zd.ZoneName, "err", err)
 		snap, err = buildSigningKeysSnapshot(kdb, zd.ZoneName)
 	}
 	if err != nil {
-		zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
+		if zd.signingKeysGen.Load() == gen {
+			zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
+		}
 		lgSigner.Error("republishSigningKeys: failed after retry; marked unbuilt",
 			"zone", zd.ZoneName, "err", err)
 		return err
 	}
-	zd.signingKeys.Store(snap)
+	if zd.signingKeysGen.Load() == gen {
+		zd.signingKeys.Store(snap)
+	}
 	return nil
 }
 
@@ -183,6 +192,11 @@ SELECT keyid, flags, algorithm, privatekey, keyrr FROM DnssecKeyStore WHERE zone
 			dk.ZSKs = append(dk.ZSKs, pkc)
 			logmsg += fmt.Sprintf("%d (ZSK) ", keyid)
 		}
+	}
+
+	if err := rows.Err(); err != nil {
+		lgSigner.Error("iterate DNSSEC keys failed", "zone", zonename, "state", state, "err", err)
+		return nil, fmt.Errorf("iterate DNSSEC keys for zone %s: %w", zonename, err)
 	}
 
 	if !keysfound {

--- a/v2/signing_keys_snapshot.go
+++ b/v2/signing_keys_snapshot.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Per-zone copy-on-write signing-keys snapshot (G3). Replaces the global
+ * KeystoreDnskeyCache map. See docs/2026-07-16-signing-keys-snapshot-design.md.
+ */
+
+package tdns
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// signingKeysSnapshot is an immutable, keystore-derived view of the keys a
+// zone signs with. Published snapshots are never mutated in place; a key-set
+// change builds a fresh one and swaps the pointer.
+type signingKeysSnapshot struct {
+	// built is true iff this snapshot was produced by a successful DB build
+	// (eager republish or CAS-if-unbuilt lazy fill). false means unbuilt —
+	// either the package sentinel or a post-failed-republish marker.
+	// Keyless-but-loaded zones have built=true with empty Active slices.
+	built  bool
+	Active *DnssecKeys
+}
+
+// emptySigningKeys is returned when Load() is nil. built=false.
+// NEVER Store this shared instance onto a zone (ABA with CAS-if-unbuilt).
+var emptySigningKeys = &signingKeysSnapshot{built: false, Active: &DnssecKeys{}}
+
+// SigningKeys returns the current keys snapshot. Never nil, lock-free.
+func (zd *ZoneData) SigningKeys() *signingKeysSnapshot {
+	if zd == nil {
+		return emptySigningKeys
+	}
+	if s := zd.signingKeys.Load(); s != nil {
+		return s
+	}
+	return emptySigningKeys
+}
+
+// ActiveDnssecKeys is the hot-path sugar: never nil *DnssecKeys (may be empty).
+// Does not trigger a DB load; callers that need freshness after mutation use
+// refreshActiveDnssecKeys / republishSigningKeys. For unbuilt snapshots the
+// returned set is empty until eager republish or activeKeysCAS runs.
+func (zd *ZoneData) ActiveDnssecKeys() *DnssecKeys {
+	s := zd.SigningKeys()
+	if s.Active == nil {
+		return &DnssecKeys{}
+	}
+	return s.Active
+}
+
+// buildSigningKeysSnapshot loads active keys from the keystore DB and returns a
+// fresh immutable snapshot with built=true (including keyless empty Active).
+func buildSigningKeysSnapshot(kdb *KeyDB, zone string) (*signingKeysSnapshot, error) {
+	dak, err := loadDnssecKeysFromDB(kdb, zone, DnskeyStateActive)
+	if err != nil {
+		return nil, err
+	}
+	return &signingKeysSnapshot{built: true, Active: dak}, nil
+}
+
+// republishSigningKeys builds from DB and atomically publishes onto zd.
+// Call ONLY after the keystore transaction that changed this zone's keys has
+// COMMITTED. On persistent build failure: loud Error, mark unbuilt with a
+// fresh allocation (never the shared sentinel), return err (M3).
+func (zd *ZoneData) republishSigningKeys(kdb *KeyDB) error {
+	if zd == nil {
+		return fmt.Errorf("republishSigningKeys: nil ZoneData")
+	}
+	snap, err := buildSigningKeysSnapshot(kdb, zd.ZoneName)
+	if err != nil {
+		lgSigner.Error("republishSigningKeys: build failed, retrying", "zone", zd.ZoneName, "err", err)
+		snap, err = buildSigningKeysSnapshot(kdb, zd.ZoneName)
+	}
+	if err != nil {
+		zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
+		lgSigner.Error("republishSigningKeys: failed after retry; marked unbuilt",
+			"zone", zd.ZoneName, "err", err)
+		return err
+	}
+	zd.signingKeys.Store(snap)
+	return nil
+}
+
+// republishSigningKeysForZone looks up the loaded ZoneData by FQDN and
+// republishes. If the zone is not loaded, this is a no-op.
+func republishSigningKeysForZone(kdb *KeyDB, zone string) error {
+	zone = dns.Fqdn(strings.TrimSpace(zone))
+	if zone == "." {
+		return nil
+	}
+	zd, ok := Zones.Get(zone)
+	if !ok || zd == nil {
+		return nil
+	}
+	return zd.republishSigningKeys(kdb)
+}
+
+// activeKeysCAS returns the active key set, building from DB with CAS-if-unbuilt
+// when the snapshot is not yet built (M1). Never plain-Stores from the read path.
+func (zd *ZoneData) activeKeysCAS(kdb *KeyDB) (*DnssecKeys, error) {
+	loaded := zd.signingKeys.Load()
+	if loaded != nil && loaded.built {
+		if loaded.Active == nil {
+			return &DnssecKeys{}, nil
+		}
+		return loaded.Active, nil
+	}
+	built, err := buildSigningKeysSnapshot(kdb, zd.ZoneName)
+	if err != nil {
+		return nil, err
+	}
+	if zd.signingKeys.CompareAndSwap(loaded, built) {
+		return built.Active, nil
+	}
+	// Lost the race — a concurrent republish or another CAS won.
+	winner := zd.signingKeys.Load()
+	if winner == nil || winner.Active == nil {
+		return &DnssecKeys{}, nil
+	}
+	return winner.Active, nil
+}
+
+// loadDnssecKeysFromDB loads DNSSEC keys for zone+state directly from the
+// keystore (no snapshot, no cache). Used for cold states and as the build
+// source for the active signing-keys snapshot.
+func loadDnssecKeysFromDB(kdb *KeyDB, zonename, state string) (*DnssecKeys, error) {
+	const fetchDnssecPrivKeySql = `
+SELECT keyid, flags, algorithm, privatekey, keyrr FROM DnssecKeyStore WHERE zonename=? AND state=?`
+
+	var dk DnssecKeys
+
+	rows, err := kdb.Query(fetchDnssecPrivKeySql, zonename, state)
+	if err != nil {
+		lgSigner.Error("failed to query DNSSEC keys", "sql", fetchDnssecPrivKeySql, "zone", zonename, "err", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	var algorithm, privatekey, keyrrstr, logmsg string
+	var flags, keyid int
+	var keysfound bool
+
+	for rows.Next() {
+		err := rows.Scan(&keyid, &flags, &algorithm, &privatekey, &keyrrstr)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				lgSigner.Debug("no active DNSSEC key found", "zone", zonename)
+				return &dk, nil
+			}
+			lgSigner.Error("rows.Scan failed", "err", err)
+			return nil, err
+		}
+
+		keysfound = true
+
+		_, alg, bindFormat, err := ParsePrivateKeyFromDB(privatekey, algorithm, keyrrstr)
+		if err != nil {
+			lgSigner.Error("ParsePrivateKeyFromDB failed", "err", err)
+			return nil, err
+		}
+
+		pkc, err := PrepareKeyCache(bindFormat, keyrrstr)
+		if err != nil {
+			lgSigner.Error("PrepareKeyCache failed", "err", err)
+			return nil, err
+		}
+
+		if pkc.Algorithm != alg {
+			lgSigner.Warn("algorithm mismatch", "stored", alg, "parsed", pkc.Algorithm)
+			return nil, fmt.Errorf("error: algorithm mismatch for key %s: stored=%d, parsed=%d", keyrrstr, alg, pkc.Algorithm)
+		}
+
+		if (flags & 0x0001) != 0 {
+			dk.KSKs = append(dk.KSKs, pkc)
+			logmsg += fmt.Sprintf("%d (KSK) ", keyid)
+		} else {
+			dk.ZSKs = append(dk.ZSKs, pkc)
+			logmsg += fmt.Sprintf("%d (ZSK) ", keyid)
+		}
+	}
+
+	if !keysfound {
+		lgSigner.Debug("no DNSSEC keys found", "state", state, "zone", zonename)
+		return &dk, nil
+	}
+
+	if len(dk.KSKs) == 0 {
+		lgSigner.Warn("no DNSSEC KSK found", "state", state, "zone", zonename)
+		return &dk, nil
+	}
+
+	if len(dk.ZSKs) == 0 {
+		lgSigner.Info("no DNSSEC ZSK found, reusing KSK as CSK", "state", state, "zone", zonename)
+		dk.ZSKs = append(dk.ZSKs, dk.KSKs[0])
+	}
+
+	lgSigner.Debug("loadDnssecKeysFromDB returned keys", "zone", zonename, "state", state, "keys", logmsg)
+	return &dk, nil
+}

--- a/v2/signing_keys_snapshot_test.go
+++ b/v2/signing_keys_snapshot_test.go
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package tdns
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func registerAlgZone(t *testing.T, zd *ZoneData) {
+	t.Helper()
+	Zones.Set(zd.ZoneName, zd)
+	t.Cleanup(func() { Zones.Remove(zd.ZoneName) })
+}
+
+func activeKeyIDsFromDB(t *testing.T, kdb *KeyDB, zone string) map[uint16]bool {
+	t.Helper()
+	rows, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
+	if err != nil {
+		t.Fatalf("GetDnssecKeysByState: %v", err)
+	}
+	out := map[uint16]bool{}
+	for _, k := range rows {
+		out[k.KeyTag] = true
+	}
+	return out
+}
+
+func activeKeyIDsFromSnap(dak *DnssecKeys) map[uint16]bool {
+	out := map[uint16]bool{}
+	if dak == nil {
+		return out
+	}
+	for _, k := range dak.KSKs {
+		out[k.KeyId] = true
+	}
+	for _, k := range dak.ZSKs {
+		if k.DnskeyRR.Flags == 256 {
+			out[k.KeyId] = true
+		}
+	}
+	return out
+}
+
+func assertSnapMatchesDB(t *testing.T, kdb *KeyDB, zd *ZoneData) {
+	t.Helper()
+	want := activeKeyIDsFromDB(t, kdb, zd.ZoneName)
+	got := activeKeyIDsFromSnap(zd.ActiveDnssecKeys())
+	if len(want) != len(got) {
+		t.Fatalf("snapshot/DB keyid count mismatch: snap=%v db=%v", got, want)
+	}
+	for id := range want {
+		if !got[id] {
+			t.Fatalf("snapshot missing keyid %d (db=%v snap=%v)", id, want, got)
+		}
+	}
+	s := zd.SigningKeys()
+	if !s.built {
+		t.Fatal("expected built=true after successful mutation/republish")
+	}
+}
+
+// TestSigningKeysSnapshotNoRace hammers concurrent snapshot reads against a
+// republishing mutator. Must stay clean under -race.
+func TestSigningKeysSnapshotNoRace(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("initial republish: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = zd.republishSigningKeys(kdb)
+			}
+		}
+	}()
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					dak := zd.ActiveDnssecKeys()
+					_ = len(dak.KSKs) + len(dak.ZSKs)
+					_ = zd.SigningKeys().built
+				}
+			}
+		}()
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// TestSigningKeysMassResignDoesNotStore asserts SignZone without key mutation
+// leaves the signing-keys pointer unchanged.
+func TestSigningKeysMassResignDoesNotStore(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("republish: %v", err)
+	}
+	before := zd.signingKeys.Load()
+	if before == nil || !before.built {
+		t.Fatal("expected built snapshot before resign")
+	}
+
+	// Minimal apex so SignZone can run; if SignZone fails for fixture reasons,
+	// still assert a no-op path: ActiveDnssecKeys read must not Store.
+	_ = zd.ActiveDnssecKeys()
+	afterRead := zd.signingKeys.Load()
+	if afterRead != before {
+		t.Fatal("ActiveDnssecKeys read republished keys snapshot")
+	}
+
+	// Mutation must change the pointer.
+	if err := UpdateDnssecKeyState(kdb, algZone, before.Active.KSKs[0].KeyId, DnskeyStateActive); err != nil {
+		// same-state update still commits + republishes
+		t.Logf("setstate same-state: %v", err)
+	}
+	// Force a real active-set change via generate standby then rollover needs standby —
+	// simpler: GenerateKeypair another ZSK as standby doesn't change active pointer
+	// content but republish still Stores a new built snapshot.
+	genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("republish after standby: %v", err)
+	}
+	afterMut := zd.signingKeys.Load()
+	if afterMut == before {
+		t.Fatal("expected new snapshot pointer after explicit republish")
+	}
+}
+
+func TestSigningKeysFreshnessGenerate(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	assertSnapMatchesDB(t, kdb, zd)
+}
+
+func TestSigningKeysFreshnessPromote(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	pub := genZSK(t, kdb, DnskeyStatePublished, dns.ED25519)
+	stampPublishedAt(t, kdb, pub, time.Now().Add(-time.Hour))
+
+	if err := kdb.PromoteDnssecKey(algZone, pub, DnskeyStatePublished, DnskeyStateActive); err != nil {
+		t.Fatalf("PromoteDnssecKey: %v", err)
+	}
+	assertSnapMatchesDB(t, kdb, zd)
+}
+
+func TestSigningKeysFreshnessRollover(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	sb := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	stampPublishedAt(t, kdb, sb, time.Now().Add(-time.Hour))
+
+	if _, _, err := kdb.RolloverKey(algZone, "ZSK", nil); err != nil {
+		t.Fatalf("RolloverKey: %v", err)
+	}
+	assertSnapMatchesDB(t, kdb, zd)
+}
+
+func TestSigningKeysFreshnessForceRoles(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+
+	pol := &DnssecPolicy{
+		Mode:         DnssecPolicyModeKSKZSK,
+		KSKAlgorithm: dns.ED25519,
+		ZSKAlgorithm: dns.ED25519,
+		Algorithm:    dns.ED25519,
+	}
+	if _, err := kdb.forceZoneKeysToPolicyRoles(zd, pol, false, true); err != nil {
+		t.Fatalf("forceZoneKeysToPolicyRoles: %v", err)
+	}
+	assertSnapMatchesDB(t, kdb, zd)
+}
+
+// TestSigningKeysCASLazyVsMutation (M1): concurrent lazy fill must not leave
+// a stale pre-mutation snapshot installed after a mutation republish.
+func TestSigningKeysCASLazyVsMutation(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	oldZSK := genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("republish: %v", err)
+	}
+	oldIDs := activeKeyIDsFromSnap(zd.ActiveDnssecKeys())
+
+	// Force unbuilt so the next read takes the lazy CAS path.
+	zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = zd.activeKeysCAS(kdb)
+	}()
+
+	// Mutate active set while lazy fill may be in flight.
+	sb := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	stampPublishedAt(t, kdb, sb, time.Now().Add(-time.Hour))
+	if _, _, err := kdb.RolloverKey(algZone, "ZSK", nil); err != nil {
+		t.Fatalf("RolloverKey: %v", err)
+	}
+	wg.Wait()
+
+	assertSnapMatchesDB(t, kdb, zd)
+	newIDs := activeKeyIDsFromSnap(zd.ActiveDnssecKeys())
+	if newIDs[oldZSK] && len(newIDs) == len(oldIDs) {
+		// After rollover the old active ZSK is retired — must not equal old set.
+		t.Fatalf("snapshot still looks like pre-mutation set: old=%v new=%v", oldIDs, newIDs)
+	}
+}
+
+// TestSigningKeysRepublishFailureMarksUnbuilt (M3).
+func TestSigningKeysRepublishFailureMarksUnbuilt(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("republish: %v", err)
+	}
+	if !zd.SigningKeys().built {
+		t.Fatal("expected built before failure")
+	}
+
+	// Close DB so rebuild fails.
+	if err := kdb.DB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	err := zd.republishSigningKeys(kdb)
+	if err == nil {
+		t.Fatal("expected republish error after DB close")
+	}
+	s := zd.SigningKeys()
+	if s.built {
+		t.Fatal("M3: failed republish must not leave built=true stale snapshot")
+	}
+	// Must not be the shared sentinel (ABA).
+	if s == emptySigningKeys {
+		t.Fatal("M3: must not Store the shared emptySigningKeys sentinel")
+	}
+}
+
+func TestSigningKeysBuiltNegativeCache(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	// No keys — build empty with built=true.
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("republish empty: %v", err)
+	}
+	s := zd.SigningKeys()
+	if !s.built {
+		t.Fatal("keyless zone must have built=true (negative cache)")
+	}
+	if len(s.Active.KSKs)+len(s.Active.ZSKs) != 0 {
+		t.Fatalf("expected empty active set, got KSK=%d ZSK=%d", len(s.Active.KSKs), len(s.Active.ZSKs))
+	}
+	// Second CAS must return without replacing (still built).
+	dak, err := zd.activeKeysCAS(kdb)
+	if err != nil {
+		t.Fatalf("activeKeysCAS: %v", err)
+	}
+	if zd.signingKeys.Load() != s {
+		t.Fatal("built keyless snapshot must not be replaced on second read")
+	}
+	if len(dak.KSKs)+len(dak.ZSKs) != 0 {
+		t.Fatal("expected empty from negative-cached snapshot")
+	}
+}
+
+func TestSigningKeysAccessorNeverNil(t *testing.T) {
+	zd := &ZoneData{ZoneName: "nil-snap.example."}
+	if zd.SigningKeys() == nil || zd.ActiveDnssecKeys() == nil {
+		t.Fatal("accessors must never return nil")
+	}
+	if zd.SigningKeys().built {
+		t.Fatal("fresh ZoneData should report unbuilt")
+	}
+}

--- a/v2/signing_keys_snapshot_test.go
+++ b/v2/signing_keys_snapshot_test.go
@@ -4,7 +4,10 @@
 package tdns
 
 import (
+	"log"
+	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -82,6 +85,7 @@ func TestSigningKeysSnapshotNoRace(t *testing.T) {
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
+	var republishErr atomic.Pointer[error]
 
 	wg.Add(1)
 	go func() {
@@ -91,7 +95,10 @@ func TestSigningKeysSnapshotNoRace(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				_ = zd.republishSigningKeys(kdb)
+				if err := zd.republishSigningKeys(kdb); err != nil {
+					e := err
+					republishErr.CompareAndSwap(nil, &e)
+				}
 			}
 		}
 	}()
@@ -116,14 +123,38 @@ func TestSigningKeysSnapshotNoRace(t *testing.T) {
 	time.Sleep(40 * time.Millisecond)
 	close(stop)
 	wg.Wait()
+	if errp := republishErr.Load(); errp != nil {
+		t.Fatalf("republishSigningKeys failed during race: %v", *errp)
+	}
 }
 
 // TestSigningKeysMassResignDoesNotStore asserts SignZone without key mutation
 // leaves the signing-keys pointer unchanged.
 func TestSigningKeysMassResignDoesNotStore(t *testing.T) {
 	kdb := newTestKeyDB(t)
-	zd := algTestZone(dns.ED25519, dns.ED25519)
-	zd.KeyDB = kdb
+	zoneStr := `zsk-alg.example.		3600	IN	SOA	ns.zsk-alg.example. hostmaster.zsk-alg.example. 1 7200 1800 604800 7200
+zsk-alg.example.		3600	IN	NS	ns.zsk-alg.example.
+ns.zsk-alg.example.		3600	IN	A	192.0.2.1
+`
+	zd := &ZoneData{
+		ZoneName:  algZone,
+		ZoneStore: MapZone,
+		Options:   map[ZoneOption]bool{OptOnlineSigning: true},
+		DnssecPolicy: &DnssecPolicy{
+			Mode:         DnssecPolicyModeKSKZSK,
+			KSKAlgorithm: dns.ED25519,
+			ZSKAlgorithm: dns.ED25519,
+		},
+		DnssecPolicyName: "base",
+		KeyDB:            kdb,
+		Logger:           log.New(os.Stderr, "", 0),
+	}
+	if _, _, err := zd.ReadZoneData(zoneStr, true); err != nil {
+		t.Fatalf("ReadZoneData: %v", err)
+	}
+	zd.Ready = true
+	zd.InstallInitialSnapshot()
+	t.Cleanup(zd.stopPublisher)
 	registerAlgZone(t, zd)
 
 	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
@@ -138,22 +169,19 @@ func TestSigningKeysMassResignDoesNotStore(t *testing.T) {
 		t.Fatal("expected built snapshot before resign")
 	}
 
-	// Minimal apex so SignZone can run; if SignZone fails for fixture reasons,
-	// still assert a no-op path: ActiveDnssecKeys read must not Store.
 	_ = zd.ActiveDnssecKeys()
-	afterRead := zd.signingKeys.Load()
-	if afterRead != before {
+	if zd.signingKeys.Load() != before {
 		t.Fatal("ActiveDnssecKeys read republished keys snapshot")
 	}
 
-	// Mutation must change the pointer.
-	if err := UpdateDnssecKeyState(kdb, algZone, before.Active.KSKs[0].KeyId, DnskeyStateActive); err != nil {
-		// same-state update still commits + republishes
-		t.Logf("setstate same-state: %v", err)
+	if _, err := zd.SignZone(kdb, true); err != nil {
+		t.Fatalf("SignZone: %v", err)
 	}
-	// Force a real active-set change via generate standby then rollover needs standby —
-	// simpler: GenerateKeypair another ZSK as standby doesn't change active pointer
-	// content but republish still Stores a new built snapshot.
+	if zd.signingKeys.Load() != before {
+		t.Fatal("SignZone without key mutation republished signing-keys snapshot")
+	}
+
+	// Explicit republish must install a new pointer.
 	genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
 	if err := zd.republishSigningKeys(kdb); err != nil {
 		t.Fatalf("republish after standby: %v", err)
@@ -258,11 +286,10 @@ func TestSigningKeysCASLazyVsMutation(t *testing.T) {
 	// Force unbuilt so the next read takes the lazy CAS path.
 	zd.signingKeys.Store(&signingKeysSnapshot{built: false, Active: &DnssecKeys{}})
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	casErr := make(chan error, 1)
 	go func() {
-		defer wg.Done()
-		_, _ = zd.activeKeysCAS(kdb)
+		_, err := zd.activeKeysCAS(kdb)
+		casErr <- err
 	}()
 
 	// Mutate active set while lazy fill may be in flight.
@@ -271,7 +298,9 @@ func TestSigningKeysCASLazyVsMutation(t *testing.T) {
 	if _, _, err := kdb.RolloverKey(algZone, "ZSK", nil); err != nil {
 		t.Fatalf("RolloverKey: %v", err)
 	}
-	wg.Wait()
+	if err := <-casErr; err != nil {
+		t.Fatalf("activeKeysCAS: %v", err)
+	}
 
 	assertSnapMatchesDB(t, kdb, zd)
 	newIDs := activeKeyIDsFromSnap(zd.ActiveDnssecKeys())
@@ -354,5 +383,42 @@ func TestSigningKeysAccessorNeverNil(t *testing.T) {
 	}
 	if zd.SigningKeys().built {
 		t.Fatal("fresh ZoneData should report unbuilt")
+	}
+}
+
+// TestSigningKeysRepublishGenerationGate: an older overlapping republish must
+// not overwrite a newer published snapshot (generation check at Store time).
+func TestSigningKeysRepublishGenerationGate(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("republish: %v", err)
+	}
+	newer := zd.signingKeys.Load()
+	oldGen := zd.signingKeysGen.Load()
+
+	// A newer republish starts (bumps gen) and publishes.
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("second republish: %v", err)
+	}
+	latest := zd.signingKeys.Load()
+	if latest == newer {
+		t.Fatal("expected a new snapshot pointer from second republish")
+	}
+
+	// Late finish of the older generation must not Store.
+	stale := &signingKeysSnapshot{built: true, Active: &DnssecKeys{}}
+	if zd.signingKeysGen.Load() == oldGen {
+		zd.signingKeys.Store(stale)
+	}
+	if zd.signingKeys.Load() != latest {
+		t.Fatal("older generation must not overwrite newer snapshot")
 	}
 }

--- a/v2/signing_keys_snapshot_test.go
+++ b/v2/signing_keys_snapshot_test.go
@@ -266,6 +266,81 @@ func TestSigningKeysFreshnessForceRoles(t *testing.T) {
 	assertSnapMatchesDB(t, kdb, zd)
 }
 
+// TestSigningKeysFreshnessDnssecKeyMgmtExternalTx covers the APIkeystore shape:
+// DnssecKeyMgmt always receives a non-nil tx, so its localtx republish never runs.
+// Commit alone must leave the snapshot stale; the external caller must republish
+// when NeedsSigningKeysRepublish is set (apihandler_funcs.go post-commit).
+func TestSigningKeysFreshnessDnssecKeyMgmtExternalTx(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	zd := algTestZone(dns.ED25519, dns.ED25519)
+	zd.KeyDB = kdb
+	registerAlgZone(t, zd)
+
+	if _, _, err := kdb.GenerateKeypair(algZone, "test", DnskeyStateActive, dns.TypeDNSKEY, dns.ED25519, "KSK", nil); err != nil {
+		t.Fatalf("KSK: %v", err)
+	}
+	oldZSK := genZSK(t, kdb, DnskeyStateActive, dns.ED25519)
+	sb := genZSK(t, kdb, DnskeyStateStandby, dns.ED25519)
+	stampPublishedAt(t, kdb, sb, time.Now().Add(-time.Hour))
+	if err := zd.republishSigningKeys(kdb); err != nil {
+		t.Fatalf("initial republish: %v", err)
+	}
+	before := zd.signingKeys.Load()
+
+	tx, err := kdb.Begin("TestSigningKeysFreshnessDnssecKeyMgmtExternalTx")
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	resp, err := kdb.DnssecKeyMgmt(t.Context(), tx, KeystorePost{
+		Command:    "dnssec-mgmt",
+		SubCommand: "rollover",
+		Zone:       algZone,
+		KeyType:    "ZSK",
+	})
+	if err != nil {
+		tx.Rollback()
+		t.Fatalf("DnssecKeyMgmt: %v", err)
+	}
+	if resp == nil || !resp.NeedsSigningKeysRepublish {
+		tx.Rollback()
+		t.Fatal("rollover must set NeedsSigningKeysRepublish for the external-tx caller")
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Pre-fix API gap: commit without republish leaves the pre-mutation snapshot.
+	if zd.signingKeys.Load() != before {
+		t.Fatal("DnssecKeyMgmt with external tx must not republish mid-tx or inside the call")
+	}
+	stale := activeKeyIDsFromSnap(zd.ActiveDnssecKeys())
+	want := activeKeyIDsFromDB(t, kdb, algZone)
+	if len(stale) == len(want) {
+		same := true
+		for id := range want {
+			if !stale[id] {
+				same = false
+				break
+			}
+		}
+		if same {
+			t.Fatal("expected stale snapshot after external-tx commit without republish")
+		}
+	}
+	if !stale[oldZSK] {
+		t.Fatalf("stale snapshot should still hold retired ZSK %d; got %v", oldZSK, stale)
+	}
+
+	// Production fix path (APIkeystore post-commit).
+	if err := republishSigningKeysForZone(kdb, algZone); err != nil {
+		t.Fatalf("republishSigningKeysForZone: %v", err)
+	}
+	assertSnapMatchesDB(t, kdb, zd)
+	if activeKeyIDsFromSnap(zd.ActiveDnssecKeys())[oldZSK] {
+		t.Fatalf("after republish, retired ZSK %d must not remain active in snapshot", oldZSK)
+	}
+}
+
 // TestSigningKeysCASLazyVsMutation (M1): concurrent lazy fill must not leave
 // a stale pre-mutation snapshot installed after a mutation republish.
 func TestSigningKeysCASLazyVsMutation(t *testing.T) {

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -187,7 +187,11 @@ type ZoneData struct {
 	// Lock-free reads via SigningKeys() / ActiveDnssecKeys(); writers republish
 	// post-commit via republishSigningKeys. Separate from the zone-data snapshot.
 	signingKeys atomic.Pointer[signingKeysSnapshot]
-	workingSet  map[string]*OwnerData
+	// signingKeysGen is bumped at the start of each republishSigningKeys call.
+	// A build may Store only if it still owns the latest generation, so an
+	// older overlapping republish cannot overwrite a newer snapshot.
+	signingKeysGen atomic.Uint64
+	workingSet     map[string]*OwnerData
 	// wsSignalSynth stages the synthesized-transport-signal fallback map for the
 	// next publish (see zoneSnapshot.signalSynth). Seeded from the published
 	// snapshot in ensureWorkingSet so unrelated publishes preserve it.

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -182,8 +182,12 @@ type ZoneData struct {
 	ParentDSTTLObserved uint32
 
 	// Zone snapshot publish path (Project B).
-	snapshot   atomic.Pointer[zoneSnapshot]
-	workingSet map[string]*OwnerData
+	snapshot atomic.Pointer[zoneSnapshot]
+	// signingKeys is the per-zone copy-on-write active DNSSEC key set (G3).
+	// Lock-free reads via SigningKeys() / ActiveDnssecKeys(); writers republish
+	// post-commit via republishSigningKeys. Separate from the zone-data snapshot.
+	signingKeys atomic.Pointer[signingKeysSnapshot]
+	workingSet  map[string]*OwnerData
 	// wsSignalSynth stages the synthesized-transport-signal fallback map for the
 	// next publish (see zoneSnapshot.signalSynth). Seeded from the published
 	// snapshot in ensureWorkingSet so unrelated publishes preserve it.
@@ -816,8 +820,7 @@ type KeyDB struct {
 	mu     sync.Mutex
 	// Sig0Cache   map[string]*Sig0KeyCache
 	KeystoreSig0Cache   map[string]*Sig0ActiveKeys
-	TruststoreSig0Cache *Sig0StoreT            // was *Sig0StoreT
-	KeystoreDnskeyCache map[string]*DnssecKeys // map[zonename]*DnssecActiveKeys
+	TruststoreSig0Cache *Sig0StoreT // was *Sig0StoreT
 	Ctx                 string
 	UpdateQ             chan UpdateRequest
 	KeyBootstrapperQ    chan KeyBootstrapperRequest

--- a/v2/zsk_rollover.go
+++ b/v2/zsk_rollover.go
@@ -419,7 +419,8 @@ func rolloverZskForZone(ctx context.Context, conf *Config, kdb *KeyDB, zd *ZoneD
 	// afterward if anything was stamped.
 	if activeZSK.ActiveAt == nil || activeZSK.ActiveSeq == nil {
 		healZskActiveAt(kdb, zone, activeZSK)
-		delete(kdb.KeystoreDnskeyCache, zone+"+"+DnskeyStateActive)
+		// Metadata-only heal (active_at / active_seq); active key set unchanged —
+		// no signing-keys snapshot republish.
 		activeKeys, err = GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
 		if err != nil {
 			return fmt.Errorf("re-list active keys after heal: %w", err)


### PR DESCRIPTION
## Summary
- Replace the global unlocked `KeystoreDnskeyCache` map with a per-`ZoneData` copy-on-write signing-keys snapshot (`atomic.Pointer`), mirroring the zone-data (#279) and RuntimeConfig (#287) patterns.
- Active keys only in the snapshot; cold states stay DB-direct via `GetDnssecKeysByState`. Lazy fill uses CAS-if-unbuilt (`built` flag) so it cannot clobber a concurrent post-commit republish; failed republish marks unbuilt loudly (no silent stale keys).
- Own-tx mutators self-republish post-commit; external-tx helpers document caller republish (`AtomicRollover`, `DnssecKeyMgmt` once per zone). Grep-clean of the global map.

## Test plan
- [x] `go vet ./...` and `go test -race ./...` in `v2/` (GOROOT=/opt/local/lib/go CGO_ENABLED=1)
- [x] `TestSigningKeysSnapshotNoRace` — concurrent reads vs republish
- [x] Freshness matrix: generate / promote / rollover / force; M1 CAS vs mutation; M3 republish failure marks unbuilt
- [x] Mass-resign path does not Store a new keys snapshot on read
- [ ] Live: policy-reset / clear / ZSK rollover on a signed zone; confirm no map-race fatals under load

Design: `docs/2026-07-16-signing-keys-snapshot-design.md`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added per-zone DNSSEC signing-key snapshots for faster, consistent key access.
  * Signing-key data now refreshes automatically after key changes, including generation, promotion, rollover, and deletion.
  * Improved handling of concurrent updates and transaction failures to prevent stale signing-key information.
  * DNSSEC refresh operations now reliably reflect the latest stored key data.
* **Tests**
  * Added coverage for snapshot freshness, concurrency, key lifecycle changes, empty zones, and refresh failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->