### PR TITLE
Phase 0: align tdns to delegation-mgmt-via-ddns-02 + keystate-03 (correctness fixes)

### DIFF
--- a/v2/childsync_utils.go
+++ b/v2/childsync_utils.go
@@ -56,21 +56,21 @@ func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, UpdateResul
 	var edeCode uint16
 	var edeMessage string
 
-	// If the packed message exceeds the EDNS UDP buffer advertised on
-	// the message's OPT RR, use TCP. dns.Exchange is hardcoded UDP and
-	// does not fall back on truncation, so a too-large UPDATE just
-	// times out — common with ML-DSA-44 SIG(0), where the signature
-	// alone is ~2.4 KB. Fall back to 1232 (EDNS "safe" default) if the
-	// caller didn't attach an OPT.
-	udpSafeLimit := 1232
-	if opt := msg.IsEdns0(); opt != nil {
-		udpSafeLimit = int(opt.UDPSize())
-	}
-	useTCP := msg.Len() > udpSafeLimit
-	client := &dns.Client{}
-	if useTCP {
-		client.Net = "tcp"
-	}
+	// Force TCP for these delegation-sync UPDATEs regardless of message
+	// size. Per draft-ietf-dnsop-delegation-mgmt-via-ddns-02 §"Choice of
+	// SIG(0) Signature Algorithm": these UPDATEs are infrequent and SHOULD
+	// be carried over TCP (or a connection-oriented secure transport such
+	// as DoT). TCP avoids the UDP spoofing/fragmentation exposure of a
+	// message that mutates parent-side state, and accommodates the larger
+	// SIG(0) signatures of post-quantum algorithms (e.g. ML-DSA-44, whose
+	// signature alone is ~2.4 KB).
+	//
+	// Do NOT "optimize" this back to a size-gated UDP-first path: dns.Exchange
+	// is hardcoded UDP and does not fall back on truncation, so a too-large
+	// UPDATE would just time out — and the draft prefers TCP for all of these
+	// UPDATEs regardless of size, not only the large ones.
+	useTCP := true
+	client := &dns.Client{Net: "tcp"}
 
 	for _, dst := range addrs {
 		lgDns.Debug("sending DNS UPDATE", "zone", zonename, "dst", dst,

--- a/v2/childsync_utils_phase0_test.go
+++ b/v2/childsync_utils_phase0_test.go
@@ -1,0 +1,67 @@
+package tdns
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestSendUpdateForcesTCP asserts D-2a: delegation-sync UPDATEs go over TCP
+// regardless of size. The responder listens on TCP only; a small UPDATE
+// (which the removed size gate would have sent over UDP) still reaches it and
+// gets NOERROR, proving TCP was forced.
+func TestSendUpdateForcesTCP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	defer ln.Close()
+
+	var gotTCP int32
+	srv := &dns.Server{
+		Listener: ln,
+		Net:      "tcp",
+		// The default MsgAcceptFunc rejects the UPDATE opcode as NOTIMP
+		// before the handler runs; use tdns's own accept func (the one the
+		// real server installs) so UPDATE messages reach the handler.
+		MsgAcceptFunc: MsgAcceptFunc,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			atomic.AddInt32(&gotTCP, 1)
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.Rcode = dns.RcodeSuccess
+			_ = w.WriteMsg(m)
+		}),
+	}
+	started := make(chan struct{})
+	srv.NotifyStartedFunc = func() { close(started) }
+	go func() { _ = srv.ActivateAndServe() }()
+	defer srv.Shutdown()
+	<-started
+
+	// A small UPDATE — well under the 1232-byte UDP "safe" limit, so the old
+	// size-gated path would have chosen UDP for it.
+	m := new(dns.Msg)
+	m.SetUpdate("child.example.")
+	rr, err := dns.NewRR("child.example. 3600 IN NS ns1.child.example.")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	m.Insert([]dns.RR{rr})
+	if m.Len() >= 1232 {
+		t.Fatalf("test message unexpectedly large (%d bytes); it must be small to prove TCP is forced", m.Len())
+	}
+
+	rcode, _, err := SendUpdate(m, "child.example.", []string{ln.Addr().String()})
+	if err != nil {
+		t.Fatalf("SendUpdate: %v", err)
+	}
+	if rcode != dns.RcodeSuccess {
+		t.Errorf("rcode = %s, want NOERROR", dns.RcodeToString[rcode])
+	}
+	if atomic.LoadInt32(&gotTCP) == 0 {
+		t.Error("responder received no TCP query — the UPDATE was not delivered over TCP")
+	}
+}

--- a/v2/childsync_utils_phase0_test.go
+++ b/v2/childsync_utils_phase0_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -38,7 +39,20 @@ func TestSendUpdateForcesTCP(t *testing.T) {
 	started := make(chan struct{})
 	srv.NotifyStartedFunc = func() { close(started) }
 	go func() { _ = srv.ActivateAndServe() }()
-	defer srv.Shutdown()
+	// dns.Server.Shutdown takes no context; wrap it in a watchdog so a shutdown
+	// blocked on a lingering test connection fails the test instead of hanging it.
+	defer func() {
+		done := make(chan struct{})
+		go func() {
+			_ = srv.Shutdown()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("srv.Shutdown() timed out after 5s")
+		}
+	}()
 	<-started
 
 	// A small UPDATE — well under the 1232-byte UDP "safe" limit, so the old

--- a/v2/defaultqueryhandlers.go
+++ b/v2/defaultqueryhandlers.go
@@ -50,7 +50,7 @@ func DefaultQueryHandler(ctx context.Context, req *DnsQueryRequest) error {
 
 	// If the query contains a KeyState EDNS(0) option and we are a parent zone,
 	// process the KeyState request and wrap the ResponseWriter to attach the
-	// response option to whatever DNS reply is sent. Per draft-berra-dnsop-keystate-02,
+	// response option to whatever DNS reply is sent. Per draft-berra-dnsop-keystate-03,
 	// the response is also signed with the UPDATE Receiver's SIG(0) key.
 	if msgoptions.KeyState != nil && kdb != nil {
 		if zd, _ := FindZone(qname); zd != nil && zd.Options[OptDelSyncParent] {

--- a/v2/edns0/edns0_keystate.go
+++ b/v2/edns0/edns0_keystate.go
@@ -11,26 +11,38 @@ const (
 	// KeyState Option Code (temporary until IANA assignment)
 	// OptcodeKeyState = 65002
 
-	// Sender (Child) KeyStates — per draft-berra-dnsop-keystate-02
-	KeyStateRequestAutoBootstrap   = 0
-	KeyStateRequestManualBootstrap = 1
-	KeyStateInquiryKey             = 2
-	// Code 3 removed in draft-02 (policy discovery via SVCB bootstrap SvcParamKey)
+	// KeyState codepoints per draft-berra-dnsop-keystate-03,
+	// §"Defined and Reserved Values" (the KeyState registry table).
+	//
+	// Protocol-level responses, set by the UPDATE Receiver. These report
+	// on the KeyState exchange itself — the equivalents of DNS FORMERR
+	// and SERVFAIL — rather than on the state of any particular key.
+	// NOTE: codes 0 and 1 carried *sender* bootstrap-request meanings in
+	// keystate-02 (auto/manual bootstrap request); -03 removed those and
+	// reassigned both to receiver protocol-level responses. Bootstrap
+	// initiation is now via the self-signed DNS UPDATE plus the SVCB
+	// bootstrap SvcParamKey, not via a KeyState request code.
+	KeyStateRequestMalformed = 0 // KEY_REQUEST_MALFORMED: unrecognized/unassigned KEY-STATE, invalid KEY-DATA, or unparseable option
+	KeyStateTemporaryFailure = 1 // KEY_TEMPORARY_FAILURE: understood but temporarily unable to determine key state; child MAY retry
 
-	// Receiver (Parent) KeyStates — per draft-berra-dnsop-keystate-02
-	KeyStateTrusted                 = 4
-	KeyStateUnknown                 = 5
-	KeyStateInvalid                 = 6
-	KeyStateRefused                 = 7
-	KeyStateValidationFail          = 8
-	KeyStateBootstrapAutoOngoing    = 9
-	KeyStateBootstrapManualRequired = 10
-	KeyStateBootstrapAutoPending    = 11
+	// Inquiry, set by the sender (the child).
+	KeyStateInquiryKey = 2 // INTENT_INQUIRE_KEY: request the current KeyState for KEY-ID
+	// Code 3 is unassigned in -03.
 
-	KeyStateUninitialized = 255 // Uninitialized state
+	// Key-state reports, set by the UPDATE Receiver (the parent or its agent).
+	KeyStateTrusted                 = 4  // KEY_TRUSTED
+	KeyStateUnknown                 = 5  // KEY_UNKNOWN
+	KeyStateInvalid                 = 6  // KEY_INVALID
+	KeyStateRefused                 = 7  // KEY_REFUSED
+	KeyStateValidationFail          = 8  // KEY_VALIDATION_FAILED
+	KeyStateBootstrapAutoOngoing    = 9  // KEY_BOOTSTRAP_AUTO
+	KeyStateBootstrapManualRequired = 10 // KEY_BOOTSTRAP_MANUAL
+	// Codes 11-127 are unassigned; 128-255 are reserved for Private Use.
+
+	KeyStateUninitialized = 255 // local sentinel (in the Private Use range)
 )
 
-// KeyStateOption represents the KeyState EDNS(0) option per draft-berra-dnsop-keystate-02.
+// KeyStateOption represents the KeyState EDNS(0) option per draft-berra-dnsop-keystate-03.
 // Wire format: KEY-ID (16 bits) + KEY-STATE (8 bits) + KEY-DATA (8 bits) + EXTRA-TEXT (variable)
 type KeyStateOption struct {
 	KeyID     uint16
@@ -56,7 +68,7 @@ func CreateKeyStateOption(keyID uint16, keyState uint8, keyData uint8, extraText
 }
 
 // ParseKeyStateOption extracts KeyState data from an EDNS0_LOCAL option.
-// Wire format per draft-02: KEY-ID(2) + KEY-STATE(1) + KEY-DATA(1) + EXTRA-TEXT(var) = 4+ bytes
+// Wire format per draft-03: KEY-ID(2) + KEY-STATE(1) + KEY-DATA(1) + EXTRA-TEXT(var) = 4+ bytes
 func ParseKeyStateOption(opt *dns.EDNS0_LOCAL) (*KeyStateOption, error) {
 	if opt == nil {
 		return nil, fmt.Errorf("nil EDNS0_LOCAL option")
@@ -76,8 +88,8 @@ func ParseKeyStateOption(opt *dns.EDNS0_LOCAL) (*KeyStateOption, error) {
 // KeyStateToString returns a human-readable string for a KeyState code.
 func KeyStateToString(state uint8) string {
 	states := map[uint8]string{
-		KeyStateRequestAutoBootstrap:    "Request Auto Bootstrap",
-		KeyStateRequestManualBootstrap:  "Request Manual Bootstrap",
+		KeyStateRequestMalformed:        "Request Malformed",
+		KeyStateTemporaryFailure:        "Temporary Failure",
 		KeyStateInquiryKey:              "Key Inquiry",
 		KeyStateTrusted:                 "Trusted",
 		KeyStateUnknown:                 "Unknown",
@@ -86,7 +98,6 @@ func KeyStateToString(state uint8) string {
 		KeyStateValidationFail:          "Validation Failed",
 		KeyStateBootstrapAutoOngoing:    "Auto Bootstrap Ongoing",
 		KeyStateBootstrapManualRequired: "Manual Bootstrap Required",
-		KeyStateBootstrapAutoPending:    "Auto Bootstrap Pending",
 		KeyStateUninitialized:           "Uninitialized",
 	}
 	if s, ok := states[state]; ok {

--- a/v2/edns0/edns0_keystate03_test.go
+++ b/v2/edns0/edns0_keystate03_test.go
@@ -1,0 +1,71 @@
+package edns0
+
+import (
+	"testing"
+)
+
+// TestKeyStateCodepoints03 pins the KeyState codepoints to the
+// draft-berra-dnsop-keystate-03 registry. Phase 0 (K-1) reassigned codes 0
+// and 1 — which carried sender bootstrap-request meanings in keystate-02 — to
+// the receiver protocol-level responses KEY_REQUEST_MALFORMED and
+// KEY_TEMPORARY_FAILURE, and removed the invented code 11 (BootstrapAutoPending).
+func TestKeyStateCodepoints03(t *testing.T) {
+	cases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"KEY_REQUEST_MALFORMED", KeyStateRequestMalformed, 0},
+		{"KEY_TEMPORARY_FAILURE", KeyStateTemporaryFailure, 1},
+		{"INTENT_INQUIRE_KEY", KeyStateInquiryKey, 2},
+		{"KEY_TRUSTED", KeyStateTrusted, 4},
+		{"KEY_UNKNOWN", KeyStateUnknown, 5},
+		{"KEY_INVALID", KeyStateInvalid, 6},
+		{"KEY_REFUSED", KeyStateRefused, 7},
+		{"KEY_VALIDATION_FAILED", KeyStateValidationFail, 8},
+		{"KEY_BOOTSTRAP_AUTO", KeyStateBootstrapAutoOngoing, 9},
+		{"KEY_BOOTSTRAP_MANUAL", KeyStateBootstrapManualRequired, 10},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d (keystate-03 registry)", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestKeyStateMalformedRoundTrip round-trips a KEY_REQUEST_MALFORMED(0)
+// response option on the wire and asserts the -03 value survives, KEY-ID is
+// echoed, and KEY-DATA is 0.
+func TestKeyStateMalformedRoundTrip(t *testing.T) {
+	opt := CreateKeyStateOption(4242, uint8(KeyStateRequestMalformed), 0, "bad")
+	parsed, err := ParseKeyStateOption(opt)
+	if err != nil {
+		t.Fatalf("ParseKeyStateOption: %v", err)
+	}
+	if parsed.KeyState != 0 {
+		t.Errorf("KeyState wire value = %d, want 0 (KEY_REQUEST_MALFORMED)", parsed.KeyState)
+	}
+	if parsed.KeyID != 4242 {
+		t.Errorf("KeyID = %d, want 4242 (echoed)", parsed.KeyID)
+	}
+	if parsed.KeyData != 0 {
+		t.Errorf("KeyData = %d, want 0", parsed.KeyData)
+	}
+}
+
+// TestKeyStateToString03 asserts the -02 sender-request labels are gone and
+// the -03 protocol-level labels are present, and that the removed code 11
+// falls through to the unassigned default.
+func TestKeyStateToString03(t *testing.T) {
+	if got := KeyStateToString(uint8(KeyStateRequestMalformed)); got != "Request Malformed" {
+		t.Errorf("KeyStateToString(0) = %q, want %q", got, "Request Malformed")
+	}
+	if got := KeyStateToString(uint8(KeyStateTemporaryFailure)); got != "Temporary Failure" {
+		t.Errorf("KeyStateToString(1) = %q, want %q", got, "Temporary Failure")
+	}
+	// Code 11 is unassigned in -03 → not in the map → the "Unknown State"
+	// default, never the -02 "Auto Bootstrap Pending" label.
+	if got := KeyStateToString(11); got != "Unknown State (11)" {
+		t.Errorf("KeyStateToString(11) = %q, want the unassigned default %q", got, "Unknown State (11)")
+	}
+}

--- a/v2/keystate.go
+++ b/v2/keystate.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/johanix/tdns/v2/edns0"
 	"github.com/miekg/dns"
-	"github.com/spf13/viper"
 )
 
 // keyStateResponseWriter wraps a dns.ResponseWriter to intercept WriteMsg
@@ -19,22 +18,33 @@ type keyStateResponseWriter struct {
 }
 
 func (w *keyStateResponseWriter) WriteMsg(m *dns.Msg) error {
-	if w.keyStateResponse != nil {
-		edns0.AttachKeyStateToResponse(m, w.keyStateResponse)
+	if w.keyStateResponse == nil {
+		return w.ResponseWriter.WriteMsg(m)
 	}
-	// Sign the response with the UPDATE Receiver's SIG(0) key per
-	// draft-berra-dnsop-keystate-02: responses containing a KeyState
-	// option MUST be signed by the UPDATE Receiver.
-	if w.sig0Signer != "" && w.sig0Keys != nil && len(w.sig0Keys.Keys) > 0 {
-		signed, err := SignMsg(*m, w.sig0Signer, w.sig0Keys)
-		if err != nil {
-			lgSigner.Error("failed to SIG(0)-sign KeyState response", "signer", w.sig0Signer, "err", err)
-			// Send unsigned — better than failing entirely
-		} else {
-			m = signed
-		}
+
+	// draft-berra-dnsop-keystate-03 §"KeyStates Set By The UPDATE Receiver":
+	// a response carrying a KeyState option MUST be signed by the UPDATE
+	// Receiver's SIG(0) key. Fail closed — if we cannot sign, send the reply
+	// WITHOUT the KeyState option rather than emitting an unsigned key-state
+	// signal, which §"Security Considerations" names as the forged-response
+	// DoS vector (a child MUST NOT trust an unsigned signal). The option is
+	// attached only to the copy we actually sign, so the optionless fallback
+	// never carries it.
+	if w.sig0Signer == "" || w.sig0Keys == nil || len(w.sig0Keys.Keys) == 0 {
+		lgSigner.Warn("cannot SIG(0)-sign KeyState response: no active UPDATE Receiver key; omitting KeyState option (fail closed)",
+			"signer", w.sig0Signer)
+		return w.ResponseWriter.WriteMsg(m)
 	}
-	return w.ResponseWriter.WriteMsg(m)
+
+	signedMsg := m.Copy()
+	edns0.AttachKeyStateToResponse(signedMsg, w.keyStateResponse)
+	signed, err := SignMsg(*signedMsg, w.sig0Signer, w.sig0Keys)
+	if err != nil {
+		lgSigner.Error("failed to SIG(0)-sign KeyState response; omitting KeyState option (fail closed)",
+			"signer", w.sig0Signer, "err", err)
+		return w.ResponseWriter.WriteMsg(m)
+	}
+	return w.ResponseWriter.WriteMsg(signed)
 }
 
 // Ensure keyStateResponseWriter satisfies dns.ResponseWriter.
@@ -55,57 +65,35 @@ func (w *keyStateResponseWriter) Hijack() { w.ResponseWriter.Hijack() }
 func (kdb *KeyDB) ProcessKeyState(ks *edns0.KeyStateOption, zonename string) (*edns0.KeyStateOption, error) {
 	lgSigner.Debug("processing KeyState request", "zone", zonename, "keyid", ks.KeyID, "state", ks.KeyState)
 
-	switch ks.KeyState {
-	case edns0.KeyStateRequestAutoBootstrap:
-		// Check if automatic bootstrap is allowed by policy
-		if viper.GetBool("keystate.require_manual_bootstrap") {
-			return &edns0.KeyStateOption{
-				KeyID:     ks.KeyID,
-				KeyState:  edns0.KeyStateBootstrapManualRequired,
-				ExtraText: "Manual bootstrap required by policy",
-			}, nil
-		}
-
-		if !viper.GetBool("keystate.allow_auto_bootstrap") {
-			return &edns0.KeyStateOption{
-				KeyID:     ks.KeyID,
-				KeyState:  edns0.KeyStateBootstrapManualRequired,
-				ExtraText: "Automatic bootstrap not allowed by policy",
-			}, nil
-		}
-
-		// Auto-bootstrap is not yet implemented. Log and return a truthful
-		// pending state so callers know the request was accepted but no work
-		// will happen yet.
-		lgSigner.Warn("auto-bootstrap requested but not yet implemented", "zone", zonename, "keyid", ks.KeyID)
-
+	// Per draft-berra-dnsop-keystate-03 §"Protocol-Level Responses", the
+	// only valid sender code in a request is 2 (INTENT_INQUIRE_KEY). Any
+	// other KEY-STATE — including the unassigned codes 3 and 11-127 and the
+	// receiver-only codes 0/1/4-10 — MUST be treated as malformed and
+	// answered with KEY_REQUEST_MALFORMED(0), echoing the KEY-ID and with
+	// KEY-DATA=0. (keystate-02's sender-set bootstrap-request codes 0/1 were
+	// removed in -03; bootstrap is initiated via the self-signed UPDATE plus
+	// the SVCB bootstrap SvcParamKey, not via a KeyState request.)
+	if ks.KeyState != edns0.KeyStateInquiryKey {
+		lgSigner.Warn("malformed KeyState request: unexpected KEY-STATE", "zone", zonename, "keyid", ks.KeyID, "state", ks.KeyState)
 		return &edns0.KeyStateOption{
 			KeyID:     ks.KeyID,
-			KeyState:  edns0.KeyStateBootstrapAutoPending,
-			ExtraText: "Auto bootstrap process queued",
-		}, nil
-
-	case edns0.KeyStateInquiryKey:
-		// Get current key status from truststore
-		status, err := kdb.GetKeyStatus(zonename, ks.KeyID)
-		if err != nil {
-			lgSigner.Error("failed to get key status from truststore", "err", err)
-			return &edns0.KeyStateOption{
-				KeyID:     ks.KeyID,
-				KeyState:  edns0.KeyStateUnknown,
-				ExtraText: "Failed to get key status",
-			}, nil
-		}
-
-		return status, nil
-
-	default:
-		return &edns0.KeyStateOption{
-			KeyID:     ks.KeyID,
-			KeyState:  edns0.KeyStateInvalid,
-			ExtraText: fmt.Sprintf("Invalid key state request: %d", ks.KeyState),
+			KeyState:  edns0.KeyStateRequestMalformed,
+			KeyData:   0,
+			ExtraText: fmt.Sprintf("Malformed KeyState request: unexpected KEY-STATE %d", ks.KeyState),
 		}, nil
 	}
+
+	// KEY-STATE == 2 (INTENT_INQUIRE_KEY): report the current key status.
+	status, err := kdb.GetKeyStatus(zonename, ks.KeyID)
+	if err != nil {
+		lgSigner.Error("failed to get key status from truststore", "err", err)
+		return &edns0.KeyStateOption{
+			KeyID:     ks.KeyID,
+			KeyState:  edns0.KeyStateUnknown,
+			ExtraText: "Failed to get key status",
+		}, nil
+	}
+	return status, nil
 }
 
 func (kdb *KeyDB) HandleKeyStateOption(opt *dns.OPT, zonename string) (*edns0.KeyStateOption, error) {

--- a/v2/keystate_phase0_test.go
+++ b/v2/keystate_phase0_test.go
@@ -1,0 +1,35 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/johanix/tdns/v2/edns0"
+)
+
+// TestProcessKeyStateMalformed asserts K-2: per keystate-03, the only valid
+// sender code in a KeyState request is 2 (INTENT_INQUIRE_KEY). Every other
+// value — the unassigned codes, the receiver-only codes, and anything above
+// the registry — MUST be answered with KEY_REQUEST_MALFORMED(0), echoing the
+// KEY-ID and with KEY-DATA=0. All the values below are answered without
+// touching the truststore, so a zero-value KeyDB suffices.
+func TestProcessKeyStateMalformed(t *testing.T) {
+	kdb := &KeyDB{}
+	for _, state := range []uint8{0, 1, 3, 4, 5, 10, 11, 99, 200} {
+		resp, err := kdb.ProcessKeyState(&edns0.KeyStateOption{KeyID: 4242, KeyState: state}, "child.example.")
+		if err != nil {
+			t.Fatalf("state=%d: ProcessKeyState: %v", state, err)
+		}
+		if resp == nil {
+			t.Fatalf("state=%d: nil response", state)
+		}
+		if resp.KeyState != uint8(edns0.KeyStateRequestMalformed) {
+			t.Errorf("state=%d: KeyState = %d, want 0 (KEY_REQUEST_MALFORMED)", state, resp.KeyState)
+		}
+		if resp.KeyID != 4242 {
+			t.Errorf("state=%d: KeyID = %d, want 4242 (echoed)", state, resp.KeyID)
+		}
+		if resp.KeyData != 0 {
+			t.Errorf("state=%d: KeyData = %d, want 0", state, resp.KeyData)
+		}
+	}
+}

--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -213,31 +213,60 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 	// At this point we have a set of zero or more keys that match the signername and keyid for a
 	// SIG validating the update. Now we must iterate over the keys to see if any of them actually
 	// verify correctly.
+	verifySigners(us, msgbuf)
 
-	// Iterate by index so signer.Validated writes back into the
-	// slice (the previous range-over-value form mutated a copy).
-	//
-	// EVERY signer is verified; we deliberately do NOT stop at the first
-	// success. signer.Validated is a PER-SIGNER property ("this signer's own
-	// signature verified over the message bytes") and TrustUpdate reads it to
-	// decide whether a given signer may confer trust. Breaking on the first
-	// success left every later signer at Validated=false, which made trust
-	// depend on SIG RR ORDER: in a dual-signed rollover UPDATE (old trusted
-	// key + new not-yet-trusted key, both signing genuinely), if the untrusted
-	// key's SIG happened to come first the trusted key was never verified,
-	// TrustUpdate skipped it on !key.Validated, and a legitimate rollover was
-	// refused. Reversing the SIG order accepted the very same message.
-	//
-	// The aggregate fields (ValidationRcode / RejectionEDE / Validated /
-	// SignerName) still mean "at least one signature verified", so a later
-	// FAILING signer must not overwrite an earlier success — every failure
-	// path below is guarded on !us.Validated, which is what the old `break`
-	// was really protecting. First success wins for SignerName.
-	//
-	// This does not weaken the check TrustUpdate relies on: a forged SIG
-	// naming a trusted key still fails Verify(), keeps Validated=false, and is
-	// still skipped there. The signer set is bounded by the discovery loop
-	// above, which only appends signers whose key was actually locatable.
+	// When we get here then we have tried to validate all signatures and the result is in
+	// the us.Signers data.
+	return nil
+}
+
+// sig0Verify indirects SIG(0) signature verification so that verifySigners can
+// be exercised without a real, fully-packed, genuinely-signed DNS message.
+//
+// This seam exists because the per-signer semantics below CANNOT be driven
+// end-to-end against the real verifier today: miekg/dns's SIG.Verify always
+// verifies the LAST record in the packed buffer whatever *SIG receiver it is
+// called on (it derives bodyend and `sig := buf[sigend:]` from the buffer
+// tail, using the receiver only for the KeyTag/SignerName/Algorithm sanity
+// checks). With multiple SIG(0) RRs only the last one can ever verify, so in a
+// real message "the first signer that verifies" is necessarily also the last,
+// and the multi-signer ordering behaviour is unreachable.
+//
+// Production code MUST NOT reassign this. Tests reassign it and restore the
+// original via t.Cleanup (see stubSig0Verify).
+var sig0Verify = func(sig *dns.SIG, key *dns.KEY, msgbuf []byte) error {
+	return sig.Verify(key, msgbuf)
+}
+
+// verifySigners verifies each located signer's own signature over msgbuf and
+// records the outcome in us: signer.Validated per signer, plus the aggregate
+// ValidationRcode / RejectionEDE / Validated / SignerName fields.
+//
+// Iterate by index so signer.Validated writes back into the
+// slice (the previous range-over-value form mutated a copy).
+//
+// EVERY signer is verified; we deliberately do NOT stop at the first
+// success. signer.Validated is a PER-SIGNER property ("this signer's own
+// signature verified over the message bytes") and TrustUpdate reads it to
+// decide whether a given signer may confer trust. Breaking on the first
+// success left every later signer at Validated=false, which made trust
+// depend on SIG RR ORDER: in a dual-signed rollover UPDATE (old trusted
+// key + new not-yet-trusted key, both signing genuinely), if the untrusted
+// key's SIG happened to come first the trusted key was never verified,
+// TrustUpdate skipped it on !key.Validated, and a legitimate rollover was
+// refused. Reversing the SIG order accepted the very same message.
+//
+// The aggregate fields (ValidationRcode / RejectionEDE / Validated /
+// SignerName) still mean "at least one signature verified", so a later
+// FAILING signer must not overwrite an earlier success — every failure
+// path below is guarded on !us.Validated, which is what the old `break`
+// was really protecting. First success wins for SignerName.
+//
+// This does not weaken the check TrustUpdate relies on: a forged SIG
+// naming a trusted key still fails Verify(), keeps Validated=false, and is
+// still skipped there. The signer set is bounded by ValidateUpdate's
+// discovery loop, which only appends signers whose key was actually locatable.
+func verifySigners(us *UpdateStatus, msgbuf []byte) {
 	for i := range us.Signers {
 		signer := &us.Signers[i]
 		// Use the per-signer SIG, not the outer sig variable (which
@@ -251,7 +280,7 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 			continue
 		}
 		keyrr := signer.Sig0Key.Key
-		err = ssig.Verify(&keyrr, msgbuf)
+		err := sig0Verify(ssig, &keyrr, msgbuf)
 		if err != nil {
 			// This key failed to validate the update. Categorize the
 			// failure: if NOW is outside the signature's validity
@@ -308,10 +337,6 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 			us.SignerName = signer.Name
 		}
 	}
-
-	// When we get here then we have tried to validate all signatures and the result is in
-	// the us.Signers data.
-	return nil
 }
 
 // BERRA TODO kolla om man kan förbättra detta, så man kan skicka en EDE

--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -318,6 +318,21 @@ func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 
 	for _, key := range us.Signers {
 		// dump.P(key)
+		// A located key confers trust ONLY if its OWN signature verified over
+		// the message bytes. us.Validated above is an aggregate ("at least one
+		// signature verified"), which is not sufficient here: ValidateUpdate's
+		// discovery loop appends a signer for every SIG RR matched on
+		// SignerName+KeyTag alone (before any signature is checked), and its
+		// verification loop breaks on the first success — so later entries keep
+		// Validated=false. Without this per-signer check, a multi-SIG(0) UPDATE
+		// could pair a genuine signature from an untrusted key with a forged SIG
+		// naming a trusted key and be granted "by-trusted" status even though
+		// the trusted key's signature was never verified. That would also defeat
+		// the untrusted-KEY-delete refusal in ApproveTrustUpdate, which is gated
+		// on us.ValidatedByTrustedKey.
+		if !key.Validated {
+			continue
+		}
 		if key.Sig0Key.Trusted {
 			lgDns.Info("TrustUpdate: update signed by trusted SIG(0) key", "signer", key.Name, "keyid", key.KeyId)
 			us.SignatureType = "by-trusted"

--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -216,9 +216,28 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 
 	// Iterate by index so signer.Validated writes back into the
 	// slice (the previous range-over-value form mutated a copy).
-	// Break on first success so a later failing signer can't
-	// overwrite ValidationRcode / RejectionEDE / Validated and
-	// leave the status struct internally inconsistent.
+	//
+	// EVERY signer is verified; we deliberately do NOT stop at the first
+	// success. signer.Validated is a PER-SIGNER property ("this signer's own
+	// signature verified over the message bytes") and TrustUpdate reads it to
+	// decide whether a given signer may confer trust. Breaking on the first
+	// success left every later signer at Validated=false, which made trust
+	// depend on SIG RR ORDER: in a dual-signed rollover UPDATE (old trusted
+	// key + new not-yet-trusted key, both signing genuinely), if the untrusted
+	// key's SIG happened to come first the trusted key was never verified,
+	// TrustUpdate skipped it on !key.Validated, and a legitimate rollover was
+	// refused. Reversing the SIG order accepted the very same message.
+	//
+	// The aggregate fields (ValidationRcode / RejectionEDE / Validated /
+	// SignerName) still mean "at least one signature verified", so a later
+	// FAILING signer must not overwrite an earlier success — every failure
+	// path below is guarded on !us.Validated, which is what the old `break`
+	// was really protecting. First success wins for SignerName.
+	//
+	// This does not weaken the check TrustUpdate relies on: a forged SIG
+	// naming a trusted key still fails Verify(), keeps Validated=false, and is
+	// still skipped there. The signer set is bounded by the discovery loop
+	// above, which only appends signers whose key was actually locatable.
 	for i := range us.Signers {
 		signer := &us.Signers[i]
 		// Use the per-signer SIG, not the outer sig variable (which
@@ -244,11 +263,16 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 			// rollover overhaul: surface this as a specific rcode +
 			// EDE so the child operator can diagnose clock skew
 			// without parent-side log access.
-			if !cache.WithinValidityPeriod(ssig.Inception, ssig.Expiration, time.Now().UTC()) {
-				us.ValidationRcode = dns.RcodeBadTime
-				us.RejectionEDE = edns0.EDESig0BadTime
-			} else if us.RejectionEDE == 0 {
-				us.RejectionEDE = edns0.EDESig0BadSignature
+			//
+			// Guarded on !us.Validated: an earlier signer may already have
+			// verified, and this failure must not downgrade that success.
+			if !us.Validated {
+				if !cache.WithinValidityPeriod(ssig.Inception, ssig.Expiration, time.Now().UTC()) {
+					us.ValidationRcode = dns.RcodeBadTime
+					us.RejectionEDE = edns0.EDESig0BadTime
+				} else if us.RejectionEDE == 0 {
+					us.RejectionEDE = edns0.EDESig0BadSignature
+				}
 			}
 			lgDns.Warn("ValidateUpdate: signature verification failed", "signer", signer.Name, "keyid", signer.KeyId, "err", err)
 			lgDns.Debug("ValidateUpdate: timing details", "currentTime", time.Now(), "inception", ssig.Inception, "expiration", ssig.Expiration)
@@ -258,22 +282,31 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 		// Ok, we have a signature that validated.
 		if !cache.WithinValidityPeriod(ssig.Inception, ssig.Expiration, time.Now().UTC()) {
 			lgDns.Warn("ValidateUpdate: signature NOT within validity period", "signer", signer.Name, "keyid", signer.KeyId)
-			us.ValidationRcode = dns.RcodeBadTime
-			us.RejectionEDE = edns0.EDESig0BadTime
+			// Guarded: must not downgrade an earlier signer's success.
+			if !us.Validated {
+				us.ValidationRcode = dns.RcodeBadTime
+				us.RejectionEDE = edns0.EDESig0BadTime
+			}
 			// This key validated the signature, but the signature is not within its validity period.
 			// Try the next key.
 			continue
 		}
 
-		// Signature is valid and within its validity period.
+		// Signature is valid and within its validity period. Mark THIS signer
+		// unconditionally — that is the per-signer fact TrustUpdate consumes.
 		lgDns.Info("ValidateUpdate: signature within validity period", "signer", signer.Name, "keyid", signer.KeyId)
 		lgDns.Info("ValidateUpdate: update validated by known and validated key")
-		us.ValidationRcode = dns.RcodeSuccess
-		us.RejectionEDE = 0 // success — clear any prior key's failure EDE
-		us.Validated = true // Now at least one key has validated the update
-		us.SignerName = signer.Name
 		signer.Validated = true
-		break
+
+		// Aggregate status: record the first success and leave it alone
+		// thereafter, so SignerName stays stable and a later signer cannot
+		// churn the rcode/EDE.
+		if !us.Validated {
+			us.ValidationRcode = dns.RcodeSuccess
+			us.RejectionEDE = 0 // success — clear any prior key's failure EDE
+			us.Validated = true // Now at least one key has validated the update
+			us.SignerName = signer.Name
+		}
 	}
 
 	// When we get here then we have tried to validate all signatures and the result is in
@@ -322,14 +355,19 @@ func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 		// the message bytes. us.Validated above is an aggregate ("at least one
 		// signature verified"), which is not sufficient here: ValidateUpdate's
 		// discovery loop appends a signer for every SIG RR matched on
-		// SignerName+KeyTag alone (before any signature is checked), and its
-		// verification loop breaks on the first success — so later entries keep
+		// SignerName+KeyTag alone, before any signature is checked, so a signer
+		// whose signature then failed to verify is still present with
 		// Validated=false. Without this per-signer check, a multi-SIG(0) UPDATE
 		// could pair a genuine signature from an untrusted key with a forged SIG
 		// naming a trusted key and be granted "by-trusted" status even though
 		// the trusted key's signature was never verified. That would also defeat
 		// the untrusted-KEY-delete refusal in ApproveTrustUpdate, which is gated
 		// on us.ValidatedByTrustedKey.
+		//
+		// ValidateUpdate verifies every signer (it does not stop at the first
+		// success), so in a legitimately dual-signed rollover UPDATE both the
+		// old and the new key carry Validated=true and the loop below finds the
+		// trusted one regardless of SIG RR order.
 		if !key.Validated {
 			continue
 		}

--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -344,13 +344,20 @@ func verifySigners(us *UpdateStatus, msgbuf []byte) {
 func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 	// dump.P(us)
 	if len(us.Signers) == 0 {
-		// No locatable signing key for any SIG in the UPDATE. This branch
-		// also covers a fully-unsigned UPDATE (no SIG RR at all): both map
-		// to BADKEY(17). Per draft-ietf-dnsop-delegation-mgmt-via-ddns-02
-		// §"RCODE BADKEY", an unknown key is a definitive BADKEY so the
-		// child falls back to bootstrapping its key into the receiver.
-		// Conflating "unsigned" with "unknown key" is a deliberate choice:
-		// a child re-bootstrapping off its own unsigned UPDATE is harmless.
+		// No locatable signing key for any SIG in the UPDATE. Per
+		// draft-ietf-dnsop-delegation-mgmt-via-ddns-02 §"RCODE BADKEY", an
+		// unknown key is a definitive BADKEY(17) so the child falls back to
+		// bootstrapping its key into the receiver.
+		//
+		// This also covers an UPDATE carrying no SIG RR at all but a
+		// non-empty Additional section (in practice: an OPT RR) — the
+		// discovery loop finds no SIG, so us.Signers is empty and we land
+		// here. Conflating "unsigned" with "unknown key" is a deliberate
+		// choice: a child re-bootstrapping off its own unsigned UPDATE is
+		// harmless. Note it does NOT cover an UPDATE with a completely
+		// empty Additional section: that short-circuits earlier, in
+		// ValidateUpdate's len(r.Extra)==0 branch, as FORMERR +
+		// EDESig0FormatError, which the responder now relays.
 		us.ValidationRcode = dns.RcodeBadKey
 		us.RejectionEDE = edns0.EDESig0KeyNotKnown
 		return fmt.Errorf("update has no locatable signing key")
@@ -368,6 +375,16 @@ func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 	// signature. A well-formed self-signed key upload verifies, so it has
 	// Validated=true and is unaffected.
 	if !us.Validated {
+		// Defensive: this branch relies on ValidateUpdate having run first and
+		// left a non-success ValidationRcode (its line-31 fail-closed default).
+		// If TrustUpdate is ever reached with a fresh UpdateStatus{} from a
+		// future call site, ValidationRcode would still be its zero value
+		// (RcodeSuccess) while we return an error — reintroducing exactly the
+		// "responder answers NOERROR for a rejected update" bug that default
+		// was added to prevent. Do not rely on a precondition we can enforce.
+		if us.ValidationRcode == dns.RcodeSuccess {
+			us.ValidationRcode = dns.RcodeBadSig
+		}
 		if us.RejectionEDE == 0 {
 			us.RejectionEDE = edns0.EDESig0BadSignature
 		}

--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -286,8 +286,36 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 	// dump.P(us)
 	if len(us.Signers) == 0 {
-		return fmt.Errorf("update has no signature")
+		// No locatable signing key for any SIG in the UPDATE. This branch
+		// also covers a fully-unsigned UPDATE (no SIG RR at all): both map
+		// to BADKEY(17). Per draft-ietf-dnsop-delegation-mgmt-via-ddns-02
+		// §"RCODE BADKEY", an unknown key is a definitive BADKEY so the
+		// child falls back to bootstrapping its key into the receiver.
+		// Conflating "unsigned" with "unknown key" is a deliberate choice:
+		// a child re-bootstrapping off its own unsigned UPDATE is harmless.
+		us.ValidationRcode = dns.RcodeBadKey
+		us.RejectionEDE = edns0.EDESig0KeyNotKnown
+		return fmt.Errorf("update has no locatable signing key")
 	}
+
+	// A key was located but no signature actually verified over the message
+	// bytes (forged/tampered signature, or one outside its validity window).
+	// ValidateUpdate already recorded the precise failure (BadSig / BadTime
+	// plus the matching EDE); do NOT fall through to the trust checks below,
+	// which read only the key's stored flags. Without this guard a trusted
+	// key's KeyTag placed over tampered bytes would be reported as trusted
+	// (us.ValidatedByTrustedKey=true) while ValidationRcode is still BadSig.
+	// ApproveUpdate also hard-rejects a non-Success ValidationRcode, but we
+	// fail closed here so the trust flags are never set for an unverified
+	// signature. A well-formed self-signed key upload verifies, so it has
+	// Validated=true and is unaffected.
+	if !us.Validated {
+		if us.RejectionEDE == 0 {
+			us.RejectionEDE = edns0.EDESig0BadSignature
+		}
+		return fmt.Errorf("update signed by %s (keyid %d) but no signature verified", us.Signers[0].Name, us.Signers[0].KeyId)
+	}
+
 	for _, key := range us.Signers {
 		// dump.P(key)
 		if key.Sig0Key.Trusted {
@@ -305,11 +333,14 @@ func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 			return nil
 		}
 	}
-	// If we get here then the update is not signed by any trusted, or DNSSEC validated key. Nor
-	// is it self-signed.
-	us.ValidationRcode = dns.RcodeBadKey
+	// A signature verified with a located key that is nonetheless neither
+	// trusted, DNSSEC-validated, nor a self-signed upload. Per ddns-02
+	// §"Communication in Case of Errors" the key is known but not (or no
+	// longer) trusted, so respond REFUSED carrying EDE KEY-KNOWN-NOT-TRUSTED
+	// — distinct from BADKEY, which means the key is unknown.
+	us.ValidationRcode = dns.RcodeRefused
 	us.RejectionEDE = edns0.EDESig0KeyKnownButNotTrusted
-	return fmt.Errorf("update is signed by %s (keyid %d) which is neither a trusted SIG(0) key nor a DNSSEC validated key", us.Signers[0].Name, us.Signers[0].KeyId)
+	return fmt.Errorf("update is signed by %s (keyid %d) which is known but not trusted", us.Signers[0].Name, us.Signers[0].KeyId)
 }
 
 func (zd *ZoneData) FindSig0KeyViaDNS(signer string, keyid uint16) (*Sig0Key, error) {

--- a/v2/sig0_validate_multisig_test.go
+++ b/v2/sig0_validate_multisig_test.go
@@ -1,0 +1,90 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestTrustUpdateIsIndependentOfSignerOrder pins the contract that the
+// per-signer Validated fix exists to guarantee: when more than one signer in a
+// dual-signed rollover UPDATE has verified its own signature, TrustUpdate must
+// find the trusted one and confer "by-trusted" status REGARDLESS of the order
+// the signers appear in.
+//
+// Before the fix, ValidateUpdate's verification loop broke on the first
+// success, so every later signer kept Validated=false and TrustUpdate skipped
+// it on the !key.Validated guard — making the outcome depend on SIG RR order.
+// The loop now marks every signer whose own signature verified, so both
+// orderings below must reach the same verdict.
+func TestTrustUpdateIsIndependentOfSignerOrder(t *testing.T) {
+	zd := &ZoneData{}
+
+	untrusted := Sig0UpdateSigner{
+		Name:      "child.example.",
+		KeyId:     111,
+		Validated: true, // its own signature verified...
+		Sig0Key:   &Sig0Key{Name: "child.example.", Keyid: 111},
+	}
+	trusted := Sig0UpdateSigner{
+		Name:      "child.example.",
+		KeyId:     222,
+		Validated: true, // ...and so did this one
+		Sig0Key:   &Sig0Key{Name: "child.example.", Keyid: 222, Trusted: true},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		signers []Sig0UpdateSigner
+	}{
+		{"trusted key signs first", []Sig0UpdateSigner{trusted, untrusted}},
+		{"trusted key signs second", []Sig0UpdateSigner{untrusted, trusted}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			us := &UpdateStatus{
+				Validated:       true,
+				ValidationRcode: dns.RcodeSuccess,
+				Signers:         tc.signers,
+			}
+			if err := zd.TrustUpdate(nil, us); err != nil {
+				t.Fatalf("TrustUpdate returned error: %v", err)
+			}
+			if !us.ValidatedByTrustedKey {
+				t.Error("ValidatedByTrustedKey = false; the trusted signer must confer trust in either order")
+			}
+			if us.SignatureType != "by-trusted" {
+				t.Errorf("SignatureType = %q, want \"by-trusted\"", us.SignatureType)
+			}
+		})
+	}
+}
+
+// TestTrustUpdateSkipsUnverifiedSigner is the security counterpart: a signer
+// that did NOT verify its own signature must never confer trust, even when it
+// names a trusted key. This is what the per-signer Validated guard in
+// TrustUpdate protects, and the fix above must not weaken it — a forged SIG
+// naming a trusted key still fails Verify() and keeps Validated=false.
+func TestTrustUpdateSkipsUnverifiedSigner(t *testing.T) {
+	zd := &ZoneData{}
+	us := &UpdateStatus{
+		Validated:       true, // an untrusted key's signature did verify
+		ValidationRcode: dns.RcodeSuccess,
+		Signers: []Sig0UpdateSigner{
+			{
+				Name: "child.example.", KeyId: 111, Validated: true,
+				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111},
+			},
+			{
+				// Forged SIG naming a trusted key: never verified.
+				Name: "child.example.", KeyId: 222, Validated: false,
+				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 222, Trusted: true},
+			},
+		},
+	}
+	if err := zd.TrustUpdate(nil, us); err == nil {
+		t.Fatal("expected an error: no verified signer is trusted")
+	}
+	if us.ValidatedByTrustedKey {
+		t.Error("ValidatedByTrustedKey must be false: the trusted key's signature was never verified")
+	}
+}

--- a/v2/sig0_validate_multisig_test.go
+++ b/v2/sig0_validate_multisig_test.go
@@ -2,21 +2,20 @@ package tdns
 
 import (
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 )
 
-// TestTrustUpdateIsIndependentOfSignerOrder pins the contract that the
-// per-signer Validated fix exists to guarantee: when more than one signer in a
-// dual-signed rollover UPDATE has verified its own signature, TrustUpdate must
-// find the trusted one and confer "by-trusted" status REGARDLESS of the order
-// the signers appear in.
+// TestTrustUpdateIsIndependentOfSignerOrder pins TrustUpdate's half of the
+// contract: GIVEN that more than one signer is already marked Validated, the
+// trusted one must confer "by-trusted" status regardless of its position.
 //
-// Before the fix, ValidateUpdate's verification loop broke on the first
-// success, so every later signer kept Validated=false and TrustUpdate skipped
-// it on the !key.Validated guard — making the outcome depend on SIG RR order.
-// The loop now marks every signer whose own signature verified, so both
-// orderings below must reach the same verdict.
+// NOTE ON COVERAGE: this test builds UpdateStatus by hand and therefore does
+// NOT exercise the per-signer marking fix in verifySigners — it passes both
+// with and without it, because TrustUpdate already iterated every signer. It
+// documents the consuming end of the contract only. The test that actually
+// fails without the fix is TestVerifySignersMarksEverySigner below.
 func TestTrustUpdateIsIndependentOfSignerOrder(t *testing.T) {
 	zd := &ZoneData{}
 
@@ -86,5 +85,124 @@ func TestTrustUpdateSkipsUnverifiedSigner(t *testing.T) {
 	}
 	if us.ValidatedByTrustedKey {
 		t.Error("ValidatedByTrustedKey must be false: the trusted key's signature was never verified")
+	}
+}
+
+// mkTestSigner builds a signer whose SIG is inside its validity window. The
+// signature bytes are irrelevant: these tests substitute sig0Verify, because
+// the real miekg/dns verifier cannot be driven to verify two SIG(0) RRs in one
+// message (see the sig0Verify doc comment).
+func mkTestSigner(name string, keyid uint16, trusted bool) Sig0UpdateSigner {
+	now := uint32(time.Now().UTC().Unix())
+	sig := &dns.SIG{}
+	sig.Inception = now - 300
+	sig.Expiration = now + 300
+	sig.KeyTag = keyid
+	sig.SignerName = name
+	return Sig0UpdateSigner{
+		Name:    name,
+		KeyId:   keyid,
+		Sig:     sig,
+		Sig0Key: &Sig0Key{Name: name, Keyid: keyid, Trusted: trusted},
+	}
+}
+
+// stubSig0Verify substitutes the SIG(0) verifier for the duration of a test.
+// fail lists the KeyIds whose verification should fail; everything else
+// verifies. The original verifier is restored on cleanup.
+func stubSig0Verify(t *testing.T, fail ...uint16) {
+	t.Helper()
+	orig := sig0Verify
+	t.Cleanup(func() { sig0Verify = orig })
+	failing := make(map[uint16]bool, len(fail))
+	for _, k := range fail {
+		failing[k] = true
+	}
+	sig0Verify = func(sig *dns.SIG, key *dns.KEY, msgbuf []byte) error {
+		if failing[sig.RRSIG.KeyTag] {
+			return dns.ErrSig
+		}
+		return nil
+	}
+}
+
+// TestVerifySignersMarksEverySigner is the test that fails without the fix.
+//
+// verifySigners must mark EVERY signer whose own signature verified, not just
+// the first. The pre-fix loop broke on first success, leaving every later
+// signer at Validated=false — which made TrustUpdate's verdict depend on SIG
+// RR order, since it skips signers on !key.Validated. Reverting the fix (a
+// `break` after the first success) makes this test fail on the second signer.
+//
+// This cannot be driven through a real signed message: miekg/dns's SIG.Verify
+// only ever verifies the LAST record in the packed buffer, so in practice the
+// first signer that verifies is also the last and the ordering behaviour is
+// unreachable. Hence the sig0Verify seam.
+func TestVerifySignersMarksEverySigner(t *testing.T) {
+	stubSig0Verify(t) // both signatures verify
+
+	// A dual-signed rollover UPDATE: same child zone, two keys.
+	us := &UpdateStatus{
+		Signers: []Sig0UpdateSigner{
+			mkTestSigner("child.example.", 111, false), // new, not yet trusted
+			mkTestSigner("child.example.", 222, true),  // old, trusted
+		},
+	}
+
+	verifySigners(us, nil)
+
+	for i := range us.Signers {
+		if !us.Signers[i].Validated {
+			t.Errorf("Signers[%d] (keyid %d): Validated = false, want true; "+
+				"every signer whose own signature verified must be marked",
+				i, us.Signers[i].KeyId)
+		}
+	}
+
+	// Aggregate status: first success wins and is not churned by later signers.
+	if !us.Validated {
+		t.Error("us.Validated = false, want true")
+	}
+	if us.ValidationRcode != dns.RcodeSuccess {
+		t.Errorf("us.ValidationRcode = %d, want NOERROR", us.ValidationRcode)
+	}
+	if us.RejectionEDE != 0 {
+		t.Errorf("us.RejectionEDE = %d, want 0", us.RejectionEDE)
+	}
+}
+
+// TestVerifySignersFailureDoesNotDowngradeEarlierSuccess covers the other half
+// of removing the `break`: now that the loop keeps going, a LATER failing
+// signer must not overwrite the aggregate status an earlier success recorded.
+// That is what the !us.Validated guards on each failure path protect.
+func TestVerifySignersFailureDoesNotDowngradeEarlierSuccess(t *testing.T) {
+	stubSig0Verify(t, 222) // the second signer's signature does NOT verify
+
+	us := &UpdateStatus{
+		Signers: []Sig0UpdateSigner{
+			mkTestSigner("child.example.", 111, true), // verifies
+			mkTestSigner("child.example.", 222, true), // fails
+		},
+	}
+
+	verifySigners(us, nil)
+
+	if !us.Signers[0].Validated {
+		t.Error("Signers[0]: Validated = false, want true (its signature verified)")
+	}
+	if us.Signers[1].Validated {
+		t.Error("Signers[1]: Validated = true, want false (its signature did not verify)")
+	}
+	if !us.Validated {
+		t.Error("us.Validated = false; a later failure must not clear an earlier success")
+	}
+	if us.ValidationRcode != dns.RcodeSuccess {
+		t.Errorf("us.ValidationRcode = %d, want NOERROR; a later failure must not downgrade it", us.ValidationRcode)
+	}
+	if us.RejectionEDE != 0 {
+		t.Errorf("us.RejectionEDE = %d, want 0; a later failure must not set a rejection EDE", us.RejectionEDE)
+	}
+	if us.SignerName != "child.example." {
+		t.Errorf("us.SignerName = %q, want %q", us.SignerName, "child.example.")
 	}
 }

--- a/v2/sig0_validate_phase0_test.go
+++ b/v2/sig0_validate_phase0_test.go
@@ -1,0 +1,105 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// TestTrustUpdateRcodeMapping asserts D-8: the UPDATE-receiver rcode/EDE
+// mapping matches delegation-mgmt-via-ddns-02. Unknown key → BADKEY(17);
+// known-but-not-trusted (with a verified signature) → REFUSED + EDE
+// KEY-KNOWN-NOT-TRUSTED; a located key whose signature did NOT verify keeps
+// BADSIG and is never treated as trusted (the added defense-in-depth guard).
+func TestTrustUpdateRcodeMapping(t *testing.T) {
+	zd := &ZoneData{}
+
+	t.Run("unknown key -> BADKEY", func(t *testing.T) {
+		// ValidateUpdate leaves the RcodeBadSig default when no key is located.
+		us := &UpdateStatus{ValidationRcode: dns.RcodeBadSig}
+		if err := zd.TrustUpdate(nil, us); err == nil {
+			t.Fatal("expected error for an unknown/unsigned key")
+		}
+		if us.ValidationRcode != dns.RcodeBadKey {
+			t.Errorf("ValidationRcode = %d, want BADKEY(%d)", us.ValidationRcode, dns.RcodeBadKey)
+		}
+		if us.RejectionEDE != edns0.EDESig0KeyNotKnown {
+			t.Errorf("RejectionEDE = %d, want EDESig0KeyNotKnown(%d)", us.RejectionEDE, edns0.EDESig0KeyNotKnown)
+		}
+		if us.ValidatedByTrustedKey {
+			t.Error("ValidatedByTrustedKey must be false")
+		}
+	})
+
+	t.Run("known but not trusted -> REFUSED + EDE514", func(t *testing.T) {
+		us := &UpdateStatus{
+			Validated:       true, // a signature verified...
+			ValidationRcode: dns.RcodeSuccess,
+			Signers: []Sig0UpdateSigner{{
+				Name:  "child.example.",
+				KeyId: 111,
+				// ...but the key is neither trusted, DNSSEC-validated, nor an upload.
+				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111},
+			}},
+		}
+		if err := zd.TrustUpdate(nil, us); err == nil {
+			t.Fatal("expected error for a known-but-not-trusted key")
+		}
+		if us.ValidationRcode != dns.RcodeRefused {
+			t.Errorf("ValidationRcode = %d, want REFUSED(%d)", us.ValidationRcode, dns.RcodeRefused)
+		}
+		if us.RejectionEDE != edns0.EDESig0KeyKnownButNotTrusted {
+			t.Errorf("RejectionEDE = %d, want EDESig0KeyKnownButNotTrusted(%d)", us.RejectionEDE, edns0.EDESig0KeyKnownButNotTrusted)
+		}
+		if us.ValidatedByTrustedKey {
+			t.Error("ValidatedByTrustedKey must be false")
+		}
+	})
+
+	t.Run("trusted key + bad signature -> BADSIG, not accepted", func(t *testing.T) {
+		us := &UpdateStatus{
+			Validated:       false,           // signature did NOT verify
+			ValidationRcode: dns.RcodeBadSig, // set by ValidateUpdate
+			RejectionEDE:    edns0.EDESig0BadSignature,
+			Signers: []Sig0UpdateSigner{{
+				Name:    "child.example.",
+				KeyId:   222,
+				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 222, Trusted: true}, // trusted key
+			}},
+		}
+		if err := zd.TrustUpdate(nil, us); err == nil {
+			t.Fatal("expected error: a trusted key with a forged signature must not be accepted")
+		}
+		if us.ValidationRcode != dns.RcodeBadSig {
+			t.Errorf("ValidationRcode = %d, want BADSIG(%d) preserved", us.ValidationRcode, dns.RcodeBadSig)
+		}
+		if us.ValidatedByTrustedKey {
+			t.Error("a forged signature over a trusted key's tag must NOT set ValidatedByTrustedKey")
+		}
+		if us.SignatureType == "by-trusted" {
+			t.Error("SignatureType must not be by-trusted for an unverified signature")
+		}
+	})
+
+	t.Run("trusted key + valid signature -> accepted", func(t *testing.T) {
+		us := &UpdateStatus{
+			Validated:       true,
+			ValidationRcode: dns.RcodeSuccess,
+			Signers: []Sig0UpdateSigner{{
+				Name:    "child.example.",
+				KeyId:   333,
+				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 333, Trusted: true},
+			}},
+		}
+		if err := zd.TrustUpdate(nil, us); err != nil {
+			t.Fatalf("trusted key + valid signature should be accepted: %v", err)
+		}
+		if !us.ValidatedByTrustedKey {
+			t.Error("ValidatedByTrustedKey must be true")
+		}
+		if us.SignatureType != "by-trusted" {
+			t.Errorf("SignatureType = %q, want by-trusted", us.SignatureType)
+		}
+	})
+}

--- a/v2/sig0_validate_phase0_test.go
+++ b/v2/sig0_validate_phase0_test.go
@@ -37,8 +37,9 @@ func TestTrustUpdateRcodeMapping(t *testing.T) {
 			Validated:       true, // a signature verified...
 			ValidationRcode: dns.RcodeSuccess,
 			Signers: []Sig0UpdateSigner{{
-				Name:  "child.example.",
-				KeyId: 111,
+				Name:      "child.example.",
+				KeyId:     111,
+				Validated: true, // ...this signer's own signature verified...
 				// ...but the key is neither trusted, DNSSEC-validated, nor an upload.
 				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111},
 			}},
@@ -87,9 +88,10 @@ func TestTrustUpdateRcodeMapping(t *testing.T) {
 			Validated:       true,
 			ValidationRcode: dns.RcodeSuccess,
 			Signers: []Sig0UpdateSigner{{
-				Name:    "child.example.",
-				KeyId:   333,
-				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 333, Trusted: true},
+				Name:      "child.example.",
+				KeyId:     333,
+				Validated: true, // this signer's own signature verified
+				Sig0Key:   &Sig0Key{Name: "child.example.", Keyid: 333, Trusted: true},
 			}},
 		}
 		if err := zd.TrustUpdate(nil, us); err != nil {
@@ -100,6 +102,53 @@ func TestTrustUpdateRcodeMapping(t *testing.T) {
 		}
 		if us.SignatureType != "by-trusted" {
 			t.Errorf("SignatureType = %q, want by-trusted", us.SignatureType)
+		}
+	})
+
+	// Multi-SIG(0) cross-signer confusion. ValidateUpdate's discovery loop
+	// appends a signer for every SIG RR matched on SignerName+KeyTag alone, and
+	// its verification loop breaks on the first success — so a later entry can
+	// name a trusted key whose signature was never verified. An attacker pairs a
+	// genuine signature from their own untrusted key with a forged SIG naming a
+	// trusted key; only the aggregate us.Validated is true. TrustUpdate must NOT
+	// grant "by-trusted" off the unverified entry, or the untrusted-KEY-delete
+	// refusal in ApproveTrustUpdate (gated on ValidatedByTrustedKey) is defeated.
+	t.Run("forged SIG naming a trusted key must not confer trust", func(t *testing.T) {
+		us := &UpdateStatus{
+			Validated:       true, // aggregate: signer[0]'s signature verified
+			ValidationRcode: dns.RcodeSuccess,
+			Signers: []Sig0UpdateSigner{
+				{
+					// The attacker's own key: signature genuinely verified,
+					// but the key is not trusted.
+					Name:      "attacker.example.",
+					KeyId:     111,
+					Validated: true,
+					Sig0Key:   &Sig0Key{Name: "attacker.example.", Keyid: 111},
+				},
+				{
+					// Forged SIG naming a trusted key: located during discovery
+					// by name+keytag, but its signature was NEVER verified.
+					Name:      "child.example.",
+					KeyId:     222,
+					Validated: false,
+					Sig0Key:   &Sig0Key{Name: "child.example.", Keyid: 222, Trusted: true},
+				},
+			},
+		}
+		if err := zd.TrustUpdate(nil, us); err == nil {
+			t.Fatal("expected error: an unverified trusted-key SIG must not confer trust")
+		}
+		if us.ValidatedByTrustedKey {
+			t.Error("ValidatedByTrustedKey must be false — the trusted key's signature was never verified")
+		}
+		if us.SignatureType == "by-trusted" {
+			t.Errorf("SignatureType = %q, must not be by-trusted", us.SignatureType)
+		}
+		// Falls through to the known-but-not-trusted tail: a signature did
+		// verify, but no *verified* signer is trusted.
+		if us.ValidationRcode != dns.RcodeRefused {
+			t.Errorf("ValidationRcode = %d, want REFUSED(%d)", us.ValidationRcode, dns.RcodeRefused)
 		}
 	})
 }

--- a/v2/sig0_validate_rcoderelay_test.go
+++ b/v2/sig0_validate_rcoderelay_test.go
@@ -114,13 +114,34 @@ func TestApplyValidationFailureRelaysRecordedRcodeAndEDE(t *testing.T) {
 			if got != tc.ede {
 				t.Errorf("EDE info code = %d, want %d", got, tc.ede)
 			}
+
+			// The rejection must actually be sendable. BADSIG/BADKEY/BADTIME
+			// are extended rcodes: Pack() refuses Rcode > 0xF without an OPT
+			// RR to carry the upper bits, and WriteMsg's error is discarded
+			// by both rejection paths — an unpackable reply reaches the child
+			// as a TIMEOUT, not a rejection.
+			wire, err := m.Pack()
+			if err != nil {
+				t.Fatalf("rejection does not pack: %v", err)
+			}
+			var rt dns.Msg
+			if err := rt.Unpack(wire); err != nil {
+				t.Fatalf("packed rejection does not unpack: %v", err)
+			}
+			if rt.Rcode != int(tc.rcode) {
+				t.Errorf("rcode after wire round-trip = %d, want %d", rt.Rcode, tc.rcode)
+			}
 		})
 	}
 }
 
-// TestApplyValidationFailureOmitsZeroEDE: an EDE of 0 means "none recorded"
-// and must not be attached as if it were a real extended error.
-func TestApplyValidationFailureOmitsZeroEDE(t *testing.T) {
+// TestApplyValidationFailureZeroEDEStillPacks: an EDE of 0 means "none
+// recorded" and must not be attached as if it were a real extended error —
+// but an extended rcode (here BADSIG=16) must STILL produce a packable
+// message, which requires an OPT RR even without an EDE option in it. This
+// is the combination no current caller produces (every extended-rcode path
+// also records an EDE); the helper must not depend on that staying true.
+func TestApplyValidationFailureZeroEDEStillPacks(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetUpdate("example.")
 
@@ -135,6 +156,17 @@ func TestApplyValidationFailureOmitsZeroEDE(t *testing.T) {
 				t.Error("an EDE was attached for RejectionEDE=0")
 			}
 		}
+	}
+	wire, err := m.Pack()
+	if err != nil {
+		t.Fatalf("BADSIG rejection without an EDE does not pack: %v", err)
+	}
+	var rt dns.Msg
+	if err := rt.Unpack(wire); err != nil {
+		t.Fatalf("packed rejection does not unpack: %v", err)
+	}
+	if rt.Rcode != dns.RcodeBadSig {
+		t.Errorf("rcode after wire round-trip = %d, want BADSIG(%d)", rt.Rcode, dns.RcodeBadSig)
 	}
 }
 

--- a/v2/sig0_validate_rcoderelay_test.go
+++ b/v2/sig0_validate_rcoderelay_test.go
@@ -1,0 +1,166 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// TestTrustUpdateDefaultsRcodeWhenUnvalidated covers the defensive default in
+// TrustUpdate's !us.Validated branch.
+//
+// The branch previously relied on ValidateUpdate having run first and left a
+// non-success ValidationRcode behind. A caller that reaches TrustUpdate with a
+// fresh UpdateStatus{} would return an error while ValidationRcode was still
+// its zero value (RcodeSuccess), and UpdateResponder relays that value
+// directly — so the child would receive NOERROR for an update the receiver
+// actually rejected.
+func TestTrustUpdateDefaultsRcodeWhenUnvalidated(t *testing.T) {
+	zd := &ZoneData{}
+
+	// A fresh UpdateStatus, as if TrustUpdate were called without
+	// ValidateUpdate having set its fail-closed default first.
+	us := &UpdateStatus{
+		Validated: false,
+		Signers: []Sig0UpdateSigner{
+			{Name: "child.example.", KeyId: 111, Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111}},
+		},
+	}
+	if us.ValidationRcode != dns.RcodeSuccess {
+		t.Fatalf("precondition: zero-valued ValidationRcode should be RcodeSuccess, got %d", us.ValidationRcode)
+	}
+
+	if err := zd.TrustUpdate(nil, us); err == nil {
+		t.Fatal("expected an error: no signature verified")
+	}
+	if us.ValidationRcode == dns.RcodeSuccess {
+		t.Error("ValidationRcode is still NOERROR while TrustUpdate returned an error; " +
+			"the responder would answer NOERROR for a rejected update")
+	}
+	if us.ValidationRcode != dns.RcodeBadSig {
+		t.Errorf("ValidationRcode = %d, want BADSIG(%d)", us.ValidationRcode, dns.RcodeBadSig)
+	}
+	if us.RejectionEDE != edns0.EDESig0BadSignature {
+		t.Errorf("RejectionEDE = %d, want EDESig0BadSignature(%d)", us.RejectionEDE, edns0.EDESig0BadSignature)
+	}
+}
+
+// TestTrustUpdatePreservesRecordedRcode is the counterpart: when ValidateUpdate
+// HAS recorded a specific failure (e.g. BADTIME for clock skew), the defensive
+// default must not overwrite it with the generic BADSIG.
+func TestTrustUpdatePreservesRecordedRcode(t *testing.T) {
+	zd := &ZoneData{}
+	us := &UpdateStatus{
+		Validated:       false,
+		ValidationRcode: dns.RcodeBadTime,
+		RejectionEDE:    edns0.EDESig0BadTime,
+		Signers: []Sig0UpdateSigner{
+			{Name: "child.example.", KeyId: 111, Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111}},
+		},
+	}
+
+	if err := zd.TrustUpdate(nil, us); err == nil {
+		t.Fatal("expected an error: no signature verified")
+	}
+	if us.ValidationRcode != dns.RcodeBadTime {
+		t.Errorf("ValidationRcode = %d, want BADTIME(%d) preserved", us.ValidationRcode, dns.RcodeBadTime)
+	}
+	if us.RejectionEDE != edns0.EDESig0BadTime {
+		t.Errorf("RejectionEDE = %d, want EDESig0BadTime(%d) preserved", us.RejectionEDE, edns0.EDESig0BadTime)
+	}
+}
+
+// TestApplyValidationFailureRelaysRecordedRcodeAndEDE is the test for the
+// responder fix: the rejection path must relay whatever ValidateUpdate /
+// TrustUpdate recorded, not a hardcoded rcode + EDE. Reverting the fix (a
+// hardcoded SERVFAIL + EDESig0KeyNotKnown, as the ValidateUpdate path had)
+// fails the FORMERR case below.
+func TestApplyValidationFailureRelaysRecordedRcodeAndEDE(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		rcode uint8
+		ede   uint16
+	}{
+		{"unsigned/malformed -> FORMERR", dns.RcodeFormatError, edns0.EDESig0FormatError},
+		{"unknown key -> BADKEY", dns.RcodeBadKey, edns0.EDESig0KeyNotKnown},
+		{"known but untrusted -> REFUSED", dns.RcodeRefused, edns0.EDESig0KeyKnownButNotTrusted},
+		{"bad signature -> BADSIG", dns.RcodeBadSig, edns0.EDESig0BadSignature},
+		{"clock skew -> BADTIME", dns.RcodeBadTime, edns0.EDESig0BadTime},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := new(dns.Msg)
+			m.SetUpdate("example.")
+
+			applyValidationFailure(m, &UpdateStatus{ValidationRcode: tc.rcode, RejectionEDE: tc.ede})
+
+			if m.Rcode != int(tc.rcode) {
+				t.Errorf("response rcode = %d, want %d", m.Rcode, tc.rcode)
+			}
+			opt := m.IsEdns0()
+			if opt == nil {
+				t.Fatal("no OPT RR on the response; the EDE was not attached")
+			}
+			var got uint16
+			var found bool
+			for _, o := range opt.Option {
+				if ede, ok := o.(*dns.EDNS0_EDE); ok {
+					got, found = ede.InfoCode, true
+				}
+			}
+			if !found {
+				t.Fatal("no EDE option on the response")
+			}
+			if got != tc.ede {
+				t.Errorf("EDE info code = %d, want %d", got, tc.ede)
+			}
+		})
+	}
+}
+
+// TestApplyValidationFailureOmitsZeroEDE: an EDE of 0 means "none recorded"
+// and must not be attached as if it were a real extended error.
+func TestApplyValidationFailureOmitsZeroEDE(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetUpdate("example.")
+
+	applyValidationFailure(m, &UpdateStatus{ValidationRcode: dns.RcodeBadSig, RejectionEDE: 0})
+
+	if m.Rcode != dns.RcodeBadSig {
+		t.Errorf("response rcode = %d, want BADSIG(%d)", m.Rcode, dns.RcodeBadSig)
+	}
+	if opt := m.IsEdns0(); opt != nil {
+		for _, o := range opt.Option {
+			if _, ok := o.(*dns.EDNS0_EDE); ok {
+				t.Error("an EDE was attached for RejectionEDE=0")
+			}
+		}
+	}
+}
+
+// TestValidateUpdateUnsignedSetsFormError pins the source of what the responder
+// relays for an UPDATE with an empty Additional section: FORMERR + a
+// format-error EDE, rather than anything resembling "key not known". A child
+// that receives "key not known" is directed at bootstrapping a key, which does
+// not fix a malformed message.
+func TestValidateUpdateUnsignedSetsFormError(t *testing.T) {
+	zd := &ZoneData{}
+	us := &UpdateStatus{}
+
+	r := new(dns.Msg)
+	r.SetUpdate("example.")
+	r.Extra = nil // no OPT, no SIG
+
+	if err := zd.ValidateUpdate(r, us); err == nil {
+		t.Fatal("expected an error for an UPDATE with no signature")
+	}
+	if us.ValidationRcode != dns.RcodeFormatError {
+		t.Errorf("ValidationRcode = %d, want FORMERR(%d)", us.ValidationRcode, dns.RcodeFormatError)
+	}
+	if us.RejectionEDE != edns0.EDESig0FormatError {
+		t.Errorf("RejectionEDE = %d, want EDESig0FormatError(%d)", us.RejectionEDE, edns0.EDESig0FormatError)
+	}
+	if us.Validated || us.ValidatedByTrustedKey {
+		t.Error("Validated/ValidatedByTrustedKey must both be false for an unsigned UPDATE")
+	}
+}

--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -293,8 +293,16 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	err = zd.TrustUpdate(r, dur.Status)
 	if err != nil {
 		zd.Logger.Printf("Error from TrustUpdate(): %v", err)
+		// Relay the rcode + EDE that TrustUpdate/ValidateUpdate selected
+		// for this specific failure: BADKEY + key-not-known for an unknown
+		// key, REFUSED + key-known-not-trusted for a known-but-untrusted
+		// key, and BADSIG/BADTIME for a signature that did not verify.
+		// The previous hardcoded EDESig0KeyKnownButNotTrusted mislabelled
+		// the unknown-key and bad-signature cases.
 		m.SetRcode(m, int(dur.Status.ValidationRcode))
-		edns0.AttachEDEToResponse(m, edns0.EDESig0KeyKnownButNotTrusted)
+		if dur.Status.RejectionEDE != 0 {
+			edns0.AttachEDEToResponse(m, dur.Status.RejectionEDE)
+		}
 		w.WriteMsg(m)
 		return err
 	}

--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -72,6 +72,23 @@ func UpdateHandler(ctx context.Context, conf *Config) error {
 	}
 }
 
+// applyValidationFailure stamps the response with the rcode and EDE that
+// ValidateUpdate / TrustUpdate recorded for a rejected SIG(0) UPDATE, rather
+// than a hardcoded guess at the reason. Both rejection paths must use this so
+// they cannot drift apart again.
+//
+// us.ValidationRcode is authoritative: ValidateUpdate fails closed by
+// defaulting it to BADSIG on entry, and TrustUpdate defends the same way, so
+// an error return always carries a non-success rcode. The EDE is attached only
+// when one was actually selected — an EDE of 0 is "none recorded", not a
+// meaningful extended error.
+func applyValidationFailure(m *dns.Msg, us *UpdateStatus) {
+	m.SetRcode(m, int(us.ValidationRcode))
+	if us.RejectionEDE != 0 {
+		edns0.AttachEDEToResponse(m, us.RejectionEDE)
+	}
+}
+
 func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	w := dur.ResponseWriter
 	r := dur.Msg
@@ -278,11 +295,18 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	// this is an update to auth data) then the update will validate and the SIG(0) key will be
 	// trusted. We always trust SIG(0) keys in the zone we are authoritative for.
 
+	// applyValidationFailure is deliberately shared by both the ValidateUpdate
+	// and TrustUpdate rejection paths below. They previously each hardcoded
+	// their own rcode + EDE, and correcting only one of them is exactly how
+	// they drifted apart: the TrustUpdate path was fixed to relay the recorded
+	// values while the ValidateUpdate path kept answering SERVFAIL + "key not
+	// known" for what is actually FORMERR + a format error — mislabelling a
+	// malformed request as a server-side fault and directing the child at
+	// bootstrapping a key, which does not fix a malformed message.
 	err := zd.ValidateUpdate(r, dur.Status)
 	if err != nil {
 		zd.Logger.Printf("Error from ValidateUpdate(): %v", err)
-		m.SetRcode(m, dns.RcodeServerFailure)
-		edns0.AttachEDEToResponse(m, edns0.EDESig0KeyNotKnown)
+		applyValidationFailure(m, dur.Status)
 		w.WriteMsg(m)
 		return err
 	}
@@ -293,16 +317,7 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	err = zd.TrustUpdate(r, dur.Status)
 	if err != nil {
 		zd.Logger.Printf("Error from TrustUpdate(): %v", err)
-		// Relay the rcode + EDE that TrustUpdate/ValidateUpdate selected
-		// for this specific failure: BADKEY + key-not-known for an unknown
-		// key, REFUSED + key-known-not-trusted for a known-but-untrusted
-		// key, and BADSIG/BADTIME for a signature that did not verify.
-		// The previous hardcoded EDESig0KeyKnownButNotTrusted mislabelled
-		// the unknown-key and bad-signature cases.
-		m.SetRcode(m, int(dur.Status.ValidationRcode))
-		if dur.Status.RejectionEDE != 0 {
-			edns0.AttachEDEToResponse(m, dur.Status.RejectionEDE)
-		}
+		applyValidationFailure(m, dur.Status)
 		w.WriteMsg(m)
 		return err
 	}

--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -87,6 +87,17 @@ func applyValidationFailure(m *dns.Msg, us *UpdateStatus) {
 	if us.RejectionEDE != 0 {
 		edns0.AttachEDEToResponse(m, us.RejectionEDE)
 	}
+	// BADSIG(16)/BADKEY(17)/BADTIME(18) are extended rcodes: the header field
+	// is 4 bits, and Pack() refuses Rcode > 0xF unless an OPT RR is present
+	// to carry the upper bits (ErrExtendedRcode). Every path that records
+	// such an rcode today also records an EDE, and AttachEDEToResponse
+	// creates the OPT — but that is an invariant of the current callers, not
+	// of this helper. Guarantee it here: without the OPT the rejection would
+	// fail to pack inside WriteMsg, whose error both rejection paths discard,
+	// and the child would see a TIMEOUT instead of a rejection.
+	if us.ValidationRcode > 0xF && m.IsEdns0() == nil {
+		m.SetEdns0(4096, false)
+	}
 }
 
 func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {


### PR DESCRIPTION
## PR-1 = Phase 0: correctness fixes aligning tdns to the current drafts

Implements **Phase 0** of `docs/2026-07-16-ddns-delegation-keystate-draft-alignment-plan.md` — the correctness fixes where tdns currently *contradicts* the current draft text. tdns is the reference implementation, so this is re-alignment to:

- **draft-berra-dnsop-keystate-03** (KeyState EDNS(0) option)
- **draft-ietf-dnsop-delegation-mgmt-via-ddns-02** (SIG(0) UPDATE across the zone cut)

Work is in the `v2/` tree only. Phases 1 (KeyState completion) and 2 (delegation completion) are separate follow-on PRs and are **not** included. Phase 3 (IANA codepoints) stays deferred.

### What changed

**K-1 — KeyState codepoints → keystate-03 registry** (`v2/edns0/edns0_keystate.go`)
Reassigns `0 = KEY_REQUEST_MALFORMED` and `1 = KEY_TEMPORARY_FAILURE` (both receiver-set), removing the -02 sender bootstrap-request meanings of `0`/`1` and the invented `11 = BootstrapAutoPending`. Codes `2` and `4-10` are unchanged. All `-02` source comments bumped to `-03`. The send path only ever emits `2 (INTENT_INQUIRE_KEY)` and every child-side response handler switches on `4/5/9`, so the semantic flip of code `0` cannot invert a live branch.

**K-2 — malformed-request handling** (`v2/keystate.go` `ProcessKeyState`)
Accepts only sender code `2`; any other/unassigned KEY-STATE in a request is answered with `KEY_REQUEST_MALFORMED(0)`, KEY-ID echoed, KEY-DATA=0 (keystate-03 §"Protocol-Level Responses"). Drops the never-implemented auto-bootstrap branch.

**K-3 — KeyState response MUST be SIG(0)-signed** (`v2/keystate.go` `WriteMsg`)
Fail closed: if the UPDATE Receiver cannot sign, the reply is sent **without** the KeyState option rather than as an unsigned key-state signal (the forged-response DoS vector, keystate-03 §Security). The option is attached only to the signed copy, so the optionless fallback never carries it. Coordinates with D-7 (Phase 2, receiver-key publication): until then a receiver lacking its own SIG(0) key omits the option — intended, since an unsigned signal was never trustworthy.

**D-8 — UPDATE-receiver RCODE/EDE mapping** (`v2/sig0_validate.go` `TrustUpdate`, `v2/updateresponder.go`)
The mapping was inverted vs ddns-02. Corrected:

| Case | Before | After |
|------|--------|-------|
| Unknown / unlocatable key | `BADSIG(16)` + EDE"known-not-trusted" | **`BADKEY(17)`** + EDE"key-not-known" |
| Key known but not trusted (sig verified) | `BADKEY(17)` | **`REFUSED(5)`** + EDE"known-not-trusted" |
| Key found, signature did not verify | `BADKEY(17)` (clobbered) | **`BADSIG`/`BADTIME`** preserved |

Per §"RCODE BADKEY" an unknown key is a definitive `BADKEY` so the child re-bootstraps; per §"Communication in Case of Errors" a known-but-untrusted key is `REFUSED` + EDE, distinct from `BADKEY`. A fully-unsigned UPDATE also maps to `BADKEY` (harmless — the child would re-bootstrap off its own update). **Added defense-in-depth:** `TrustUpdate` now guards its trust checks on `us.Validated`, so a located key whose signature did *not* verify (e.g. a trusted key's KeyTag over tampered bytes) is never reported as trusted; `ApproveUpdate` already hard-rejected such updates downstream, but the trust flags are now never set for an unverified signature.

**D-2a — carry SIG(0) UPDATEs over TCP** (`v2/childsync_utils.go` `SendUpdate`)
Forces TCP unconditionally instead of gating on message size (ddns-02 §"Choice of SIG(0) Signature Algorithm": infrequent, parent-state-mutating, larger PQ sigs). `SendUpdate` is shared by all delegation-sync senders; the one generic consumer (`tdns-cli update`) only benefits. A comment guards against reintroducing a UDP-first gate.

### Tests
- `edns0`: -03 codepoint pinning, malformed(0) wire round-trip, string-map (code 11 now unassigned).
- `tdns`: `ProcessKeyState(KEY-STATE≠2) → 0`; `TrustUpdate` matrix (unknown→BADKEY, known-untrusted→REFUSED+EDE514, trusted-key+bad-sig→BADSIG-not-accepted, trusted+valid→accepted); `SendUpdate` delivers a small UPDATE over a TCP-only responder.

### Verification
`go build` + `go vet` + full `go test -race` green on `v2` and `v2/edns0` (`GOROOT=/opt/local/lib/go CGO_ENABLED=1`); `tdns-auth` builds against the modified `v2`. Live/testbed validation not yet done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Protocol Updates**
  * Updated EDNS(0) KeyState to the latest draft (keystate-03), including updated constants and standardized malformed responses.
* **Security and Validation**
  * Responses now “fail closed” by only including KeyState when they can be properly signed.
  * SIG(0) trust handling was tightened: unverified signatures no longer influence trust decisions, and denial mappings now use the correct DNS Rcode/EDE.
  * Error responses now reflect the actual validation status code and EDE.
* **Reliability**
  * Delegation-sync DNS `UPDATE` traffic is now always sent over TCP.
* **Tests**
  * Added tests covering TCP delivery, KeyState malformed handling, and SIG(0) trust/rcode mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->