### PR TITLE
fix(auth): attach EDNS OPT to authoritative query responses (RFC 6891 §6.1.1)

### DIFF
--- a/v2/edns0/edns0.go
+++ b/v2/edns0/edns0.go
@@ -102,3 +102,34 @@ func RequestUDPSize(r *dns.Msg) uint16 {
 	}
 	return size
 }
+
+// EnsureResponseOPT makes the response m carry an EDNS(0) OPT record whenever
+// the query r carried one. RFC 6891 §6.1.1 requires a compliant responder to
+// include an OPT in the response to any request that carried an OPT; omitting
+// it can make a strict resolver downgrade to plain DNS (dropping the DO bit and
+// breaking DNSSEC validation). The OPT advertises version 0 and udpsize (the
+// server's own reassembly capacity) and copies the DO bit from the query, as
+// mandated by RFC 3225 §3.
+//
+// It is deliberately a no-op in two cases:
+//   - the query carried no OPT: a plain-DNS query gets a plain-DNS reply; and
+//   - m already carries an OPT: the EDE / KeyState paths build their own OPT,
+//     and a second SetEdns0 would append a duplicate OPT to the Additional
+//     section.
+//
+// The OPT is attached with an empty option list, leaving room for EDE (or any
+// other option) to be appended later on error paths (AttachEDEToResponse finds
+// and reuses this OPT rather than creating a second one).
+func EnsureResponseOPT(m, r *dns.Msg, udpsize uint16) {
+	if m == nil || r == nil {
+		return
+	}
+	reqOpt := r.IsEdns0()
+	if reqOpt == nil {
+		return
+	}
+	if m.IsEdns0() != nil {
+		return
+	}
+	m.SetEdns0(udpsize, reqOpt.Do())
+}

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -711,6 +711,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 		lgHandler.Info("QueryResponder: context cancelled")
 		m := new(dns.Msg)
 		m.SetReply(r)
+		edns0.EnsureResponseOPT(m, r, dns.DefaultMsgSize)
 		m.MsgHdr.Rcode = dns.RcodeServerFailure
 		w.WriteMsg(m)
 		return ctx.Err()
@@ -750,6 +751,13 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.MsgHdr.Authoritative = true
+	// RFC 6891 §6.1.1: an EDNS query MUST get an OPT in the response. Attach it
+	// once here, up front, so every exit path below (positive answers,
+	// referrals, NXDOMAIN/NODATA, DS, CNAME, SOA, REFUSED — all of which reuse
+	// this m) carries it. No-op for non-EDNS queries. Later EDE/CDE error paths
+	// find and reuse this OPT rather than adding a second one. Downstream UDP
+	// truncation preserves the OPT and re-appends it after trimming.
+	edns0.EnsureResponseOPT(m, r, dns.DefaultMsgSize)
 
 	// Pin ONE snapshot for the whole response so the answer, authority SOA, NS,
 	// and glue all come from the same serial — no intra-response tearing (C1).
@@ -913,6 +921,7 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 					servfail := new(dns.Msg)
 					servfail.SetReply(r)
 					servfail.MsgHdr.Authoritative = true
+					edns0.EnsureResponseOPT(servfail, r, dns.DefaultMsgSize)
 					servfail.MsgHdr.Rcode = dns.RcodeServerFailure
 					w.WriteMsg(servfail)
 					return nil

--- a/v2/queryresponder_edns_test.go
+++ b/v2/queryresponder_edns_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"context"
+	"testing"
+
+	edns0 "github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// TestQueryResponderEDNSOPTEcho locks in RFC 6891 §6.1.1: an authoritative
+// QUERY response MUST carry an EDNS OPT record iff the query carried one.
+//
+// Regression test for the pre-existing bug where QueryResponder built its reply
+// with SetReply(r) but never re-attached an OPT, so every EDNS query (plain
+// +dnssec, +oots, SVCB, ...) got an OPT-less answer. A strict resolver that
+// sends EDNS and sees no OPT may downgrade to plain DNS, dropping the DO bit and
+// breaking DNSSEC validation against tdns-auth.
+func TestQueryResponderEDNSOPTEcho(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	// A legitimately unsigned zone: signRRsetForZone serves its RRsets as-is
+	// even for a DO query, so the positive-answer path stays NOERROR and we can
+	// assert on the OPT without dragging in the signing machinery.
+	zd := testSnapshotZone(t, "example.", `example. 3600 IN SOA ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example. 3600 IN NS ns.example.
+ns.example. 3600 IN A 10.0.0.1
+www.example. 3600 IN A 10.0.0.2
+`)
+	ctx := context.Background()
+
+	// respFor drives QueryResponder for www.example./A the way the real handler
+	// does — deriving msgoptions from the request via ExtractFlagsAndEDNS0Options
+	// — and returns the written response.
+	respFor := func(t *testing.T, edns, do bool) *dns.Msg {
+		t.Helper()
+		req := new(dns.Msg)
+		req.SetQuestion("www.example.", dns.TypeA)
+		if edns {
+			// Client advertises 1232; the server must advertise its OWN size
+			// (dns.DefaultMsgSize) back, not echo the client's.
+			req.SetEdns0(1232, do)
+		}
+		msgo, err := edns0.ExtractFlagsAndEDNS0Options(req)
+		if err != nil {
+			t.Fatalf("ExtractFlagsAndEDNS0Options: %v", err)
+		}
+		rw := &fakeRW{}
+		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeA, msgo, kdb, nil); err != nil {
+			t.Fatalf("QueryResponder: %v", err)
+		}
+		if rw.written == nil {
+			t.Fatal("no response written")
+		}
+		return rw.written
+	}
+
+	// 1. A non-EDNS query MUST NOT get an OPT in the response.
+	t.Run("non-EDNS query gets no OPT", func(t *testing.T) {
+		resp := respFor(t, false, false)
+		if opt := resp.IsEdns0(); opt != nil {
+			t.Fatalf("non-EDNS query got an OPT in the response: %s", opt.String())
+		}
+	})
+
+	// 2. An EDNS query (DO=0) MUST get an OPT echoing EDNS version 0 and the
+	//    server's advertised UDP size, with the DO bit reflected off.
+	t.Run("EDNS query gets OPT, DO off", func(t *testing.T) {
+		resp := respFor(t, true, false)
+		opt := resp.IsEdns0()
+		if opt == nil {
+			t.Fatal("EDNS query got no OPT in the response (RFC 6891 §6.1.1 violation)")
+		}
+		if resp.Rcode != dns.RcodeSuccess {
+			t.Fatalf("expected NOERROR, got %s", dns.RcodeToString[resp.Rcode])
+		}
+		if opt.Version() != 0 {
+			t.Fatalf("OPT EDNS version = %d, want 0", opt.Version())
+		}
+		if got := opt.UDPSize(); got != dns.DefaultMsgSize {
+			t.Fatalf("OPT advertised UDP size = %d, want server's %d", got, uint16(dns.DefaultMsgSize))
+		}
+		if opt.Do() {
+			t.Fatal("response OPT has DO set for a non-DO query")
+		}
+	})
+
+	// 3. An EDNS query with DO=1 MUST get an OPT with the DO bit reflected on
+	//    (RFC 3225 §3: copy the query's DO into the response).
+	t.Run("EDNS query gets OPT, DO on", func(t *testing.T) {
+		resp := respFor(t, true, true)
+		opt := resp.IsEdns0()
+		if opt == nil {
+			t.Fatal("EDNS+DO query got no OPT in the response")
+		}
+		if !opt.Do() {
+			t.Fatal("response OPT does not reflect the query's DO bit")
+		}
+	})
+
+	// 4. The EDE error paths must reuse the OPT attached up front rather than
+	//    adding a second one. A TypeNXNAME query (RFC 9824) is rejected FORMERR
+	//    with an EDE; the response must carry exactly one OPT, and it must hold
+	//    the EDE. This guards the "leave room for EDE, no duplicate OPT" contract
+	//    against AttachEDEToResponse.
+	t.Run("EDE path reuses the OPT (no duplicate)", func(t *testing.T) {
+		req := new(dns.Msg)
+		req.SetQuestion("www.example.", dns.TypeNXNAME)
+		req.SetEdns0(1232, true)
+		msgo, err := edns0.ExtractFlagsAndEDNS0Options(req)
+		if err != nil {
+			t.Fatalf("ExtractFlagsAndEDNS0Options: %v", err)
+		}
+		rw := &fakeRW{}
+		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeNXNAME, msgo, kdb, nil); err != nil {
+			t.Fatalf("QueryResponder: %v", err)
+		}
+		resp := rw.written
+		if resp == nil {
+			t.Fatal("no response written")
+		}
+		if resp.Rcode != dns.RcodeFormatError {
+			t.Fatalf("TypeNXNAME query: expected FORMERR, got %s", dns.RcodeToString[resp.Rcode])
+		}
+		opts := 0
+		for _, rr := range resp.Extra {
+			if _, ok := rr.(*dns.OPT); ok {
+				opts++
+			}
+		}
+		if opts != 1 {
+			t.Fatalf("expected exactly one OPT in the response, got %d", opts)
+		}
+		if ok, _, _ := edns0.ExtractEDEFromMsg(resp); !ok {
+			t.Fatal("EDE response carries no EDE option")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

tdns-auth's authoritative QUERY responses omit the EDNS OPT record even when the query carried one, violating **RFC 6891 §6.1.1** (an EDNS-aware responder must include an OPT in the response to an EDNS query).

Reproduced with `dog @127.0.0.1 -p 5354 ddns.test ns +oots` and `... _dns.ns.ddns.test SVCB +dnssec`: both responses come back with no OPT — confirmed on the wire via `tdns.MsgPrint` (no `;; EDNS:` line, `len(m.Extra)` missing the OPT). The server *is* EDNS-aware (it honors DO, returns RRSIGs, and reads the `oots` opt-in option), so this is a response-builder gap, not a capability gap.

This is **pre-existing and general** — it affects plain `+dnssec` queries too, not just OOTS. It was not introduced by the OOTS branch (#293).

**Root cause:** `QueryResponder` in `v2/queryresponder.go` builds every reply with `m.SetReply(r)` but never calls `SetEdns0` / attaches an OPT.

**Impact if unfixed:** a strict resolver that sends EDNS and receives no OPT may downgrade to plain DNS, disabling DO and breaking DNSSEC validation against tdns-auth.

## Fix

New helper `edns0.EnsureResponseOPT(m, r, udpsize)`:

- no-op when the query carried no OPT (a plain-DNS query gets a plain-DNS reply);
- no-op when `m` already has an OPT (the EDE / KeyState paths build their own — no duplicate OPT);
- otherwise attaches an OPT advertising EDNS **version 0** and the server's UDP size (`dns.DefaultMsgSize`, matching `srv.UDPSize` in `do53.go`), copying the query's **DO** bit (RFC 3225 §3);
- leaves the option list empty so EDE can be appended later — `AttachEDEToResponse` finds and reuses this OPT.

It is attached once, up front in `QueryResponder`, so every exit path reuses it: positive answers, referrals, NXDOMAIN/NODATA, DS, CNAME, SOA, REFUSED, plus the context-cancel and sign-failure SERVFAILs. Downstream UDP truncation (`udp_truncate.go`) already pops/reserves/re-appends the OPT, so it survives truncation and TC.

**Scope:** the general authoritative query path only. The UPDATE / KeyState / EDE builders (`AttachEDEToResponse`, `AttachKeyStateToResponse`) already build their own OPT and are untouched.

## Test

`TestQueryResponderEDNSOPTEcho` (`v2/queryresponder_edns_test.go`):

- an EDNS query gets an OPT — version 0, server UDP size, DO reflected both off and on;
- a non-EDNS query gets **no** OPT;
- the EDE path (`TypeNXNAME` → FORMERR) carries exactly **one** OPT and it holds the EDE.

## Verification

- `GOROOT=/opt/local/lib/go CGO_ENABLED=1 go test -race ./` — full `v2` package green
- `go test -race ./...` in `v2/edns0` — green
- `go vet ./` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responses now preserve EDNS(0) when the incoming request includes it.
  * EDNS response records retain the client’s DNSSEC OK (DO) setting.
  * Error and cancellation responses consistently include EDNS(0) when appropriate.

* **Bug Fixes**
  * Prevented duplicate EDNS records on error responses.
  * Preserved Extended DNS Errors alongside EDNS response data.

* **Tests**
  * Added coverage for EDNS behavior across standard, DNSSEC, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->