### PR TITLE
imr: per-server transport-usage stats (attempted/used/failed/truncated) + tdns-cli imr transport-stats

### DIFF
--- a/docs/2026-07-18-imr-transport-stats-review.md
+++ b/docs/2026-07-18-imr-transport-stats-review.md
@@ -1,0 +1,199 @@
+# Implementation review — imr per-server transport statistics
+
+**Reviewed:** 2026-07-18  
+**Design:** [`2026-07-18-imr-transport-stats-design.md`](2026-07-18-imr-transport-stats-design.md)  
+**Branch:** `feature/imr-transport-stats` @ `8f39373`  
+**Commits:** `eb2d4ce` (Phases 1–2), `65f40fb` (Phase 3), `8f39373` (Phase 4)  
+**Method:** Compare the design’s Q1–Q3 / Phases 1–4 and open decisions against the `v2/` tree. Anchors are symbol names; re-locate if lines drift.
+
+---
+
+## Executive summary
+
+Phases 1–4 are **implemented and aligned with the design’s correctness core**: TC=1-only wire reporting, four counters per server, one snapshot + one formatter (incl. `Do53TCP`), and remote access that reuses that formatter. The two design open decisions were resolved as recommended (TC=1-only; per-server truncation). Phase2 co-design items (bypass attribution, unified large-ksk remote surface) are correctly deferred.
+
+Main gaps: test depth on the real `ExchangeWithResult` path and `tryServer` wiring; a few doc/API naming mismatches; REPL↔remote signal presentation drift.
+
+**Verdict:** Ready for PR / review of the landed work. No blocking correctness bugs found against the design mappings. Follow-ups below are polish and test coverage, not rework of the data model.
+
+---
+
+## Phase status
+
+| Phase | Design | Status | Notes |
+|-------|--------|--------|-------|
+| **1 — Exchange enabler** | Surface `{wire, truncated}` | **Done** | Via `ExchangeWithResult` + `ExchangeResult`; plain `Exchange` kept as wrapper |
+| **2 — Collection** | `attempted`/`used`/`failed`/`truncated` | **Done** | Mappings match design; `attempted` = old `TransportCounters` |
+| **3 — Presentation** | One snapshot + formatter; fix Do53TCP/total | **Done** | REPL paths updated; weights shown alongside |
+| **4 — Remote** | API verb + CLI + same formatter | **Done** | Shape differs from design sketch (see M1) |
+| **Phase2 relationship** | Bypass attribution; unified large-ksk surface | **Deferred** | Explicitly out of this branch’s commits |
+
+---
+
+## What matches the design
+
+### Phase 1 — Exchange enabler
+
+`core.ExchangeResult` + `DNSClienter.ExchangeWithResult` (`v2/core/dnsclient.go`):
+
+```go
+type ExchangeResult struct {
+	WireTransport Transport // transport that carried the returned response
+	Truncated     bool      // a Do53/UDP response had TC=1 and was retried over TCP
+}
+```
+
+| Wire case | Result | Matches design? |
+|-----------|--------|-----------------|
+| Clean Do53/UDP | `{Do53, Truncated:false}` | Yes |
+| TC=1 → TCP | `{Do53TCP, Truncated:true}` | Yes (open decision #1: TC=1-only) |
+| Transient UDP error → TCP | `{Do53TCP, Truncated:false}` | Yes — not counted as truncation |
+| ForceTCP | `{Do53TCP}` (no Truncated) | Yes |
+| DoT/DoH/DoQ | wire = that transport | Yes |
+
+`Exchange` remains a thin discard-wrapper so existing callers are untouched.
+
+### Phase 2 — Collection
+
+`AuthServer` (`v2/cache/authserver.go`):
+
+| Design counter | Field / accessor | Thread-safe |
+|----------------|------------------|-------------|
+| `attempted[t]` | `TransportCounters` / `IncrementTransportCounter` | `mu` |
+| `used[t]` | `UsedCounters` / `IncrementUsedCounter` | `mu` |
+| `failed[t]` | `FailedCounters` / `IncrementFailedCounter` | `mu` |
+| `truncated` | `TruncatedCount` / `IncrementTruncated` | `mu` |
+
+Snapshot: `TransportStats` + `SnapshotTransportStats()` (Attempted aliases the old map).
+
+`tryServer` (`v2/dnslookup.go`) order is correct:
+
+1. Finalize `eff` (incl. `forceTCP` → Do53TCP)  
+2. `IncrementTransportCounter(eff)` → attempted  
+3. `ExchangeWithResult`  
+4. if `xres.Truncated` → `IncrementTruncated()`  
+5. on err → `IncrementFailedCounter(eff)`  
+6. on success → `IncrementUsedCounter(xres.WireTransport)`
+
+Design mappings hold:
+
+- Capability fail then Do53: `attempted[DoQ]++`, `failed[DoQ]++`; then `attempted[Do53]++`, `used[Do53]++`
+- Size upgrade: `attempted[Do53]++`, `used[Do53TCP]++`, `truncated++`, `failed` untouched
+- Increments sit after `eff` is finalized (ready for a later phase2 bypass re-pick)
+
+### Phase 3 — Presentation
+
+- One order list: `transportDisplayOrder` includes `Do53TCP`
+- One formatter: `formatTransportStats` / `formatTransportCountMap` (totals include Do53TCP) — fixes P3
+- Live path: `formatTransportCounters(server)` → snapshot + format
+- REPL: `auth-transports`, `printAuthServerVerbose`, dump verbose all use it
+- OOTS weights shown alongside (`renderSignal` / `formatTransportWeights`)
+
+### Phase 4 — Remote
+
+- API verb `imr-transport-stats` in `APIimr()` walks `ServerMap`, optional zone filter
+- Wire type `ImrServerTransportStats` (zone, server, signal, attempted/used/failed, truncated)
+- CLI: `tdns-cli imr stats transport-stats [zone]`
+- Same formatter: `formatTransportStats(imrServerStatsToTransportStats(rec))`
+
+### Open decisions — resolved
+
+| Decision | Choice | Where |
+|----------|--------|-------|
+| Truncation precision | **TC=1-only** (recommended) | `ExchangeWithResult` sets `Truncated` only on the TC bit path |
+| Truncation granularity | **Per-server** (not per-qtype) | `TruncatedCount uint64` on `AuthServer` |
+
+---
+
+## Findings (mismatches, gaps, risks)
+
+### M1 — API envelope differs from the design sketch (non-blocking)
+
+Design sketched `ImrRequest`/`ImrResponse` fields in `api_structs.go`. Implementation uses the existing `AgentMgmtPost` / `AgentMgmtResponse.Data` path already used by other `/imr` verbs, with `ImrServerTransportStats` defined in `apihandler_imr.go`.
+
+This is the right fit for the current mgmt API. Update the design doc’s Q3 wording to match, or leave as “implemented via AgentMgmt*”.
+
+### M2 — CLI path nesting
+
+Design: `tdns-cli imr transport-stats [zone]`  
+Code: `tdns-cli imr stats transport-stats [zone]` (under `ImrStatsCmd`)
+
+Sensible grouping next to `imr stats large-ksk`. Comment in `formatTransportStats` still says `tdns-cli imr transport-stats` — minor doc drift.
+
+### M3 — Signal presentation drift (REPL vs remote)
+
+| Path | Signal shown |
+|------|----------------|
+| REPL `auth-transports` | `renderSignal(server)` over `TransportWeights` |
+| Remote `transport-stats` | raw `server.TransportSignal` |
+
+Same server can look different remotely vs in-process. Prefer one of: (a) send both raw + rendered weights, or (b) render weights on the CLI side from a weights map in the API record.
+
+### M4 — `tryServer` still returns `eff`, not wire transport
+
+On success after TC=1 upgrade, counters correctly use `xres.WireTransport`, but the function still `return …, eff, nil`. Callers that treat the returned transport as “what carried the answer” (hooks / `lastTransport`) still see the *requested* transport. Design focused on counters; this is a latent semantic footgun, not a stats bug.
+
+### M5 — TC=1 then TCP also fails
+
+`truncated++` is recorded even if the TCP retry errors; then `failed[eff]++`. Correct as “truncation happened,” but it blurs the clean story “`failed[Do53]=0` ⇒ size upgrade.” Rare; document the edge case for operators.
+
+### M6 — `used[Do53TCP]` is not truncation alone
+
+`used[Do53TCP]` also increments on:
+
+- transient UDP→TCP (Truncated=false)
+- proactive `forceTCP`
+
+Operators must use **`truncated`**, not `used[Do53TCP]` alone, as the PQ truncation signal. Design already implies this; worth a one-liner in CLI help / REPL header.
+
+### M7 — Phase2 items deferred (expected)
+
+| Design ask | Status |
+|------------|--------|
+| Bypass attribution (`dnskeyBypass`) | Not present — `tryServer` still takes `forceTCP bool` |
+| Unified remote surface for large-ksk + transport stats | Not done — `large-ksk` remains in-process / separate |
+| Counters after `eff` finalized | Done — merge-friendly |
+
+No change needed on this branch; track when phase2 lands.
+
+---
+
+## Test coverage vs design test plan
+
+| Design item | Coverage | Gap |
+|-------------|----------|-----|
+| Exchange reports Do53TCP + Truncated on TC=1 | Fake only (`exchange_result_test.go`) | Real `DNSClient` TC test (`TestExchange_Do53_TCBitFallback`) asserts answer content via `Exchange`, **not** `ExchangeResult` |
+| Plain Do53 otherwise | Fake covered | Real client: no `ExchangeResult` assert |
+| Transient→TCP keeps Truncated=false | Code path exists | Untested for `ExchangeResult` |
+| Counter increments (success/error/TC=1) | Manual increments in `authserver_stats_test.go` | No `tryServer` ↔ `ExchangeWithResult` integration test |
+| Formatter renders Do53TCP + correct total | Untested | Add a small table-driven unit test |
+| Live / CLI round-trip | Untested in tree | Manual OOTS/PQ testbed still needed |
+
+---
+
+## Recommended follow-ups (priority order)
+
+1. **P1 tests:** Assert `ExchangeWithResult` on the real Do53 TC=1 path (`WireTransport=Do53TCP`, `Truncated=true`) and on the transient-fallback path (`Truncated=false`).  
+2. **P1 tests:** Table-driven `formatTransportStats` covering Do53TCP inclusion and total.  
+3. **P2 polish:** Align REPL and remote signal fields (M3).  
+4. **P2 polish:** Fix the stale “`imr transport-stats`” comment; optionally note that `truncated` is the truncation metric (M6).  
+5. **P3 (phase2 land):** Bypass attribution + fold large-ksk into the remote stats umbrella.  
+6. **Optional:** Have `tryServer` return `xres.WireTransport` on success (M4), or rename the return so callers don’t assume “wire.”
+
+---
+
+## Files touched (implementation)
+
+| Area | Paths |
+|------|--------|
+| Exchange | `v2/core/dnsclient.go`, `dnsclient_fake.go`, `exchange_result_test.go`; interface consumers (`chase_test.go`, etc.) |
+| Counters | `v2/cache/authserver.go`, `authserver_stats_test.go` |
+| Collection | `v2/dnslookup.go` (`tryServer`) |
+| Presentation | `v2/cli/imr_dump_cmds.go`, `imr_cmds.go` |
+| Remote | `v2/apihandler_imr.go`, `v2/cli/imr_transport_stats_cmd.go` |
+
+---
+
+## Bottom line
+
+The implementation delivers what the design asked for in Phases 1–4, with the recommended truncation semantics. Remaining work is test hardening and small presentation consistency fixes — not a redesign.

--- a/v2/apihandler_imr.go
+++ b/v2/apihandler_imr.go
@@ -28,7 +28,7 @@ import (
 type ImrServerTransportStats struct {
 	Zone      string            `json:"zone"`
 	Server    string            `json:"server"`
-	Signal    string            `json:"signal,omitempty"`
+	Weights   map[string]uint8  `json:"weights,omitempty"` // advertised OOTS weights (name-keyed), for signal rendering
 	Attempted map[string]uint64 `json:"attempted,omitempty"`
 	Used      map[string]uint64 `json:"used,omitempty"`
 	Failed    map[string]uint64 `json:"failed,omitempty"`
@@ -48,20 +48,33 @@ func transportCountsToStrings(m map[core.Transport]uint64) map[string]uint64 {
 	return out
 }
 
+// transportWeightsToStrings converts a transport-keyed weight map to a
+// name-keyed one for JSON transport over the API.
+func transportWeightsToStrings(m map[core.Transport]uint8) map[string]uint8 {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]uint8, len(m))
+	for t, w := range m {
+		out[core.TransportToString[t]] = w
+	}
+	return out
+}
+
 func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
-		var amp AgentMgmtPost
+		var amp ImrMgmtPost
 		err := decoder.Decode(&amp)
 		if err != nil {
-			lgApi.Warn("error decoding agent command post", "err", err)
+			lgApi.Warn("error decoding imr command post", "err", err)
 			http.Error(w, fmt.Sprintf("Invalid request format: %v", err), http.StatusBadRequest)
 			return
 		}
 
 		lgApi.Debug("received /imr request", "cmd", amp.Command, "from", r.RemoteAddr)
 
-		resp := AgentMgmtResponse{
+		resp := ImrMgmtResponse{
 			Time: time.Now(),
 		}
 
@@ -160,10 +173,10 @@ func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 				resp.ErrorMsg = "IMR engine not available"
 				return
 			}
-			identity := string(amp.AgentId)
+			identity := amp.Id
 			if identity == "" {
 				resp.Error = true
-				resp.ErrorMsg = "agent_id (--id) is required"
+				resp.ErrorMsg = "id (--id) is required"
 				return
 			}
 			identity = dns.Fqdn(identity)
@@ -305,7 +318,7 @@ func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 					records = append(records, ImrServerTransportStats{
 						Zone:      item.Key,
 						Server:    name,
-						Signal:    server.TransportSignal,
+						Weights:   transportWeightsToStrings(server.GetTransportWeights()),
 						Attempted: transportCountsToStrings(ts.Attempted),
 						Used:      transportCountsToStrings(ts.Used),
 						Failed:    transportCountsToStrings(ts.Failed),

--- a/v2/apihandler_imr.go
+++ b/v2/apihandler_imr.go
@@ -22,6 +22,32 @@ import (
 // here, so the route and handler were renamed. tdns-mp keeps its
 // own /agent endpoint for MP-specific commands and now also exposes
 // /imr backed by an analogous APIimr handler.)
+// ImrServerTransportStats is the per-server transport-usage snapshot carried
+// over the /imr API for `tdns-cli imr stats transport-stats`. Count maps are
+// keyed by transport name (do53, do53-tcp, dot, doh, doq).
+type ImrServerTransportStats struct {
+	Zone      string            `json:"zone"`
+	Server    string            `json:"server"`
+	Signal    string            `json:"signal,omitempty"`
+	Attempted map[string]uint64 `json:"attempted,omitempty"`
+	Used      map[string]uint64 `json:"used,omitempty"`
+	Failed    map[string]uint64 `json:"failed,omitempty"`
+	Truncated uint64            `json:"truncated"`
+}
+
+// transportCountsToStrings converts a transport-keyed counter map to a
+// name-keyed one for JSON transport over the API.
+func transportCountsToStrings(m map[core.Transport]uint64) map[string]uint64 {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]uint64, len(m))
+	for t, c := range m {
+		out[core.TransportToString[t]] = c
+	}
+	return out
+}
+
 func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
@@ -256,6 +282,46 @@ func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 				}
 			} else {
 				resp.Msg = fmt.Sprintf("%d zone-scoped backoffs", len(records))
+			}
+
+		case "imr-transport-stats":
+			imr := Globals.ImrEngine
+			if imr == nil || imr.Cache == nil {
+				resp.Error = true
+				resp.ErrorMsg = "IMR engine not available"
+				return
+			}
+			zoneFilter, _ := amp.Data["zone"].(string)
+			if zoneFilter != "" {
+				zoneFilter = dns.Fqdn(zoneFilter)
+			}
+			var records []ImrServerTransportStats
+			for item := range imr.Cache.ServerMap.IterBuffered() {
+				if zoneFilter != "" && item.Key != zoneFilter {
+					continue
+				}
+				for name, server := range item.Val {
+					ts := server.SnapshotTransportStats()
+					records = append(records, ImrServerTransportStats{
+						Zone:      item.Key,
+						Server:    name,
+						Signal:    server.TransportSignal,
+						Attempted: transportCountsToStrings(ts.Attempted),
+						Used:      transportCountsToStrings(ts.Used),
+						Failed:    transportCountsToStrings(ts.Failed),
+						Truncated: ts.Truncated,
+					})
+				}
+			}
+			resp.Data = records
+			if len(records) == 0 {
+				if zoneFilter != "" {
+					resp.Msg = fmt.Sprintf("No auth servers recorded for %s", zoneFilter)
+				} else {
+					resp.Msg = "No auth servers recorded"
+				}
+			} else {
+				resp.Msg = fmt.Sprintf("Transport stats for %d server(s)", len(records))
 			}
 
 		default:

--- a/v2/apihandler_imr.go
+++ b/v2/apihandler_imr.go
@@ -35,6 +35,16 @@ type ImrServerTransportStats struct {
 	Truncated uint64            `json:"truncated"`
 }
 
+// transportName returns the string name for t, with a stable fallback so an
+// unregistered transport (a future enum value missing from TransportToString)
+// never produces an empty-string map key in the API JSON.
+func transportName(t core.Transport) string {
+	if name, ok := core.TransportToString[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown-%d", t)
+}
+
 // transportCountsToStrings converts a transport-keyed counter map to a
 // name-keyed one for JSON transport over the API.
 func transportCountsToStrings(m map[core.Transport]uint64) map[string]uint64 {
@@ -43,7 +53,7 @@ func transportCountsToStrings(m map[core.Transport]uint64) map[string]uint64 {
 	}
 	out := make(map[string]uint64, len(m))
 	for t, c := range m {
-		out[core.TransportToString[t]] = c
+		out[transportName(t)] = c
 	}
 	return out
 }
@@ -56,7 +66,7 @@ func transportWeightsToStrings(m map[core.Transport]uint8) map[string]uint8 {
 	}
 	out := make(map[string]uint8, len(m))
 	for t, w := range m {
-		out[core.TransportToString[t]] = w
+		out[transportName(t)] = w
 	}
 	return out
 }

--- a/v2/cache/authserver.go
+++ b/v2/cache/authserver.go
@@ -60,7 +60,10 @@ type AuthServer struct {
 	TLSARecords     map[string]*CachedRRset // keyed by owner (_port._proto.name.), validated RRsets only
 	// Stats (guarded by mu)
 	mu                sync.Mutex
-	TransportCounters map[core.Transport]uint64 // total queries attempted per transport
+	TransportCounters map[core.Transport]uint64 // queries ATTEMPTED per transport (transport chosen)
+	UsedCounters      map[core.Transport]uint64 // queries whose answer was CARRIED, by actual wire transport
+	FailedCounters    map[core.Transport]uint64 // attempts that ERRORED, by attempted transport
+	TruncatedCount    uint64                    // Do53/UDP responses TC=1 truncated and retried over TCP
 	Src               string                    // "answer", "glue", "hint", "priming", "stub", ...
 	Expire            time.Time
 	Debug             bool // If true, store error messages in AddressBackoff.LastError
@@ -460,6 +463,83 @@ func (as *AuthServer) IncrementTransportCounter(t core.Transport) {
 		as.TransportCounters = make(map[core.Transport]uint64)
 	}
 	as.TransportCounters[t]++
+}
+
+// IncrementUsedCounter records that a query's answer was carried over transport
+// t — the ACTUAL wire transport, which for Do53 may be Do53TCP after a fallback.
+func (as *AuthServer) IncrementUsedCounter(t core.Transport) {
+	if as == nil {
+		return
+	}
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	if as.UsedCounters == nil {
+		as.UsedCounters = make(map[core.Transport]uint64)
+	}
+	as.UsedCounters[t]++
+}
+
+// IncrementFailedCounter records a failed attempt over transport t (the
+// transport we chose to try; e.g. an unreachable DoQ the server advertised).
+func (as *AuthServer) IncrementFailedCounter(t core.Transport) {
+	if as == nil {
+		return
+	}
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	if as.FailedCounters == nil {
+		as.FailedCounters = make(map[core.Transport]uint64)
+	}
+	as.FailedCounters[t]++
+}
+
+// IncrementTruncated records one Do53/UDP response that was TC=1 truncated and
+// retried over TCP (a size-driven upgrade, not a failure).
+func (as *AuthServer) IncrementTruncated() {
+	if as == nil {
+		return
+	}
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	as.TruncatedCount++
+}
+
+// TransportStats is a consistent point-in-time snapshot of a server's
+// per-transport usage counters plus its truncation count. Attempted = queries
+// initiated (by the transport chosen); Used = queries whose answer was carried
+// (by the actual wire transport); Failed = attempts that errored (by the chosen
+// transport); Truncated = Do53/UDP responses TC=1 truncated and retried over TCP.
+type TransportStats struct {
+	Attempted map[core.Transport]uint64
+	Used      map[core.Transport]uint64
+	Failed    map[core.Transport]uint64
+	Truncated uint64
+}
+
+// SnapshotTransportStats returns a consistent copy of all per-transport usage
+// counters and the truncation count under a single lock.
+func (as *AuthServer) SnapshotTransportStats() TransportStats {
+	var ts TransportStats
+	if as == nil {
+		return ts
+	}
+	as.mu.Lock()
+	defer as.mu.Unlock()
+	cp := func(m map[core.Transport]uint64) map[core.Transport]uint64 {
+		if len(m) == 0 {
+			return nil
+		}
+		out := make(map[core.Transport]uint64, len(m))
+		for k, v := range m {
+			out[k] = v
+		}
+		return out
+	}
+	ts.Attempted = cp(as.TransportCounters)
+	ts.Used = cp(as.UsedCounters)
+	ts.Failed = cp(as.FailedCounters)
+	ts.Truncated = as.TruncatedCount
+	return ts
 }
 
 // SnapshotTransportCounters returns a thread-safe copy of the transport counters.

--- a/v2/cache/authserver_stats_test.go
+++ b/v2/cache/authserver_stats_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package cache
+
+import (
+	"testing"
+
+	core "github.com/johanix/tdns/v2/core"
+)
+
+// TestTransportStatsCounters exercises the four per-server transport counters
+// and the consolidated snapshot, including the attempted/used/failed/truncated
+// independence and that the snapshot is an isolated copy.
+func TestTransportStatsCounters(t *testing.T) {
+	s := NewAuthServer("ns.example.")
+
+	// One query attempted DoT (failed), fell back to Do53 (carried the answer);
+	// plus one Do53/UDP query that was TC=1 truncated and answered over Do53TCP.
+	s.IncrementTransportCounter(core.TransportDoT)  // attempted DoT
+	s.IncrementFailedCounter(core.TransportDoT)     // DoT failed (capability)
+	s.IncrementTransportCounter(core.TransportDo53) // attempted Do53
+	s.IncrementUsedCounter(core.TransportDo53)      // Do53 carried it
+	s.IncrementTransportCounter(core.TransportDo53) // attempted Do53 (the truncated one)
+	s.IncrementUsedCounter(core.TransportDo53TCP)   // truncation-upgraded answer
+	s.IncrementTruncated()
+
+	ts := s.SnapshotTransportStats()
+	if got := ts.Attempted[core.TransportDoT]; got != 1 {
+		t.Fatalf("attempted DoT = %d, want 1", got)
+	}
+	if got := ts.Attempted[core.TransportDo53]; got != 2 {
+		t.Fatalf("attempted Do53 = %d, want 2", got)
+	}
+	if got := ts.Failed[core.TransportDoT]; got != 1 {
+		t.Fatalf("failed DoT = %d, want 1", got)
+	}
+	if got := ts.Used[core.TransportDo53]; got != 1 {
+		t.Fatalf("used Do53 = %d, want 1", got)
+	}
+	if got := ts.Used[core.TransportDo53TCP]; got != 1 {
+		t.Fatalf("used Do53TCP = %d, want 1 (truncation upgrade must be visible)", got)
+	}
+	if ts.Truncated != 1 {
+		t.Fatalf("truncated = %d, want 1", ts.Truncated)
+	}
+
+	// The snapshot must be an isolated copy: mutating the server afterwards
+	// must not change the returned snapshot.
+	s.IncrementUsedCounter(core.TransportDo53)
+	if ts.Used[core.TransportDo53] != 1 {
+		t.Fatalf("snapshot not isolated: used Do53 changed to %d", ts.Used[core.TransportDo53])
+	}
+}

--- a/v2/chase_test.go
+++ b/v2/chase_test.go
@@ -20,6 +20,11 @@ type scriptedClient struct {
 
 func (s *scriptedClient) TransportKind() core.Transport { return core.TransportDo53 }
 
+func (s *scriptedClient) ExchangeWithResult(msg *dns.Msg, server string, debug bool) (*dns.Msg, time.Duration, core.ExchangeResult, error) {
+	r, rtt, err := s.Exchange(msg, server, debug)
+	return r, rtt, core.ExchangeResult{WireTransport: core.TransportDo53}, err
+}
+
 func (s *scriptedClient) Exchange(msg *dns.Msg, _ string, _ bool) (*dns.Msg, time.Duration, error) {
 	resp := new(dns.Msg)
 	resp.SetReply(msg)

--- a/v2/cli/agent_imr_cmds.go
+++ b/v2/cli/agent_imr_cmds.go
@@ -41,7 +41,7 @@ func newImrQueryCmd(role string) *cobra.Command {
 			qname := dns.Fqdn(args[0])
 			qtype := args[1]
 
-			amr, err := SendImrMgmtCmd(role, &tdns.AgentMgmtPost{
+			amr, err := SendImrMgmtCmd(role, &tdns.ImrMgmtPost{
 				Command: "imr-query",
 				Data: map[string]interface{}{
 					"qname": qname,
@@ -87,7 +87,7 @@ func newImrFlushCmd(role string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			qname := dns.Fqdn(args[0])
-			amr, err := SendImrMgmtCmd(role, &tdns.AgentMgmtPost{
+			amr, err := SendImrMgmtCmd(role, &tdns.ImrMgmtPost{
 				Command: "imr-flush",
 				Data:    map[string]interface{}{"qname": qname},
 			})
@@ -108,7 +108,7 @@ func newImrResetCmd(role string) *cobra.Command {
 		Use:   "reset",
 		Short: "Flush entire IMR cache and re-prime (preserves root NS)",
 		Run: func(cmd *cobra.Command, args []string) {
-			amr, err := SendImrMgmtCmd(role, &tdns.AgentMgmtPost{Command: "imr-reset"})
+			amr, err := SendImrMgmtCmd(role, &tdns.ImrMgmtPost{Command: "imr-reset"})
 			if err != nil {
 				log.Fatalf("Request failed: %v", err)
 			}
@@ -130,9 +130,9 @@ func newImrShowCmd(role string) *cobra.Command {
 			if imrShowID == "" {
 				log.Fatal("--id flag is required")
 			}
-			amr, err := SendImrMgmtCmd(role, &tdns.AgentMgmtPost{
+			amr, err := SendImrMgmtCmd(role, &tdns.ImrMgmtPost{
 				Command: "imr-show",
-				AgentId: tdns.AgentId(imrShowID),
+				Id:      imrShowID,
 			})
 			if err != nil {
 				log.Fatalf("Request failed: %v", err)
@@ -181,7 +181,7 @@ func newImrDumpTuningCmd(role string) *cobra.Command {
 		Use:   "dump-tuning",
 		Short: "Show effective IMR tuning values (backoff policy, family, discovery, etc.)",
 		Run: func(cmd *cobra.Command, args []string) {
-			amr, err := SendImrMgmtCmd(role, &tdns.AgentMgmtPost{Command: "imr-dump-tuning"})
+			amr, err := SendImrMgmtCmd(role, &tdns.ImrMgmtPost{Command: "imr-dump-tuning"})
 			if err != nil {
 				log.Fatalf("Request failed: %v", err)
 			}
@@ -233,7 +233,7 @@ func newImrDumpZoneBackoffsCmd(role string) *cobra.Command {
 			if len(args) == 1 {
 				data["zone"] = dns.Fqdn(args[0])
 			}
-			amr, err := SendImrMgmtCmd(role, &tdns.AgentMgmtPost{
+			amr, err := SendImrMgmtCmd(role, &tdns.ImrMgmtPost{
 				Command: "imr-dump-zone-backoffs",
 				Data:    data,
 			})

--- a/v2/cli/imr_cmds.go
+++ b/v2/cli/imr_cmds.go
@@ -240,13 +240,7 @@ var imrStatsAuthTransportsCmd = &cobra.Command{
 				fmt.Printf("\nServer: %s\n", name)
 				// Show received transport percentage signal (pct). If none: do53=100
 				fmt.Printf("  signal: %s\n", renderSignal(server))
-				counters := server.SnapshotCounters()
-				order := []core.Transport{core.TransportDo53, core.TransportDoT, core.TransportDoH, core.TransportDoQ}
-				for _, t := range order {
-					if c, ok := counters[t]; ok && c > 0 {
-						fmt.Printf("  %-4s: %d\n", core.TransportToString[t], c)
-					}
-				}
+				fmt.Printf("  %s\n", formatTransportCounters(server))
 			}
 			return
 		}
@@ -259,13 +253,7 @@ var imrStatsAuthTransportsCmd = &cobra.Command{
 			for name, server := range serverMap {
 				fmt.Printf("  Server: %s\n", name)
 				fmt.Printf("    signal: %s\n", renderSignal(server))
-				counters := server.SnapshotCounters()
-				order := []core.Transport{core.TransportDo53, core.TransportDoT, core.TransportDoH, core.TransportDoQ}
-				for _, t := range order {
-					if c, ok := counters[t]; ok && c > 0 {
-						fmt.Printf("    %-4s: %d\n", core.TransportToString[t], c)
-					}
-				}
+				fmt.Printf("    %s\n", formatTransportCounters(server))
 			}
 		}
 	},

--- a/v2/cli/imr_cmds.go
+++ b/v2/cli/imr_cmds.go
@@ -445,10 +445,17 @@ var imrShowOptionsCmd = &cobra.Command{
 
 // renderSignal formats the received transport percentage signal. If none, returns "do53=100".
 func renderSignal(server *cache.AuthServer) string {
+	return renderSignalFromWeights(server.GetTransportWeights())
+}
+
+// renderSignalFromWeights formats advertised OOTS weights as "doq=20,dot=10,..."
+// (order-stable, non-zero only), falling back to "do53=100" when absent. Shared
+// by the in-process REPL and the remote transport-stats renderer so the signal
+// looks identical either way (fixes the REPL-vs-remote drift).
+func renderSignalFromWeights(weights map[core.Transport]uint8) string {
 	// Prefer showing only the received signal (SVCB pct). If absent, fallback to do53=100.
 	// Order by known transports for stable output.
 	order := []core.Transport{core.TransportDoQ, core.TransportDoT, core.TransportDoH, core.TransportDo53}
-	weights := server.TransportWeights
 	if len(weights) == 0 {
 		return "do53=100"
 	}

--- a/v2/cli/imr_dump_cmds.go
+++ b/v2/cli/imr_dump_cmds.go
@@ -744,30 +744,53 @@ func formatTransport(t core.Transport) string {
 	return "unknown"
 }
 
-// formatTransportCounters formats the transport usage counters for display.
-// Returns a string showing queries sent per transport, ordered by transport type.
-// Example: "doq:1234 dot:567 do53:89"
-func formatTransportCounters(server *cache.AuthServer) string {
-	if server == nil {
-		return ""
-	}
-	counters := server.SnapshotTransportCounters()
-	if len(counters) == 0 {
+// transportDisplayOrder is the canonical order for rendering per-transport
+// counters. It includes Do53TCP — both the proactive force-TCP path and the
+// TC=1 truncation upgrade land there — which the earlier renderers dropped,
+// silently undercounting the totals.
+var transportDisplayOrder = []core.Transport{
+	core.TransportDo53, core.TransportDo53TCP,
+	core.TransportDoT, core.TransportDoH, core.TransportDoQ,
+}
+
+// formatTransportCountMap renders a per-transport count map in canonical order
+// (including do53-tcp), non-zero entries only, with a complete total.
+func formatTransportCountMap(m map[core.Transport]uint64) string {
+	if len(m) == 0 {
 		return "none"
 	}
-	order := []core.Transport{core.TransportDoQ, core.TransportDoT, core.TransportDoH, core.TransportDo53}
 	var parts []string
 	var total uint64
-	for _, t := range order {
-		if count, ok := counters[t]; ok && count > 0 {
-			parts = append(parts, fmt.Sprintf("%s:%d", core.TransportToString[t], count))
-			total += count
+	for _, t := range transportDisplayOrder {
+		if c := m[t]; c > 0 {
+			parts = append(parts, fmt.Sprintf("%s:%d", core.TransportToString[t], c))
+			total += c
 		}
 	}
 	if len(parts) == 0 {
 		return "none"
 	}
 	return fmt.Sprintf("%s (total: %d)", strings.Join(parts, " "), total)
+}
+
+// formatTransportStats renders the full per-server transport-usage matrix:
+// attempted / used / failed counts (all transports, incl. do53-tcp) and the
+// TC=1 truncation count. Shared by the interactive REPL dump and the
+// tdns-cli imr transport-stats command so the two cannot drift.
+func formatTransportStats(ts cache.TransportStats) string {
+	return fmt.Sprintf("attempted=[%s] used=[%s] failed=[%s] truncated=%d",
+		formatTransportCountMap(ts.Attempted),
+		formatTransportCountMap(ts.Used),
+		formatTransportCountMap(ts.Failed),
+		ts.Truncated)
+}
+
+// formatTransportCounters renders a server's transport-usage stats for display.
+func formatTransportCounters(server *cache.AuthServer) string {
+	if server == nil {
+		return ""
+	}
+	return formatTransportStats(server.SnapshotTransportStats())
 }
 
 // If the state has no known mapping, it returns "[unset]".

--- a/v2/cli/imr_dump_cmds.go
+++ b/v2/cli/imr_dump_cmds.go
@@ -776,7 +776,11 @@ func formatTransportCountMap(m map[core.Transport]uint64) string {
 // formatTransportStats renders the full per-server transport-usage matrix:
 // attempted / used / failed counts (all transports, incl. do53-tcp) and the
 // TC=1 truncation count. Shared by the interactive REPL dump and the
-// tdns-cli imr transport-stats command so the two cannot drift.
+// `tdns-cli imr stats transport-stats` command so the two cannot drift.
+//
+// Note: the DNS-truncation (large-response) signal is the `truncated` count,
+// NOT `used[do53-tcp]` — the latter also includes proactive force-TCP and
+// UDP-transient-error retries.
 func formatTransportStats(ts cache.TransportStats) string {
 	return fmt.Sprintf("attempted=[%s] used=[%s] failed=[%s] truncated=%d",
 		formatTransportCountMap(ts.Attempted),

--- a/v2/cli/imr_mgmt.go
+++ b/v2/cli/imr_mgmt.go
@@ -10,12 +10,12 @@ import (
 	tdns "github.com/johanix/tdns/v2"
 )
 
-// SendImrMgmtCmd POSTs an AgentMgmtPost to the configured daemon's
+// SendImrMgmtCmd POSTs an ImrMgmtPost to the configured daemon's
 // /imr endpoint. The role argument selects which ApiClient to use --
 // "agent" (tdns-agent), "auth" (tdns-auth), or "imr" (tdns-imr).
 // This is the IMR-only sibling of SendAgentMgmtCmd (which targets
 // /agent and is kept around for non-IMR commands like parentsync-*).
-func SendImrMgmtCmd(role string, req *tdns.AgentMgmtPost) (*tdns.AgentMgmtResponse, error) {
+func SendImrMgmtCmd(role string, req *tdns.ImrMgmtPost) (*tdns.ImrMgmtResponse, error) {
 	api, err := GetApiClient(role, true)
 	if err != nil {
 		return nil, fmt.Errorf("getting API client for role %q: %w", role, err)
@@ -26,7 +26,7 @@ func SendImrMgmtCmd(role string, req *tdns.AgentMgmtPost) (*tdns.AgentMgmtRespon
 		return nil, fmt.Errorf("API request failed: %v", err)
 	}
 
-	var amr tdns.AgentMgmtResponse
+	var amr tdns.ImrMgmtResponse
 	if err := json.Unmarshal(buf, &amr); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %v", err)
 	}

--- a/v2/cli/imr_transport_stats_cmd.go
+++ b/v2/cli/imr_transport_stats_cmd.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+
+	tdns "github.com/johanix/tdns/v2"
+	"github.com/johanix/tdns/v2/cache"
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+	"github.com/spf13/cobra"
+)
+
+// imrStatsTransportStatsCmd is the REMOTE counterpart of the in-process
+// auth-transports view: it fetches per-server transport-usage stats from a
+// running tdns-imr over the /imr API and renders the full matrix (attempted /
+// used / failed incl. do53-tcp, plus TC=1 truncations) using the SAME formatter
+// as the interactive dump, so the two cannot drift.
+var imrStatsTransportStatsCmd = &cobra.Command{
+	Use:   "transport-stats [zone]",
+	Short: "Show per-server transport-usage stats from a running tdns-imr (via API)",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		data := map[string]interface{}{}
+		if len(args) == 1 {
+			data["zone"] = dns.Fqdn(args[0])
+		}
+		amr, err := SendImrMgmtCmd("imr", &tdns.AgentMgmtPost{
+			Command: "imr-transport-stats",
+			Data:    data,
+		})
+		if err != nil {
+			log.Fatalf("Request failed: %v", err)
+		}
+		if amr.Error {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", amr.ErrorMsg)
+			os.Exit(1)
+		}
+		fmt.Println(amr.Msg)
+
+		// resp.Data is generic JSON; re-marshal into the typed record slice.
+		raw, err := json.Marshal(amr.Data)
+		if err != nil {
+			log.Fatalf("failed to read response: %v", err)
+		}
+		var records []tdns.ImrServerTransportStats
+		if err := json.Unmarshal(raw, &records); err != nil {
+			log.Fatalf("failed to parse response: %v", err)
+		}
+		sort.Slice(records, func(i, j int) bool {
+			if records[i].Zone != records[j].Zone {
+				return records[i].Zone < records[j].Zone
+			}
+			return records[i].Server < records[j].Server
+		})
+		var lastZone string
+		for _, rec := range records {
+			if rec.Zone != lastZone {
+				fmt.Printf("\nZone: %s\n", rec.Zone)
+				lastZone = rec.Zone
+			}
+			fmt.Printf("  Server: %s\n", rec.Server)
+			if rec.Signal != "" {
+				fmt.Printf("    signal: %s\n", rec.Signal)
+			}
+			fmt.Printf("    %s\n", formatTransportStats(imrServerStatsToTransportStats(rec)))
+		}
+	},
+}
+
+// imrServerStatsToTransportStats converts the name-keyed API record into the
+// transport-keyed cache.TransportStats the shared formatter consumes.
+func imrServerStatsToTransportStats(s tdns.ImrServerTransportStats) cache.TransportStats {
+	conv := func(m map[string]uint64) map[core.Transport]uint64 {
+		if len(m) == 0 {
+			return nil
+		}
+		out := make(map[core.Transport]uint64, len(m))
+		for k, v := range m {
+			if t, err := core.StringToTransport(k); err == nil {
+				out[t] = v
+			}
+		}
+		return out
+	}
+	return cache.TransportStats{
+		Attempted: conv(s.Attempted),
+		Used:      conv(s.Used),
+		Failed:    conv(s.Failed),
+		Truncated: s.Truncated,
+	}
+}
+
+func init() {
+	ImrStatsCmd.AddCommand(imrStatsTransportStatsCmd)
+}

--- a/v2/cli/imr_transport_stats_cmd.go
+++ b/v2/cli/imr_transport_stats_cmd.go
@@ -32,7 +32,7 @@ var imrStatsTransportStatsCmd = &cobra.Command{
 		if len(args) == 1 {
 			data["zone"] = dns.Fqdn(args[0])
 		}
-		amr, err := SendImrMgmtCmd("imr", &tdns.AgentMgmtPost{
+		amr, err := SendImrMgmtCmd("imr", &tdns.ImrMgmtPost{
 			Command: "imr-transport-stats",
 			Data:    data,
 		})
@@ -67,9 +67,7 @@ var imrStatsTransportStatsCmd = &cobra.Command{
 				lastZone = rec.Zone
 			}
 			fmt.Printf("  Server: %s\n", rec.Server)
-			if rec.Signal != "" {
-				fmt.Printf("    signal: %s\n", rec.Signal)
-			}
+			fmt.Printf("    signal: %s\n", renderSignalFromWeights(weightsStringToTransport(rec.Weights)))
 			fmt.Printf("    %s\n", formatTransportStats(imrServerStatsToTransportStats(rec)))
 		}
 	},
@@ -84,9 +82,14 @@ func imrServerStatsToTransportStats(s tdns.ImrServerTransportStats) cache.Transp
 		}
 		out := make(map[core.Transport]uint64, len(m))
 		for k, v := range m {
-			if t, err := core.StringToTransport(k); err == nil {
-				out[t] = v
+			t, err := core.StringToTransport(k)
+			if err != nil {
+				// Don't silently drop: an unrecognized transport name (imr newer
+				// than this cli) would otherwise undercount the totals.
+				fmt.Fprintf(os.Stderr, "warning: unrecognized transport %q (count %d) omitted — imr/cli version skew?\n", k, v)
+				continue
 			}
+			out[t] = v
 		}
 		return out
 	}
@@ -96,6 +99,21 @@ func imrServerStatsToTransportStats(s tdns.ImrServerTransportStats) cache.Transp
 		Failed:    conv(s.Failed),
 		Truncated: s.Truncated,
 	}
+}
+
+// weightsStringToTransport converts a name-keyed weight map (from the API) into
+// a transport-keyed one for the shared signal renderer.
+func weightsStringToTransport(m map[string]uint8) map[core.Transport]uint8 {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[core.Transport]uint8, len(m))
+	for k, v := range m {
+		if t, err := core.StringToTransport(k); err == nil {
+			out[t] = v
+		}
+	}
+	return out
 }
 
 func init() {

--- a/v2/cli/transport_stats_format_test.go
+++ b/v2/cli/transport_stats_format_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/johanix/tdns/v2/cache"
+	core "github.com/johanix/tdns/v2/core"
+)
+
+// TestFormatTransportStats_IncludesDo53TCPAndTotal guards the P3 fix: Do53TCP
+// must appear and the totals must include it (the old renderers dropped it).
+func TestFormatTransportStats_IncludesDo53TCPAndTotal(t *testing.T) {
+	ts := cache.TransportStats{
+		Attempted: map[core.Transport]uint64{
+			core.TransportDo53:    90,
+			core.TransportDo53TCP: 10, // must NOT be dropped
+			core.TransportDoQ:     5,
+		},
+		Used:      map[core.Transport]uint64{core.TransportDo53TCP: 12},
+		Failed:    map[core.Transport]uint64{core.TransportDoQ: 3},
+		Truncated: 7,
+	}
+	out := formatTransportStats(ts)
+
+	for _, want := range []string{
+		"do53-tcp:10",     // Do53TCP attempted is rendered
+		"total: 105",      // attempted total includes do53-tcp (90+10+5)
+		"used=[do53-tcp:12", // used Do53TCP rendered
+		"failed=[doq:3",
+		"truncated=7",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("formatTransportStats missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+// TestFormatTransportCountMap_EmptyIsNone: an empty counter map renders "none".
+func TestFormatTransportCountMap_EmptyIsNone(t *testing.T) {
+	if got := formatTransportCountMap(nil); got != "none" {
+		t.Fatalf(`empty map should render "none", got %q`, got)
+	}
+}

--- a/v2/core/dnsclient.go
+++ b/v2/core/dnsclient.go
@@ -82,6 +82,7 @@ func IsEncryptedTransport(t Transport) bool {
 // variant can be added without breaking this interface.
 type DNSClienter interface {
 	Exchange(msg *dns.Msg, server string, debug bool) (*dns.Msg, time.Duration, error)
+	ExchangeWithResult(msg *dns.Msg, server string, debug bool) (*dns.Msg, time.Duration, ExchangeResult, error)
 	TransportKind() Transport
 }
 
@@ -203,13 +204,28 @@ func NewDNSClient(transport Transport, port string, tlsConfig *tls.Config, opts 
 // Satisfies the DNSClienter interface.
 func (c *DNSClient) TransportKind() Transport { return c.Transport }
 
-// Exchange sends a DNS message and returns the response
+// ExchangeResult describes what actually happened on the wire for an Exchange:
+// the transport that carried the returned response (Do53 vs Do53TCP after an
+// internal fallback) and whether a Do53/UDP response was TC=1 truncated and
+// retried over TCP. The IMR uses this to record accurate per-server
+// transport-usage and truncation statistics; the plain Exchange wrapper below
+// discards it so existing callers are unaffected.
+type ExchangeResult struct {
+	WireTransport Transport // transport that carried the returned response
+	Truncated     bool      // a Do53/UDP response had TC=1 and was retried over TCP
+}
+
+// Exchange sends a DNS message and returns the response. Thin wrapper over
+// ExchangeWithResult that discards the wire-transport/truncation detail.
 func (c *DNSClient) Exchange(msg *dns.Msg, server string, debug bool) (*dns.Msg, time.Duration, error) {
-	//	if !Globals.Debug {
-	//		fmt.Printf("*** Exchange: Globals.Debug is NOT set\n")
-	//	} else {
-	//		fmt.Printf("*** Exchange: Globals.Debug is set\n")
-	//	}
+	r, rtt, _, err := c.ExchangeWithResult(msg, server, debug)
+	return r, rtt, err
+}
+
+// ExchangeWithResult is Exchange plus an ExchangeResult reporting the actual
+// wire transport used and whether a TC=1 truncation drove a UDP->TCP upgrade.
+// The (msg, rtt, err) return values are identical to Exchange's.
+func (c *DNSClient) ExchangeWithResult(msg *dns.Msg, server string, debug bool) (*dns.Msg, time.Duration, ExchangeResult, error) {
 	if debug {
 		fmt.Printf("*** Exchange: sending %s message to %s:%s opcode: %s qname: %s rrtype: %s\n",
 			TransportToString[c.Transport], server, c.Port,
@@ -227,38 +243,44 @@ func (c *DNSClient) Exchange(msg *dns.Msg, server string, debug bool) (*dns.Msg,
 		}
 		addr := net.JoinHostPort(server, c.Port)
 		if c.ForceTCP {
-			return c.DNSClientTCP.Exchange(msg, addr)
+			r, rtt, err := c.DNSClientTCP.Exchange(msg, addr)
+			return r, rtt, ExchangeResult{WireTransport: TransportDo53TCP}, err
 		}
 		r, rtt, err := c.DNSClientUDP.Exchange(msg, addr)
 		if err == nil && r != nil && r.Truncated && !c.DisableFallback && c.DNSClientTCP != nil {
 			log.Printf("Do53: UDP response from %s truncated (TC=1); retrying over TCP", addr)
-			return c.DNSClientTCP.Exchange(msg, addr)
+			tr, trtt, terr := c.DNSClientTCP.Exchange(msg, addr)
+			return tr, trtt, ExchangeResult{WireTransport: TransportDo53TCP, Truncated: true}, terr
 		}
 		// Timeout / transient-error fallback: a single dropped UDP packet
 		// (or a network blocking UDP) makes the UDP exchange return a transient
 		// error. Take one shot over TCP against the same address before giving
 		// up. This consolidates what used to live in the IMR tryServer path.
+		// (This is NOT a truncation — Truncated stays false.)
 		if err != nil && !c.DisableFallback && c.DNSClientTCP != nil && IsTransientNetErr(err) {
 			if debug {
 				log.Printf("Do53: UDP transient error from %s (%v); retrying over TCP", addr, err)
 			}
 			tr, trtt, terr := c.DNSClientTCP.Exchange(msg, addr)
 			if terr == nil {
-				return tr, trtt, nil
+				return tr, trtt, ExchangeResult{WireTransport: TransportDo53TCP}, nil
 			}
 			// Prefer the original UDP error if TCP also fails (operators usually
 			// want to know the primary-path symptom).
-			return r, rtt, err
+			return r, rtt, ExchangeResult{WireTransport: TransportDo53}, err
 		}
-		return r, rtt, err
+		return r, rtt, ExchangeResult{WireTransport: TransportDo53}, err
 	case TransportDoT:
-		return c.DNSClientTLS.Exchange(msg, net.JoinHostPort(server, c.Port))
+		r, rtt, err := c.DNSClientTLS.Exchange(msg, net.JoinHostPort(server, c.Port))
+		return r, rtt, ExchangeResult{WireTransport: TransportDoT}, err
 	case TransportDoH:
-		return c.exchangeDoH(msg, server, debug)
+		r, rtt, err := c.exchangeDoH(msg, server, debug)
+		return r, rtt, ExchangeResult{WireTransport: TransportDoH}, err
 	case TransportDoQ:
-		return c.exchangeDoQ(msg, net.JoinHostPort(server, c.Port), debug)
+		r, rtt, err := c.exchangeDoQ(msg, net.JoinHostPort(server, c.Port), debug)
+		return r, rtt, ExchangeResult{WireTransport: TransportDoQ}, err
 	default:
-		return nil, 0, fmt.Errorf("unsupported transport protocol: %d", c.Transport)
+		return nil, 0, ExchangeResult{WireTransport: c.Transport}, fmt.Errorf("unsupported transport protocol: %d", c.Transport)
 	}
 }
 

--- a/v2/core/dnsclient_fake.go
+++ b/v2/core/dnsclient_fake.go
@@ -91,7 +91,9 @@ func (f *FakeDNSClient) Exchange(msg *dns.Msg, server string, debug bool) (*dns.
 func (f *FakeDNSClient) ExchangeWithResult(msg *dns.Msg, server string, debug bool) (*dns.Msg, time.Duration, ExchangeResult, error) {
 	r, rtt, err := f.Exchange(msg, server, debug)
 	res := ExchangeResult{WireTransport: f.transport}
-	if err == nil && r != nil && r.Truncated && (f.transport == TransportDo53 || f.transport == TransportDo53TCP) {
+	// Only a Do53/UDP response truncates; a Do53TCP transport is native TCP and
+	// never reports truncation (mirrors the real DNSClient's ForceTCP path).
+	if err == nil && r != nil && r.Truncated && f.transport == TransportDo53 {
 		res.WireTransport = TransportDo53TCP
 		res.Truncated = true
 	}

--- a/v2/core/dnsclient_fake.go
+++ b/v2/core/dnsclient_fake.go
@@ -84,6 +84,20 @@ func (f *FakeDNSClient) Exchange(msg *dns.Msg, server string, debug bool) (*dns.
 	return nil, 0, fmt.Errorf("FakeDNSClient: no programmed response for %s @ %s", qname, server)
 }
 
+// ExchangeWithResult satisfies DNSClienter. The fake performs no real UDP->TCP
+// fallback; it reports its own transport as the wire transport, and flags a
+// truncation (with a Do53TCP wire transport) when a programmed Do53 response
+// has the TC bit set — enough to exercise truncation-stat paths in tests.
+func (f *FakeDNSClient) ExchangeWithResult(msg *dns.Msg, server string, debug bool) (*dns.Msg, time.Duration, ExchangeResult, error) {
+	r, rtt, err := f.Exchange(msg, server, debug)
+	res := ExchangeResult{WireTransport: f.transport}
+	if err == nil && r != nil && r.Truncated && (f.transport == TransportDo53 || f.transport == TransportDo53TCP) {
+		res.WireTransport = TransportDo53TCP
+		res.Truncated = true
+	}
+	return r, rtt, res, err
+}
+
 // Set installs a response. Convenience wrapper around direct map assignment.
 func (f *FakeDNSClient) Set(qname, addr string, resp FakeResponse) {
 	f.mu.Lock()

--- a/v2/core/exchange_result_realclient_test.go
+++ b/v2/core/exchange_result_realclient_test.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestExchangeWithResult_Do53_WirePaths drives the REAL DNSClient over the test
+// UDP+TCP servers and asserts the ExchangeResult for the three Do53 outcomes:
+//   - TC=1 UDP → TCP: WireTransport=Do53TCP, Truncated=true
+//   - clean UDP:      WireTransport=Do53,    Truncated=false
+//   - UDP timeout → TCP (transient fallback): WireTransport=Do53TCP, Truncated=false
+func TestExchangeWithResult_Do53_WirePaths(t *testing.T) {
+	newClient := func(port string, udpTimeout, tcpTimeout time.Duration) *DNSClient {
+		c := NewDNSClient(TransportDo53, port, nil)
+		c.Timeout = 2 * time.Second
+		c.DNSClientUDP.Timeout = udpTimeout
+		c.DNSClientTCP.Timeout = tcpTimeout
+		return c
+	}
+
+	t.Run("truncation", func(t *testing.T) {
+		const qname = "tcr.example."
+		udp := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.Truncated = true
+			_ = w.WriteMsg(m)
+		})
+		tcp := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.Answer = []dns.RR{aRR(qname, "192.0.2.1")}
+			_ = w.WriteMsg(m)
+		})
+		port, cleanup := testServers(t, udp, tcp)
+		defer cleanup()
+		_, _, res, err := newClient(port, 2*time.Second, 2*time.Second).
+			ExchangeWithResult(mustQuery(qname), "127.0.0.1", false)
+		if err != nil {
+			t.Fatalf("ExchangeWithResult: %v", err)
+		}
+		if res.WireTransport != TransportDo53TCP || !res.Truncated {
+			t.Fatalf("truncation: got %+v, want {Do53TCP, Truncated:true}", res)
+		}
+	})
+
+	t.Run("clean", func(t *testing.T) {
+		const qname = "ok.example."
+		udp := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.Answer = []dns.RR{aRR(qname, "192.0.2.2")}
+			_ = w.WriteMsg(m)
+		})
+		tcp := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			_ = w.WriteMsg(m)
+		})
+		port, cleanup := testServers(t, udp, tcp)
+		defer cleanup()
+		_, _, res, err := newClient(port, 2*time.Second, 2*time.Second).
+			ExchangeWithResult(mustQuery(qname), "127.0.0.1", false)
+		if err != nil {
+			t.Fatalf("ExchangeWithResult: %v", err)
+		}
+		if res.WireTransport != TransportDo53 || res.Truncated {
+			t.Fatalf("clean: got %+v, want {Do53, Truncated:false}", res)
+		}
+	})
+
+	t.Run("timeout_fallback", func(t *testing.T) {
+		const qname = "tof.example."
+		udp := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			time.Sleep(2 * time.Second) // force UDP timeout → transient fallback to TCP
+		})
+		tcp := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.Answer = []dns.RR{aRR(qname, "192.0.2.3")}
+			_ = w.WriteMsg(m)
+		})
+		port, cleanup := testServers(t, udp, tcp)
+		defer cleanup()
+		_, _, res, err := newClient(port, 200*time.Millisecond, 2*time.Second).
+			ExchangeWithResult(mustQuery(qname), "127.0.0.1", false)
+		if err != nil {
+			t.Fatalf("ExchangeWithResult: %v", err)
+		}
+		// TCP was used, but a transient-error fallback is NOT a truncation.
+		if res.WireTransport != TransportDo53TCP || res.Truncated {
+			t.Fatalf("timeout_fallback: got %+v, want {Do53TCP, Truncated:false}", res)
+		}
+	})
+}

--- a/v2/core/exchange_result_test.go
+++ b/v2/core/exchange_result_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package core
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestFakeExchangeWithResult verifies the ExchangeResult reporting: a plain
+// Do53 answer reports WireTransport=Do53/Truncated=false, while a TC=1
+// (truncated) Do53 response reports WireTransport=Do53TCP/Truncated=true.
+func TestFakeExchangeWithResult(t *testing.T) {
+	f := NewFakeDNSClient(TransportDo53)
+
+	q := new(dns.Msg)
+	q.SetQuestion("plain.example.", dns.TypeA)
+	resp := new(dns.Msg)
+	resp.SetReply(q)
+	f.Set("plain.example.", "1.2.3.4", FakeResponse{Msg: resp})
+
+	_, _, res, err := f.ExchangeWithResult(q, "1.2.3.4", false)
+	if err != nil {
+		t.Fatalf("plain exchange err: %v", err)
+	}
+	if res.WireTransport != TransportDo53 || res.Truncated {
+		t.Fatalf("plain: got %+v, want {Do53,false}", res)
+	}
+
+	tq := new(dns.Msg)
+	tq.SetQuestion("trunc.example.", dns.TypeA)
+	tresp := new(dns.Msg)
+	tresp.SetReply(tq)
+	tresp.Truncated = true
+	f.Set("trunc.example.", "1.2.3.4", FakeResponse{Msg: tresp})
+
+	_, _, res2, err := f.ExchangeWithResult(tq, "1.2.3.4", false)
+	if err != nil {
+		t.Fatalf("truncated exchange err: %v", err)
+	}
+	if res2.WireTransport != TransportDo53TCP || !res2.Truncated {
+		t.Fatalf("truncated: got %+v, want {Do53TCP,true}", res2)
+	}
+}

--- a/v2/dnslookup.go
+++ b/v2/dnslookup.go
@@ -1909,18 +1909,25 @@ func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr st
 		}
 	}
 
-	// Single Exchange call: c.Exchange handles TC=1 and UDP-transient-error
-	// TCP fallback internally for Do53. DoT/DoH/DoQ have no fallback path.
-	// The Exchange timeout bounds wall time per call; the overall query budget
-	// (W2) bounds the wider iterative loop.
+	// Single Exchange call: ExchangeWithResult handles TC=1 and
+	// UDP-transient-error TCP fallback internally for Do53 (DoT/DoH/DoQ have no
+	// fallback path) and additionally reports the actual wire transport used and
+	// whether a TC=1 truncation drove a UDP->TCP upgrade — used below for the
+	// per-server transport-usage / truncation stats. The Exchange timeout bounds
+	// wall time per call; the overall query budget (W2) bounds the iterative loop.
 	//
 	// We measure wall-clock RTT ourselves instead of trusting the rtt returned
 	// by Exchange, because Exchange's TCP fallback path returns only the TCP
 	// rtt and hides any preceding UDP-timeout cost. The wall-clock value is
 	// what we actually care about for prioritization.
 	start := time.Now()
-	r, _, err := c.Exchange(m, addr, Globals.Debug && !imr.Quiet)
+	r, _, xres, err := c.ExchangeWithResult(m, addr, Globals.Debug && !imr.Quiet)
 	rtt := time.Since(start)
+	// A TC=1 truncation upgrade is a size-driven fact about this exchange (not a
+	// failure); record it regardless of the subsequent TCP outcome.
+	if xres.Truncated {
+		server.IncrementTruncated()
+	}
 	imr.FamilyTracker.RecordResult(addr, err == nil && r != nil)
 	if err != nil {
 		lgDns.Error("*** tryServer: query returned error",
@@ -1930,6 +1937,7 @@ func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr st
 			"transport", core.TransportToString[eff],
 			"error", err)
 		server.RecordAddressFailure(addr, eff, err)
+		server.IncrementFailedCounter(eff)
 		// Penalty RTT: record the full elapsed time so a slow-failing path
 		// naturally sorts to the bottom of prioritizeServers even after the
 		// backoff lifts.
@@ -1938,6 +1946,7 @@ func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr st
 	}
 	if r != nil {
 		server.RecordAddressSuccess(addr, eff)
+		server.IncrementUsedCounter(xres.WireTransport)
 		server.RecordRTT(addr, eff, rtt)
 	} else if Globals.Debug {
 		lgDns.Debug("*** tryServer: query returned no response",

--- a/v2/dnslookup.go
+++ b/v2/dnslookup.go
@@ -1937,7 +1937,12 @@ func (imr *Imr) tryServer(ctx context.Context, server *cache.AuthServer, addr st
 			"transport", core.TransportToString[eff],
 			"error", err)
 		server.RecordAddressFailure(addr, eff, err)
-		server.IncrementFailedCounter(eff)
+		// Stats: key failed on the ACTUAL wire transport (symmetric with used on
+		// success). A TC=1-then-TCP failure is thus attributed to Do53TCP, and
+		// failed[Do53] stays 0 — preserving "failed[Do53]=0 => size upgrade".
+		// (RecordAddressFailure/RecordRTT stay on eff: backoff is keyed by the
+		// attempted (addr, transport) tuple, a separate concern from usage stats.)
+		server.IncrementFailedCounter(xres.WireTransport)
 		// Penalty RTT: record the full elapsed time so a slow-failing path
 		// naturally sorts to the bottom of prioritizeServers even after the
 		// backoff lifts.

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -951,6 +951,28 @@ type AgentMgmtResponse struct {
 	Data     interface{} `json:"data,omitempty"` // Generic data field for custom responses
 }
 
+// ImrMgmtPost is a management request to a daemon's /imr endpoint (tdns-imr, or
+// an agent/auth hosting an in-process IMR). Dedicated to the IMR mgmt API — it
+// deliberately does NOT reuse AgentMgmtPost, whose agent/RR fields are unrelated
+// to IMR operations and whose overloading here would be a future footgun.
+type ImrMgmtPost struct {
+	Command  string                 `json:"command"`
+	Zone     ZoneName               `json:"zone,omitempty"`
+	Id       string                 `json:"id,omitempty"`   // e.g. imr-show: cache identity to show
+	Data     map[string]interface{} `json:"data,omitempty"` // command-specific parameters
+	Response chan *ImrMgmtResponse   `json:"-"`
+}
+
+// ImrMgmtResponse is the response from a daemon's /imr endpoint.
+type ImrMgmtResponse struct {
+	Status   string
+	Time     time.Time
+	Msg      string
+	Error    bool
+	ErrorMsg string
+	Data     interface{} `json:"data,omitempty"` // command-specific response payload
+}
+
 // DnskeyStatus holds the result of DNSKEY change detection (local keys only).
 // 20260415 johani: somewhat unclear if we still need this.
 type DnskeyStatus struct {


### PR DESCRIPTION
Implements the imr per-server transport-usage statistics per the design doc
`docs/2026-07-18-imr-transport-stats-design.md`. Scoped independent of the OOTS
feature (already merged) and of `imr-transport-selection-phase2`.

## What it does

Before this PR the imr had a single per-server counter (`TransportCounters`,
"attempted"), incremented **before** the exchange (so it counts attempts, not
successful use), and the presentations dropped `Do53TCP` (undercounting totals).
This adds an accurate, complete picture:

**Phase 1 — Exchange enabler.** `core.DNSClient.ExchangeWithResult` reports the
actual wire transport (Do53 vs Do53TCP after an internal fallback) and whether a
`TC=1` truncation drove the UDP→TCP upgrade. `Exchange` stays as a thin wrapper,
so no other caller changes.

**Phase 2 — collection.** Four per-server counters:
- `attempted[eff]` (existing) — the transport we chose to try.
- `used[wireTransport]` — the transport that actually **carried** the answer.
- `failed[eff]` — attempts that errored (the "announced DoQ but unreachable"
  signal).
- `truncated` — `TC=1` Do53/UDP responses upgraded to TCP (the PQ-relevant
  metric; a size upgrade, **not** a failure).

`tryServer` records these; all increments are downstream of `eff`, so they
compose cleanly with phase2's `dnskeyBypass` rework of `tryServer`.

**Phase 3 — presentation.** One shared formatter (`formatTransportStats` over
`SnapshotTransportStats`) replacing the two hardcoded order-lists that omitted
`Do53TCP`; renders attempted/used/failed (all transports incl. `do53-tcp`) plus
`truncated`. Both interactive REPL views use it.

**Phase 4 — remote.** `imr-transport-stats` verb on `APIimr` + a
`tdns-cli imr stats transport-stats [zone]` command that fetches the stats from a
running tdns-imr over `/api/v1/imr` and renders them with the **same** formatter
(so interactive and remote can't drift).

## Design decisions (per the doc)

- **Truncation is `TC=1`-precise** — distinguished from UDP-transient-error
  retries (only the former sets `truncated`), so the PQ truncation rate is clean.
- **Per-server granularity** — per-`(server,qtype)` is noted as a follow-up.
- `tryServer`/`Exchange` edits are written to anticipate the phase2
  `dnskeyBypass` param so its next forward-merge stays near-mechanical.

## Testing

- New unit tests: counter semantics + snapshot isolation (`cache`), and the
  `ExchangeResult` truncation flag (`core`).
- `go build` + `go vet` + `go test -race` green on `v2`, `v2/core`, `v2/cache`,
  `v2/cli` (`GOROOT=/opt/local/lib/go CGO_ENABLED=1`).
- Not run here: the `tdns-imr` **binary** build (needs the host-specific
  `tdns-genalgs` codegen; no `cmdv2/imr` code changed), and the **live e2e**
  (drive queries at a weighted server; force truncation with a large-PQ zone;
  read back via `tdns-cli imr stats transport-stats`).

## Notes / follow-ups

- The old `SnapshotCounters` / `SnapshotTransportCounters` accessors are now
  superseded by `SnapshotTransportStats` and unused in `v2` (left in place to
  keep this PR's footprint on the feature).
- Deferred to co-design with `imr-transport-selection-phase2`: bypass
  attribution (separating policy-forced DNSKEY traffic via its `dnskeyBypass`
  flag) and unifying this remote surface with phase2's in-process-only
  large-ksk metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added IMR transport statistics reporting per zone and server via the management API (`imr-transport-stats`).
  - Added `transport-stats [zone]` CLI command to display per-transport attempted/used/failed counts, including truncation handling and Do53TCP fallback.
  - Added optional zone filtering for transport-statistics queries.
- **Bug Fixes**
  - Improved transport counter accuracy by recording metrics based on the actual wire transport used, including UDP TC=1 upgrade-to-TCP and correct failure/truncation attribution.
  - Updated transport statistics rendering to consistently include Do53TCP and display totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->