### PR TITLE
tsignal: don't require signing capability for an unsigned zone's transport signal

### DIFF
--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -283,9 +283,18 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config, dak *DnssecKeys) err
 		// resigner keeps its signature fresh thereafter. Store as a real
 		// _dns.<ns> owner RRset (replacing any prior synthesized server SVCB),
 		// so it is directly queryable and injected from the stored copy.
-		// dak is nil exactly when the zone has neither online- nor
-		// inline-signing enabled (see CreateTransportSignalRRs) — an unsigned
-		// zone gets an unsigned transport signal, not a hard failure.
+		// Gate on dak, not on the static online/inline-signing options: this is
+		// deliberate and provably correct. CreateTransportSignalRRs resolves dak
+		// via EnsureActiveDnssecKeys, which for a signing zone returns non-nil
+		// keys or an error — never (nil, nil) — so a signing zone that is
+		// transiently keyless (bootstrap / mid policy-reset) errors out upstream
+		// and never reaches here with a nil dak; dak == nil is therefore exactly
+		// "the zone doesn't sign." Gating on dak is also what keeps a nil dak out
+		// of SignRRset, which under zd.mu would self-deadlock via PublishDnskeyRRs
+		// (the reason keys are resolved up in CreateTransportSignalRRs). An
+		// unsigned zone gets an unsigned transport signal, not a hard failure.
+		// (Revisit if EnsureActiveDnssecKeys is ever changed to return a nil dak
+		// for a signing zone.)
 		if dak != nil {
 			if _, err := zd.SignRRset(stored, "", dak, false, nil); err != nil {
 				lgDns.Error("createTransportSignalSVCB: error signing SVCB; not staging unsigned signal",
@@ -365,10 +374,16 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config, dak *DnssecKeys) er
 		}
 		stored := core.RRset{Name: ownerName, RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
 		// Sign BEFORE staging (fixes the prior sign-after-commit ordering that
-		// froze an unsigned TSYNC into the snapshot). dak is nil exactly when
-		// the zone has neither online- nor inline-signing enabled (see
-		// CreateTransportSignalRRs) — an unsigned zone gets an unsigned
-		// transport signal, not a hard failure.
+		// froze an unsigned TSYNC into the snapshot). Gate on dak, not the static
+		// signing options: CreateTransportSignalRRs resolves dak via
+		// EnsureActiveDnssecKeys, which for a signing zone returns non-nil keys or
+		// an error — never (nil, nil) — so a transiently-keyless signing zone
+		// (bootstrap / policy-reset) errors out upstream and never reaches here
+		// with a nil dak; dak == nil is exactly "the zone doesn't sign." Gating on
+		// dak also keeps nil out of SignRRset, which under zd.mu self-deadlocks
+		// via PublishDnskeyRRs. An unsigned zone gets an unsigned signal, not a
+		// hard failure. (Revisit if EnsureActiveDnssecKeys ever returns a nil dak
+		// for a signing zone.)
 		if dak != nil {
 			if _, err := zd.SignRRset(&stored, "", dak, false, nil); err != nil {
 				lgDns.Error("createTransportSignalTSYNC: error signing TSYNC; not staging unsigned signal",

--- a/v2/tsignal.go
+++ b/v2/tsignal.go
@@ -283,10 +283,15 @@ func (zd *ZoneData) createTransportSignalSVCB(conf *Config, dak *DnssecKeys) err
 		// resigner keeps its signature fresh thereafter. Store as a real
 		// _dns.<ns> owner RRset (replacing any prior synthesized server SVCB),
 		// so it is directly queryable and injected from the stored copy.
-		if _, err := zd.SignRRset(stored, "", dak, false, nil); err != nil {
-			lgDns.Error("createTransportSignalSVCB: error signing SVCB; not staging unsigned signal",
-				"owner", ownerName, "err", err)
-			return fmt.Errorf("createTransportSignalSVCB: failed to sign SVCB for %q: %w", ownerName, err)
+		// dak is nil exactly when the zone has neither online- nor
+		// inline-signing enabled (see CreateTransportSignalRRs) — an unsigned
+		// zone gets an unsigned transport signal, not a hard failure.
+		if dak != nil {
+			if _, err := zd.SignRRset(stored, "", dak, false, nil); err != nil {
+				lgDns.Error("createTransportSignalSVCB: error signing SVCB; not staging unsigned signal",
+					"owner", ownerName, "err", err)
+				return fmt.Errorf("createTransportSignalSVCB: failed to sign SVCB for %q: %w", ownerName, err)
+			}
 		}
 		lgDns.Debug("createTransportSignalSVCB: stored synthesized server SVCB",
 			"zone", zd.ZoneName, "ns", nsName, "owner", ownerName)
@@ -360,11 +365,16 @@ func (zd *ZoneData) createTransportSignalTSYNC(conf *Config, dak *DnssecKeys) er
 		}
 		stored := core.RRset{Name: ownerName, RRtype: core.TypeTSYNC, RRs: []dns.RR{trr}}
 		// Sign BEFORE staging (fixes the prior sign-after-commit ordering that
-		// froze an unsigned TSYNC into the snapshot).
-		if _, err := zd.SignRRset(&stored, "", dak, false, nil); err != nil {
-			lgDns.Error("createTransportSignalTSYNC: error signing TSYNC; not staging unsigned signal",
-				"owner", ownerName, "err", err)
-			return fmt.Errorf("createTransportSignalTSYNC: failed to sign TSYNC for %q: %w", ownerName, err)
+		// froze an unsigned TSYNC into the snapshot). dak is nil exactly when
+		// the zone has neither online- nor inline-signing enabled (see
+		// CreateTransportSignalRRs) — an unsigned zone gets an unsigned
+		// transport signal, not a hard failure.
+		if dak != nil {
+			if _, err := zd.SignRRset(&stored, "", dak, false, nil); err != nil {
+				lgDns.Error("createTransportSignalTSYNC: error signing TSYNC; not staging unsigned signal",
+					"owner", ownerName, "err", err)
+				return fmt.Errorf("createTransportSignalTSYNC: failed to sign TSYNC for %q: %w", ownerName, err)
+			}
 		}
 		lgDns.Debug("createTransportSignalTSYNC: stored synthesized TSYNC",
 			"zone", zd.ZoneName, "ns", nsName, "owner", ownerName, "rr", trr.String())


### PR DESCRIPTION
## Summary
Found live while testing `add-transport-signal` on an unsigned zone on foffe (johani.dsync.se, no `dnssecpolicy:`, no `online-signing`/`inline-signing`).

`createTransportSignalSVCB`/`TSYNC` unconditionally called `SignRRset` even when the zone doesn't sign, where `SignRRset` legitimately errors with "does not allow signing" — not a transient failure, but the expected state of an unsigned zone. A recent fix (turning a swallowed `SignRRset` error into a hard failure, rather than silently staging an unsigned RRset) regressed `add-transport-signal` on every unsigned zone as a side effect.

`dak` is nil exactly when the zone doesn't sign (computed by the caller, `CreateTransportSignalRRs`, from the same online-signing/inline-signing check `SignRRset` itself makes). Only attempt to sign when `dak != nil`; an unsigned zone gets an unsigned transport signal, matching the documented behavior ("If the zone is DNSSEC-signed, the RRSIG for the SVCB is included as well" — implying unsigned zones get the record without one).

## Test plan
- [x] `go build`/`go vet` clean
- [ ] Live-verify on foffe: `johani.dsync.se.` zone (unsigned, `add-transport-signal`, `service.transport.type: tsync`) now synthesizes `_dns.ns1.johani.dsync.se. TSYNC` instead of erroring at load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transport signals can now be staged successfully when DNSSEC signing is unavailable.
  * DNSSEC signing failures are reported clearly, and unsigned signals are not staged when signing was required.
  * SVCB and TSYNC signal handling now behaves consistently across signed and unsigned configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->