### PR TITLE
imr nits: apex-NS lookup fix, transport-stats REPL fix + suffix filter

### DIFF
--- a/v2/apihandler_imr.go
+++ b/v2/apihandler_imr.go
@@ -71,6 +71,24 @@ func transportWeightsToStrings(m map[core.Transport]uint8) map[string]uint8 {
 	return out
 }
 
+// ZoneMatchesSelector reports whether zone (an fqdn) is selected by an optional
+// exact-zone / suffix filter pair — DNS-label-aware and case-insensitive. When
+// both are set, exactZone takes precedence; when both are empty, everything
+// matches. A suffix matches the zone itself and any subdomain of it, never a
+// partial label (e.g. suffix "sync.se." does NOT match "dsync.se."). Shared by
+// the /imr API handler and the cli transport-stats filter so the two cannot
+// diverge.
+func ZoneMatchesSelector(zone, exactZone, suffix string) bool {
+	switch {
+	case exactZone != "":
+		return strings.EqualFold(zone, exactZone)
+	case suffix != "":
+		return dns.IsSubDomain(suffix, zone)
+	default:
+		return true
+	}
+}
+
 func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
@@ -324,10 +342,7 @@ func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 			}
 			var records []ImrServerTransportStats
 			for item := range imr.Cache.ServerMap.IterBuffered() {
-				if zoneFilter != "" && item.Key != zoneFilter {
-					continue
-				}
-				if suffixFilter != "" && !strings.HasSuffix(item.Key, suffixFilter) {
+				if !ZoneMatchesSelector(item.Key, zoneFilter, suffixFilter) {
 					continue
 				}
 				for name, server := range item.Val {

--- a/v2/apihandler_imr.go
+++ b/v2/apihandler_imr.go
@@ -318,9 +318,16 @@ func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 			if zoneFilter != "" {
 				zoneFilter = dns.Fqdn(zoneFilter)
 			}
+			suffixFilter, _ := amp.Data["suffix"].(string)
+			if suffixFilter != "" {
+				suffixFilter = dns.Fqdn(suffixFilter)
+			}
 			var records []ImrServerTransportStats
 			for item := range imr.Cache.ServerMap.IterBuffered() {
 				if zoneFilter != "" && item.Key != zoneFilter {
+					continue
+				}
+				if suffixFilter != "" && !strings.HasSuffix(item.Key, suffixFilter) {
 					continue
 				}
 				for name, server := range item.Val {
@@ -338,9 +345,12 @@ func (conf *Config) APIimr() func(w http.ResponseWriter, r *http.Request) {
 			}
 			resp.Data = records
 			if len(records) == 0 {
-				if zoneFilter != "" {
+				switch {
+				case zoneFilter != "":
 					resp.Msg = fmt.Sprintf("No auth servers recorded for %s", zoneFilter)
-				} else {
+				case suffixFilter != "":
+					resp.Msg = fmt.Sprintf("No auth servers recorded with suffix %s", suffixFilter)
+				default:
 					resp.Msg = "No auth servers recorded"
 				}
 			} else {

--- a/v2/cli/imr_transport_stats_cmd.go
+++ b/v2/cli/imr_transport_stats_cmd.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os"
 	"sort"
-	"strings"
 
 	tdns "github.com/johanix/tdns/v2"
 	"github.com/johanix/tdns/v2/cache"
@@ -30,15 +29,10 @@ type transportStatsFilter struct {
 }
 
 // matches reports whether a zone (ServerMap key, an fqdn) passes the filter.
+// Delegates to the shared, DNS-label-aware predicate so the in-process and API
+// paths cannot diverge.
 func (f transportStatsFilter) matches(zone string) bool {
-	switch {
-	case f.zone != "":
-		return zone == f.zone
-	case f.suffix != "":
-		return strings.HasSuffix(zone, f.suffix)
-	default:
-		return true
-	}
+	return tdns.ZoneMatchesSelector(zone, f.zone, f.suffix)
 }
 
 // data renders the filter into the API request payload for the remote path.

--- a/v2/cli/imr_transport_stats_cmd.go
+++ b/v2/cli/imr_transport_stats_cmd.go
@@ -25,52 +25,123 @@ import (
 // as the interactive dump, so the two cannot drift.
 var imrStatsTransportStatsCmd = &cobra.Command{
 	Use:   "transport-stats [zone]",
-	Short: "Show per-server transport-usage stats from a running tdns-imr (via API)",
+	Short: "Show per-server transport-usage stats for a running tdns-imr",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		data := map[string]interface{}{}
-		if len(args) == 1 {
-			data["zone"] = dns.Fqdn(args[0])
+		// When invoked inside the imr itself (the `tdns-imr --cli` interactive
+		// REPL) the live RRset cache is present in this process, so render the
+		// stats directly from it. There is no reason for the imr to open an API
+		// client to talk to itself — and doing so previously KILLED the REPL:
+		// SendImrMgmtCmd found no self-client and the error path called
+		// log.Fatalf/os.Exit, terminating the process (a #297 regression).
+		// Only the standalone tdns-cli binary (which has no local cache) uses
+		// the remote API path.
+		if Conf.Internal.RRsetCache != nil {
+			renderTransportStatsLocal(args)
+			return
 		}
-		amr, err := SendImrMgmtCmd("imr", &tdns.ImrMgmtPost{
-			Command: "imr-transport-stats",
-			Data:    data,
-		})
-		if err != nil {
-			log.Fatalf("Request failed: %v", err)
-		}
-		if amr.Error {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", amr.ErrorMsg)
-			os.Exit(1)
-		}
-		fmt.Println(amr.Msg)
-
-		// resp.Data is generic JSON; re-marshal into the typed record slice.
-		raw, err := json.Marshal(amr.Data)
-		if err != nil {
-			log.Fatalf("failed to read response: %v", err)
-		}
-		var records []tdns.ImrServerTransportStats
-		if err := json.Unmarshal(raw, &records); err != nil {
-			log.Fatalf("failed to parse response: %v", err)
-		}
-		sort.Slice(records, func(i, j int) bool {
-			if records[i].Zone != records[j].Zone {
-				return records[i].Zone < records[j].Zone
-			}
-			return records[i].Server < records[j].Server
-		})
-		var lastZone string
-		for _, rec := range records {
-			if rec.Zone != lastZone {
-				fmt.Printf("\nZone: %s\n", rec.Zone)
-				lastZone = rec.Zone
-			}
-			fmt.Printf("  Server: %s\n", rec.Server)
-			fmt.Printf("    signal: %s\n", renderSignalFromWeights(weightsStringToTransport(rec.Weights)))
-			fmt.Printf("    %s\n", formatTransportStats(imrServerStatsToTransportStats(rec)))
-		}
+		renderTransportStatsRemote(args)
 	},
+}
+
+// renderTransportStatsLocal renders per-server transport-usage stats straight
+// from the in-process RRset cache (used by the interactive imr REPL). It mirrors
+// the layout of the remote path so `stats transport-stats` looks identical
+// whether run inside the imr or via tdns-cli. The caller guarantees the cache
+// is non-nil.
+func renderTransportStatsLocal(args []string) {
+	rc := Conf.Internal.RRsetCache
+	var zoneFilter string
+	if len(args) == 1 {
+		zoneFilter = dns.Fqdn(args[0])
+	}
+	type row struct {
+		zone, server string
+		srv          *cache.AuthServer
+	}
+	var rows []row
+	for item := range rc.ServerMap.IterBuffered() {
+		if zoneFilter != "" && item.Key != zoneFilter {
+			continue
+		}
+		for name, server := range item.Val {
+			rows = append(rows, row{zone: item.Key, server: name, srv: server})
+		}
+	}
+	if len(rows) == 0 {
+		if zoneFilter != "" {
+			fmt.Printf("No auth servers recorded for %s\n", zoneFilter)
+		} else {
+			fmt.Println("No auth servers recorded")
+		}
+		return
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].zone != rows[j].zone {
+			return rows[i].zone < rows[j].zone
+		}
+		return rows[i].server < rows[j].server
+	})
+	var lastZone string
+	for _, r := range rows {
+		if r.zone != lastZone {
+			fmt.Printf("\nZone: %s\n", r.zone)
+			lastZone = r.zone
+		}
+		fmt.Printf("  Server: %s\n", r.server)
+		fmt.Printf("    signal: %s\n", renderSignal(r.srv))
+		fmt.Printf("    %s\n", formatTransportCounters(r.srv))
+	}
+}
+
+// renderTransportStatsRemote fetches per-server transport-usage stats from a
+// running tdns-imr over the /imr API and renders the full matrix using the SAME
+// formatter as the local/interactive path, so the two cannot drift. Used only
+// by the standalone tdns-cli binary (no in-process cache); log.Fatalf/os.Exit
+// on error is acceptable here because that is a short-lived one-shot process.
+func renderTransportStatsRemote(args []string) {
+	data := map[string]interface{}{}
+	if len(args) == 1 {
+		data["zone"] = dns.Fqdn(args[0])
+	}
+	amr, err := SendImrMgmtCmd("imr", &tdns.ImrMgmtPost{
+		Command: "imr-transport-stats",
+		Data:    data,
+	})
+	if err != nil {
+		log.Fatalf("Request failed: %v", err)
+	}
+	if amr.Error {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", amr.ErrorMsg)
+		os.Exit(1)
+	}
+	fmt.Println(amr.Msg)
+
+	// resp.Data is generic JSON; re-marshal into the typed record slice.
+	raw, err := json.Marshal(amr.Data)
+	if err != nil {
+		log.Fatalf("failed to read response: %v", err)
+	}
+	var records []tdns.ImrServerTransportStats
+	if err := json.Unmarshal(raw, &records); err != nil {
+		log.Fatalf("failed to parse response: %v", err)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Zone != records[j].Zone {
+			return records[i].Zone < records[j].Zone
+		}
+		return records[i].Server < records[j].Server
+	})
+	var lastZone string
+	for _, rec := range records {
+		if rec.Zone != lastZone {
+			fmt.Printf("\nZone: %s\n", rec.Zone)
+			lastZone = rec.Zone
+		}
+		fmt.Printf("  Server: %s\n", rec.Server)
+		fmt.Printf("    signal: %s\n", renderSignalFromWeights(weightsStringToTransport(rec.Weights)))
+		fmt.Printf("    %s\n", formatTransportStats(imrServerStatsToTransportStats(rec)))
+	}
 }
 
 // imrServerStatsToTransportStats converts the name-keyed API record into the

--- a/v2/cli/imr_transport_stats_cmd.go
+++ b/v2/cli/imr_transport_stats_cmd.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strings"
 
 	tdns "github.com/johanix/tdns/v2"
 	"github.com/johanix/tdns/v2/cache"
@@ -18,30 +19,99 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// imrStatsTransportStatsCmd is the REMOTE counterpart of the in-process
-// auth-transports view: it fetches per-server transport-usage stats from a
-// running tdns-imr over the /imr API and renders the full matrix (attempted /
-// used / failed incl. do53-tcp, plus TC=1 truncations) using the SAME formatter
-// as the interactive dump, so the two cannot drift.
+// transportStatsFilter selects which zones' transport stats to show. At most
+// one of zone (exact match) / suffix (zone-name suffix, à la `dump suffix`) is
+// set; both empty means "all zones". It is applied identically on the in-process
+// and remote paths so the filtering behaves the same in the REPL and via
+// tdns-cli.
+type transportStatsFilter struct {
+	zone   string // exact zone (fqdn), or ""
+	suffix string // zone-name suffix (fqdn), or ""
+}
+
+// matches reports whether a zone (ServerMap key, an fqdn) passes the filter.
+func (f transportStatsFilter) matches(zone string) bool {
+	switch {
+	case f.zone != "":
+		return zone == f.zone
+	case f.suffix != "":
+		return strings.HasSuffix(zone, f.suffix)
+	default:
+		return true
+	}
+}
+
+// data renders the filter into the API request payload for the remote path.
+func (f transportStatsFilter) data() map[string]interface{} {
+	data := map[string]interface{}{}
+	if f.zone != "" {
+		data["zone"] = f.zone
+	}
+	if f.suffix != "" {
+		data["suffix"] = f.suffix
+	}
+	return data
+}
+
+// noneMsg is the "nothing matched" message, scoped to the active filter.
+func (f transportStatsFilter) noneMsg() string {
+	switch {
+	case f.zone != "":
+		return fmt.Sprintf("No auth servers recorded for %s", f.zone)
+	case f.suffix != "":
+		return fmt.Sprintf("No auth servers recorded with suffix %s", f.suffix)
+	default:
+		return "No auth servers recorded"
+	}
+}
+
+// imrStatsTransportStatsCmd shows per-server transport-usage stats (attempted /
+// used / failed incl. do53-tcp, plus TC=1 truncations) for a running tdns-imr.
+// It works both in-process (the `tdns-imr --cli` REPL, straight from the live
+// cache) and remotely (the tdns-cli binary, over the /imr API), rendering an
+// identical matrix either way. An optional [zone] positional narrows to a single
+// zone; the `suffix` subcommand narrows to a zone-name suffix.
 var imrStatsTransportStatsCmd = &cobra.Command{
 	Use:   "transport-stats [zone]",
 	Short: "Show per-server transport-usage stats for a running tdns-imr",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// When invoked inside the imr itself (the `tdns-imr --cli` interactive
-		// REPL) the live RRset cache is present in this process, so render the
-		// stats directly from it. There is no reason for the imr to open an API
-		// client to talk to itself — and doing so previously KILLED the REPL:
-		// SendImrMgmtCmd found no self-client and the error path called
-		// log.Fatalf/os.Exit, terminating the process (a #297 regression).
-		// Only the standalone tdns-cli binary (which has no local cache) uses
-		// the remote API path.
-		if Conf.Internal.RRsetCache != nil {
-			renderTransportStatsLocal(args)
-			return
+		var f transportStatsFilter
+		if len(args) == 1 {
+			f.zone = dns.Fqdn(args[0])
 		}
-		renderTransportStatsRemote(args)
+		runTransportStats(f)
 	},
+}
+
+// imrStatsTransportStatsSuffixCmd is the suffix-filtered counterpart, mirroring
+// `dump suffix {suffix}`: it shows only zones whose name ends in {suffix}. A
+// missing suffix arg means "all zones" (same as the bare command).
+var imrStatsTransportStatsSuffixCmd = &cobra.Command{
+	Use:   "suffix [suffix]",
+	Short: "Show transport-usage stats for zones whose name ends in suffix",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var f transportStatsFilter
+		if len(args) == 1 {
+			f.suffix = dns.Fqdn(args[0])
+		}
+		runTransportStats(f)
+	},
+}
+
+// runTransportStats dispatches to the in-process renderer when the live RRset
+// cache is present (the imr REPL) and to the remote API renderer otherwise (the
+// standalone tdns-cli binary). There is no reason for the imr to open an API
+// client to talk to itself — and doing so previously KILLED the REPL:
+// SendImrMgmtCmd found no self-client and the error path called
+// log.Fatalf/os.Exit, terminating the process (a #297 regression).
+func runTransportStats(f transportStatsFilter) {
+	if Conf.Internal.RRsetCache != nil {
+		renderTransportStatsLocal(f)
+		return
+	}
+	renderTransportStatsRemote(f)
 }
 
 // renderTransportStatsLocal renders per-server transport-usage stats straight
@@ -49,19 +119,15 @@ var imrStatsTransportStatsCmd = &cobra.Command{
 // the layout of the remote path so `stats transport-stats` looks identical
 // whether run inside the imr or via tdns-cli. The caller guarantees the cache
 // is non-nil.
-func renderTransportStatsLocal(args []string) {
+func renderTransportStatsLocal(f transportStatsFilter) {
 	rc := Conf.Internal.RRsetCache
-	var zoneFilter string
-	if len(args) == 1 {
-		zoneFilter = dns.Fqdn(args[0])
-	}
 	type row struct {
 		zone, server string
 		srv          *cache.AuthServer
 	}
 	var rows []row
 	for item := range rc.ServerMap.IterBuffered() {
-		if zoneFilter != "" && item.Key != zoneFilter {
+		if !f.matches(item.Key) {
 			continue
 		}
 		for name, server := range item.Val {
@@ -69,11 +135,7 @@ func renderTransportStatsLocal(args []string) {
 		}
 	}
 	if len(rows) == 0 {
-		if zoneFilter != "" {
-			fmt.Printf("No auth servers recorded for %s\n", zoneFilter)
-		} else {
-			fmt.Println("No auth servers recorded")
-		}
+		fmt.Println(f.noneMsg())
 		return
 	}
 	sort.Slice(rows, func(i, j int) bool {
@@ -99,14 +161,10 @@ func renderTransportStatsLocal(args []string) {
 // formatter as the local/interactive path, so the two cannot drift. Used only
 // by the standalone tdns-cli binary (no in-process cache); log.Fatalf/os.Exit
 // on error is acceptable here because that is a short-lived one-shot process.
-func renderTransportStatsRemote(args []string) {
-	data := map[string]interface{}{}
-	if len(args) == 1 {
-		data["zone"] = dns.Fqdn(args[0])
-	}
+func renderTransportStatsRemote(f transportStatsFilter) {
 	amr, err := SendImrMgmtCmd("imr", &tdns.ImrMgmtPost{
 		Command: "imr-transport-stats",
-		Data:    data,
+		Data:    f.data(),
 	})
 	if err != nil {
 		log.Fatalf("Request failed: %v", err)
@@ -189,4 +247,5 @@ func weightsStringToTransport(m map[string]uint8) map[core.Transport]uint8 {
 
 func init() {
 	ImrStatsCmd.AddCommand(imrStatsTransportStatsCmd)
+	imrStatsTransportStatsCmd.AddCommand(imrStatsTransportStatsSuffixCmd)
 }

--- a/v2/cli/transport_stats_filter_test.go
+++ b/v2/cli/transport_stats_filter_test.go
@@ -27,9 +27,18 @@ func TestTransportStatsFilter_Matches(t *testing.T) {
 		{"suffix-hit-child", transportStatsFilter{suffix: "dsync.se."}, "johani.dsync.se.", true},
 		{"suffix-hit-tld", transportStatsFilter{suffix: "se."}, "iis.se.", true},
 		{"suffix-miss", transportStatsFilter{suffix: "se."}, "example.com.", false},
+		// Suffix matching must respect DNS label boundaries: "sync.se." is a raw
+		// string suffix of "dsync.se." but NOT a zone suffix (it cuts into the
+		// "dsync" label), so it must NOT match.
+		{"suffix-partial-label-rejected", transportStatsFilter{suffix: "sync.se."}, "dsync.se.", false},
+		// DNS names are case-insensitive: mixed-case filters match.
+		{"suffix-mixed-case", transportStatsFilter{suffix: "SE."}, "dsync.se.", true},
+		{"exact-mixed-case", transportStatsFilter{zone: "DSYNC.SE."}, "dsync.se.", true},
 		// zone takes precedence over suffix when both are set (they never are in
 		// practice, but the precedence must be deterministic).
 		{"zone-wins-over-suffix", transportStatsFilter{zone: "dsync.se.", suffix: "com."}, "dsync.se.", true},
+		// precedence again, this time with a suffix that WOULD match: zone still wins.
+		{"zone-wins-over-matching-suffix", transportStatsFilter{zone: "iis.se.", suffix: "se."}, "dsync.se.", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v2/cli/transport_stats_filter_test.go
+++ b/v2/cli/transport_stats_filter_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestTransportStatsFilter_Matches guards the zone/suffix/all selection used by
+// `stats transport-stats`, `... {zone}`, and `... suffix {suffix}`. ServerMap
+// keys are fqdns, so the filter operands are fqdns too.
+func TestTransportStatsFilter_Matches(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter transportStatsFilter
+		zone   string
+		want   bool
+	}{
+		{"all-matches-anything", transportStatsFilter{}, "dsync.se.", true},
+		{"exact-hit", transportStatsFilter{zone: "dsync.se."}, "dsync.se.", true},
+		{"exact-miss-child", transportStatsFilter{zone: "dsync.se."}, "johani.dsync.se.", false},
+		{"exact-miss-other", transportStatsFilter{zone: "dsync.se."}, "iis.se.", false},
+		{"suffix-hit-self", transportStatsFilter{suffix: "dsync.se."}, "dsync.se.", true},
+		{"suffix-hit-child", transportStatsFilter{suffix: "dsync.se."}, "johani.dsync.se.", true},
+		{"suffix-hit-tld", transportStatsFilter{suffix: "se."}, "iis.se.", true},
+		{"suffix-miss", transportStatsFilter{suffix: "se."}, "example.com.", false},
+		// zone takes precedence over suffix when both are set (they never are in
+		// practice, but the precedence must be deterministic).
+		{"zone-wins-over-suffix", transportStatsFilter{zone: "dsync.se.", suffix: "com."}, "dsync.se.", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.filter.matches(tt.zone); got != tt.want {
+				t.Errorf("matches(%q) = %v, want %v", tt.zone, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTransportStatsFilter_Data checks the API request payload the remote path
+// (tdns-cli) sends, so the imr applies the same filter it would in-process.
+func TestTransportStatsFilter_Data(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter transportStatsFilter
+		want   map[string]interface{}
+	}{
+		{"all-empty", transportStatsFilter{}, map[string]interface{}{}},
+		{"zone-only", transportStatsFilter{zone: "dsync.se."}, map[string]interface{}{"zone": "dsync.se."}},
+		{"suffix-only", transportStatsFilter{suffix: "se."}, map[string]interface{}{"suffix": "se."}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.filter.data(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("data() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/dnslookup.go
+++ b/v2/dnslookup.go
@@ -2364,13 +2364,14 @@ func (imr *Imr) handleAnswer(ctx context.Context, qname string, qtype uint16, r 
 func extractReferral(r *dns.Msg, qname string, qtype uint16) (*core.RRset, string, map[string]bool) {
 	nsMap := map[string]bool{}
 	zonename := ""
-	var nsrrs []dns.RR
-	switch qtype {
-	case dns.TypeNS:
-		nsrrs = r.Answer
-	default:
-		nsrrs = r.Ns
-	}
+	// A referral always carries its NS RRset in the AUTHORITY section, regardless
+	// of the query type — including a QTYPE=NS query whose parent delegation puts
+	// the child NS in Authority with an empty Answer. (The apex-NS *answer* case,
+	// NS in the ANSWER section with aa=1, is handled earlier by handleAnswer;
+	// extractReferral is only ever reached to extract a referral/delegation.)
+	// Previously this read r.Answer for QTYPE=NS, so a QTYPE=NS query would find
+	// no NS in the parent's referral and loop until "max iterations reached".
+	nsrrs := r.Ns
 	var rrset core.RRset
 	for _, rr := range nsrrs {
 		switch rr.Header().Rrtype {


### PR DESCRIPTION
Collector branch for a batch of tdns-imr nits, all verified live on real DNS (auth servers for axfr.net / dsync.se / johani.dsync.se).

## Fixes

**N1 — cold QTYPE=NS lookup looped to "max iterations"** (`5aae020`)
`extractReferral` read the NS RRset from `r.Answer` for `qtype==NS`, but a referral carries its NS in the AUTHORITY section (`r.Ns`) with an empty Answer. So a cold `query <zone> ns` found no NS in the parent's referral and re-queried the parent until it gave up. A referral's NS is always in Authority regardless of qtype (the apex-NS *answer* case is handled earlier by `handleAnswer`), so read `r.Ns` unconditionally.

**N6 — `stats transport-stats` silently killed the REPL** (`84edd47`, a #297 regression)
In the `tdns-imr --cli` REPL the command issued a remote `SendImrMgmtCmd("imr", ...)` API call, but inside the imr there is no API client to talk to itself, so the error path hit `log.Fatalf`/`os.Exit` and terminated the process. Now branch on `Conf.Internal.RRsetCache`: when the live cache is present (REPL) render from it directly; only the standalone `tdns-cli` binary uses the remote API path. Both share the same formatters.

**`suffix` filter for `transport-stats`** (`c66f757`)
`stats transport-stats` lists every server in every zone, which is unwieldy. Mirrors `dump` / `dump suffix {suffix}` with a `suffix` subcommand showing only zones whose name ends in `{suffix}`. The selection is a small `transportStatsFilter` (exact zone / suffix / all) applied identically in-process and via the `/imr` API (handler reads a `suffix` field alongside the existing exact `zone`). Unit tests included.

## Not yet included
- N1 regression test (feed a QTYPE=NS parent-referral, assert the child is queried) — still to add.
- N2–N5 (crash on encrypted-transport A query; counter/cache-expiry behavior; SVCB `port` SvcParam; soft "prefer encrypted" knob) — separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added suffix-based filtering for transport statistics, alongside existing exact zone filtering.
  * Introduced a suffix-focused transport-stats command option and unified local/remote rendering for consistent output and sorting.

* **Bug Fixes**
  * Improved “no records” messaging to reflect whether results were filtered by zone, suffix, or neither.
  * Corrected DNS referral extraction for NS queries to improve resolver reliability and avoid referral loops.

* **Tests**
  * Added unit tests covering filter matching behavior and request payload generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->