### PR TITLE
cli: add `zone desc` — full single-zone describe with DNSSEC applied-policy + policy detail

### DIFF
--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -189,74 +189,27 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 
 		case "list-zones":
 			zones := map[string]ZoneConf{}
+			// Single-zone describe path (`zone desc`): scope the response to the
+			// named zone and populate the extra detail fields (last-applied policy
+			// record + bound-policy algorithm/lifetime detail). The bulk path below
+			// is left byte-identical so `zone list` (plain and -v) is unchanged.
+			if zp.Zone != "" {
+				zname := dns.Fqdn(zp.Zone)
+				zd, ok := Zones.Get(zname)
+				if !ok || zd == nil {
+					resp.Error = true
+					resp.ErrorMsg = fmt.Sprintf("Zone %s is unknown", zname)
+					return
+				}
+				zconf := buildListZoneConf(zd, zname, kdb)
+				populateZoneDescDetail(&zconf, zd, zname, kdb)
+				zones[zname] = zconf
+				resp.Zones = zones
+				return
+			}
 			lgApi.Debug("listing zones", "count", len(Zones.Keys()))
 			for item := range Zones.IterBuffered() {
-				zname := item.Key
-				zd := item.Val
-
-				// dump.P(zd.Options)
-				options := []ZoneOption{}
-				for opt, val := range zd.Options {
-					if val {
-						options = append(options, opt)
-					}
-				}
-
-				// For secondary zones, list as-written primaries from runtime state.
-				primaries := clonePeerConfs(zd.PrimariesConf)
-
-				// Snapshot the notify slice under the lock — the catalog notify
-				// add/remove handlers mutate zd.Notify under zd.mu, so an
-				// unsynchronized read here would race the slice header.
-				zd.mu.Lock()
-				notifySnapshot := append([]PeerConf(nil), zd.Notify...)
-				zd.mu.Unlock()
-
-				// Effective DNSSEC policy (the one bound to the running zone)
-				// and, when it came from a dynamic set-policy override, the
-				// config-base policy it overrides (for display). A lookup error
-				// degrades that one zone's override flag to false (the listing
-				// still succeeds); log it rather than silently swallow.
-				_, overridden, ovErr := GetZonePolicyOverride(kdb, zname)
-				if ovErr != nil {
-					lgApi.Warn("list-zones: failed to read DNSSEC policy override", "zone", zname, "err", ovErr)
-				}
-				configPolicy := ""
-				if overridden {
-					// Conf.Zones is replaced wholesale by a config reload;
-					// guard the scan with confMu (read lock).
-					confMu.RLock()
-					for i := range Conf.Zones {
-						if dns.Fqdn(Conf.Zones[i].Name) == zname {
-							configPolicy = Conf.Zones[i].DnssecPolicy
-							break
-						}
-					}
-					confMu.RUnlock()
-				}
-
-				zconf := ZoneConf{
-					Name:                   zname,
-					Type:                   ZoneTypeToString[zd.ZoneType],
-					Store:                  ZoneStoreToString[zd.ZoneStore],
-					Dirty:                  zd.Options[OptDirty],
-					Frozen:                 zd.Options[OptFrozen],
-					Options:                options,
-					Error:                  zd.Error,
-					ErrorType:              zd.ErrorType,
-					ErrorMsg:               zd.ErrorMsg,
-					RefreshCount:           zd.RefreshCount,
-					SourceCatalog:          zd.SourceCatalog,
-					ApiManaged:             zd.Options[OptApiManagedZone],
-					Provisioning:           zoneProvisioning(zd),
-					Zonefile:               zd.Zonefile,
-					Primaries:              primaries,
-					Notify:                 notifySnapshot, // Notify addresses (displayed by CLI)
-					EffectiveDnssecPolicy:  zd.DnssecPolicyName,
-					DnssecPolicyOverridden: overridden,
-					DnssecPolicyConfigBase: configPolicy,
-				}
-				zones[zname] = zconf
+				zones[item.Key] = buildListZoneConf(item.Val, item.Key, kdb)
 			}
 			resp.Zones = zones
 
@@ -341,6 +294,117 @@ func zoneProvisioning(zd *ZoneData) string {
 		return "error"
 	}
 	return ZoneStatusToString[zd.GetStatus()]
+}
+
+// buildListZoneConf builds the display ZoneConf for one zone exactly as the bulk
+// `list-zones` path renders it (type/store/options/primaries/notify/error state
+// plus effective-policy and override info). It is shared by the bulk listing and
+// the single-zone `zone desc` path so both show identical base fields; `zone
+// desc` additionally fills the detail fields via populateZoneDescDetail.
+func buildListZoneConf(zd *ZoneData, zname string, kdb *KeyDB) ZoneConf {
+	options := []ZoneOption{}
+	for opt, val := range zd.Options {
+		if val {
+			options = append(options, opt)
+		}
+	}
+
+	// For secondary zones, list as-written primaries from runtime state.
+	primaries := clonePeerConfs(zd.PrimariesConf)
+
+	// Snapshot the notify slice under the lock — the catalog notify add/remove
+	// handlers mutate zd.Notify under zd.mu, so an unsynchronized read here would
+	// race the slice header.
+	zd.mu.Lock()
+	notifySnapshot := append([]PeerConf(nil), zd.Notify...)
+	zd.mu.Unlock()
+
+	// Effective DNSSEC policy (the one bound to the running zone) and, when it
+	// came from a dynamic set-policy override, the config-base policy it overrides
+	// (for display). A lookup error degrades that one zone's override flag to
+	// false (the listing still succeeds); log it rather than silently swallow.
+	_, overridden, ovErr := GetZonePolicyOverride(kdb, zname)
+	if ovErr != nil {
+		lgApi.Warn("list-zones: failed to read DNSSEC policy override", "zone", zname, "err", ovErr)
+	}
+	configPolicy := ""
+	if overridden {
+		// Conf.Zones is replaced wholesale by a config reload; guard the scan with
+		// confMu (read lock).
+		confMu.RLock()
+		for i := range Conf.Zones {
+			if dns.Fqdn(Conf.Zones[i].Name) == zname {
+				configPolicy = Conf.Zones[i].DnssecPolicy
+				break
+			}
+		}
+		confMu.RUnlock()
+	}
+
+	return ZoneConf{
+		Name:                   zname,
+		Type:                   ZoneTypeToString[zd.ZoneType],
+		Store:                  ZoneStoreToString[zd.ZoneStore],
+		Dirty:                  zd.Options[OptDirty],
+		Frozen:                 zd.Options[OptFrozen],
+		Options:                options,
+		Error:                  zd.Error,
+		ErrorType:              zd.ErrorType,
+		ErrorMsg:               zd.ErrorMsg,
+		RefreshCount:           zd.RefreshCount,
+		SourceCatalog:          zd.SourceCatalog,
+		ApiManaged:             zd.Options[OptApiManagedZone],
+		Provisioning:           zoneProvisioning(zd),
+		Zonefile:               zd.Zonefile,
+		Primaries:              primaries,
+		Notify:                 notifySnapshot, // Notify addresses (displayed by CLI)
+		EffectiveDnssecPolicy:  zd.DnssecPolicyName,
+		DnssecPolicyOverridden: overridden,
+		DnssecPolicyConfigBase: configPolicy,
+	}
+}
+
+// populateZoneDescDetail fills the `zone desc`-only detail fields on zconf: the
+// zone's last-applied DNSSEC-policy record (from the keystore) and a display
+// projection of the policy currently bound to the running zone. Both degrade
+// gracefully — an absent applied record leaves AppliedPolicy empty; an unsigned
+// zone (no bound policy) or a bound-policy name that is not resolvable in the
+// live config snapshot leaves PolicyDetail nil — so the describe listing always
+// succeeds. The bound policy is read from the immutable runtime-config snapshot
+// (ConfLive), which is lock-free: a concurrent reload publishes a fresh snapshot
+// rather than mutating in place, so pol is a stable value copy.
+func populateZoneDescDetail(zconf *ZoneConf, zd *ZoneData, zname string, kdb *KeyDB) {
+	name, source, appliedAt, ok, err := GetZoneAppliedPolicyDetail(kdb, zname)
+	if err != nil {
+		lgApi.Warn("zone desc: failed to read applied policy", "zone", zname, "err", err)
+	} else if ok {
+		zconf.AppliedPolicy = name
+		zconf.AppliedSource = source
+		zconf.AppliedAt = appliedAt
+	}
+
+	polName := zd.DnssecPolicyName
+	if polName == "" {
+		return // unsigned zone: no bound policy → PolicyDetail stays nil ("not signed")
+	}
+	pol, polOK := ConfLive().DnssecPolicies[polName]
+	if !polOK {
+		return // bound policy not in the live snapshot → PolicyDetail stays nil ("policy unavailable")
+	}
+	zconf.PolicyDetail = &DnssecPolicyView{
+		Name:               polName,
+		Error:              pol.Error,
+		Mode:               pol.Mode,
+		Algorithm:          pol.Algorithm,
+		KSKAlgorithm:       pol.KSKAlgorithm,
+		ZSKAlgorithm:       pol.ZSKAlgorithm,
+		KSKLifetime:        pol.KSK.Lifetime,
+		ZSKLifetime:        pol.ZSK.Lifetime,
+		CSKLifetime:        pol.CSK.Lifetime,
+		SigValidityDefault: pol.SigValidity.Default,
+		SigValidityDNSKEY:  pol.SigValidity.DNSKEY,
+		SigValidityDS:      pol.SigValidity.DS,
+	}
 }
 
 // zoneOptionsFromStrings converts ZoneOption name strings (from the API) into

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -376,7 +376,10 @@ func buildListZoneConf(zd *ZoneData, zname string, kdb *KeyDB) ZoneConf {
 func populateZoneDescDetail(zconf *ZoneConf, zd *ZoneData, zname string, kdb *KeyDB) {
 	name, source, appliedAt, ok, err := GetZoneAppliedPolicyDetail(kdb, zname)
 	if err != nil {
+		// Surface the failure distinctly (not as an absent record) so the CLI can
+		// tell a backend error apart from "nothing was ever applied"; also log it.
 		lgApi.Warn("zone desc: failed to read applied policy", "zone", zname, "err", err)
+		zconf.AppliedError = err.Error()
 	} else if ok {
 		zconf.AppliedPolicy = name
 		zconf.AppliedSource = source

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -10,7 +10,9 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	tdns "github.com/johanix/tdns/v2"
 	"github.com/miekg/dns"
@@ -46,6 +48,26 @@ func NewZoneCmd(role string, extras ...*cobra.Command) *cobra.Command {
 	list.Flags().BoolVarP(&showfile, "file", "f", false, "Show zone input file")
 	list.Flags().BoolVarP(&shownotify, "notify", "N", false, "Show zone downstream notify addresses")
 	list.Flags().BoolVarP(&showprimary, "primary", "P", false, "Show zone primary nameserver")
+
+	desc := &cobra.Command{
+		Use:   "desc",
+		Short: "Describe a single zone in full, including DNSSEC applied-policy state and policy detail",
+		Long: `Print a detailed, multi-line record for one zone: everything "zone list -v"
+shows (type, store, options, primaries, notify, error/warning state, effective
+DNSSEC policy and override info) plus two DNSSEC sections not otherwise visible
+from the CLI:
+
+  1. the last-applied policy record recorded in the keystore (applied policy
+     name, source config|command, and when it was applied); and
+  2. the currently-bound policy's detail — mode, KSK/ZSK (or CSK) algorithms,
+     key lifetimes and RRSIG validity.
+
+An unsigned zone or an unresolvable policy degrades gracefully rather than
+failing. Does not change anything; read-only.`,
+		Run: func(cmd *cobra.Command, args []string) { RunZoneDesc(role, args) },
+	}
+	desc.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to describe")
+	desc.MarkFlagRequired("zone")
 
 	reload := &cobra.Command{
 		Use:   "reload",
@@ -251,7 +273,7 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 	dnssecCmd.AddCommand(setPolicy, policyReset, newAutoRolloverPolicyChangeCmd(), newAutoRolloverCmd(role),
 		sign, resign, nsec)
 
-	c.AddCommand(list, dnssecCmd, reload, bump, write, freeze, thaw, proxyKey, add, del, modify, listDynamic)
+	c.AddCommand(list, desc, dnssecCmd, reload, bump, write, freeze, thaw, proxyKey, add, del, modify, listDynamic)
 	// Role-independent extras attached to every zone tree. Each is built
 	// fresh so the command pointer is unique per NewZoneCmd invocation.
 	c.AddCommand(newZoneReadFakeCmd(), newZoneUpdateCmd(role), newZoneDsyncCmd(role))
@@ -470,6 +492,41 @@ func RunZoneList(parent string, args []string) {
 	case false:
 		ListZones(cr)
 	}
+}
+
+// RunZoneDesc drives `zone desc`: it asks the server for the single named zone
+// (list-zones scoped to that zone, which also populates the extra DNSSEC detail
+// fields) and prints the full describe block. Requires a zone.
+func RunZoneDesc(parent string, args []string) {
+	if tdns.Globals.Zonename == "" {
+		fmt.Println("Error: zone name not specified")
+		os.Exit(1)
+	}
+	zone := dns.Fqdn(tdns.Globals.Zonename)
+
+	api, err := GetApiClient(parent, true)
+	if err != nil {
+		log.Fatalf("Error getting API client for %s: %v", parent, err)
+	}
+
+	cr, err := SendZoneCommand(api, tdns.ZonePost{
+		Command: "list-zones",
+		Zone:    zone,
+	})
+	if err != nil {
+		fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+		os.Exit(1)
+	}
+	if cr.Msg != "" {
+		fmt.Printf("%s\n", cr.Msg)
+	}
+
+	zconf, ok := cr.Zones[zone]
+	if !ok {
+		fmt.Printf("Error: server returned no data for zone %s\n", zone)
+		os.Exit(1)
+	}
+	fmt.Print(DescribeZone(zconf))
 }
 
 func RunZoneBump(parent string, args []string) {
@@ -812,4 +869,143 @@ func VerboseListZone(cr tdns.ZoneResponse) {
 		return zoneLines[i] < zoneLines[j]
 	})
 	fmt.Printf("%s\n", columnize.SimpleFormat(zoneLines))
+}
+
+// DescribeZone renders the full single-zone detail block for `zone desc`:
+// everything VerboseListZone shows for a zone (state, type/store/options,
+// effective DNSSEC policy + override, primaries/notify/file, frozen/dirty/config
+// source) plus two sections that are only available via `zone desc` — the
+// last-applied DNSSEC-policy record and the bound policy's algorithm/lifetime/
+// sig-validity detail. It returns the text (trailing newline included) so it is
+// straightforward to unit test; RunZoneDesc prints the result.
+func DescribeZone(zconf tdns.ZoneConf) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "zone: %s\n", zconf.Name)
+
+	if zconf.Error {
+		// A service-impacting error is ERROR; a non-service-impacting warning
+		// (e.g. ConfigWarning) leaves the zone serving — mirror VerboseListZone.
+		if tdns.ErrorTypeIsServiceImpacting(zconf.ErrorType) {
+			fmt.Fprintf(&b, "\tState: ERROR ErrorType: %s ErrorMsg: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
+		} else {
+			fmt.Fprintf(&b, "\tState: serving Warning[%s]: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
+		}
+	}
+
+	opts := []string{}
+	for _, opt := range zconf.Options {
+		opts = append(opts, tdns.ZoneOptionToString[opt])
+	}
+	sort.Strings(opts)
+	fmt.Fprintf(&b, "\tType: %s\tStore: %s\tOptions: %v\n", zconf.Type, zconf.Store, opts)
+
+	if zconf.EffectiveDnssecPolicy != "" {
+		pol := zconf.EffectiveDnssecPolicy
+		if zconf.DnssecPolicyOverridden {
+			if zconf.DnssecPolicyConfigBase != "" {
+				pol += fmt.Sprintf(" (override from config: %s)", zconf.DnssecPolicyConfigBase)
+			} else {
+				pol += " (override; set live, not in config)"
+			}
+		}
+		fmt.Fprintf(&b, "\tDNSSEC policy: %s\n", pol)
+	}
+
+	fmt.Fprintf(&b, "\tPrimary: %s\tNotify: %s\tFile: %s\n",
+		peerConfAddrsString(zconf.Primaries), peerConfAddrsString(zconf.Notify), zconf.Zonefile)
+
+	// Config-source line (catalog / auto / manual), same derivation as VerboseListZone.
+	isCatalogZone := false
+	isAutoConfigured := false
+	for _, opt := range zconf.Options {
+		if opt == tdns.OptCatalogZone {
+			isCatalogZone = true
+		}
+		if opt == tdns.OptAutomaticZone {
+			isAutoConfigured = true
+		}
+	}
+	configInfo := "Config: manual"
+	if isCatalogZone {
+		configInfo = "Catalog Zone"
+	} else if isAutoConfigured {
+		if zconf.SourceCatalog != "" {
+			configInfo = fmt.Sprintf("Config: auto (from catalog %s)", zconf.SourceCatalog)
+		} else {
+			configInfo = "Config: auto"
+		}
+	}
+	fmt.Fprintf(&b, "\tFrozen: %t\tDirty: %t\t%s\n", zconf.Frozen, zconf.Dirty, configInfo)
+
+	// Section 1: last-applied DNSSEC policy record (from the keystore).
+	if zconf.AppliedPolicy != "" {
+		src := zconf.AppliedSource
+		if src == "" {
+			src = "(unknown)"
+		}
+		at := zconf.AppliedAt
+		if at == "" {
+			at = "(unknown)"
+		}
+		fmt.Fprintf(&b, "\tApplied policy: %s\tSource: %s\tApplied at: %s\n", zconf.AppliedPolicy, src, at)
+	} else {
+		b.WriteString("\tApplied policy: (not recorded)\n")
+	}
+
+	// Section 2: bound-policy algorithm / lifetime / sig-validity detail.
+	b.WriteString(describePolicyDetail(zconf))
+
+	return b.String()
+}
+
+// describePolicyDetail renders the bound-policy DNSSEC detail block for
+// `zone desc`. It degrades gracefully: a zone with no bound policy prints
+// "not signed"; a bound policy name that the server could not resolve in the
+// running config prints "policy unavailable". Otherwise it renders mode, the
+// role algorithms (KSK/ZSK, or CSK in csk mode), key lifetimes and RRSIG
+// validity, and surfaces the policy's parse Error when set.
+func describePolicyDetail(zconf tdns.ZoneConf) string {
+	pd := zconf.PolicyDetail
+	if pd == nil {
+		if zconf.EffectiveDnssecPolicy == "" {
+			return "\tDNSSEC detail: not signed\n"
+		}
+		return fmt.Sprintf("\tDNSSEC detail: policy unavailable (%s)\n", zconf.EffectiveDnssecPolicy)
+	}
+
+	var b strings.Builder
+	mode := pd.Mode
+	if mode == "" {
+		mode = "(unset)"
+	}
+	fmt.Fprintf(&b, "\tDNSSEC detail: Mode: %s\n", mode)
+	if pd.Error != "" {
+		fmt.Fprintf(&b, "\t\tError: %s\n", pd.Error)
+	}
+	if pd.Mode == tdns.DnssecPolicyModeCSK {
+		fmt.Fprintf(&b, "\t\tCSK algorithm: %s\n", algName(pd.Algorithm))
+		fmt.Fprintf(&b, "\t\tCSK lifetime: %s\n", secsToDuration(pd.CSKLifetime))
+	} else {
+		fmt.Fprintf(&b, "\t\tKSK algorithm: %s\tZSK algorithm: %s\n", algName(pd.KSKAlgorithm), algName(pd.ZSKAlgorithm))
+		fmt.Fprintf(&b, "\t\tKSK lifetime: %s\tZSK lifetime: %s\n", secsToDuration(pd.KSKLifetime), secsToDuration(pd.ZSKLifetime))
+	}
+	fmt.Fprintf(&b, "\t\tSigValidity: default=%s DNSKEY=%s DS=%s\n",
+		secsToDuration(pd.SigValidityDefault), secsToDuration(pd.SigValidityDNSKEY), secsToDuration(pd.SigValidityDS))
+	return b.String()
+}
+
+// algName renders a DNSSEC algorithm number as its mnemonic, falling back to the
+// decimal number for algorithms miekg/dns does not name (matching how dns prints
+// an unknown algorithm).
+func algName(alg uint8) string {
+	if name := dns.AlgorithmToString[alg]; name != "" {
+		return name
+	}
+	return strconv.Itoa(int(alg))
+}
+
+// secsToDuration renders a seconds count as a human duration (e.g. "720h0m0s");
+// 0 renders as "0s".
+func secsToDuration(secs uint32) string {
+	return (time.Duration(secs) * time.Second).String()
 }

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -804,65 +804,7 @@ func VerboseListZone(cr tdns.ZoneResponse) {
 	hdr += "Frozen|Dirty|Options"
 	zoneLines := []string{}
 	for zname, zconf := range cr.Zones {
-		line := fmt.Sprintf("zone: %s\n", zname)
-		if zconf.Error {
-			// A service-impacting error is ERROR; a non-service-impacting
-			// warning (e.g. ConfigWarning) leaves the zone serving — render it
-			// as such, matching ListZones rather than masquerading as ERROR.
-			if tdns.ErrorTypeIsServiceImpacting(zconf.ErrorType) {
-				line += fmt.Sprintf("\tState: ERROR ErrorType: %s ErrorMsg: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
-			} else {
-				line += fmt.Sprintf("\tState: serving Warning[%s]: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
-			}
-		}
-		opts := []string{}
-		for _, opt := range zconf.Options {
-			opts = append(opts, tdns.ZoneOptionToString[opt])
-		}
-		sort.Strings(opts)
-		line += fmt.Sprintf("\tType: %s\tStore: %s\tOptions: %v\n", zconf.Type, zconf.Store, opts)
-
-		if zconf.EffectiveDnssecPolicy != "" {
-			pol := zconf.EffectiveDnssecPolicy
-			if zconf.DnssecPolicyOverridden {
-				if zconf.DnssecPolicyConfigBase != "" {
-					pol += fmt.Sprintf(" (override from config: %s)", zconf.DnssecPolicyConfigBase)
-				} else {
-					pol += " (override; set live, not in config)"
-				}
-			}
-			line += fmt.Sprintf("\tDNSSEC policy: %s\n", pol)
-		}
-
-		line += fmt.Sprintf("\tPrimary: %s\tNotify: %s\tFile: %s\n", peerConfAddrsString(zconf.Primaries), peerConfAddrsString(zconf.Notify), zconf.Zonefile)
-
-		// Check for catalog zone flags
-		isCatalogZone := false
-		isAutoConfigured := false
-		for _, opt := range zconf.Options {
-			if opt == tdns.OptCatalogZone {
-				isCatalogZone = true
-			}
-			if opt == tdns.OptAutomaticZone {
-				isAutoConfigured = true
-			}
-		}
-
-		configInfo := ""
-		if isCatalogZone {
-			configInfo = "Catalog Zone"
-		} else if isAutoConfigured {
-			if zconf.SourceCatalog != "" {
-				configInfo = fmt.Sprintf("Config: auto (from catalog %s)", zconf.SourceCatalog)
-			} else {
-				configInfo = "Config: auto"
-			}
-		} else {
-			configInfo = "Config: manual"
-		}
-
-		line += fmt.Sprintf("\tFrozen: %t\tDirty: %t\t%s\n", zconf.Frozen, zconf.Dirty, configInfo)
-		zoneLines = append(zoneLines, line)
+		zoneLines = append(zoneLines, zoneBaseDetail(zname, zconf))
 	}
 
 	sort.Slice(zoneLines, func(i, j int) bool {
@@ -871,27 +813,27 @@ func VerboseListZone(cr tdns.ZoneResponse) {
 	fmt.Printf("%s\n", columnize.SimpleFormat(zoneLines))
 }
 
-// DescribeZone renders the full single-zone detail block for `zone desc`:
-// everything VerboseListZone shows for a zone (state, type/store/options,
-// effective DNSSEC policy + override, primaries/notify/file, frozen/dirty/config
-// source) plus two sections that are only available via `zone desc` — the
-// last-applied DNSSEC-policy record and the bound policy's algorithm/lifetime/
-// sig-validity detail. It returns the text (trailing newline included) so it is
-// straightforward to unit test; RunZoneDesc prints the result.
-func DescribeZone(zconf tdns.ZoneConf) string {
+// zoneBaseDetail renders the per-zone detail block shared by VerboseListZone
+// (`zone list -v`) and DescribeZone (`zone desc`): the zone header, error/warning
+// state, type/store/options, effective DNSSEC policy + override, primaries/
+// notify/file, and the frozen/dirty/config-source line. It returns the multi-line
+// block (each line ending in a newline). Both renderers call it so they cannot
+// drift; the caller passes the display name (VerboseListZone uses the map key,
+// DescribeZone uses zconf.Name — equal in practice). `zone list -v` output must
+// stay byte-identical — see TestVerboseListZone_GoldenParity.
+func zoneBaseDetail(name string, zconf tdns.ZoneConf) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "zone: %s\n", zconf.Name)
-
+	fmt.Fprintf(&b, "zone: %s\n", name)
 	if zconf.Error {
 		// A service-impacting error is ERROR; a non-service-impacting warning
-		// (e.g. ConfigWarning) leaves the zone serving — mirror VerboseListZone.
+		// (e.g. ConfigWarning) leaves the zone serving — render it as such,
+		// matching ListZones rather than masquerading as ERROR.
 		if tdns.ErrorTypeIsServiceImpacting(zconf.ErrorType) {
 			fmt.Fprintf(&b, "\tState: ERROR ErrorType: %s ErrorMsg: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
 		} else {
 			fmt.Fprintf(&b, "\tState: serving Warning[%s]: %s\n", tdns.ErrorTypeToString[zconf.ErrorType], zconf.ErrorMsg)
 		}
 	}
-
 	opts := []string{}
 	for _, opt := range zconf.Options {
 		opts = append(opts, tdns.ZoneOptionToString[opt])
@@ -911,10 +853,9 @@ func DescribeZone(zconf tdns.ZoneConf) string {
 		fmt.Fprintf(&b, "\tDNSSEC policy: %s\n", pol)
 	}
 
-	fmt.Fprintf(&b, "\tPrimary: %s\tNotify: %s\tFile: %s\n",
-		peerConfAddrsString(zconf.Primaries), peerConfAddrsString(zconf.Notify), zconf.Zonefile)
+	fmt.Fprintf(&b, "\tPrimary: %s\tNotify: %s\tFile: %s\n", peerConfAddrsString(zconf.Primaries), peerConfAddrsString(zconf.Notify), zconf.Zonefile)
 
-	// Config-source line (catalog / auto / manual), same derivation as VerboseListZone.
+	// Check for catalog zone flags
 	isCatalogZone := false
 	isAutoConfigured := false
 	for _, opt := range zconf.Options {
@@ -925,7 +866,8 @@ func DescribeZone(zconf tdns.ZoneConf) string {
 			isAutoConfigured = true
 		}
 	}
-	configInfo := "Config: manual"
+
+	configInfo := ""
 	if isCatalogZone {
 		configInfo = "Catalog Zone"
 	} else if isAutoConfigured {
@@ -934,11 +876,33 @@ func DescribeZone(zconf tdns.ZoneConf) string {
 		} else {
 			configInfo = "Config: auto"
 		}
+	} else {
+		configInfo = "Config: manual"
 	}
-	fmt.Fprintf(&b, "\tFrozen: %t\tDirty: %t\t%s\n", zconf.Frozen, zconf.Dirty, configInfo)
 
-	// Section 1: last-applied DNSSEC policy record (from the keystore).
-	if zconf.AppliedPolicy != "" {
+	fmt.Fprintf(&b, "\tFrozen: %t\tDirty: %t\t%s\n", zconf.Frozen, zconf.Dirty, configInfo)
+	return b.String()
+}
+
+// DescribeZone renders the full single-zone detail block for `zone desc`:
+// everything VerboseListZone shows for a zone (state, type/store/options,
+// effective DNSSEC policy + override, primaries/notify/file, frozen/dirty/config
+// source) plus two sections that are only available via `zone desc` — the
+// last-applied DNSSEC-policy record and the bound policy's algorithm/lifetime/
+// sig-validity detail. It returns the text (trailing newline included) so it is
+// straightforward to unit test; RunZoneDesc prints the result.
+func DescribeZone(zconf tdns.ZoneConf) string {
+	var b strings.Builder
+	// Shared base block (identical to what `zone list -v` renders for the zone).
+	b.WriteString(zoneBaseDetail(zconf.Name, zconf))
+
+	// Section 1: last-applied DNSSEC policy record (from the keystore). A backend
+	// read failure is surfaced distinctly from a genuinely absent record so an
+	// operator diagnosing DNSSEC state isn't misled by "(not recorded)".
+	switch {
+	case zconf.AppliedError != "":
+		fmt.Fprintf(&b, "\tApplied policy: (lookup failed: %s)\n", zconf.AppliedError)
+	case zconf.AppliedPolicy != "":
 		src := zconf.AppliedSource
 		if src == "" {
 			src = "(unknown)"
@@ -948,7 +912,7 @@ func DescribeZone(zconf tdns.ZoneConf) string {
 			at = "(unknown)"
 		}
 		fmt.Fprintf(&b, "\tApplied policy: %s\tSource: %s\tApplied at: %s\n", zconf.AppliedPolicy, src, at)
-	} else {
+	default:
 		b.WriteString("\tApplied policy: (not recorded)\n")
 	}
 

--- a/v2/cli/zone_desc_test.go
+++ b/v2/cli/zone_desc_test.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+// TestDescribeZone_Signed: a signed zone renders the applied-policy triplet and
+// the bound policy's KSK/ZSK algorithm + lifetime + sig-validity detail, with
+// algorithm numbers rendered as names and lifetimes as durations.
+func TestDescribeZone_Signed(t *testing.T) {
+	zconf := tdns.ZoneConf{
+		Name:                  "signed.example.",
+		Type:                  "primary",
+		Store:                 "MapZone",
+		EffectiveDnssecPolicy: "pol-a",
+		AppliedPolicy:         "pol-a",
+		AppliedSource:         "command",
+		AppliedAt:             "2026-07-18 12:00:00",
+		PolicyDetail: &tdns.DnssecPolicyView{
+			Name:               "pol-a",
+			Mode:               tdns.DnssecPolicyModeKSKZSK,
+			KSKAlgorithm:       13, // ECDSAP256SHA256
+			ZSKAlgorithm:       13,
+			KSKLifetime:        31536000, // 365d
+			ZSKLifetime:        2592000,  // 30d
+			SigValidityDefault: 1209600,
+			SigValidityDNSKEY:  1209600,
+			SigValidityDS:      86400,
+		},
+	}
+	out := DescribeZone(zconf)
+	for _, want := range []string{
+		"zone: signed.example.",
+		"Type: primary",
+		"DNSSEC policy: pol-a",
+		"Applied policy: pol-a",
+		"Source: command",
+		"Applied at: 2026-07-18 12:00:00",
+		"DNSSEC detail: Mode: ksk-zsk",
+		"KSK algorithm: ECDSAP256SHA256",
+		"ZSK algorithm: ECDSAP256SHA256",
+		"KSK lifetime: 8760h0m0s",
+		"ZSK lifetime: 720h0m0s",
+		"SigValidity: default=336h0m0s DNSKEY=336h0m0s DS=24h0m0s",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("DescribeZone missing %q in output:\n%s", want, out)
+		}
+	}
+	// CSK-only wording must NOT appear for a ksk-zsk policy.
+	if strings.Contains(out, "CSK algorithm") {
+		t.Fatalf("ksk-zsk policy should not render a CSK line:\n%s", out)
+	}
+}
+
+// TestDescribeZone_CSK: a csk-mode policy renders a single CSK algorithm/lifetime
+// line (from Algorithm / CSKLifetime), not KSK/ZSK.
+func TestDescribeZone_CSK(t *testing.T) {
+	zconf := tdns.ZoneConf{
+		Name:                  "csk.example.",
+		EffectiveDnssecPolicy: "csk-pol",
+		PolicyDetail: &tdns.DnssecPolicyView{
+			Name:        "csk-pol",
+			Mode:        tdns.DnssecPolicyModeCSK,
+			Algorithm:   15, // ED25519
+			CSKLifetime: 5184000,
+		},
+	}
+	out := DescribeZone(zconf)
+	if !strings.Contains(out, "CSK algorithm: ED25519") {
+		t.Fatalf("csk policy should render CSK algorithm name:\n%s", out)
+	}
+	if strings.Contains(out, "KSK algorithm") || strings.Contains(out, "ZSK algorithm") {
+		t.Fatalf("csk policy should not render KSK/ZSK lines:\n%s", out)
+	}
+}
+
+// TestDescribeZone_Unsigned: no bound policy and no applied record degrade to
+// clear "(not recorded)" / "not signed" lines rather than blanks.
+func TestDescribeZone_Unsigned(t *testing.T) {
+	out := DescribeZone(tdns.ZoneConf{Name: "plain.example.", Type: "primary"})
+	if !strings.Contains(out, "Applied policy: (not recorded)") {
+		t.Fatalf("unsigned zone should render (not recorded):\n%s", out)
+	}
+	if !strings.Contains(out, "DNSSEC detail: not signed") {
+		t.Fatalf("unsigned zone should render not signed:\n%s", out)
+	}
+}
+
+// TestDescribeZone_PolicyUnavailable: a zone bound to a policy the server could
+// not resolve (PolicyDetail nil but a policy name is bound) renders a clear
+// "policy unavailable" line naming the policy.
+func TestDescribeZone_PolicyUnavailable(t *testing.T) {
+	out := DescribeZone(tdns.ZoneConf{
+		Name:                  "ghost.example.",
+		EffectiveDnssecPolicy: "ghost-pol",
+	})
+	if !strings.Contains(out, "DNSSEC detail: policy unavailable (ghost-pol)") {
+		t.Fatalf("bound-but-unresolvable policy should render policy unavailable:\n%s", out)
+	}
+}

--- a/v2/cli/zone_desc_test.go
+++ b/v2/cli/zone_desc_test.go
@@ -94,6 +94,21 @@ func TestDescribeZone_Unsigned(t *testing.T) {
 	}
 }
 
+// TestDescribeZone_AppliedError: a keystore read failure is rendered distinctly
+// (lookup failed: …), not conflated with a genuinely absent record.
+func TestDescribeZone_AppliedError(t *testing.T) {
+	out := DescribeZone(tdns.ZoneConf{
+		Name:         "err.example.",
+		AppliedError: "boom: disk gone",
+	})
+	if !strings.Contains(out, "Applied policy: (lookup failed: boom: disk gone)") {
+		t.Fatalf("keystore read error should render distinctly:\n%s", out)
+	}
+	if strings.Contains(out, "(not recorded)") {
+		t.Fatalf("a lookup error must not be shown as (not recorded):\n%s", out)
+	}
+}
+
 // TestDescribeZone_PolicyUnavailable: a zone bound to a policy the server could
 // not resolve (PolicyDetail nil but a policy name is bound) renders a clear
 // "policy unavailable" line naming the policy.

--- a/v2/cli/zone_render_parity_test.go
+++ b/v2/cli/zone_render_parity_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package cli
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+// captureStdout runs f with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+	return string(b)
+}
+
+// parityZoneResponse is the fixed input for the VerboseListZone/DescribeZone
+// parity guard: one zone exercising the shared base block (no error, empty
+// options → manual config, effective policy with a config-base override,
+// primaries/notify/file, frozen/dirty).
+func parityZoneResponse() tdns.ZoneResponse {
+	return tdns.ZoneResponse{
+		Zones: map[string]tdns.ZoneConf{
+			"example.": {
+				Name:                   "example.",
+				Type:                   "primary",
+				Store:                  "MapZone",
+				EffectiveDnssecPolicy:  "default",
+				DnssecPolicyOverridden: true,
+				DnssecPolicyConfigBase: "base",
+				Primaries:              []tdns.PeerConf{{Addr: "192.0.2.1:53"}},
+				Notify:                 []tdns.PeerConf{{Addr: "192.0.2.2:53"}},
+				Zonefile:               "/etc/tdns/example.zone",
+				Dirty:                  true,
+			},
+		},
+	}
+}
+
+// TestVerboseListZone_GoldenParity pins VerboseListZone's exact stdout so the
+// shared base-renderer (zoneBaseDetail, used by both VerboseListZone and
+// DescribeZone) cannot silently change `zone list -v` output.
+func TestVerboseListZone_GoldenParity(t *testing.T) {
+	got := captureStdout(t, func() { VerboseListZone(parityZoneResponse()) })
+	// Golden captured from VerboseListZone BEFORE the zoneBaseDetail extraction;
+	// it must remain byte-for-byte identical afterwards.
+	const golden = "zone: example.\n\tType: primary\tStore: MapZone\tOptions: []\n" +
+		"\tDNSSEC policy: default (override from config: base)\n" +
+		"\tPrimary: 192.0.2.1:53\tNotify: 192.0.2.2:53\tFile: /etc/tdns/example.zone\n" +
+		"\tFrozen: false\tDirty: true\tConfig: manual\n"
+	if got != golden {
+		t.Fatalf("VerboseListZone output changed.\n--- got ---\n%s\n--- quoted ---\n%q", got, got)
+	}
+}
+
+// TestDescribeZone_SharesBaseWithList proves DescribeZone's base block is exactly
+// the shared zoneBaseDetail output for the same zone (its extra applied-policy /
+// DNSSEC-detail sections are appended after). This is what structurally prevents
+// the two renderers from drifting.
+func TestDescribeZone_SharesBaseWithList(t *testing.T) {
+	zconf := parityZoneResponse().Zones["example."]
+	base := zoneBaseDetail(zconf.Name, zconf)
+	out := DescribeZone(zconf)
+	if len(out) < len(base) || out[:len(base)] != base {
+		t.Fatalf("DescribeZone must start with the shared base block.\n--- base ---\n%s\n--- out ---\n%s", base, out)
+	}
+}

--- a/v2/db_zone_applied_detail_test.go
+++ b/v2/db_zone_applied_detail_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import "testing"
+
+// TestGetZoneAppliedPolicyDetail exercises the read-only accessor added for the
+// `zone desc` CLI: it returns the applied policy name + source AND the applied_at
+// timestamp, and reports ok=false with empty strings when there is no record.
+func TestGetZoneAppliedPolicyDetail(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// No record yet: ok=false, everything empty.
+	if name, source, at, ok, err := GetZoneAppliedPolicyDetail(kdb, "example."); err != nil || ok || name != "" || source != "" || at != "" {
+		t.Fatalf("no record: got (%q, %q, %q, ok=%v, err=%v), want (\"\",\"\",\"\", false, nil)", name, source, at, ok, err)
+	}
+
+	// Record one (FQDN-normalized): name+source round-trip and applied_at is set.
+	if err := SetZoneAppliedPolicy(kdb, "example", "pol-a", "command"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy: %v", err)
+	}
+	name, source, at, ok, err := GetZoneAppliedPolicyDetail(kdb, "example.")
+	if err != nil || !ok || name != "pol-a" || source != "command" {
+		t.Fatalf("round-trip: got (%q, %q, ok=%v, err=%v), want (\"pol-a\", \"command\", true, nil)", name, source, ok, err)
+	}
+	if at == "" {
+		t.Fatalf("applied_at should be set by SetZoneAppliedPolicy, got empty")
+	}
+
+	// Clearing the applied record makes the accessor report absence again even
+	// though the (override) row still exists.
+	if err := SetZonePolicyOverride(kdb, "example.", "override-pol"); err != nil {
+		t.Fatalf("SetZonePolicyOverride: %v", err)
+	}
+	if err := ClearZoneAppliedPolicy(kdb, "example."); err != nil {
+		t.Fatalf("ClearZoneAppliedPolicy: %v", err)
+	}
+	if _, _, at, ok, err := GetZoneAppliedPolicyDetail(kdb, "example."); err != nil || ok || at != "" {
+		t.Fatalf("after clear: got (at=%q, ok=%v, err=%v), want (\"\", false, nil)", at, ok, err)
+	}
+
+	// Nil keystore is a clean error, not a panic.
+	if _, _, _, _, err := GetZoneAppliedPolicyDetail(nil, "example."); err == nil {
+		t.Fatalf("nil keystore should error")
+	}
+}

--- a/v2/db_zone_policy_override.go
+++ b/v2/db_zone_policy_override.go
@@ -160,6 +160,32 @@ func GetZoneAppliedPolicy(kdb *KeyDB, zone string) (name string, source string, 
 	return strings.TrimSpace(p.String), strings.TrimSpace(s.String), true, nil
 }
 
+// GetZoneAppliedPolicyDetail is like GetZoneAppliedPolicy but also returns the
+// applied_at timestamp (as stored by SQLite datetime('now'): 'YYYY-MM-DD
+// HH:MM:SS' in UTC). It is a read-only accessor for display (the `zone desc`
+// CLI); appliedAt is "" when the column is NULL. ok is false (and all strings
+// "") when the zone has no applied record.
+func GetZoneAppliedPolicyDetail(kdb *KeyDB, zone string) (name, source, appliedAt string, ok bool, err error) {
+	if kdb == nil || kdb.DB == nil {
+		return "", "", "", false, fmt.Errorf("GetZoneAppliedPolicyDetail: nil keystore")
+	}
+	zone = dns.Fqdn(strings.TrimSpace(zone))
+	var p, s, a sql.NullString
+	err = kdb.DB.QueryRow(
+		`SELECT applied_policy, applied_source, applied_at FROM ZonePolicyOverride WHERE zone = ?`, zone,
+	).Scan(&p, &s, &a)
+	if err == sql.ErrNoRows {
+		return "", "", "", false, nil
+	}
+	if err != nil {
+		return "", "", "", false, err
+	}
+	if !p.Valid || strings.TrimSpace(p.String) == "" {
+		return "", "", "", false, nil
+	}
+	return strings.TrimSpace(p.String), strings.TrimSpace(s.String), strings.TrimSpace(a.String), true, nil
+}
+
 // ClearZoneAppliedPolicy clears a zone's last-applied record (applied_* → NULL)
 // while leaving the CLI override row intact. Used by the `policy-reset` escape
 // hatch (§6.7) so a forced re-sign starts from a clean last-applied slate.

--- a/v2/db_zone_policy_override.go
+++ b/v2/db_zone_policy_override.go
@@ -140,24 +140,10 @@ ON CONFLICT(zone) DO UPDATE SET
 // zone. ok is false (and name/source "") when the zone has no applied record,
 // whether because it has no row at all or the applied_policy column is unset.
 func GetZoneAppliedPolicy(kdb *KeyDB, zone string) (name string, source string, ok bool, err error) {
-	if kdb == nil || kdb.DB == nil {
-		return "", "", false, fmt.Errorf("GetZoneAppliedPolicy: nil keystore")
-	}
-	zone = dns.Fqdn(strings.TrimSpace(zone))
-	var p, s sql.NullString
-	err = kdb.DB.QueryRow(
-		`SELECT applied_policy, applied_source FROM ZonePolicyOverride WHERE zone = ?`, zone,
-	).Scan(&p, &s)
-	if err == sql.ErrNoRows {
-		return "", "", false, nil
-	}
-	if err != nil {
-		return "", "", false, err
-	}
-	if !p.Valid || strings.TrimSpace(p.String) == "" {
-		return "", "", false, nil
-	}
-	return strings.TrimSpace(p.String), strings.TrimSpace(s.String), true, nil
+	// Delegate to the detail accessor (single source of truth for the query and
+	// the ErrNoRows/blank-policy handling); the applied_at column is ignored here.
+	name, source, _, ok, err = GetZoneAppliedPolicyDetail(kdb, zone)
+	return name, source, ok, err
 }
 
 // GetZoneAppliedPolicyDetail is like GetZoneAppliedPolicy but also returns the

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -280,16 +280,27 @@ type ZoneConf struct {
 	// `set-policy` override (rather than the config base); and, when
 	// overridden, the config-base policy it overrides. Not config; not
 	// serialized to YAML.
-	EffectiveDnssecPolicy  string    `yaml:"-"`
-	DnssecPolicyOverridden bool      `yaml:"-"`
-	DnssecPolicyConfigBase string    `yaml:"-"`
-	Template               string    `yaml:"template" mapstructure:"template"`
-	MultiSigner            string    `yaml:"multisigner" mapstructure:"multisigner"`
-	Error                  bool      // zone is broken and cannot be used
-	ErrorType              ErrorType // "config" | "refresh" | "agent" | "DNSSEC"
-	ErrorMsg               string    // reason for the error (if known)
-	RefreshCount           int       // number of times the zone has been sucessfully refreshed (used to determine if we have zonedata)
-	SourceCatalog          string    // if auto-configured, which catalog zone created this zone
+	EffectiveDnssecPolicy  string `yaml:"-"`
+	DnssecPolicyOverridden bool   `yaml:"-"`
+	DnssecPolicyConfigBase string `yaml:"-"`
+	// AppliedPolicy / AppliedSource / AppliedAt and PolicyDetail are display-only
+	// fields populated ONLY by the single-zone `zone desc` path (list-zones scoped
+	// to one zone): the last-applied DNSSEC-policy record from the keystore
+	// (policy name; source config|command; the applied_at timestamp) and a
+	// projection of the zone's currently-bound policy's algorithm/lifetime/
+	// sig-validity detail. The bulk `list-zones` path (backing `zone list`) never
+	// sets these, so its output is unchanged. Not config; not serialized to YAML.
+	AppliedPolicy string            `yaml:"-"`
+	AppliedSource string            `yaml:"-"`
+	AppliedAt     string            `yaml:"-"`
+	PolicyDetail  *DnssecPolicyView `yaml:"-"`
+	Template      string            `yaml:"template" mapstructure:"template"`
+	MultiSigner   string            `yaml:"multisigner" mapstructure:"multisigner"`
+	Error         bool              // zone is broken and cannot be used
+	ErrorType     ErrorType         // "config" | "refresh" | "agent" | "DNSSEC"
+	ErrorMsg      string            // reason for the error (if known)
+	RefreshCount  int               // number of times the zone has been sucessfully refreshed (used to determine if we have zonedata)
+	SourceCatalog string            // if auto-configured, which catalog zone created this zone
 	// ApiManaged marks a zone created/managed via the dynamic-zones API (zone
 	// add/delete/modify). Persisted so OptApiManagedZone can be re-derived on
 	// reload — a dedicated bool, not a SourceCatalog="api" sentinel.
@@ -301,6 +312,28 @@ type ZoneConf struct {
 	// ("pending"|"loading"|"ready"|"error") populated by the list handlers from
 	// ZoneStatus + the error registry. Not config; not serialized to YAML.
 	Provisioning string `yaml:"-" mapstructure:"-"`
+}
+
+// DnssecPolicyView is a display-only projection of the DnssecPolicy bound to a
+// zone, carried in ZoneConf.PolicyDetail and populated only by the `zone desc`
+// path. It holds the operator-relevant algorithm/lifetime/sig-validity fields as
+// raw values (algorithm numbers, lifetimes and sig-validity in seconds); the CLI
+// renderer turns them into algorithm names and human durations. Error mirrors
+// DnssecPolicy.Error: non-empty means the policy failed to parse and the other
+// fields may be incomplete. Not config; not serialized to YAML.
+type DnssecPolicyView struct {
+	Name               string
+	Error              string
+	Mode               string // ksk-zsk | csk
+	Algorithm          uint8  // default / CSK algorithm
+	KSKAlgorithm       uint8
+	ZSKAlgorithm       uint8
+	KSKLifetime        uint32 // seconds
+	ZSKLifetime        uint32 // seconds
+	CSKLifetime        uint32 // seconds
+	SigValidityDefault uint32 // seconds
+	SigValidityDNSKEY  uint32 // seconds
+	SigValidityDS      uint32 // seconds
 }
 
 type TemplateConf struct {

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -290,9 +290,14 @@ type ZoneConf struct {
 	// projection of the zone's currently-bound policy's algorithm/lifetime/
 	// sig-validity detail. The bulk `list-zones` path (backing `zone list`) never
 	// sets these, so its output is unchanged. Not config; not serialized to YAML.
-	AppliedPolicy string            `yaml:"-"`
-	AppliedSource string            `yaml:"-"`
-	AppliedAt     string            `yaml:"-"`
+	AppliedPolicy string `yaml:"-"`
+	AppliedSource string `yaml:"-"`
+	AppliedAt     string `yaml:"-"`
+	// AppliedError is set (to the error text) when the keystore read for the
+	// applied-policy record failed, so `zone desc` can distinguish a backend
+	// failure from a genuinely absent record rather than showing both as
+	// "(not recorded)".
+	AppliedError  string            `yaml:"-"`
 	PolicyDetail  *DnssecPolicyView `yaml:"-"`
 	Template      string            `yaml:"template" mapstructure:"template"`
 	MultiSigner   string            `yaml:"multisigner" mapstructure:"multisigner"`

--- a/v2/zone_desc_detail_test.go
+++ b/v2/zone_desc_detail_test.go
@@ -83,3 +83,26 @@ func TestPopulateZoneDescDetail(t *testing.T) {
 		t.Fatalf("applied record must still be surfaced: got (%q, %q)", zGhost.AppliedPolicy, zGhost.AppliedSource)
 	}
 }
+
+// TestPopulateZoneDescDetail_AppliedError: a keystore read failure sets
+// AppliedError (distinct from an absent record) and does not block bound-policy
+// resolution. A nil keystore forces GetZoneAppliedPolicyDetail to error.
+func TestPopulateZoneDescDetail_AppliedError(t *testing.T) {
+	withLiveConfig(t, &RuntimeConfig{
+		DnssecPolicies: map[string]DnssecPolicy{
+			"pol-a": {Name: "pol-a", Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: 13, ZSKAlgorithm: 13},
+		},
+	})
+	zconf := ZoneConf{Name: "z.example."}
+	populateZoneDescDetail(&zconf, &ZoneData{DnssecPolicyName: "pol-a"}, "z.example.", nil)
+
+	if zconf.AppliedError == "" {
+		t.Fatalf("a keystore read error must set AppliedError")
+	}
+	if zconf.AppliedPolicy != "" {
+		t.Fatalf("AppliedPolicy must stay empty on a read error, got %q", zconf.AppliedPolicy)
+	}
+	if zconf.PolicyDetail == nil {
+		t.Fatalf("an applied-read error must not block bound-policy resolution")
+	}
+}

--- a/v2/zone_desc_detail_test.go
+++ b/v2/zone_desc_detail_test.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import "testing"
+
+// withLiveConfig swaps in a runtime-config snapshot for the duration of a test
+// and restores the previous one on cleanup.
+func withLiveConfig(t *testing.T, rc *RuntimeConfig) {
+	t.Helper()
+	prev := liveConfig.Load()
+	liveConfig.Store(rc)
+	t.Cleanup(func() { liveConfig.Store(prev) })
+}
+
+// TestPopulateZoneDescDetail covers the three `zone desc` detail cases: a signed
+// zone with an applied record and a resolvable bound policy; an unsigned zone
+// (no bound policy → no PolicyDetail, no applied record); and a zone bound to a
+// policy name that is not present in the live config snapshot (→ no PolicyDetail
+// but the applied record is still surfaced).
+func TestPopulateZoneDescDetail(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	withLiveConfig(t, &RuntimeConfig{
+		DnssecPolicies: map[string]DnssecPolicy{
+			"pol-a": {
+				Name:         "pol-a",
+				Mode:         DnssecPolicyModeKSKZSK,
+				KSKAlgorithm: 13, // ECDSAP256SHA256
+				ZSKAlgorithm: 13,
+				KSK:          KeyLifetime{Lifetime: 31536000}, // 365d
+				ZSK:          KeyLifetime{Lifetime: 2592000},  // 30d
+				SigValidity:  PolicySigValidity{Default: 1209600, DNSKEY: 1209600, DS: 86400},
+			},
+		},
+	})
+
+	// --- signed zone with applied record + resolvable policy ---
+	if err := SetZoneAppliedPolicy(kdb, "signed.example.", "pol-a", "command"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy: %v", err)
+	}
+	zconf := ZoneConf{Name: "signed.example."}
+	populateZoneDescDetail(&zconf, &ZoneData{DnssecPolicyName: "pol-a"}, "signed.example.", kdb)
+
+	if zconf.AppliedPolicy != "pol-a" || zconf.AppliedSource != "command" || zconf.AppliedAt == "" {
+		t.Fatalf("applied fields: got (%q, %q, at=%q), want (\"pol-a\", \"command\", non-empty)",
+			zconf.AppliedPolicy, zconf.AppliedSource, zconf.AppliedAt)
+	}
+	if zconf.PolicyDetail == nil {
+		t.Fatalf("PolicyDetail should be populated for a resolvable bound policy")
+	}
+	pd := zconf.PolicyDetail
+	if pd.Name != "pol-a" || pd.Mode != DnssecPolicyModeKSKZSK || pd.KSKAlgorithm != 13 || pd.ZSKAlgorithm != 13 {
+		t.Fatalf("PolicyDetail alg/mode: got %+v", pd)
+	}
+	if pd.KSKLifetime != 31536000 || pd.ZSKLifetime != 2592000 || pd.SigValidityDS != 86400 {
+		t.Fatalf("PolicyDetail lifetimes/sigvalidity: got %+v", pd)
+	}
+
+	// --- unsigned zone: no bound policy, no applied record ---
+	zUnsigned := ZoneConf{Name: "plain.example."}
+	populateZoneDescDetail(&zUnsigned, &ZoneData{DnssecPolicyName: ""}, "plain.example.", kdb)
+	if zUnsigned.PolicyDetail != nil {
+		t.Fatalf("unsigned zone must have nil PolicyDetail, got %+v", zUnsigned.PolicyDetail)
+	}
+	if zUnsigned.AppliedPolicy != "" {
+		t.Fatalf("unsigned zone without applied record must have empty AppliedPolicy, got %q", zUnsigned.AppliedPolicy)
+	}
+
+	// --- bound policy name not in the live snapshot: applied record still shown,
+	// PolicyDetail nil (renderer prints "policy unavailable") ---
+	if err := SetZoneAppliedPolicy(kdb, "ghost.example.", "ghost-pol", "config"); err != nil {
+		t.Fatalf("SetZoneAppliedPolicy: %v", err)
+	}
+	zGhost := ZoneConf{Name: "ghost.example.", EffectiveDnssecPolicy: "ghost-pol"}
+	populateZoneDescDetail(&zGhost, &ZoneData{DnssecPolicyName: "ghost-pol"}, "ghost.example.", kdb)
+	if zGhost.PolicyDetail != nil {
+		t.Fatalf("unresolvable bound policy must have nil PolicyDetail, got %+v", zGhost.PolicyDetail)
+	}
+	if zGhost.AppliedPolicy != "ghost-pol" || zGhost.AppliedSource != "config" {
+		t.Fatalf("applied record must still be surfaced: got (%q, %q)", zGhost.AppliedPolicy, zGhost.AppliedSource)
+	}
+}


### PR DESCRIPTION
## What & why

`zone list -v` shows only the effective DNSSEC policy *name*, and the keystore's last-applied policy record (`applied_policy` / `applied_source` / `applied_at` on `ZonePolicyOverride`) had **no CLI surface** — reading it meant `sqlite3`-ing into the keystore. Ahead of live-testing transactional policy reload, this adds a dedicated describe command that makes the `applied_*` triplet and the bound policy's algorithm detail visible from the CLI.

## The command

```
tdns-cli auth zone desc -z <zone>
```

Prints a detailed multi-line record for **one** zone: everything `zone list -v` shows (type/store/options, primaries/notify/file, error/warning state, effective policy + override info) plus two new sections:

1. **Applied-policy record** — `applied_policy`, `applied_source` (`config`|`command`), `applied_at`; a clear `(not recorded)` when absent.
2. **DNSSEC policy detail** — for the currently-bound policy: `Mode` (ksk-zsk/csk), KSK/ZSK (or CSK) algorithms rendered as names via `dns.AlgorithmToString`, key lifetimes, and RRSIG validity (default/DNSKEY/DS). The policy's parse `Error` is surfaced if set. An unsigned zone degrades to `not signed`; a bound-but-unresolvable policy to `policy unavailable`.

## Wiring (minimal, read-only)

- `zone desc` sends `list-zones` **scoped to one zone** (`ZonePost.Zone` set). The handler's scoped path reuses a shared `buildListZoneConf` and additionally fills display-only fields on `ZoneConf` (`AppliedPolicy`/`AppliedSource`/`AppliedAt` + a `*DnssecPolicyView`). The bound policy is resolved **lock-free** from `ConfLive().DnssecPolicies[...]`.
- The bulk `list-zones` path is refactored onto the **same builder** and left **byte-identical**, so `zone list` (plain and `-v`) is unchanged. The new `ZoneConf` fields are `yaml:"-"` and never rendered by `ListZones`/`VerboseListZone`.
- `applied_at` comes from a new **read-only** accessor `GetZoneAppliedPolicyDetail`; the existing `GetZoneAppliedPolicy` signature is untouched.
- No transactional-reload logic (`zone_policy_apply.go`, `refreshengine.go`) is modified.

## Tests

- Renderer `DescribeZone`: signed / csk / unsigned / policy-unavailable cases.
- Handler `populateZoneDescDetail`: applied-record + bound-policy field population, unsigned, and unresolvable-policy cases.
- New DB accessor `GetZoneAppliedPolicyDetail`.

## Verification

- `GOROOT=/opt/local/lib/go CGO_ENABLED=1` build + vet + full `-race` green for both the `v2` and `v2/cli` modules.
- Manual smoke against a running `tdns-auth` still to do (signed zone shows effective policy + `applied_*` + KSK/ZSK detail; unsigned degrades gracefully; empty `-z` errors cleanly; `zone list`/`list -v` unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `zone desc` command to show a full, single-zone multi-section description (requires `--zone`).

- **Improvements**
  - DNSSEC section now reports signed/unsigned state, applied policy name/source/time, and bound-policy details (including clear messaging for “policy unavailable” and applied-policy lookup failures).
  - Improved consistency between verbose zone listing and `zone desc` output (shared base rendering).

- **Tests**
  - Expanded CLI tests for signed, CSK, unsigned, policy-unavailable, and applied-error scenarios.
  - Added rendering parity and applied-policy accessor coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->