### PR TITLE
tdns-cli: add `auth config check` and `auth config mwe`

### DIFF
--- a/v2/cli/config_check_cmds.go
+++ b/v2/cli/config_check_cmds.go
@@ -229,7 +229,7 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 	fmt.Println()
 
 	// Load the config the way the daemon does (main + single-level includes).
-	v, loadErr := loadAuthConfigViper(cfgPath, rep)
+	v, loadErr := loadConfigViper(cfgPath, rep)
 	if loadErr != nil {
 		rep.fail("Config file", "load", fmt.Sprintf("cannot load %s: %v", cfgPath, loadErr),
 			"fix the YAML syntax / missing file, then re-run")
@@ -240,7 +240,7 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 
 	// Required-field validation via the exported tdns validator (drives the
 	// `validate:"required"` struct tags AND the cert/key pair validation).
-	checkRequiredFields(v, cfgPath, rep)
+	checkRequiredFields(v, cfgPath, rep, tdns.AppTypeAuth)
 
 	// Decode into a typed Config for the structural checks. Best-effort: the
 	// legacy bare-string primary/ACL decode hooks live in the tdns package and
@@ -286,10 +286,10 @@ func finishCheckconf(rep *ccReport) {
 // Config loading (mirrors cmdv2/cli/root.go initConfig include handling)
 // ---------------------------------------------------------------------------
 
-// loadAuthConfigViper reads path into a fresh viper instance and merges any
+// loadConfigViper reads path into a fresh viper instance and merges any
 // top-level include: files (single level, non-recursive), exactly as the
 // daemon/CLI loaders do. A missing include is reported as a WARN, not fatal.
-func loadAuthConfigViper(path string, rep *ccReport) (*viper.Viper, error) {
+func loadConfigViper(path string, rep *ccReport) (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigFile(path)
 	if err := v.ReadInConfig(); err != nil {
@@ -321,24 +321,30 @@ func loadAuthConfigViper(path string, rep *ccReport) (*viper.Viper, error) {
 // Static checks
 // ---------------------------------------------------------------------------
 
-func checkRequiredFields(v *viper.Viper, cfgPath string, rep *ccReport) {
-	// tdns.ValidateConfig selects the sections to validate based on the app
-	// type. Force AppTypeAuth so it validates service/db/apiserver/dnsengine.
+// checkRequiredFields runs the exported required-field validator for the given
+// app type (which selects the sections tdns.ValidateConfig checks: auth →
+// service/db/apiserver/dnsengine + log; imr → imrengine + log).
+func checkRequiredFields(v *viper.Viper, cfgPath string, rep *ccReport, appType tdns.AppType) {
 	saved := tdns.Globals.App.Type
-	tdns.Globals.App.Type = tdns.AppTypeAuth
+	tdns.Globals.App.Type = appType
 	defer func() { tdns.Globals.App.Type = saved }()
 
+	suggestion := "add the missing required keys (service.name, dnsengine.addresses/transports, apiserver.*, db.file, log.file)"
+	passMsg := "all required sections/keys present; apiserver cert/key pair valid"
+	if appType == tdns.AppTypeImr {
+		suggestion = "add the missing required keys (imrengine.addresses, imrengine.transports, log.file)"
+		passMsg = "required sections present (imrengine.addresses/transports, log.file)"
+	}
+
 	if err := tdns.ValidateConfig(v, cfgPath); err != nil {
-		rep.fail("Required fields", "required",
-			firstLine(err.Error()),
-			"add the missing required keys (service.name, dnsengine.addresses/transports, apiserver.*, db.file, log.file)")
+		rep.fail("Required fields", "required", firstLine(err.Error()), suggestion)
 		// Fall through: also surface the raw multi-line detail for the operator.
 		for _, ln := range extraLines(err.Error()) {
 			rep.info("Required fields", "detail", ln)
 		}
 		return
 	}
-	rep.pass("Required fields", "required", "all required sections/keys present; apiserver cert/key pair valid")
+	rep.pass("Required fields", "required", passMsg)
 }
 
 func checkDnsEngine(cfg *tdns.Config, rep *ccReport) {

--- a/v2/cli/config_check_cmds.go
+++ b/v2/cli/config_check_cmds.go
@@ -1,0 +1,1004 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * `tdns-cli auth config check` — validate a tdns-auth configuration file and
+ * correlate it against the running daemon.
+ *
+ * The command is deliberately CLI-side and self-contained: it re-reads the
+ * YAML the same way the daemon's loader does (main file + single-level
+ * include: merge), reuses the exported tdns validators for the parts that
+ * have them (required-field tags, DNSSEC policy algorithm gating), and adds
+ * its own referential / filesystem / cross-file checks on top. When a daemon
+ * is reachable it also pulls the running config (via the mgmt API) and reports
+ * drift between what is on disk and what the server actually loaded.
+ *
+ * Modeled on `auto-rollover validate` (auto_rollover_validate.go), which
+ * established the "ask the daemon for its config path via /config/paths, then
+ * re-parse the YAML offline" pattern.
+ */
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/miekg/dns"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+// ---------------------------------------------------------------------------
+// Result model
+// ---------------------------------------------------------------------------
+
+type ccLevel int
+
+const (
+	ccPASS ccLevel = iota
+	ccINFO
+	ccWARN
+	ccFAIL
+)
+
+func (l ccLevel) label() string {
+	switch l {
+	case ccPASS:
+		return "PASS"
+	case ccINFO:
+		return "INFO"
+	case ccWARN:
+		return "WARN"
+	case ccFAIL:
+		return "FAIL"
+	}
+	return "????"
+}
+
+type ccResult struct {
+	level      ccLevel
+	check      string // short check name
+	msg        string // one-line detail
+	suggestion string // optional operator-actionable hint
+}
+
+// ccReport accumulates results grouped by section, preserving insertion order.
+type ccReport struct {
+	sections []string
+	byGroup  map[string][]ccResult
+}
+
+func newCCReport() *ccReport {
+	return &ccReport{byGroup: map[string][]ccResult{}}
+}
+
+func (r *ccReport) add(group string, level ccLevel, check, msg, suggestion string) {
+	if _, seen := r.byGroup[group]; !seen {
+		r.sections = append(r.sections, group)
+	}
+	r.byGroup[group] = append(r.byGroup[group], ccResult{level, check, msg, suggestion})
+}
+
+func (r *ccReport) pass(group, check, msg string) { r.add(group, ccPASS, check, msg, "") }
+func (r *ccReport) info(group, check, msg string) { r.add(group, ccINFO, check, msg, "") }
+func (r *ccReport) warn(group, check, msg, suggestion string) {
+	r.add(group, ccWARN, check, msg, suggestion)
+}
+func (r *ccReport) fail(group, check, msg, suggestion string) {
+	r.add(group, ccFAIL, check, msg, suggestion)
+}
+
+func (r *ccReport) counts() (fails, warns int) {
+	for _, g := range r.sections {
+		for _, res := range r.byGroup[g] {
+			switch res.level {
+			case ccFAIL:
+				fails++
+			case ccWARN:
+				warns++
+			}
+		}
+	}
+	return
+}
+
+// render prints the grouped report. In non-verbose mode PASS lines are
+// suppressed (only WARN/FAIL/INFO shown) unless a group has nothing but
+// passes, in which case a single summary line is printed for the group.
+func (r *ccReport) render(verbose bool) {
+	for _, g := range r.sections {
+		results := r.byGroup[g]
+		// Decide whether to print the group at all in non-verbose mode.
+		var nonPass int
+		for _, res := range results {
+			if res.level != ccPASS {
+				nonPass++
+			}
+		}
+		fmt.Printf("%s\n", g)
+		if !verbose && nonPass == 0 {
+			fmt.Printf("  PASS  (%d checks)\n", len(results))
+			continue
+		}
+		for _, res := range results {
+			if res.level == ccPASS && !verbose {
+				continue
+			}
+			line := res.check
+			if res.msg != "" {
+				line = fmt.Sprintf("%s — %s", res.check, res.msg)
+			}
+			fmt.Printf("  %-4s  %s\n", res.level.label(), line)
+			if res.suggestion != "" {
+				fmt.Printf("        ↳ %s\n", res.suggestion)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+// newConfigCheckCmd builds the `config check` command for the given role. Only
+// wired for "auth" today; the role parameter keeps the door open for imr/agent.
+func newConfigCheckCmd(role string) *cobra.Command {
+	var (
+		serverConfig string
+		offline      bool
+	)
+	c := &cobra.Command{
+		Use:   "check [config-file]",
+		Short: "Validate the tdns-" + role + " config and correlate it with the running daemon",
+		Long: `Validate a tdns-` + role + ` configuration file for completeness and internal
+consistency, and (unless --offline) correlate it against the running daemon to
+report drift between the file on disk and what the server actually loaded.
+
+Target config resolution:
+  1. an explicit path (positional arg or --serverconfig)
+  2. otherwise, online, the path the daemon reports via GET /config/paths
+  3. otherwise the compiled-in default (/etc/tdns/tdns-` + role + `.yaml)
+
+Exit status is non-zero if any check FAILs (WARNs do not fail the run).`,
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 1 && serverConfig == "" {
+				serverConfig = args[0]
+			}
+			runConfigCheck(role, serverConfig, offline)
+		},
+	}
+	c.Flags().StringVar(&serverConfig, "serverconfig", "", "path to the tdns-"+role+" config file to check (default: ask the daemon, else the compiled-in default)")
+	c.Flags().BoolVar(&offline, "offline", false, "do not contact the daemon; run static checks only")
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+func runConfigCheck(role, explicitPath string, offline bool) {
+	// config check renders its own structured findings; silence the reused
+	// tdns validators' per-section "validating config section" Info chatter
+	// (genuine config ERRORs still surface).
+	tdns.SetSubsystemLevel("config", slog.LevelError)
+
+	rep := newCCReport()
+
+	// Resolve which config file to check, and whether we can reach the daemon.
+	online := !offline
+	var daemonCfgPath, daemonDBPath string
+	if online {
+		if p, db, ok := fetchDaemonPaths(role); ok {
+			daemonCfgPath, daemonDBPath = p, db
+		} else {
+			online = false
+			rep.warn("Daemon", "reachability",
+				fmt.Sprintf("could not reach the %s daemon; running static checks only", role),
+				"start the daemon (or pass --offline) to enable running-config correlation")
+		}
+	}
+
+	cfgPath := explicitPath
+	switch {
+	case cfgPath != "":
+		// explicit path wins
+	case daemonCfgPath != "":
+		cfgPath = daemonCfgPath
+	default:
+		cfgPath = tdns.DefaultAuthCfgFile
+	}
+	cfgPath = absClean(cfgPath)
+
+	fmt.Printf("Checking %s config: %s\n", role, cfgPath)
+	if online {
+		fmt.Printf("Correlating against the running %s daemon.\n", role)
+		if daemonCfgPath != "" && absClean(daemonCfgPath) != cfgPath {
+			rep.warn("Config file", "daemon-config-mismatch",
+				fmt.Sprintf("checking %s, but the running daemon loaded %s", cfgPath, absClean(daemonCfgPath)),
+				"check the file the daemon is actually running, or reconcile the two")
+		}
+	}
+	fmt.Println()
+
+	// Load the config the way the daemon does (main + single-level includes).
+	v, loadErr := loadAuthConfigViper(cfgPath, rep)
+	if loadErr != nil {
+		rep.fail("Config file", "load", fmt.Sprintf("cannot load %s: %v", cfgPath, loadErr),
+			"fix the YAML syntax / missing file, then re-run")
+		finishCheckconf(rep)
+		return
+	}
+	rep.pass("Config file", "load", "config file (and includes) parsed as YAML")
+
+	// Required-field validation via the exported tdns validator (drives the
+	// `validate:"required"` struct tags AND the cert/key pair validation).
+	checkRequiredFields(v, cfgPath, rep)
+
+	// Decode into a typed Config for the structural checks. Best-effort: the
+	// legacy bare-string primary/ACL decode hooks live in the tdns package and
+	// are not reachable here, but modern {addr,key} configs decode cleanly.
+	var cfg tdns.Config
+	if err := v.Unmarshal(&cfg); err != nil {
+		rep.warn("Config file", "decode",
+			fmt.Sprintf("could not fully decode config into structs: %v", err),
+			"structural checks below may be incomplete; often caused by legacy bare-string primaries:/downstreams:")
+	}
+
+	checkDnsEngine(&cfg, rep)
+	checkApiServer(&cfg, cfgPath, rep)
+	checkDnssecPolicies(v, rep)
+	checkZones(&cfg, rep, online, role)
+	checkApiServerCorrelation(role, &cfg, rep)
+
+	// Running-config correlation.
+	if online {
+		correlateRunningConfig(role, &cfg, cfgPath, daemonDBPath, rep)
+	}
+
+	finishCheckconf(rep)
+}
+
+func finishCheckconf(rep *ccReport) {
+	fmt.Println()
+	rep.render(tdns.Globals.Verbose)
+	fails, warns := rep.counts()
+	fmt.Println()
+	switch {
+	case fails > 0:
+		fmt.Printf("Result: %d FAIL, %d WARN — config is not valid.\n", fails, warns)
+		os.Exit(1)
+	case warns > 0:
+		fmt.Printf("Result: 0 FAIL, %d WARN — config is usable but has warnings.\n", warns)
+	default:
+		fmt.Println("Result: all checks passed.")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config loading (mirrors cmdv2/cli/root.go initConfig include handling)
+// ---------------------------------------------------------------------------
+
+// loadAuthConfigViper reads path into a fresh viper instance and merges any
+// top-level include: files (single level, non-recursive), exactly as the
+// daemon/CLI loaders do. A missing include is reported as a WARN, not fatal.
+func loadAuthConfigViper(path string, rep *ccReport) (*viper.Viper, error) {
+	v := viper.New()
+	v.SetConfigFile(path)
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+	for _, inc := range v.GetStringSlice("include") {
+		incPath := inc
+		if !filepath.IsAbs(incPath) {
+			incPath = filepath.Join(filepath.Dir(path), incPath)
+		}
+		if _, err := os.Stat(incPath); err != nil {
+			if os.IsNotExist(err) {
+				rep.warn("Config file", "include",
+					fmt.Sprintf("included file not found: %s", incPath),
+					"create the file or remove it from the include: list")
+				continue
+			}
+			return nil, fmt.Errorf("stat include %s: %w", incPath, err)
+		}
+		v.SetConfigFile(incPath)
+		if err := v.MergeInConfig(); err != nil {
+			return nil, fmt.Errorf("merge include %s: %w", incPath, err)
+		}
+	}
+	return v, nil
+}
+
+// ---------------------------------------------------------------------------
+// Static checks
+// ---------------------------------------------------------------------------
+
+func checkRequiredFields(v *viper.Viper, cfgPath string, rep *ccReport) {
+	// tdns.ValidateConfig selects the sections to validate based on the app
+	// type. Force AppTypeAuth so it validates service/db/apiserver/dnsengine.
+	saved := tdns.Globals.App.Type
+	tdns.Globals.App.Type = tdns.AppTypeAuth
+	defer func() { tdns.Globals.App.Type = saved }()
+
+	if err := tdns.ValidateConfig(v, cfgPath); err != nil {
+		rep.fail("Required fields", "required",
+			firstLine(err.Error()),
+			"add the missing required keys (service.name, dnsengine.addresses/transports, apiserver.*, db.file, log.file)")
+		// Fall through: also surface the raw multi-line detail for the operator.
+		for _, ln := range extraLines(err.Error()) {
+			rep.info("Required fields", "detail", ln)
+		}
+		return
+	}
+	rep.pass("Required fields", "required", "all required sections/keys present; apiserver cert/key pair valid")
+}
+
+func checkDnsEngine(cfg *tdns.Config, rep *ccReport) {
+	const g = "DNS engine"
+	if len(cfg.DnsEngine.Addresses) == 0 {
+		rep.fail(g, "addresses", "dnsengine.addresses is empty — the server would not listen on any address",
+			"add at least one addr:port, e.g. [ 127.0.0.1:53, '[::1]:53' ]")
+	} else {
+		rep.pass(g, "addresses", fmt.Sprintf("listening on %v", cfg.DnsEngine.Addresses))
+	}
+
+	validT := map[string]bool{"do53": true, "dot": true, "doh": true, "doq": true}
+	if len(cfg.DnsEngine.Transports) == 0 {
+		rep.fail(g, "transports", "dnsengine.transports is empty",
+			"list at least one of do53, dot, doh, doq")
+	}
+	needCert := false
+	for _, t := range cfg.DnsEngine.Transports {
+		lt := strings.ToLower(strings.TrimSpace(t))
+		if !validT[lt] {
+			rep.fail(g, "transports", fmt.Sprintf("unknown transport %q", t),
+				"valid transports are do53, dot, doh, doq")
+			continue
+		}
+		if lt != "do53" {
+			needCert = true
+		}
+	}
+	if needCert {
+		if cfg.DnsEngine.CertFile == "" || cfg.DnsEngine.KeyFile == "" {
+			rep.warn(g, "cert", "dot/doh/doq configured but dnsengine.certfile/keyfile not set — those listeners will be skipped",
+				"set dnsengine.certfile and dnsengine.keyfile, or remove the encrypted transports")
+		} else {
+			checkFileExists(rep, g, "certfile", cfg.DnsEngine.CertFile)
+			checkFileExists(rep, g, "keyfile", cfg.DnsEngine.KeyFile)
+		}
+	}
+}
+
+func checkApiServer(cfg *tdns.Config, cfgPath string, rep *ccReport) {
+	const g = "API server"
+	if len(cfg.ApiServer.Addresses) == 0 {
+		rep.fail(g, "addresses", "apiserver.addresses is empty",
+			"set at least one addr:port (loopback is fine, e.g. 127.0.0.1:8989)")
+	} else {
+		rep.pass(g, "addresses", fmt.Sprintf("listening on %v", cfg.ApiServer.Addresses))
+	}
+	if cfg.ApiServer.ApiKey.Value() == "" {
+		rep.fail(g, "apikey", "apiserver.apikey is empty — the API router refuses to start without it",
+			"set a long random apiserver.apikey")
+	} else {
+		rep.pass(g, "apikey", "apiserver.apikey is set")
+	}
+	// certfile/keyfile are required even with usetls:false; the required-fields
+	// check validates the pair, but surface the plain existence here too.
+	if cfg.ApiServer.CertFile == "" || cfg.ApiServer.KeyFile == "" {
+		rep.fail(g, "cert", "apiserver.certfile/keyfile must be set (required even when usetls:false)",
+			"generate a cert/key pair (see `tdns-cli auth config mwe`) and point certfile/keyfile at it")
+	} else {
+		checkFileExists(rep, g, "certfile", cfg.ApiServer.CertFile)
+		checkFileExists(rep, g, "keyfile", cfg.ApiServer.KeyFile)
+	}
+}
+
+// checkDnssecPolicies validates every DNSSEC policy the same way the daemon
+// does (template expansion + split-algorithm gating + role-capability + key
+// lifetimes) by handing the merged dnssec: subtree to the exported
+// tdns.ValidateDnssecPoliciesFromFile.
+func checkDnssecPolicies(v *viper.Viper, rep *ccReport) {
+	const g = "DNSSEC policies"
+	sub := v.Get("dnssec")
+	if sub == nil {
+		rep.info(g, "policies", "no dnssec: block; zones needing signing fall back to the built-in default policy")
+		return
+	}
+	pols, _ := v.Get("dnssec.policies").(map[string]interface{})
+	if len(pols) == 0 {
+		rep.info(g, "policies", "no dnssec.policies defined (built-in default policy applies)")
+		return
+	}
+
+	tmp, err := writeTempYAML(map[string]interface{}{"dnssec": sub})
+	if err != nil {
+		rep.warn(g, "policies", fmt.Sprintf("could not stage dnssec block for validation: %v", err), "")
+		return
+	}
+	defer os.Remove(tmp)
+
+	if err := tdns.ValidateDnssecPoliciesFromFile(tmp); err != nil {
+		for _, ln := range strings.Split(strings.TrimRight(err.Error(), "\n"), "\n") {
+			ln = strings.TrimSpace(ln)
+			if ln == "" {
+				continue
+			}
+			rep.fail(g, "policy", ln,
+				"fix the policy (algorithm/lifetime/mode), or allowlist a differing KSK/ZSK pair in dnssec.split_algorithms")
+		}
+		return
+	}
+	rep.pass(g, "policies", fmt.Sprintf("all %d policy definition(s) valid (algorithms, split-gating, lifetimes)", len(pols)))
+}
+
+func checkZones(cfg *tdns.Config, rep *ccReport, online bool, role string) {
+	const g = "Zones"
+	if len(cfg.Zones) == 0 {
+		rep.info(g, "zones", "no zones declared in config")
+		return
+	}
+
+	// Build lookup sets for referential integrity (case-insensitive).
+	templateNames := map[string]tdns.ZoneConf{}
+	for _, t := range cfg.Templates {
+		templateNames[lc(t.Name)] = t
+	}
+	policyNames := map[string]bool{"": true, "none": true, "default": true}
+	for name := range collectPolicyNames(cfg) {
+		policyNames[lc(name)] = true
+	}
+	msNames := map[string]bool{"": true, "none": true}
+	for name := range cfg.MultiSigner {
+		msNames[lc(name)] = true
+	}
+
+	// Config TSIG key names (for the secondary-zone key check).
+	configTsig := map[string]bool{}
+	for _, k := range cfg.Keys.Tsig {
+		configTsig[lc(dns.Fqdn(k.Name))] = true
+	}
+	var keystoreTsig map[string]bool
+	if online {
+		keystoreTsig = fetchKeystoreTsigNames(role)
+	}
+
+	seen := map[string]bool{}
+	for i := range cfg.Zones {
+		z := cfg.Zones[i]
+		zname := z.Name
+		zlabel := zname
+		if zlabel == "" {
+			zlabel = fmt.Sprintf("zones[%d]", i)
+		}
+
+		if zname == "" {
+			rep.fail(g, zlabel, "zone has no name", "every zone needs a name (FQDN with trailing dot)")
+			continue
+		}
+		if !strings.HasSuffix(zname, ".") {
+			rep.warn(g, zname, "zone name is not a FQDN (missing trailing dot)", "write the name with a trailing dot, e.g. example.com.")
+		}
+		if seen[lc(zname)] {
+			rep.fail(g, zname, "duplicate zone declaration", "remove the duplicate entry")
+			continue
+		}
+		seen[lc(zname)] = true
+
+		// Resolve the effective zone (apply template gap-fill for the fields we check).
+		eff := effectiveZone(z, templateNames)
+
+		// Template reference.
+		if z.Template != "" {
+			if _, ok := templateNames[lc(z.Template)]; !ok {
+				rep.fail(g, zname, fmt.Sprintf("references template %q which is not defined", z.Template),
+					"define the template under templates: or fix the name")
+			}
+		}
+
+		// dnssecpolicy reference.
+		if !policyNames[lc(eff.DnssecPolicy)] {
+			rep.fail(g, zname, fmt.Sprintf("references dnssecpolicy %q which is not defined", eff.DnssecPolicy),
+				"define the policy under dnssec.policies: (not dnssec.templates:) or fix the name")
+		}
+
+		// multisigner reference.
+		if !msNames[lc(eff.MultiSigner)] {
+			rep.fail(g, zname, fmt.Sprintf("references multisigner %q which is not defined", eff.MultiSigner),
+				"define it under multisigner: or fix the name")
+		}
+
+		// Signing option requires a policy.
+		if hasSigningOption(eff.OptionsStrs) && lc(eff.DnssecPolicy) == "" {
+			rep.fail(g, zname, "online-signing/inline-signing set but no dnssecpolicy — the zone will be quarantined",
+				"set dnssecpolicy: on the zone or its template")
+		}
+
+		switch lc(eff.Type) {
+		case "primary", "":
+			if lc(eff.Type) == "" {
+				rep.warn(g, zname, "no zone type (and none inherited from a template)", "set type: primary or secondary")
+			}
+			checkPrimaryZone(rep, g, zname, eff)
+		case "secondary":
+			checkSecondaryZone(rep, g, zname, eff, configTsig, keystoreTsig, online)
+		default:
+			rep.fail(g, zname, fmt.Sprintf("unknown zone type %q", eff.Type), "type must be primary or secondary")
+		}
+	}
+}
+
+func checkPrimaryZone(rep *ccReport, g, zname string, eff tdns.ZoneConf) {
+	zf := eff.Zonefile
+	if zf == "" {
+		rep.fail(g, zname, "primary zone has no zonefile (and none inherited from a template)",
+			"set zonefile: on the zone or a zonefile pattern on its template")
+		return
+	}
+	if _, err := os.Stat(zf); err != nil {
+		rep.fail(g, zname, fmt.Sprintf("zonefile %s not found: %v", zf, err),
+			"create the zone file or fix the path")
+		return
+	}
+	if err := parseZonefile(zf, zname); err != nil {
+		rep.fail(g, zname, fmt.Sprintf("zonefile %s failed to parse: %v", zf, err),
+			"fix the zone file so the miekg/dns parser accepts it (apex SOA, valid RRs)")
+		return
+	}
+	rep.pass(g, zname, fmt.Sprintf("primary; zonefile %s exists and parses", zf))
+}
+
+func checkSecondaryZone(rep *ccReport, g, zname string, eff tdns.ZoneConf, configTsig, keystoreTsig map[string]bool, online bool) {
+	if len(eff.Primaries) == 0 {
+		rep.fail(g, zname, "secondary zone has no primaries:", "add at least one primaries: {addr, key} entry")
+	}
+	// Collect TSIG key names referenced by this zone.
+	for _, p := range eff.Primaries {
+		checkTsigRef(rep, g, zname, "primaries", p.Key, configTsig, keystoreTsig, online)
+	}
+	for _, p := range eff.Notify {
+		checkTsigRef(rep, g, zname, "notify", p.Key, configTsig, keystoreTsig, online)
+	}
+	for _, a := range eff.AllowNotify {
+		checkTsigRef(rep, g, zname, "allow-notify", a.Key, configTsig, keystoreTsig, online)
+	}
+	for _, a := range eff.Downstreams {
+		checkTsigRef(rep, g, zname, "downstreams", a.Key, configTsig, keystoreTsig, online)
+	}
+	if len(eff.Primaries) > 0 {
+		rep.pass(g, zname, "secondary; primaries configured")
+	}
+}
+
+func checkTsigRef(rep *ccReport, g, zname, field, key string, configTsig, keystoreTsig map[string]bool, online bool) {
+	k := strings.TrimSpace(key)
+	if k == "" || strings.EqualFold(k, "NOKEY") || strings.EqualFold(k, "BLOCKED") {
+		return
+	}
+	fk := lc(dns.Fqdn(k))
+	if configTsig[fk] {
+		return
+	}
+	if online {
+		if keystoreTsig[fk] {
+			return
+		}
+		rep.fail(g, zname, fmt.Sprintf("%s references TSIG key %q that is in neither keys.tsig nor the keystore — the zone will be quarantined", field, key),
+			"add the key under keys.tsig: or via `tdns-cli auth keystore tsig add`")
+		return
+	}
+	rep.warn(g, zname, fmt.Sprintf("%s references TSIG key %q not found in keys.tsig (offline: keystore not checked)", field, key),
+		"verify the key exists in the keystore, or run without --offline")
+}
+
+// checkApiServerCorrelation cross-checks the auth config's apiserver block
+// against the tdns-cli.yaml entry that `tdns-cli <role> ...` would actually use.
+func checkApiServerCorrelation(role string, cfg *tdns.Config, rep *ccReport) {
+	const g = "tdns-cli correlation"
+	if !listensOnLocalhost(cfg.ApiServer.Addresses) {
+		rep.info(g, "apiserver", "apiserver does not listen on localhost; skipping tdns-cli.yaml port/key correlation")
+		return
+	}
+	clientKey := GetClientKeyFromParent(role)
+	det := GetApiDetailsByClientKey(clientKey)
+	if det == nil {
+		rep.fail(g, "apiservers-entry",
+			fmt.Sprintf("tdns-cli.yaml has no apiservers entry named %q — `tdns-cli %s ...` cannot reach this server", clientKey, role),
+			fmt.Sprintf("add an apiservers: entry named %q pointing at this server's apiserver address", clientKey))
+		return
+	}
+
+	// Compare port.
+	cfgPort := firstPort(cfg.ApiServer.Addresses)
+	cliPort := urlPort(det.BaseURL)
+	if cfgPort != "" && cliPort != "" && cfgPort != cliPort {
+		rep.fail(g, "port",
+			fmt.Sprintf("apiserver listens on port %s but tdns-cli.yaml %q targets port %s", cfgPort, clientKey, cliPort),
+			"align the tdns-cli.yaml baseurl port with apiserver.addresses")
+	} else if cfgPort != "" && cliPort == cfgPort {
+		rep.pass(g, "port", fmt.Sprintf("tdns-cli.yaml %q targets the right port (%s)", clientKey, cfgPort))
+	}
+
+	// Compare api key.
+	if cfg.ApiServer.ApiKey.Value() != "" && det.ApiKey != "" {
+		if cfg.ApiServer.ApiKey.Value() != det.ApiKey {
+			rep.fail(g, "apikey",
+				fmt.Sprintf("apiserver.apikey does not match the apikey in tdns-cli.yaml %q", clientKey),
+				"copy the server's apiserver.apikey into the matching tdns-cli.yaml apiservers entry")
+		} else {
+			rep.pass(g, "apikey", fmt.Sprintf("tdns-cli.yaml %q apikey matches apiserver.apikey", clientKey))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Running-config correlation (online)
+// ---------------------------------------------------------------------------
+
+func correlateRunningConfig(role string, cfg *tdns.Config, cfgPath, daemonDBPath string, rep *ccReport) {
+	const g = "Running-config drift"
+
+	// db.file drift.
+	if daemonDBPath != "" && cfg.Db.File != "" && absClean(daemonDBPath) != absClean(cfg.Db.File) {
+		rep.warn(g, "db-file",
+			fmt.Sprintf("config db.file=%s but the daemon is using %s", cfg.Db.File, daemonDBPath),
+			"a reload does not move the DB; restart is needed to switch db.file")
+	}
+
+	// /config status: running dnsengine + apiserver.
+	if api, err := GetApiClient(role, false); err == nil {
+		if resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: "status"}); err == nil {
+			correlateStatus(cfg, resp, rep, g)
+		}
+	}
+
+	// Running zones vs config zones.
+	correlateZones(role, cfg, rep, g)
+
+	// Policies the server actually loaded (and any it rejected).
+	if pols, err := fetchServerPolicies(role); err == nil {
+		var broken []string
+		for _, p := range pols {
+			if p.PolicyError != "" {
+				broken = append(broken, fmt.Sprintf("%s: %s", p.Name, p.PolicyError))
+			}
+		}
+		if len(broken) > 0 {
+			for _, b := range broken {
+				rep.fail("DNSSEC policies", "loaded-policy", "server rejected policy "+b,
+					"fix the policy definition and reload")
+			}
+		} else {
+			rep.pass("DNSSEC policies", "loaded", fmt.Sprintf("server loaded %d policy(ies) with no errors", len(pols)))
+		}
+	}
+}
+
+func correlateStatus(cfg *tdns.Config, resp tdns.ConfigResponse, rep *ccReport, g string) {
+	if !sameStringSet(cfg.DnsEngine.Addresses, resp.DnsEngine.Addresses) {
+		rep.warn(g, "dnsengine-addresses",
+			fmt.Sprintf("config dnsengine.addresses %v differ from running %v", cfg.DnsEngine.Addresses, resp.DnsEngine.Addresses),
+			"a `config reload` does not re-open DNS listeners; restart to change listen addresses")
+	}
+	if resp.ApiServer.ApiKey.Value() != "" && cfg.ApiServer.ApiKey.Value() != "" &&
+		resp.ApiServer.ApiKey.Value() != cfg.ApiServer.ApiKey.Value() {
+		rep.warn(g, "apikey",
+			"apiserver.apikey in the file differs from the running server's apikey",
+			"the running apikey changes only on restart")
+	}
+}
+
+func correlateZones(role string, cfg *tdns.Config, rep *ccReport, g string) {
+	api, err := GetApiClient(role, false)
+	if err != nil {
+		return
+	}
+	resp, err := SendZoneCommand(api, tdns.ZonePost{Command: "list-zones"})
+	if err != nil {
+		return
+	}
+	running := map[string]tdns.ZoneConf{}
+	for name, zc := range resp.Zones {
+		running[lc(dns.Fqdn(name))] = zc
+	}
+	configured := map[string]bool{}
+	for _, z := range cfg.Zones {
+		if z.Name == "" {
+			continue
+		}
+		configured[lc(dns.Fqdn(z.Name))] = true
+		rn := lc(dns.Fqdn(z.Name))
+		if _, ok := running[rn]; !ok {
+			rep.warn(g, "zone-not-running",
+				fmt.Sprintf("zone %s is in the config but not running", z.Name),
+				"run `config reload-zones` to load newly-added zones")
+		}
+	}
+	for rn, zc := range running {
+		// Skip dynamic/managed zones — they are never in the static config.
+		if zc.ApiManaged || zc.SourceCatalog != "" {
+			continue
+		}
+		if !configured[rn] {
+			rep.info(g, "zone-not-in-config",
+				fmt.Sprintf("zone %s is running but not in this config file", strings.TrimSuffix(rn, ".")+"."))
+		}
+	}
+	if len(cfg.Zones) > 0 {
+		rep.pass(g, "zones", "compared configured zones against the running set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+func fetchDaemonPaths(role string) (cfgFile, dbFile string, ok bool) {
+	api, err := GetApiClient(role, false)
+	if err != nil {
+		return "", "", false
+	}
+	_, body, err := api.RequestNG("GET", "/config/paths", nil, false)
+	if err != nil {
+		return "", "", false
+	}
+	var resp tdns.ConfigPathsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", "", false
+	}
+	return resp.ConfigFile, resp.DBFile, true
+}
+
+func fetchKeystoreTsigNames(role string) map[string]bool {
+	out := map[string]bool{}
+	api, err := GetApiClient(role, false)
+	if err != nil {
+		return out
+	}
+	resp, err := SendKeystoreCmd(api, tdns.KeystorePost{Command: "tsig-mgmt", SubCommand: "list"})
+	if err != nil {
+		return out
+	}
+	for _, k := range resp.TsigKeys {
+		out[lc(dns.Fqdn(k.Name))] = true
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+func lc(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
+
+func absClean(p string) string {
+	if p == "" {
+		return p
+	}
+	if a, err := filepath.Abs(p); err == nil {
+		return a
+	}
+	return filepath.Clean(p)
+}
+
+func checkFileExists(rep *ccReport, g, check, path string) {
+	if path == "" {
+		return
+	}
+	if _, err := os.Stat(path); err != nil {
+		rep.fail(g, check, fmt.Sprintf("%s not found: %s", check, path), "create the file or fix the path")
+		return
+	}
+	rep.pass(g, check, fmt.Sprintf("%s exists: %s", check, path))
+}
+
+func parseZonefile(path, origin string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	zp := dns.NewZoneParser(f, origin, path)
+	zp.SetIncludeAllowed(true)
+	sawSOA := false
+	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
+		if rr != nil && rr.Header().Rrtype == dns.TypeSOA {
+			sawSOA = true
+		}
+	}
+	if err := zp.Err(); err != nil {
+		return err
+	}
+	if !sawSOA {
+		return fmt.Errorf("no SOA record found")
+	}
+	return nil
+}
+
+func hasSigningOption(opts []string) bool {
+	for _, o := range opts {
+		lo := lc(o)
+		if lo == "online-signing" || lo == "inline-signing" {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveZone applies the documented template gap-fill for the subset of
+// fields config check inspects (type, store, zonefile, dnssecpolicy, multisigner,
+// options-union). The zone's own non-zero values always win.
+func effectiveZone(z tdns.ZoneConf, templates map[string]tdns.ZoneConf) tdns.ZoneConf {
+	eff := z
+	if z.Template == "" {
+		return eff
+	}
+	t, ok := templates[lc(z.Template)]
+	if !ok {
+		return eff
+	}
+	if eff.Type == "" {
+		eff.Type = t.Type
+	}
+	if eff.Store == "" {
+		eff.Store = t.Store
+	}
+	if eff.DnssecPolicy == "" {
+		eff.DnssecPolicy = t.DnssecPolicy
+	}
+	if eff.MultiSigner == "" {
+		eff.MultiSigner = t.MultiSigner
+	}
+	if eff.Zonefile == "" && t.Zonefile != "" {
+		if strings.Contains(t.Zonefile, "%s") {
+			// Template zonefile is a %s pattern substituted with the zone
+			// name (incl. trailing dot). ReplaceAll (not Sprintf) keeps this
+			// a non-format string, avoiding a go vet warning.
+			eff.Zonefile = strings.ReplaceAll(t.Zonefile, "%s", z.Name)
+		} else {
+			eff.Zonefile = t.Zonefile
+		}
+	}
+	if len(eff.Primaries) == 0 {
+		eff.Primaries = t.Primaries
+	}
+	// options: is a union.
+	eff.OptionsStrs = append(append([]string{}, z.OptionsStrs...), t.OptionsStrs...)
+	return eff
+}
+
+func collectPolicyNames(cfg *tdns.Config) map[string]bool {
+	out := map[string]bool{}
+	for name := range cfg.Dnssec.Policies {
+		out[name] = true
+	}
+	return out
+}
+
+func listensOnLocalhost(addrs []string) bool {
+	for _, a := range addrs {
+		host := hostOf(a)
+		if host == "127.0.0.1" || host == "::1" || strings.EqualFold(host, "localhost") {
+			return true
+		}
+	}
+	return false
+}
+
+func hostOf(addr string) string {
+	addr = strings.TrimSpace(addr)
+	// strip [::1]:port form
+	if strings.HasPrefix(addr, "[") {
+		if i := strings.Index(addr, "]"); i >= 0 {
+			return addr[1:i]
+		}
+	}
+	if i := strings.LastIndex(addr, ":"); i >= 0 {
+		return addr[:i]
+	}
+	return addr
+}
+
+func firstPort(addrs []string) string {
+	for _, a := range addrs {
+		if p := portOf(a); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+func portOf(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if strings.HasPrefix(addr, "[") {
+		if i := strings.Index(addr, "]"); i >= 0 {
+			rest := addr[i+1:]
+			if strings.HasPrefix(rest, ":") {
+				return rest[1:]
+			}
+			return ""
+		}
+	}
+	if i := strings.LastIndex(addr, ":"); i >= 0 {
+		return addr[i+1:]
+	}
+	return ""
+}
+
+// urlPort extracts the port from a baseurl like https://127.0.0.1:8989/api/v1.
+func urlPort(baseurl string) string {
+	s := baseurl
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if i := strings.Index(s, "/"); i >= 0 {
+		s = s[:i]
+	}
+	return portOf(s)
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sa := append([]string{}, a...)
+	sb := append([]string{}, b...)
+	sort.Strings(sa)
+	sort.Strings(sb)
+	for i := range sa {
+		if sa[i] != sb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func writeTempYAML(v interface{}) (string, error) {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp("", "configcheck-*.yaml")
+	if err != nil {
+		return "", err
+	}
+	name := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(name)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(name)
+		return "", err
+	}
+	return name, nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}
+
+func extraLines(s string) []string {
+	parts := strings.Split(s, "\n")
+	var out []string
+	for _, p := range parts[1:] {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/v2/cli/config_check_cmds.go
+++ b/v2/cli/config_check_cmds.go
@@ -263,6 +263,11 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 		correlateRunningConfig(role, &cfg, cfgPath, daemonDBPath, rep)
 	}
 
+	// Signed-zone policy-algorithm vs active-key dry-run (predicts a
+	// would-break-on-reload algorithm change). Handles the offline info-skip
+	// itself.
+	checkPolicyAlgVsActiveKeys(&cfg, v, rep, online, role)
+
 	finishCheckconf(rep)
 }
 
@@ -807,6 +812,227 @@ func fetchKeystoreTsigNames(role string) (map[string]bool, error) {
 		out[lc(dns.Fqdn(k.Name))] = true
 	}
 	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Policy-algorithm vs active-key correlation
+// ---------------------------------------------------------------------------
+//
+// The OPERATOR PRE-FLIGHT consumer of "what breaks on reload" for signed zones:
+// a CLI-side dry-run of the signer's reconcileActiveKeyAlgorithms (sign.go). A
+// same-name policy algorithm edit (e.g. KSK Ed25519->FALCON512 with the zone
+// still on that policy) passes every other check — the policy is valid — but a
+// reload-zones/restart then hits the reconcile, which REFUSES (no automatic
+// KSK/ZSK-algorithm rollover), leaving the zone serving stale signatures until
+// they expire, then bogus.
+//
+// OUT OF SCOPE (do NOT build here): the server-side reload gate / startup-hold
+// (guardrail-plan PR-B) still needs its own server-side dry-run+correlate
+// primitive; this CLI check is not that shared primitive. The client-side
+// config/include re-decode (loadConfigViper) is likewise left as-is; a decoder
+// shared with the daemon is a known drift risk but a separate refactor.
+
+// wantAlgs is the effective algorithm set (lowercased NAME strings) a policy
+// requires per role. Names, not codepoints: non-standardized PQ codepoints are
+// deployment-local, but the canonical names are stable across the CLI and the
+// daemon, so the daemon's active-key algorithm names compare directly.
+type wantAlgs struct {
+	mode string // "csk" | "ksk-zsk"
+	ksk  string // KSK (split) or CSK (csk mode) algorithm name
+	zsk  string // ZSK algorithm name (unused in csk mode)
+}
+
+// activeKeyAlgs is the set of active-key algorithm NAMES present per role in the
+// running keystore: ksk = SEP-set (KSK/CSK) algorithms, zsk = SEP-clear (ZSK).
+type activeKeyAlgs struct {
+	ksk map[string]bool
+	zsk map[string]bool
+}
+
+// roleMiss records one role whose policy algorithm is provided by no active key.
+type roleMiss struct {
+	role     string
+	wantAlg  string
+	haveAlgs []string
+}
+
+// missingRoleAlgs is the pure dry-run of reconcileActiveKeyAlgorithms, in the
+// lenient zoneActiveKeysMatchAlgs sense: a role is a "miss" only when the zone
+// HAS active key(s) for that role but NONE carries the wanted algorithm. Two
+// deliberate non-findings:
+//   - zero active keys for a role -> not a miss: the signer generates fresh
+//     keys of the policy algorithm on first sign, it does not refuse.
+//   - the wanted algorithm present alongside a wrong-algorithm key
+//     (mid-rollover, both old+new active) -> not a miss.
+//
+// Pure and dependency-free so it is directly unit-testable.
+func missingRoleAlgs(want wantAlgs, active activeKeyAlgs) []roleMiss {
+	var miss []roleMiss
+	check := func(role, wantAlg string, have map[string]bool) {
+		if wantAlg == "" || len(have) == 0 {
+			return
+		}
+		if have[wantAlg] {
+			return
+		}
+		miss = append(miss, roleMiss{role: role, wantAlg: wantAlg, haveAlgs: sortedKeys(have)})
+	}
+	if want.mode == tdns.DnssecPolicyModeCSK {
+		check("CSK", want.ksk, active.ksk)
+		return miss
+	}
+	check("KSK", want.ksk, active.ksk)
+	check("ZSK", want.zsk, active.zsk)
+	return miss
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// fetchActiveKeyAlgsByZone lists the running keystore's DNSSEC keys and returns,
+// per zone (lowercased FQDN), the active-key algorithm NAMES split by SEP bit.
+// The dnssec-mgmt list endpoint returns ALL zones' keys, so it is fetched once
+// and indexed here rather than per zone.
+func fetchActiveKeyAlgsByZone(role string) (map[string]activeKeyAlgs, error) {
+	api, err := GetApiClient(role, false)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := SendKeystoreCmd(api, tdns.KeystorePost{Command: "dnssec-mgmt", SubCommand: "list"})
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]activeKeyAlgs{}
+	for _, k := range resp.Dnskeys {
+		if !strings.EqualFold(k.State, tdns.DnskeyStateActive) {
+			continue
+		}
+		zone := lc(dns.Fqdn(k.Name))
+		a, ok := out[zone]
+		if !ok {
+			a = activeKeyAlgs{ksk: map[string]bool{}, zsk: map[string]bool{}}
+		}
+		alg := lc(k.Algorithm)
+		if k.Flags&0x0001 == 0x0001 { // SEP bit set -> KSK/CSK
+			a.ksk[alg] = true
+		} else {
+			a.zsk[alg] = true
+		}
+		out[zone] = a
+	}
+	return out, nil
+}
+
+// resolveWantAlgs turns a zone's effective policy name into the algorithm NAMES
+// it requires. Config-declared policies (from the checked file) win; the
+// built-in `default` policy and any policy named only by the running server are
+// resolved from the server's loaded policies. false when neither source knows it.
+func resolveWantAlgs(polName string, declared map[string]tdns.PolicyAlgs, serverPols map[string]tdns.DnssecPolicyInfo) (wantAlgs, bool) {
+	pn := lc(polName)
+	if pa, ok := declared[pn]; ok {
+		return wantAlgs{
+			mode: normalizeMode(pa.Mode),
+			ksk:  lc(dns.AlgorithmToString[pa.KSKAlg]),
+			zsk:  lc(dns.AlgorithmToString[pa.ZSKAlg]),
+		}, true
+	}
+	if sp, ok := serverPols[pn]; ok {
+		return wantAlgs{
+			mode: normalizeMode(sp.Mode),
+			ksk:  lc(sp.KSKAlgorithm),
+			zsk:  lc(sp.ZSKAlgorithm),
+		}, true
+	}
+	return wantAlgs{}, false
+}
+
+func normalizeMode(m string) string {
+	if lc(m) == tdns.DnssecPolicyModeCSK {
+		return tdns.DnssecPolicyModeCSK
+	}
+	return tdns.DnssecPolicyModeKSKZSK
+}
+
+// checkPolicyAlgVsActiveKeys warns when a signed zone's checked policy wants a
+// role algorithm that the running zone's active keys do not provide — the one
+// "would-break-on-reload" failure the other checks miss. WARN, not FAIL: the
+// config is valid; this predicts a refusal on the next reload-zones/restart.
+// (To make check hard-block on it instead, change rep.warn -> rep.fail below.)
+func checkPolicyAlgVsActiveKeys(cfg *tdns.Config, v *viper.Viper, rep *ccReport, online bool, role string) {
+	const g = "Policy vs active keys"
+
+	// Signed zones with a resolvable effective policy name.
+	templateNames := map[string]tdns.ZoneConf{}
+	for _, t := range cfg.Templates {
+		templateNames[lc(t.Name)] = t
+	}
+	type signedZone struct{ name, policy string }
+	var signed []signedZone
+	for i := range cfg.Zones {
+		if cfg.Zones[i].Name == "" {
+			continue
+		}
+		eff := effectiveZone(cfg.Zones[i], templateNames)
+		if !hasSigningOption(eff.OptionsStrs) || lc(eff.DnssecPolicy) == "" {
+			continue
+		}
+		signed = append(signed, signedZone{name: cfg.Zones[i].Name, policy: eff.DnssecPolicy})
+	}
+	if len(signed) == 0 {
+		return
+	}
+	if !online {
+		rep.info(g, "correlation", "offline: cannot correlate policy algorithms against the running active keys")
+		return
+	}
+
+	// Config-declared policy algorithms (honors includes: same merged dnssec
+	// temp file checkDnssecPolicies validates).
+	var declared map[string]tdns.PolicyAlgs
+	if pols, _ := v.Get("dnssec.policies").(map[string]interface{}); len(pols) > 0 {
+		if tmp, err := writeTempYAML(map[string]interface{}{"dnssec": v.Get("dnssec")}); err == nil {
+			declared, _ = tdns.ResolveDnssecPolicyAlgs(tmp)
+			os.Remove(tmp)
+		}
+	}
+	// Running server's loaded policies (for `default`/server-only names).
+	serverPols := map[string]tdns.DnssecPolicyInfo{}
+	if sp, err := fetchServerPolicies(role); err == nil {
+		for _, p := range sp {
+			serverPols[lc(p.Name)] = p
+		}
+	}
+
+	activeByZone, err := fetchActiveKeyAlgsByZone(role)
+	if err != nil {
+		rep.warn(g, "keystore", fmt.Sprintf("could not list active DNSSEC keys: %v — policy/key algorithm correlation skipped", err), "")
+		return
+	}
+
+	for _, z := range signed {
+		want, ok := resolveWantAlgs(z.policy, declared, serverPols)
+		if !ok {
+			rep.info(g, z.name, fmt.Sprintf("cannot resolve algorithms for policy %q (not in this config and not loaded by the server) — skipping", z.policy))
+			continue
+		}
+		miss := missingRoleAlgs(want, activeByZone[lc(dns.Fqdn(z.name))])
+		if len(miss) == 0 {
+			rep.pass(g, z.name, fmt.Sprintf("active keys satisfy policy %q algorithms", z.policy))
+			continue
+		}
+		for _, m := range miss {
+			rep.warn(g, z.name,
+				fmt.Sprintf("config policy %q wants %s algorithm %s, but the running zone's active %s key(s) are [%s]. A reload-zones/restart would REFUSE this change (no automatic KSK/ZSK-algorithm rollover) — the zone keeps serving its current signatures until they expire, then goes bogus",
+					z.policy, m.role, m.wantAlg, m.role, strings.Join(m.haveAlgs, ", ")),
+				"roll the key deliberately via the rollover engine, or (test zones only) `tdns-cli auth zone dnssec policy-reset`")
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/v2/cli/config_check_cmds.go
+++ b/v2/cli/config_check_cmds.go
@@ -474,8 +474,17 @@ func checkZones(cfg *tdns.Config, rep *ccReport, online bool, role string) {
 		configTsig[lc(dns.Fqdn(k.Name))] = true
 	}
 	var keystoreTsig map[string]bool
+	keystoreOK := false
 	if online {
-		keystoreTsig = fetchKeystoreTsigNames(role)
+		var ksErr error
+		keystoreTsig, ksErr = fetchKeystoreTsigNames(role)
+		if ksErr != nil {
+			rep.warn(g, "keystore",
+				fmt.Sprintf("could not list TSIG keys from the keystore: %v — TSIG key presence not verified against the keystore", ksErr),
+				"re-run when the daemon/keystore is reachable")
+		} else {
+			keystoreOK = true
+		}
 	}
 
 	seen := map[string]bool{}
@@ -536,7 +545,7 @@ func checkZones(cfg *tdns.Config, rep *ccReport, online bool, role string) {
 			}
 			checkPrimaryZone(rep, g, zname, eff)
 		case "secondary":
-			checkSecondaryZone(rep, g, zname, eff, configTsig, keystoreTsig, online)
+			checkSecondaryZone(rep, g, zname, eff, configTsig, keystoreTsig, online, keystoreOK)
 		default:
 			rep.fail(g, zname, fmt.Sprintf("unknown zone type %q", eff.Type), "type must be primary or secondary")
 		}
@@ -563,29 +572,35 @@ func checkPrimaryZone(rep *ccReport, g, zname string, eff tdns.ZoneConf) {
 	rep.pass(g, zname, fmt.Sprintf("primary; zonefile %s exists and parses", zf))
 }
 
-func checkSecondaryZone(rep *ccReport, g, zname string, eff tdns.ZoneConf, configTsig, keystoreTsig map[string]bool, online bool) {
+func checkSecondaryZone(rep *ccReport, g, zname string, eff tdns.ZoneConf, configTsig, keystoreTsig map[string]bool, online, keystoreOK bool) {
 	if len(eff.Primaries) == 0 {
 		rep.fail(g, zname, "secondary zone has no primaries:", "add at least one primaries: {addr, key} entry")
 	}
 	// Collect TSIG key names referenced by this zone.
 	for _, p := range eff.Primaries {
-		checkTsigRef(rep, g, zname, "primaries", p.Key, configTsig, keystoreTsig, online)
+		checkTsigRef(rep, g, zname, "primaries", p.Key, configTsig, keystoreTsig, online, keystoreOK)
 	}
 	for _, p := range eff.Notify {
-		checkTsigRef(rep, g, zname, "notify", p.Key, configTsig, keystoreTsig, online)
+		checkTsigRef(rep, g, zname, "notify", p.Key, configTsig, keystoreTsig, online, keystoreOK)
 	}
 	for _, a := range eff.AllowNotify {
-		checkTsigRef(rep, g, zname, "allow-notify", a.Key, configTsig, keystoreTsig, online)
+		checkTsigRef(rep, g, zname, "allow-notify", a.Key, configTsig, keystoreTsig, online, keystoreOK)
 	}
 	for _, a := range eff.Downstreams {
-		checkTsigRef(rep, g, zname, "downstreams", a.Key, configTsig, keystoreTsig, online)
+		checkTsigRef(rep, g, zname, "downstreams", a.Key, configTsig, keystoreTsig, online, keystoreOK)
 	}
 	if len(eff.Primaries) > 0 {
 		rep.pass(g, zname, "secondary; primaries configured")
 	}
 }
 
-func checkTsigRef(rep *ccReport, g, zname, field, key string, configTsig, keystoreTsig map[string]bool, online bool) {
+// checkTsigRef verifies a referenced TSIG key resolves. A hard FAIL ("zone will
+// be quarantined") is reported ONLY when the keystore was actually consulted
+// (online && keystoreOK) and the key is absent there and in keys.tsig. When the
+// keystore could not be queried (offline, or the list call failed), the key's
+// keystore presence is unknown, so it is a WARN — never a FAIL — to avoid
+// manufacturing a false quarantine from a transient API error.
+func checkTsigRef(rep *ccReport, g, zname, field, key string, configTsig, keystoreTsig map[string]bool, online, keystoreOK bool) {
 	k := strings.TrimSpace(key)
 	if k == "" || strings.EqualFold(k, "NOKEY") || strings.EqualFold(k, "BLOCKED") {
 		return
@@ -594,7 +609,7 @@ func checkTsigRef(rep *ccReport, g, zname, field, key string, configTsig, keysto
 	if configTsig[fk] {
 		return
 	}
-	if online {
+	if online && keystoreOK {
 		if keystoreTsig[fk] {
 			return
 		}
@@ -602,8 +617,12 @@ func checkTsigRef(rep *ccReport, g, zname, field, key string, configTsig, keysto
 			"add the key under keys.tsig: or via `tdns-cli auth keystore tsig add`")
 		return
 	}
-	rep.warn(g, zname, fmt.Sprintf("%s references TSIG key %q not found in keys.tsig (offline: keystore not checked)", field, key),
-		"verify the key exists in the keystore, or run without --offline")
+	reason := "offline: keystore not checked"
+	if online {
+		reason = "keystore query failed: not verified"
+	}
+	rep.warn(g, zname, fmt.Sprintf("%s references TSIG key %q not found in keys.tsig (%s)", field, key, reason),
+		"verify the key exists in the keystore, or run online against a reachable daemon")
 }
 
 // checkApiServerCorrelation cross-checks the auth config's apiserver block
@@ -661,17 +680,21 @@ func correlateRunningConfig(role string, cfg *tdns.Config, cfgPath, daemonDBPath
 	}
 
 	// /config status: running dnsengine + apiserver.
-	if api, err := GetApiClient(role, false); err == nil {
-		if resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: "status"}); err == nil {
-			correlateStatus(cfg, resp, rep, g)
-		}
+	if api, err := GetApiClient(role, false); err != nil {
+		rep.warn(g, "status", fmt.Sprintf("could not reach the daemon for status: %v — status drift not correlated", err), "")
+	} else if resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: "status"}); err != nil {
+		rep.warn(g, "status", fmt.Sprintf("could not fetch running status: %v — status drift not correlated", err), "")
+	} else {
+		correlateStatus(cfg, resp, rep, g)
 	}
 
 	// Running zones vs config zones.
 	correlateZones(role, cfg, rep, g)
 
 	// Policies the server actually loaded (and any it rejected).
-	if pols, err := fetchServerPolicies(role); err == nil {
+	if pols, err := fetchServerPolicies(role); err != nil {
+		rep.warn("DNSSEC policies", "loaded", fmt.Sprintf("could not fetch loaded policies: %v — server-side policy errors not correlated", err), "")
+	} else {
 		var broken []string
 		for _, p := range pols {
 			if p.PolicyError != "" {
@@ -706,10 +729,12 @@ func correlateStatus(cfg *tdns.Config, resp tdns.ConfigResponse, rep *ccReport, 
 func correlateZones(role string, cfg *tdns.Config, rep *ccReport, g string) {
 	api, err := GetApiClient(role, false)
 	if err != nil {
+		rep.warn(g, "zones", fmt.Sprintf("could not reach the daemon to list zones: %v — zone drift not correlated", err), "")
 		return
 	}
 	resp, err := SendZoneCommand(api, tdns.ZonePost{Command: "list-zones"})
 	if err != nil {
+		rep.warn(g, "zones", fmt.Sprintf("could not list running zones: %v — zone drift not correlated", err), "")
 		return
 	}
 	running := map[string]tdns.ZoneConf{}
@@ -764,20 +789,24 @@ func fetchDaemonPaths(role string) (cfgFile, dbFile string, ok bool) {
 	return resp.ConfigFile, resp.DBFile, true
 }
 
-func fetchKeystoreTsigNames(role string) map[string]bool {
+// fetchKeystoreTsigNames lists the TSIG key names held in the daemon's
+// keystore. It returns an error rather than an empty map on failure: a failed
+// keystore-list must NOT be mistaken for "the key is absent" (that would turn a
+// transient API error into a false quarantine FAIL — see checkTsigRef).
+func fetchKeystoreTsigNames(role string) (map[string]bool, error) {
 	out := map[string]bool{}
 	api, err := GetApiClient(role, false)
 	if err != nil {
-		return out
+		return nil, err
 	}
 	resp, err := SendKeystoreCmd(api, tdns.KeystorePost{Command: "tsig-mgmt", SubCommand: "list"})
 	if err != nil {
-		return out
+		return nil, err
 	}
 	for _, k := range resp.TsigKeys {
 		out[lc(dns.Fqdn(k.Name))] = true
 	}
-	return out
+	return out, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/v2/cli/config_check_test.go
+++ b/v2/cli/config_check_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package cli
+
+import (
+	"testing"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+func algSet(algs ...string) map[string]bool {
+	m := map[string]bool{}
+	for _, a := range algs {
+		m[a] = true
+	}
+	return m
+}
+
+// TestMissingRoleAlgs exercises the pure policy-algorithm vs active-key dry-run
+// that predicts a would-break-on-reload algorithm change.
+func TestMissingRoleAlgs(t *testing.T) {
+	const ksz = tdns.DnssecPolicyModeKSKZSK
+	const csk = tdns.DnssecPolicyModeCSK
+
+	cases := []struct {
+		name     string
+		want     wantAlgs
+		active   activeKeyAlgs
+		wantMiss []string // roles expected to miss (order-independent)
+	}{
+		{
+			name:   "split: matching algs -> no finding",
+			want:   wantAlgs{mode: ksz, ksk: "ed25519", zsk: "ecdsap256sha256"},
+			active: activeKeyAlgs{ksk: algSet("ed25519"), zsk: algSet("ecdsap256sha256")},
+		},
+		{
+			name:     "split: KSK algorithm changed -> one KSK WARN",
+			want:     wantAlgs{mode: ksz, ksk: "falcon512", zsk: "ed25519"},
+			active:   activeKeyAlgs{ksk: algSet("ed25519"), zsk: algSet("ed25519")},
+			wantMiss: []string{"KSK"},
+		},
+		{
+			name:     "split: ZSK algorithm changed -> one ZSK WARN",
+			want:     wantAlgs{mode: ksz, ksk: "ed25519", zsk: "falcon512"},
+			active:   activeKeyAlgs{ksk: algSet("ed25519"), zsk: algSet("ed25519")},
+			wantMiss: []string{"ZSK"},
+		},
+		{
+			name:   "split: mid-rollover, both old+new KSK active -> no finding",
+			want:   wantAlgs{mode: ksz, ksk: "falcon512", zsk: "ed25519"},
+			active: activeKeyAlgs{ksk: algSet("ed25519", "falcon512"), zsk: algSet("ed25519")},
+		},
+		{
+			name:   "split: zero active keys (fresh zone) -> no finding",
+			want:   wantAlgs{mode: ksz, ksk: "ed25519", zsk: "ecdsap256sha256"},
+			active: activeKeyAlgs{ksk: algSet(), zsk: algSet()},
+		},
+		{
+			name:   "csk: matching alg -> no finding",
+			want:   wantAlgs{mode: csk, ksk: "ed25519"},
+			active: activeKeyAlgs{ksk: algSet("ed25519"), zsk: algSet()},
+		},
+		{
+			name:     "csk: algorithm changed -> one CSK WARN",
+			want:     wantAlgs{mode: csk, ksk: "falcon512"},
+			active:   activeKeyAlgs{ksk: algSet("ed25519"), zsk: algSet()},
+			wantMiss: []string{"CSK"},
+		},
+		{
+			name:     "split: both roles changed -> two WARNs",
+			want:     wantAlgs{mode: ksz, ksk: "falcon512", zsk: "falcon512"},
+			active:   activeKeyAlgs{ksk: algSet("ed25519"), zsk: algSet("ecdsap256sha256")},
+			wantMiss: []string{"KSK", "ZSK"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			miss := missingRoleAlgs(tc.want, tc.active)
+			gotRoles := map[string]bool{}
+			for _, m := range miss {
+				gotRoles[m.role] = true
+			}
+			if len(miss) != len(tc.wantMiss) {
+				t.Fatalf("got %d misses %v, want %d %v", len(miss), gotRoles, len(tc.wantMiss), tc.wantMiss)
+			}
+			for _, r := range tc.wantMiss {
+				if !gotRoles[r] {
+					t.Errorf("expected a miss for role %s, got %v", r, gotRoles)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckPolicyAlgVsActiveKeys_OfflineInfoSkip verifies the offline path emits
+// a single info (no API calls, no FAIL/WARN) when there is a signed zone.
+func TestCheckPolicyAlgVsActiveKeys_OfflineInfoSkip(t *testing.T) {
+	cfg := &tdns.Config{
+		Zones: []tdns.ZoneConf{
+			{Name: "signed.example.", OptionsStrs: []string{"online-signing"}, DnssecPolicy: "default"},
+		},
+	}
+	rep := newCCReport()
+	// online=false; v is unused on the offline path.
+	checkPolicyAlgVsActiveKeys(cfg, nil, rep, false, "auth")
+
+	res := rep.byGroup["Policy vs active keys"]
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result in offline path, got %d: %+v", len(res), res)
+	}
+	if res[0].level != ccINFO {
+		t.Errorf("expected an INFO result, got level %v (%q)", res[0].level, res[0].msg)
+	}
+}
+
+// TestCheckPolicyAlgVsActiveKeys_NoSignedZones verifies that a config with no
+// signed zones produces no findings at all (not even the offline info).
+func TestCheckPolicyAlgVsActiveKeys_NoSignedZones(t *testing.T) {
+	cfg := &tdns.Config{
+		Zones: []tdns.ZoneConf{
+			{Name: "plain.example.", Type: "primary"}, // no signing option
+		},
+	}
+	rep := newCCReport()
+	checkPolicyAlgVsActiveKeys(cfg, nil, rep, false, "auth")
+	if len(rep.byGroup["Policy vs active keys"]) != 0 {
+		t.Errorf("expected no findings for a config with no signed zones, got %+v", rep.byGroup["Policy vs active keys"])
+	}
+}

--- a/v2/cli/config_cmds.go
+++ b/v2/cli/config_cmds.go
@@ -63,6 +63,8 @@ overwrite all conflicts, or --interactive to prompt per conflict.`,
 	}
 
 	c.AddCommand(reload, reloadZones, reloadTsig, status)
+	c.AddCommand(newConfigCheckCmd(role))
+	c.AddCommand(newConfigMweCmd(role))
 	return c
 }
 

--- a/v2/cli/config_imr_cmds.go
+++ b/v2/cli/config_imr_cmds.go
@@ -85,12 +85,12 @@ func runImrConfigCheck(explicitPath string, offline bool) {
 	online := !offline
 	var status tdns.ConfigResponse
 	if online {
-		if s, ok := fetchImrStatus(); ok {
+		if s, err := fetchImrStatus(); err == nil {
 			status = s
 		} else {
 			online = false
 			rep.warn("Daemon", "reachability",
-				"could not reach the imr daemon; running static checks only",
+				fmt.Sprintf("could not reach the imr daemon: %v; running static checks only", err),
 				"start the daemon (or pass --offline) to enable apiserver correlation")
 		}
 	}
@@ -235,16 +235,16 @@ func checkImrApiServer(cfg *tdns.Config, v *viper.Viper, rep *ccReport) {
 // imr online correlation (thin: apiserver only)
 // ---------------------------------------------------------------------------
 
-func fetchImrStatus() (tdns.ConfigResponse, bool) {
+func fetchImrStatus() (tdns.ConfigResponse, error) {
 	api, err := GetApiClient("imr", false)
 	if err != nil {
-		return tdns.ConfigResponse{}, false
+		return tdns.ConfigResponse{}, err
 	}
 	resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: "status"})
 	if err != nil {
-		return tdns.ConfigResponse{}, false
+		return tdns.ConfigResponse{}, err
 	}
-	return resp, true
+	return resp, nil
 }
 
 func correlateImrApiServer(cfg *tdns.Config, status tdns.ConfigResponse, rep *ccReport) {

--- a/v2/cli/config_imr_cmds.go
+++ b/v2/cli/config_imr_cmds.go
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * `tdns-cli imr config check` and `tdns-cli imr config mwe` — the tdns-imr
+ * counterparts of the auth config commands. Considerably simpler than auth:
+ * tdns-imr has no zones, no DNSSEC policies, no keystore, and no
+ * GET /config/paths endpoint, so validation is mostly static (imrengine +
+ * apiserver + trust anchors) with a thin online correlation (reachability +
+ * apiserver drift via /config status). The shared report model, generic
+ * helpers, cert generation and required-field validator are reused from
+ * config_check_cmds.go / config_mwe_cmds.go.
+ */
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+// NewImrConfigCmd builds the `imr config` command group. tdns-imr has no
+// zone/tsig/keystore state, so this group carries just check and mwe (unlike
+// auth's config group, which also has reload*/status).
+func NewImrConfigCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "config",
+		Short: "Validate or generate a tdns-imr configuration",
+	}
+	c.AddCommand(newImrConfigCheckCmd())
+	c.AddCommand(newImrConfigMweCmd())
+	return c
+}
+
+func init() {
+	ImrCmd.AddCommand(NewImrConfigCmd())
+}
+
+// ---------------------------------------------------------------------------
+// imr config check
+// ---------------------------------------------------------------------------
+
+func newImrConfigCheckCmd() *cobra.Command {
+	var (
+		serverConfig string
+		offline      bool
+	)
+	c := &cobra.Command{
+		Use:   "check [config-file]",
+		Short: "Validate the tdns-imr config and correlate it with the running daemon",
+		Long: `Validate a tdns-imr configuration file for completeness and internal
+consistency, and (unless --offline) check that the daemon is reachable and its
+apiserver matches the file.
+
+tdns-imr exposes no GET /config/paths endpoint, so the target file is the
+positional arg / --serverconfig, else the compiled-in default
+(/etc/tdns/tdns-imr.yaml).
+
+Exit status is non-zero if any check FAILs (WARNs do not fail the run).`,
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 1 && serverConfig == "" {
+				serverConfig = args[0]
+			}
+			runImrConfigCheck(serverConfig, offline)
+		},
+	}
+	c.Flags().StringVar(&serverConfig, "serverconfig", "", "path to the tdns-imr config file to check (default: /etc/tdns/tdns-imr.yaml)")
+	c.Flags().BoolVar(&offline, "offline", false, "do not contact the daemon; run static checks only")
+	return c
+}
+
+func runImrConfigCheck(explicitPath string, offline bool) {
+	tdns.SetSubsystemLevel("config", slog.LevelError)
+	rep := newCCReport()
+
+	// imr has no /config/paths; the only online signal is /config status
+	// (which for imr carries just the apiserver block).
+	online := !offline
+	var status tdns.ConfigResponse
+	if online {
+		if s, ok := fetchImrStatus(); ok {
+			status = s
+		} else {
+			online = false
+			rep.warn("Daemon", "reachability",
+				"could not reach the imr daemon; running static checks only",
+				"start the daemon (or pass --offline) to enable apiserver correlation")
+		}
+	}
+
+	cfgPath := explicitPath
+	if cfgPath == "" {
+		cfgPath = tdns.DefaultImrCfgFile
+	}
+	cfgPath = absClean(cfgPath)
+
+	fmt.Printf("Checking imr config: %s\n", cfgPath)
+	if online {
+		fmt.Printf("Correlating against the running imr daemon.\n")
+	}
+	fmt.Println()
+
+	v, loadErr := loadConfigViper(cfgPath, rep)
+	if loadErr != nil {
+		rep.fail("Config file", "load", fmt.Sprintf("cannot load %s: %v", cfgPath, loadErr),
+			"fix the YAML syntax / missing file, then re-run")
+		finishCheckconf(rep)
+		return
+	}
+	rep.pass("Config file", "load", "config file (and includes) parsed as YAML")
+
+	checkRequiredFields(v, cfgPath, rep, tdns.AppTypeImr)
+
+	var cfg tdns.Config
+	if err := v.Unmarshal(&cfg); err != nil {
+		rep.warn("Config file", "decode",
+			fmt.Sprintf("could not fully decode config into structs: %v", err), "")
+	}
+
+	checkImrEngine(&cfg, rep)
+	checkImrTrustAnchors(&cfg, rep)
+	checkImrApiServer(&cfg, v, rep)
+	checkApiServerCorrelation("imr", &cfg, rep)
+
+	if online {
+		correlateImrApiServer(&cfg, status, rep)
+	}
+
+	finishCheckconf(rep)
+}
+
+func checkImrEngine(cfg *tdns.Config, rep *ccReport) {
+	const g = "IMR engine"
+	if len(cfg.Imr.Addresses) == 0 {
+		rep.fail(g, "addresses", "imrengine.addresses is empty — the resolver would not listen on any address",
+			"add at least one addr:port, e.g. [ 127.0.0.1:53, '[::1]:53' ]")
+	} else {
+		rep.pass(g, "addresses", fmt.Sprintf("listening on %v", cfg.Imr.Addresses))
+	}
+
+	validT := map[string]bool{"do53": true, "dot": true, "doh": true, "doq": true}
+	if len(cfg.Imr.Transports) == 0 {
+		rep.fail(g, "transports", "imrengine.transports is empty", "list at least one of do53, dot, doh, doq")
+	}
+	needCert := false
+	for _, t := range cfg.Imr.Transports {
+		lt := lc(t)
+		if !validT[lt] {
+			rep.fail(g, "transports", fmt.Sprintf("unknown transport %q", t), "valid transports are do53, dot, doh, doq")
+			continue
+		}
+		if lt != "do53" {
+			needCert = true
+		}
+	}
+	if needCert {
+		if cfg.Imr.CertFile == "" || cfg.Imr.KeyFile == "" {
+			rep.warn(g, "cert", "dot/doh/doq configured but imrengine.certfile/keyfile not set — those listeners will be skipped",
+				"set imrengine.certfile and imrengine.keyfile, or remove the encrypted transports")
+		} else {
+			checkFileExists(rep, g, "certfile", cfg.Imr.CertFile)
+			checkFileExists(rep, g, "keyfile", cfg.Imr.KeyFile)
+		}
+	}
+	if cfg.Imr.RootHints != "" {
+		checkFileExists(rep, g, "root-hints", cfg.Imr.RootHints)
+	}
+}
+
+// checkImrTrustAnchors flags the classic imr footgun: DNSSEC validation is on
+// by default, but if no trust anchor is configured the resolver validates
+// against an empty anchor set and returns SERVFAIL/bogus for everything.
+func checkImrTrustAnchors(cfg *tdns.Config, rep *ccReport) {
+	const g = "Trust anchors"
+	hasAnchor := cfg.Imr.TrustAnchorDS != "" || cfg.Imr.TrustAnchorDNSKEY != "" || cfg.Imr.TrustAnchorFile != ""
+	requireValidation := cfg.Imr.RequireDnssecValidation == nil || *cfg.Imr.RequireDnssecValidation
+
+	if cfg.Imr.TrustAnchorFile != "" {
+		checkFileExists(rep, g, "trust-anchor-file", cfg.Imr.TrustAnchorFile)
+	}
+
+	switch {
+	case hasAnchor:
+		rep.pass(g, "anchor", "a DNSSEC trust anchor is configured")
+	case !requireValidation:
+		rep.info(g, "anchor", "no trust anchor, but require_dnssec_validation is false (lab mode) — validation disabled")
+	default:
+		rep.fail(g, "anchor",
+			"no trust anchor configured and DNSSEC validation is on (the default) — the resolver validates against an empty anchor set and everything is BOGUS",
+			"set imrengine.trust-anchor-file (or trust_anchor_ds), or set imrengine.require_dnssec_validation: false for lab use")
+	}
+}
+
+func checkImrApiServer(cfg *tdns.Config, v *viper.Viper, rep *ccReport) {
+	const g = "API server"
+	if len(cfg.ApiServer.Addresses) == 0 {
+		rep.info(g, "addresses", "apiserver.addresses is empty — the management API will not listen (the resolver still runs)")
+		return
+	}
+	rep.pass(g, "addresses", fmt.Sprintf("listening on %v", cfg.ApiServer.Addresses))
+
+	if cfg.ApiServer.ApiKey.Value() == "" {
+		rep.fail(g, "apikey", "apiserver.apikey is empty — the imr API router refuses to start without it",
+			"set a long random apiserver.apikey")
+	} else {
+		rep.pass(g, "apikey", "apiserver.apikey is set")
+	}
+
+	// usetls defaults TRUE for imr unless explicitly set false.
+	usetls := true
+	if v.IsSet("apiserver.usetls") {
+		usetls = v.GetBool("apiserver.usetls")
+	}
+	if usetls {
+		if cfg.ApiServer.CertFile == "" || cfg.ApiServer.KeyFile == "" {
+			rep.fail(g, "cert", "apiserver.usetls is true (the imr default) but certfile/keyfile are not set — the API listener fails to start",
+				"set apiserver.certfile/keyfile (see `tdns-cli imr config mwe`) or set usetls: false")
+		} else {
+			checkFileExists(rep, g, "certfile", cfg.ApiServer.CertFile)
+			checkFileExists(rep, g, "keyfile", cfg.ApiServer.KeyFile)
+		}
+	} else {
+		rep.info(g, "usetls", "apiserver.usetls is false — plaintext management API")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// imr online correlation (thin: apiserver only)
+// ---------------------------------------------------------------------------
+
+func fetchImrStatus() (tdns.ConfigResponse, bool) {
+	api, err := GetApiClient("imr", false)
+	if err != nil {
+		return tdns.ConfigResponse{}, false
+	}
+	resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: "status"})
+	if err != nil {
+		return tdns.ConfigResponse{}, false
+	}
+	return resp, true
+}
+
+func correlateImrApiServer(cfg *tdns.Config, status tdns.ConfigResponse, rep *ccReport) {
+	const g = "Running-config drift"
+	if status.ApiServer.ApiKey.Value() != "" && cfg.ApiServer.ApiKey.Value() != "" &&
+		status.ApiServer.ApiKey.Value() != cfg.ApiServer.ApiKey.Value() {
+		rep.warn(g, "apikey",
+			"apiserver.apikey in the file differs from the running server's apikey",
+			"the running apikey changes only on restart")
+	}
+	if len(status.ApiServer.Addresses) > 0 && len(cfg.ApiServer.Addresses) > 0 &&
+		!sameStringSet(cfg.ApiServer.Addresses, status.ApiServer.Addresses) {
+		rep.warn(g, "apiserver-addresses",
+			fmt.Sprintf("config apiserver.addresses %v differ from running %v", cfg.ApiServer.Addresses, status.ApiServer.Addresses),
+			"apiserver listen addresses change only on restart")
+	}
+	rep.pass(g, "apiserver", "correlated apiserver against the running daemon")
+}
+
+// ---------------------------------------------------------------------------
+// imr config mwe
+// ---------------------------------------------------------------------------
+
+func newImrConfigMweCmd() *cobra.Command {
+	var dir string
+	c := &cobra.Command{
+		Use:   "mwe",
+		Short: "Generate a minimal working example config (+ cert) for tdns-imr",
+		Long: `Generate a Minimal Working Example configuration for tdns-imr.
+
+Writes a single self-contained YAML to <dir>/tdns-imr.yaml (or <dir>/tdns-imr.yaml.mwe
+if that file already exists), and generates a self-signed cert/key pair under
+<dir>/certs unless one is already there. The resolver listens on IPv4 and IPv6
+localhost; DNSSEC validation is disabled so it resolves out of the box (the
+config shows, commented, how to turn it into a validating resolver). The
+generated tree passes ` + "`tdns-cli imr config check`" + `.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runImrConfigMwe(dir)
+		},
+	}
+	c.Flags().StringVar(&dir, "dir", "/etc/tdns", "base directory for the generated config and cert")
+	return c
+}
+
+func runImrConfigMwe(dir string) {
+	dir = filepath.Clean(dir)
+	cfgPath := filepath.Join(dir, "tdns-imr.yaml")
+	if _, err := os.Stat(cfgPath); err == nil {
+		cfgPath += ".mwe"
+		fmt.Printf("Config %s already exists; writing MWE to %s instead.\n",
+			filepath.Join(dir, "tdns-imr.yaml"), cfgPath)
+	}
+
+	certsDir := filepath.Join(dir, "certs")
+	for _, d := range []string{dir, certsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			cliFatalf("could not create directory %s: %v", d, err)
+		}
+	}
+
+	certFile := filepath.Join(certsDir, "localhost.crt")
+	keyFile := filepath.Join(certsDir, "localhost.key")
+	certCreated, err := ensureSelfSignedCert(certFile, keyFile)
+	if err != nil {
+		cliFatalf("could not generate certificate: %v", err)
+	}
+
+	apiKey, err := randomAPIKey()
+	if err != nil {
+		cliFatalf("could not generate api key: %v", err)
+	}
+
+	apiPort := "8080"
+	dnsPort := "5353"
+	content := renderImrMweConfig(dir, certFile, keyFile, apiKey, apiPort, dnsPort)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		cliFatalf("could not write config %s: %v", cfgPath, err)
+	}
+
+	fmt.Printf("\nWrote MWE config:  %s\n", cfgPath)
+	if certCreated {
+		fmt.Printf("Generated cert:    %s\n", certFile)
+		fmt.Printf("Generated key:     %s\n", keyFile)
+	} else {
+		fmt.Printf("Reused cert/key:   %s , %s\n", certFile, keyFile)
+	}
+
+	fmt.Printf("\nTo let `tdns-cli imr ...` reach this server, add to your tdns-cli.yaml:\n\n")
+	fmt.Printf("  apiservers:\n")
+	fmt.Printf("     - name:       tdns-imr\n")
+	fmt.Printf("       baseurl:    https://127.0.0.1:%s/api/v1\n", apiPort)
+	fmt.Printf("       apikey:     %s\n", apiKey)
+	fmt.Printf("       authmethod: X-API-Key\n")
+	fmt.Printf("\nNext steps:\n")
+	fmt.Printf("  tdns-imr --config %s        # start the resolver\n", cfgPath)
+	fmt.Printf("  tdns-cli imr config check --serverconfig %s   # validate\n", cfgPath)
+}
+
+func renderImrMweConfig(dir, certFile, keyFile, apiKey, apiPort, dnsPort string) string {
+	r := strings.NewReplacer(
+		"{{DIR}}", dir,
+		"{{CERT}}", certFile,
+		"{{KEY}}", keyFile,
+		"{{APIKEY}}", apiKey,
+		"{{APIPORT}}", apiPort,
+		"{{DNSPORT}}", dnsPort,
+	)
+	return r.Replace(imrMweConfigTemplate)
+}
+
+const imrMweConfigTemplate = `# Minimal Working Example — tdns-imr
+#
+# Generated by ` + "`tdns-cli imr config mwe`" + `. Self-contained: one file plus a
+# self-signed cert. Validate it any time with:
+#   tdns-cli imr config check --serverconfig <this file>
+
+imrengine:
+   # Listen on IPv4 and IPv6 localhost. Port {{DNSPORT}} is used so the resolver
+   # runs unprivileged; use 53 for a real deployment (needs root/capabilities).
+   addresses:   [ 127.0.0.1:{{DNSPORT}}, '[::1]:{{DNSPORT}}' ]
+   #   addresses: [ 127.0.0.1:{{DNSPORT}}, '[::1]:{{DNSPORT}}', 192.0.2.53:53 ]
+   transports:  [ do53 ]
+   # For encrypted transports the cert/key below are ready to use:
+   #   transports: [ do53, dot, doh, doq ]
+   # certfile:  {{CERT}}
+   # keyfile:   {{KEY}}
+
+   # DNSSEC validation is DISABLED in this MWE so the resolver answers out of
+   # the box without a root trust anchor. To make it a validating resolver,
+   # supply a root anchor and flip this to true:
+   #   trust-anchor-file:          /etc/tdns/root.key
+   #   require_dnssec_validation:  true
+   # or paste the current root DS inline:
+   #   trust_anchor_ds: ". IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D"
+   require_dnssec_validation:  false
+
+apiserver:
+   addresses:  [ 127.0.0.1:{{APIPORT}} ]
+   apikey:     {{APIKEY}}
+   certfile:   {{CERT}}
+   keyfile:    {{KEY}}
+   usetls:     true
+
+log:
+   file:   {{DIR}}/tdns-imr.log
+   level:  info
+`

--- a/v2/cli/config_mwe_cmds.go
+++ b/v2/cli/config_mwe_cmds.go
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * `tdns-cli auth config mwe` — generate a Minimal Working Example config for
+ * tdns-auth: a single self-contained YAML, a self-signed cert/key pair, and
+ * two example primary zones (one signed, one unsigned) with generated zone
+ * files, plus a commented-out secondary. Everything is generated so the
+ * resulting tree passes `tdns-cli auth config check` and the daemon starts.
+ */
+package cli
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newConfigMweCmd builds the `config mwe` subcommand for the given role.
+// Only tdns-auth is supported today.
+func newConfigMweCmd(role string) *cobra.Command {
+	var dir string
+	c := &cobra.Command{
+		Use:   "mwe",
+		Short: "Generate a minimal working example config (+ certs, zones) for tdns-" + role,
+		Long: `Generate a Minimal Working Example configuration for tdns-` + role + `.
+
+Writes a single self-contained YAML to <dir>/tdns-` + role + `.yaml (or, if that
+file already exists, to <dir>/tdns-` + role + `.yaml.mwe so nothing is
+clobbered). Also generates, unless already present:
+
+  - a self-signed cert/key pair under <dir>/certs (for the API server and the
+    encrypted DNS transports)
+  - two example primary zones — one unsigned, one signed — using two different
+    zone templates, with generated zone files under <dir>/zones
+  - a commented-out secondary zone using a third template
+
+The DNS engine listens on IPv4 and IPv6 localhost; extra listen addresses are
+shown commented out. The generated tree is designed to pass
+` + "`tdns-cli " + role + " config check`" + `.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if role != "auth" {
+				cliFatalf("config mwe is currently only implemented for auth")
+			}
+			runConfigMwe(role, dir)
+		},
+	}
+	c.Flags().StringVar(&dir, "dir", "/etc/tdns", "base directory for the generated config, certs and zones")
+	return c
+}
+
+// mweZone describes one example zone the MWE generates.
+type mweZone struct {
+	name     string
+	template string
+	signed   bool
+}
+
+func runConfigMwe(role, dir string) {
+	dir = filepath.Clean(dir)
+	cfgPath := filepath.Join(dir, "tdns-"+role+".yaml")
+	if _, err := os.Stat(cfgPath); err == nil {
+		cfgPath += ".mwe"
+		fmt.Printf("Config %s already exists; writing MWE to %s instead.\n",
+			filepath.Join(dir, "tdns-"+role+".yaml"), cfgPath)
+	}
+
+	zonesDir := filepath.Join(dir, "zones")
+	certsDir := filepath.Join(dir, "certs")
+	for _, d := range []string{dir, zonesDir, certsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			cliFatalf("could not create directory %s: %v", d, err)
+		}
+	}
+
+	// Certificate/key pair (shared by apiserver and the encrypted DNS
+	// transports). Reused if already present.
+	certFile := filepath.Join(certsDir, "localhost.crt")
+	keyFile := filepath.Join(certsDir, "localhost.key")
+	certCreated, err := ensureSelfSignedCert(certFile, keyFile)
+	if err != nil {
+		cliFatalf("could not generate certificate: %v", err)
+	}
+
+	// Random API key.
+	apiKey, err := randomAPIKey()
+	if err != nil {
+		cliFatalf("could not generate api key: %v", err)
+	}
+
+	// Example zones: two primaries (different templates), one secondary
+	// (third template, emitted commented-out below).
+	zones := []mweZone{
+		{name: "signed.example.", template: "signed-primary", signed: true},
+		{name: "unsigned.example.", template: "unsigned-primary", signed: false},
+	}
+	var zoneFilesCreated, zoneFilesKept []string
+	for _, z := range zones {
+		zf := filepath.Join(zonesDir, strings.TrimSuffix(z.name, ".")+".zone")
+		if _, err := os.Stat(zf); err == nil {
+			zoneFilesKept = append(zoneFilesKept, zf)
+			continue
+		}
+		if err := os.WriteFile(zf, []byte(mweZoneFileContent(z.name)), 0o644); err != nil {
+			cliFatalf("could not write zone file %s: %v", zf, err)
+		}
+		zoneFilesCreated = append(zoneFilesCreated, zf)
+	}
+
+	apiPort := "8989"
+	dnsPort := "5354"
+	content := renderMweConfig(role, dir, zonesDir, certFile, keyFile, apiKey, apiPort, dnsPort)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		cliFatalf("could not write config %s: %v", cfgPath, err)
+	}
+
+	// Summary.
+	fmt.Printf("\nWrote MWE config:  %s\n", cfgPath)
+	if certCreated {
+		fmt.Printf("Generated cert:    %s\n", certFile)
+		fmt.Printf("Generated key:     %s\n", keyFile)
+	} else {
+		fmt.Printf("Reused cert/key:   %s , %s\n", certFile, keyFile)
+	}
+	for _, zf := range zoneFilesCreated {
+		fmt.Printf("Generated zone:    %s\n", zf)
+	}
+	for _, zf := range zoneFilesKept {
+		fmt.Printf("Kept zone file:    %s\n", zf)
+	}
+
+	fmt.Printf("\nTo let `tdns-cli %s ...` reach this server, add to your tdns-cli.yaml:\n\n", role)
+	fmt.Printf("  apiservers:\n")
+	fmt.Printf("     - name:       tdns-%s\n", role)
+	fmt.Printf("       baseurl:    https://127.0.0.1:%s/api/v1\n", apiPort)
+	fmt.Printf("       apikey:     %s\n", apiKey)
+	fmt.Printf("       authmethod: X-API-Key\n")
+	fmt.Printf("\nNext steps:\n")
+	fmt.Printf("  tdns-%s --config %s        # start the server\n", role, cfgPath)
+	fmt.Printf("  tdns-cli %s config check --serverconfig %s   # validate\n", role, cfgPath)
+}
+
+// ---------------------------------------------------------------------------
+// Config rendering
+// ---------------------------------------------------------------------------
+
+func renderMweConfig(role, dir, zonesDir, certFile, keyFile, apiKey, apiPort, dnsPort string) string {
+	r := strings.NewReplacer(
+		"{{ROLE}}", role,
+		"{{DIR}}", dir,
+		"{{ZONESDIR}}", zonesDir,
+		"{{CERT}}", certFile,
+		"{{KEY}}", keyFile,
+		"{{APIKEY}}", apiKey,
+		"{{APIPORT}}", apiPort,
+		"{{DNSPORT}}", dnsPort,
+	)
+	return r.Replace(mweConfigTemplate)
+}
+
+// mweConfigTemplate is the single-file MWE. Placeholders in {{...}} form are
+// substituted by renderMweConfig (avoids fmt verb collisions with the %s zone
+// pattern shown in a comment below).
+const mweConfigTemplate = `# Minimal Working Example — tdns-{{ROLE}}
+#
+# Generated by ` + "`tdns-cli {{ROLE}} config mwe`" + `. Self-contained: one file, a
+# self-signed cert, and two example primary zones with generated zone files.
+# Validate it any time with:  tdns-cli {{ROLE}} config check --serverconfig <this file>
+
+service:
+   name:  TDNS-AUTH
+
+dnsengine:
+   # Listen on IPv4 and IPv6 localhost. Port {{DNSPORT}} is used so the server
+   # runs unprivileged; use 53 for a real deployment (needs root/capabilities).
+   addresses:   [ 127.0.0.1:{{DNSPORT}}, '[::1]:{{DNSPORT}}' ]
+   # Add more listen addresses by uncommenting/extending, e.g.:
+   #   addresses: [ 127.0.0.1:{{DNSPORT}}, '[::1]:{{DNSPORT}}', 192.0.2.53:53, '[2001:db8::53]:53' ]
+   transports:  [ do53 ]
+   # For encrypted transports, add them here and the cert/key are already set:
+   #   transports: [ do53, dot, doh, doq ]
+   certfile:  {{CERT}}
+   keyfile:   {{KEY}}
+
+apiserver:
+   addresses:  [ 127.0.0.1:{{APIPORT}} ]
+   apikey:     {{APIKEY}}
+   certfile:   {{CERT}}
+   keyfile:    {{KEY}}
+   usetls:     true
+
+db:
+   file:  {{DIR}}/tdns-{{ROLE}}.db
+
+log:
+   file:   {{DIR}}/tdns-{{ROLE}}.log
+   level:  info
+
+# One DNSSEC policy, referenced by the signed zone below. ED25519 for both
+# roles (same algorithm needs no split_algorithms entry), static keys.
+dnssec:
+   policies:
+      default:
+         algorithm:  ED25519
+         ksk: { lifetime: forever }
+         zsk: { lifetime: forever }
+         csk: { lifetime: none }
+         sigvalidity:
+            default:  14d
+            dnskey:   30d
+            ds:       14d
+
+# Zone templates. The two primaries below use two DIFFERENT templates; the
+# commented-out secondary uses a third.
+templates:
+   - name:   unsigned-primary
+     type:   primary
+     store:  map
+
+   - name:          signed-primary
+     type:          primary
+     store:         map
+     options:       [ online-signing ]
+     dnssecpolicy:  default
+
+   - name:   basic-secondary
+     type:   secondary
+     store:  map
+
+zones:
+   # Unsigned primary (template: unsigned-primary).
+   - name:      unsigned.example.
+     zonefile:  {{ZONESDIR}}/unsigned.example.zone
+     template:  unsigned-primary
+     downstreams:
+        - { prefix: "127.0.0.0/8", key: NOKEY }
+        - { prefix: "::1",         key: NOKEY }
+
+   # Signed primary (template: signed-primary -> online-signing + dnssecpolicy).
+   - name:      signed.example.
+     zonefile:  {{ZONESDIR}}/signed.example.zone
+     template:  signed-primary
+     downstreams:
+        - { prefix: "127.0.0.0/8", key: NOKEY }
+        - { prefix: "::1",         key: NOKEY }
+
+   # Example SECONDARY zone (template: basic-secondary). Uncomment and point
+   # primaries: at your real primary to enable. A template may instead carry a
+   # zonefile pattern like  zonefile: {{ZONESDIR}}/%szone  to derive the path.
+   # - name:      secondary.example.
+   #   template:  basic-secondary
+   #   primaries:
+   #      - { addr: "192.0.2.1:53", key: NOKEY }
+   #   allow-notify:
+   #      - { prefix: "192.0.2.1", key: NOKEY }
+`
+
+// mweZoneFileContent returns a minimal, valid zone file (SOA + NS + address
+// records) for the named zone. The name includes its trailing dot.
+func mweZoneFileContent(zone string) string {
+	return "" +
+		"$ORIGIN " + zone + "\n" +
+		"$TTL 3600\n" +
+		"@     IN SOA  ns1." + zone + " hostmaster." + zone + " ( 1 3600 1800 1209600 3600 )\n" +
+		"@     IN NS   ns1." + zone + "\n" +
+		"ns1   IN A    127.0.0.1\n" +
+		"ns1   IN AAAA ::1\n" +
+		"www   IN A    127.0.0.1\n" +
+		"www   IN AAAA ::1\n"
+}
+
+// ---------------------------------------------------------------------------
+// Cert + key generation
+// ---------------------------------------------------------------------------
+
+// ensureSelfSignedCert writes a self-signed ECDSA P-256 cert/key pair for
+// localhost to certFile/keyFile unless BOTH already exist. Returns whether a
+// new pair was created.
+func ensureSelfSignedCert(certFile, keyFile string) (bool, error) {
+	_, cerr := os.Stat(certFile)
+	_, kerr := os.Stat(keyFile)
+	if cerr == nil && kerr == nil {
+		return false, nil // reuse existing pair
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return false, err
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return false, err
+	}
+	now := time.Now()
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             now.Add(-1 * time.Hour),
+		NotAfter:              now.AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return false, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return false, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	if err := os.WriteFile(certFile, certPEM, 0o644); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// randomAPIKey returns a URL-safe base64 random string (32 bytes of entropy).
+func randomAPIKey() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/v2/cli/config_mwe_cmds.go
+++ b/v2/cli/config_mwe_cmds.go
@@ -294,6 +294,11 @@ func ensureSelfSignedCert(certFile, keyFile string) (bool, error) {
 	if cerr == nil && kerr == nil {
 		return false, nil // reuse existing pair
 	}
+	// Only one of the pair exists: do NOT regenerate, which would silently
+	// overwrite the pre-existing file. Fail so the operator resolves it.
+	if cerr == nil || kerr == nil {
+		return false, fmt.Errorf("partial cert/key pair found (cert exists: %v, key exists: %v) — remove both or supply both, will not overwrite", cerr == nil, kerr == nil)
+	}
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/v2/ksk_rollover_policy.go
+++ b/v2/ksk_rollover_policy.go
@@ -648,21 +648,47 @@ func parseDnssecPolicyConfImpl(name string, dp *DnssecPolicyConf, quiet bool, sp
 	return out, nil
 }
 
-// ValidateDnssecPoliciesFromFile parses a YAML file with a dnssec.policies: map
-// and validates every policy the same way as runtime config loading.
-func ValidateDnssecPoliciesFromFile(path string) error {
+// PolicyAlgs is the effective algorithm set of one resolved DNSSEC policy: the
+// default/CSK algorithm plus the per-role KSK/ZSK algorithms (codepoints), and
+// the normalized mode ("csk" | "ksk-zsk"). It is the minimal projection a
+// consumer needs to dry-run the signer's active-key-algorithm reconcile against
+// a running keystore, without pulling in the full DnssecPolicy.
+type PolicyAlgs struct {
+	Mode   string
+	Alg    uint8 // default / CSK algorithm
+	KSKAlg uint8
+	ZSKAlg uint8
+}
+
+// loadDnssecPoliciesYAML reads a YAML file with a dnssec: block into the
+// policies/templates/split shape. Returns a structural error (unreadable file,
+// bad YAML, or no policies) distinct from any per-policy validation error.
+func loadDnssecPoliciesYAML(path string) (dnssecPoliciesYAML, error) {
+	var root dnssecPoliciesYAML
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return root, err
 	}
-	var root dnssecPoliciesYAML
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return fmt.Errorf("yaml: %w", err)
+		return root, fmt.Errorf("yaml: %w", err)
 	}
 	if len(root.Dnssec.Policies) == 0 {
-		return errors.New("no dnssec.policies: block found (policies live under the dnssec: key)")
+		return root, errors.New("no dnssec.policies: block found (policies live under the dnssec: key)")
 	}
+	return root, nil
+}
+
+// resolveAndValidatePolicies runs, for every policy in root, the exact template
+// + role-algorithm resolution and full validation (split gating, role
+// capability, key lifetimes, FinishDnssecPolicy) that runtime config loading
+// does. It returns each policy's effective algorithms — recorded as soon as the
+// role algorithms resolve, so a policy that later fails a validation gate still
+// contributes its algorithms — plus the joined validation error. Both
+// ValidateDnssecPoliciesFromFile and ResolveDnssecPolicyAlgs are thin wrappers
+// over this, so validation and algorithm-resolution can never drift apart.
+func resolveAndValidatePolicies(root dnssecPoliciesYAML) (map[string]PolicyAlgs, error) {
 	splitAllowed := buildSplitAlgorithmSet(root.Dnssec.SplitAlgorithms)
+	out := make(map[string]PolicyAlgs, len(root.Dnssec.Policies))
 	var errs []error
 	for name, dp := range root.Dnssec.Policies {
 		dp.Name = name
@@ -677,6 +703,15 @@ func ValidateDnssecPoliciesFromFile(path string) error {
 			errs = append(errs, err)
 			continue
 		}
+		// Record effective algorithms once resolved (before the downstream
+		// validation gates), so an algorithm-correlating consumer still sees
+		// them for a policy that fails a later gate.
+		mode := strings.ToLower(strings.TrimSpace(dp.Mode))
+		if mode == "" {
+			mode = DnssecPolicyModeKSKZSK
+		}
+		out[name] = PolicyAlgs{Mode: mode, Alg: alg, KSKAlg: kskAlg, ZSKAlg: zskAlg}
+
 		if err := validateSplitAlgorithm(name, kskAlg, zskAlg, splitAllowed); err != nil {
 			errs = append(errs, err)
 			continue
@@ -713,5 +748,34 @@ func ValidateDnssecPoliciesFromFile(path string) error {
 			errs = append(errs, err)
 		}
 	}
-	return errors.Join(errs...)
+	return out, errors.Join(errs...)
+}
+
+// ValidateDnssecPoliciesFromFile parses a YAML file with a dnssec.policies: map
+// and validates every policy the same way as runtime config loading.
+func ValidateDnssecPoliciesFromFile(path string) error {
+	root, err := loadDnssecPoliciesYAML(path)
+	if err != nil {
+		return err
+	}
+	_, verr := resolveAndValidatePolicies(root)
+	return verr
+}
+
+// ResolveDnssecPolicyAlgs returns the effective algorithms (default/CSK, KSK,
+// ZSK codepoints) and mode of every DNSSEC policy in a YAML file's dnssec:
+// block, using the SAME template + role resolution as
+// ValidateDnssecPoliciesFromFile. Intended for tdns-cli's `config check` to
+// dry-run the signer's active-key-algorithm reconcile against the running
+// keystore. Only structural errors (unreadable file / bad YAML / no policies)
+// are returned; per-policy validation errors are the province of
+// ValidateDnssecPoliciesFromFile and are intentionally dropped here, while the
+// policy's resolved algorithms are still returned.
+func ResolveDnssecPolicyAlgs(path string) (map[string]PolicyAlgs, error) {
+	root, err := loadDnssecPoliciesYAML(path)
+	if err != nil {
+		return nil, err
+	}
+	algs, _ := resolveAndValidatePolicies(root)
+	return algs, nil
 }


### PR DESCRIPTION
CLI-side config commands for **tdns-auth** and **tdns-imr**, under each daemon's `config` group. Entirely in `v2/cli/` — no server-side changes, so no conflict with in-flight server work.

## auth: `config check` + `config mwe`
`auth config check` — validate a tdns-auth config and (unless `--offline`) correlate it against the running daemon:
- **Required fields** (`tdns.ValidateConfig`), **DNSSEC policies** (`tdns.ValidateDnssecPoliciesFromFile`: template expansion + KSK/ZSK split gating + lifetimes).
- **Referential integrity** — zone `template`/`dnssecpolicy`/`multisigner` resolve; signing options require a policy.
- **Zones** — primaries: zonefile exists + parses (apex SOA); secondaries: `primaries` set, TSIG key in `keys.tsig` **or** keystore.
- **dnsengine**/**apiserver** completeness; **tdns-cli.yaml correlation** (the `apiservers` entry `tdns-cli auth …` uses, with matching port + apikey).
- **Online drift** — config-file mismatch (via `GET /config/paths`), listen-address drift, loaded-policy errors, running-vs-configured zones.

`auth config mwe` — generate a self-contained `/etc/tdns/tdns-auth.yaml` (or `.mwe`), a self-signed ECDSA P-256 cert, a random API key, and two example primaries (one signed, one unsigned) using two different zone templates with generated zone files, plus a commented-out templated secondary.

## imr: `config check` + `config mwe`
Simpler — tdns-imr has no zones, policies, keystore, or `/config/paths`, so validation is mostly static:
- **imrengine** (addresses/transports + encrypted-transport cert rules), the **trust-anchor footgun** (DNSSEC validation on by default ⇒ no anchor ⇒ empty anchor set ⇒ bogus), **apiserver** (apikey required once the API listens; `usetls` defaults true ⇒ cert required).
- **Online** correlation is thin: reachability + apiserver drift via `/config status`.
- `imr config mwe` generates a self-contained resolver config (localhost do53, self-signed cert, validation off so it resolves out of the box, with commented steps to make it validating).

Shared machinery (report model, required-field validator, apiserver↔tdns-cli.yaml correlation, cert generation) is reused across both.

## Validation
- Offline: broken configs report the expected FAIL/WARN sets; clean configs pass.
- Online against live `tdns-auth` and `tdns-imr`: correlation passes; drifted configs correctly flag config-file/address/zone divergence.
- Each generated MWE passes its own `config check` **and** starts a working daemon (auth: `dig` shows the signed zone serving SOA + ED25519 KSK/ZSK; imr: resolver comes up and answers its API).

`agent` equivalents to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration checking for auth and IMR services, including static validation, file checks, and optional online comparisons with running daemons.
  - Added minimal working example generation for auth and IMR configurations, including certificates and supporting zone files where applicable.
  - Added clear validation reports with PASS, INFO, WARN, and FAIL results, plus non-zero exit status on failures.
  - Added automatic configuration path resolution and support for included configuration files.
- **Documentation**
  - Added generated setup instructions for starting services and completing CLI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->