### PR TITLE
delegation-sync: report parent rejection RCODEs from SendUpdate (D-2b prereq)

### DIFF
--- a/v2/childsync_rcode_test.go
+++ b/v2/childsync_rcode_test.go
@@ -1,0 +1,163 @@
+package tdns
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// startRcodeResponder brings up a TCP UPDATE responder that answers every
+// request with a fixed rcode, and returns its addr:port. It attaches an OPT RR
+// because the extended rcodes (BADKEY 17, BADSIG 16, BADTIME 18) do not fit the
+// 4-bit header field: without an OPT, packing a message with Rcode > 0xF fails
+// with ErrExtendedRcode and the response is never sent.
+func startRcodeResponder(t *testing.T, answer int) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	srv := &dns.Server{
+		Listener: ln,
+		Net:      "tcp",
+		// The default MsgAcceptFunc rejects the UPDATE opcode as NOTIMP before
+		// the handler runs; use tdns's own accept func, as the real server does.
+		MsgAcceptFunc: MsgAcceptFunc,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := new(dns.Msg)
+			m.SetReply(r)
+			m.SetEdns0(4096, false)
+			m.Rcode = answer
+			_ = w.WriteMsg(m)
+		}),
+	}
+	started := make(chan struct{})
+	srv.NotifyStartedFunc = func() { close(started) }
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+	<-started
+
+	return ln.Addr().String()
+}
+
+func testUpdateMsg(t *testing.T) *dns.Msg {
+	t.Helper()
+	m := new(dns.Msg)
+	m.SetUpdate("child.parent.example.")
+	rr, err := dns.NewRR("child.parent.example. 3600 IN NS ns1.child.parent.example.")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	m.Insert([]dns.RR{rr})
+	m.SetEdns0(1232, true)
+	return m
+}
+
+// TestSendUpdateReportsRejectionRcode pins SendUpdate's return contract: a
+// response carrying a rejection RCODE is a successful exchange and must be
+// reported through the rcode with a NIL error. Only a transport failure is an
+// error.
+//
+// This is the regression guard for a bug that made the entire delegation-sync
+// RCODE policy of draft-ietf-dnsop-delegation-mgmt-via-ddns-02 unreachable:
+// SendUpdate returned the rcode only on the NOERROR path and folded every
+// rejection into a generic "all target addresses responded with errors" error
+// carrying rcode 0. sendUpdateWithRetry short-circuits on a non-nil error, so
+// its `case dns.RcodeBadKey` (re-bootstrap) and `case dns.RcodeRefused`
+// (bounded retry) arms could never fire against a real receiver — they were
+// exercised only by the injected send closure in delsync_retry_test.go.
+func TestSendUpdateReportsRejectionRcode(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		answer int
+	}{
+		{"NOERROR", dns.RcodeSuccess},
+		{"BADKEY", dns.RcodeBadKey},
+		{"REFUSED", dns.RcodeRefused},
+		{"SERVFAIL", dns.RcodeServerFailure},
+		{"NOTAUTH", dns.RcodeNotAuth},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := startRcodeResponder(t, tc.answer)
+
+			rcode, ur, err := SendUpdate(testUpdateMsg(t), "child.parent.example.", []string{addr})
+			if err != nil {
+				t.Fatalf("SendUpdate returned an error for a responding target: %v "+
+					"(a rejection RCODE is not a transport failure)", err)
+			}
+			if rcode != tc.answer {
+				t.Errorf("rcode = %d (%s), want %d (%s)",
+					rcode, dns.RcodeToString[rcode], tc.answer, dns.RcodeToString[tc.answer])
+			}
+			// The per-target detail must agree with the headline rcode.
+			ts, ok := ur.TargetStatus[addr]
+			if !ok {
+				t.Fatalf("UpdateResult has no TargetStatus for %s", addr)
+			}
+			if ts.Rcode != tc.answer {
+				t.Errorf("TargetStatus[%s].Rcode = %d, want %d", addr, ts.Rcode, tc.answer)
+			}
+		})
+	}
+}
+
+// TestSendUpdateUnreachableIsTransportError asserts the other half of the
+// contract: when NO address produces a DNS response, that IS an error, and the
+// rcode is meaningless (0).
+func TestSendUpdateUnreachableIsTransportError(t *testing.T) {
+	// Bind and immediately close, so the port is (almost certainly) refusing.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	dead := ln.Addr().String()
+	ln.Close()
+
+	rcode, _, err := SendUpdate(testUpdateMsg(t), "child.parent.example.", []string{dead})
+	if err == nil {
+		t.Fatal("SendUpdate returned nil error for an unreachable target; a transport failure must be an error")
+	}
+	if rcode != 0 {
+		t.Errorf("rcode = %d, want 0 for a transport failure", rcode)
+	}
+}
+
+// TestSendUpdatePrefersRespondingTarget asserts that an unreachable address
+// does not mask a rejection from a later one: the caller still learns the
+// RCODE, which is what drives the BADKEY -> re-bootstrap decision.
+func TestSendUpdatePrefersRespondingTarget(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	dead := ln.Addr().String()
+	ln.Close()
+
+	live := startRcodeResponder(t, dns.RcodeBadKey)
+
+	rcode, _, err := SendUpdate(testUpdateMsg(t), "child.parent.example.", []string{dead, live})
+	if err != nil {
+		t.Fatalf("SendUpdate: %v", err)
+	}
+	if rcode != dns.RcodeBadKey {
+		t.Errorf("rcode = %d (%s), want BADKEY — a dead first address must not hide the second's rejection",
+			rcode, dns.RcodeToString[rcode])
+	}
+}
+
+// TestSendUpdateSucceedsPastRejectingTarget asserts the converse: a rejecting
+// address does not stop the search, and a later NOERROR still wins.
+func TestSendUpdateSucceedsPastRejectingTarget(t *testing.T) {
+	rejecting := startRcodeResponder(t, dns.RcodeRefused)
+	accepting := startRcodeResponder(t, dns.RcodeSuccess)
+
+	rcode, _, err := SendUpdate(testUpdateMsg(t), "child.parent.example.", []string{rejecting, accepting})
+	if err != nil {
+		t.Fatalf("SendUpdate: %v", err)
+	}
+	if rcode != dns.RcodeSuccess {
+		t.Errorf("rcode = %d (%s), want NOERROR", rcode, dns.RcodeToString[rcode])
+	}
+}

--- a/v2/childsync_utils.go
+++ b/v2/childsync_utils.go
@@ -40,6 +40,21 @@ type TargetUpdateStatus struct {
 // Note: the target.Addresses must already be in addr:port format.
 // func SendUpdate(msg *dns.Msg, zonename string, target *DsyncTarget) (int, error) {
 // func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, error, UpdateResult) {
+//
+// Return contract: the error reports a TRANSPORT-level failure — no address
+// produced a DNS response at all (i/o timeout, no route to host, connection
+// refused). A response carrying a rejection RCODE is a successful exchange, so
+// it is reported through the returned rcode with a NIL error; the caller decides
+// what the rejection means.
+//
+// This matters because the whole delegation-sync RCODE policy of
+// draft-ietf-dnsop-delegation-mgmt-via-ddns-02 (BADKEY -> re-bootstrap, REFUSED
+// -> bounded retry; see sendUpdateWithRetry) keys on the rcode. An earlier
+// version returned the rcode ONLY on the NOERROR path and folded every rejection
+// into "all target addresses responded with errors", which made those branches
+// unreachable: every BADKEY and REFUSED arrived as a transport error carrying
+// rcode 0. ksk_rollover_ds_push.go already documented this contract and
+// mis-categorised every parent rejection as SoftfailTransport because of it.
 func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, UpdateResult, error) {
 	if zonename == "." {
 		lgDns.Error("SendUpdate: zone name not specified")
@@ -71,6 +86,13 @@ func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, UpdateResul
 	// UPDATEs regardless of size, not only the large ones.
 	useTCP := true
 	client := &dns.Client{Net: "tcp"}
+
+	// The last rejection RCODE actually received from a responding address.
+	// Tracked across the loop so that a non-NOERROR answer is still reported to
+	// the caller after the remaining addresses have been tried: "try the next
+	// address" must not cost us the rejection reason.
+	var lastRcode int
+	var gotResponse bool
 
 	for _, dst := range addrs {
 		lgDns.Debug("sending DNS UPDATE", "zone", zonename, "dst", dst,
@@ -110,6 +132,8 @@ func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, UpdateResul
 			Sender:     edeSender,
 		}
 
+		lastRcode, gotResponse = res.Rcode, true
+
 		if res.Rcode != dns.RcodeSuccess {
 			lgDns.Debug("got bad rcode", "rcode", dns.RcodeToString[res.Rcode], "response", res.String())
 			lgDns.Warn("error rcode from target, trying next address", "dst", dst, "rcode", dns.RcodeToString[res.Rcode])
@@ -120,7 +144,17 @@ func SendUpdate(msg *dns.Msg, zonename string, addrs []string) (int, UpdateResul
 		}
 	}
 
-	return 0, ur, fmt.Errorf("all target addresses %v responded with errors or were unreachable", addrs)
+	// At least one address answered, but none with NOERROR. That is a parent
+	// REJECTION, not a transport failure: hand the caller the rcode (and a nil
+	// error) so it can apply the draft's per-RCODE policy.
+	if gotResponse {
+		lgDns.Warn("all target addresses rejected the update", "zone", zonename,
+			"addresses", addrs, "rcode", dns.RcodeToString[lastRcode])
+		return lastRcode, ur, nil
+	}
+
+	// No address produced a DNS response at all — a genuine transport failure.
+	return 0, ur, fmt.Errorf("all target addresses %v were unreachable", addrs)
 }
 
 // Parent is the zone to apply the update to.

--- a/v2/sig0_utils.go
+++ b/v2/sig0_utils.go
@@ -87,9 +87,15 @@ func (kdb *KeyDB) SendSig0KeyUpdate(ctx context.Context, childpri, parpri string
 	rcode, _, err := SendUpdate(smsg, Globals.ParentZone, dsynctarget.Addresses)
 	if err != nil {
 		return fmt.Errorf("error from SendUpdate(%v): %v", dsynctarget, err)
-	} else {
-		lgDns.Info("SendUpdate completed", "parent", Globals.ParentZone, "target", dsynctarget.Addresses, "rcode", dns.RcodeToString[rcode])
 	}
+	// SendUpdate reports a parent REJECTION through the rcode with a nil error
+	// (only a transport failure is an error), so the rcode must be checked
+	// explicitly or a BADKEY/REFUSED would be reported to the caller as success.
+	if rcode != dns.RcodeSuccess {
+		return fmt.Errorf("parent %s rejected the update: rcode %s",
+			Globals.ParentZone, dns.RcodeToString[rcode])
+	}
+	lgDns.Info("SendUpdate completed", "parent", Globals.ParentZone, "target", dsynctarget.Addresses, "rcode", dns.RcodeToString[rcode])
 	return nil
 }
 


### PR DESCRIPTION
## What

`SendUpdate` returned the response RCODE **only on the NOERROR path**. Every non-NOERROR answer took the "try the next address" `continue` and fell out of the loop to

```go
return 0, ur, fmt.Errorf("all target addresses ... responded with errors or were unreachable")
```

so a parent *rejection* reached the caller as `rcode 0` + non-nil error — indistinguishable from an unreachable target.

## Why it matters

This made the D-2b RCODE policy dead code. `sendUpdateWithRetry` short-circuits on a non-nil error **before** its rcode switch:

```go
rcode, ur, serr := send()
if serr != nil {
    return false, serr   // <- always taken for BADKEY / REFUSED
}
switch rcode {
case dns.RcodeBadKey:  // unreachable from the real send path
case dns.RcodeRefused: // unreachable from the real send path
```

So `case dns.RcodeBadKey` (re-bootstrap once) and `case dns.RcodeRefused` (bounded retry) could never fire against a real receiver — they were exercised only by the injected `send` closure in `delsync_retry_test.go`. **A BADKEY parent got plain backoff retries and no re-bootstrap at all**, i.e. the D-2b acceptance criterion "a BADKEY response triggers re-bootstrap" was not met.

Demonstrated against a live responder before the fix:

| Receiver answered | `SendUpdate` returned |
|---|---|
| NOERROR(0) | `rcode=0`, `err=<nil>` |
| BADKEY(17) | `rcode=0`, `err=all target addresses […] responded with errors` |
| REFUSED(5) | `rcode=0`, `err=all target addresses […] responded with errors` |

`ksk_rollover_ds_push.go:579-581` already documented the intended contract —

> `SendUpdate`'s err is a network-layer failure: i/o timeout, no route to host, conn refused, etc. Rcode-level rejections from the parent come back via rcode without err.

— and mis-categorised every parent rejection as `SoftfailTransport` instead of `SoftfailParentRejected` because the implementation didn't honour it.

## The change

Make the implementation match the documented contract: track the last RCODE actually received and, if any address responded, return it with a **nil** error. Only a total absence of responses is an error. Try-every-address behaviour is unchanged, and a later NOERROR still wins over an earlier rejection.

### Caller impact

| Caller | Effect |
|---|---|
| `sendUpdateWithRetry` | BADKEY/REFUSED arms become reachable — the point of the fix |
| `ksk_rollover_ds_push.go:577` | rejections now correctly `SoftfailParentRejected`; its comment becomes true |
| `ops_key.go:379,420` (SIG(0) rollover) | error message now names the actual rcode instead of the generic send failure |
| `ops_key.go:243` (bootstrap) | unchanged: skips key promotion on non-NOERROR, reports the rcode |
| `cli/update.go:510` | prints `rcode: 17 (BADKEY)` instead of a transport-error string |
| **`sig0_utils.go:87`** | **needed an explicit rcode check** — it returned `nil` on any non-error path, so under the corrected contract a BADKEY would have been reported as success. Fixed here. |

## Tests

`v2/childsync_rcode_test.go` — wire-level, against a responder returning each rcode: NOERROR/BADKEY/REFUSED/SERVFAIL/NOTAUTH (including the extended rcodes, which need an OPT RR to survive packing), unreachable-target, and mixed dead/live address ordering in both directions. **All four new tests fail against the previous implementation**, verified by reverting the fix.

`go vet` + `go test -race` green across `v2`, `v2/core`, `v2/edns0`, `v2/cache`, `v2/cli`.

## Notes

Found while designing the `tdns-debug delsync` test framework (`docs/2026-07-20-delsync-test-framework.md`) — this is a prerequisite for matrix cases D2/D3, which assert the re-bootstrap behaviour and would otherwise fail against `main`-stack code for this reason rather than a real defect in the retry logic itself.

Base is `feature/ddns-keystate-phase3a` (#304), since the behaviour under test only exists on that stack.