### PR TITLE
edns0: resolve two silent code-point conflicts (65002, EDE 513)

### DIFF
--- a/v2/edns0/edns0_codepoints_test.go
+++ b/v2/edns0/edns0_codepoints_test.go
@@ -1,0 +1,81 @@
+package edns0
+
+import "testing"
+
+// TestLocalOptionCodesAreUnique guards against two tdns-local EDNS(0) options
+// claiming the same option code. They are all carried as dns.EDNS0_LOCAL and
+// dispatched purely on Code, so a collision means one option is silently parsed
+// as the other — EDNS0_PROVIDERSYNC_OPTION_CODE and EDNS0_KEYSTATE_OPTION_CODE
+// both held 65002, so a ProviderSync option would have been read as a KeyState
+// option. Nothing in the compiler catches that; this test does.
+//
+// Add every new tdns-local option code here as well as in edns0_defs.go.
+func TestLocalOptionCodesAreUnique(t *testing.T) {
+	codes := map[string]uint16{
+		"EDNS0_OTS_OPTION_CODE":           EDNS0_OTS_OPTION_CODE,
+		"EDNS0_KEYSTATE_OPTION_CODE":      EDNS0_KEYSTATE_OPTION_CODE,
+		"EDNS0_REPORT_OPTION_CODE":        EDNS0_REPORT_OPTION_CODE,
+		"EDNS0_CHUNK_OPTION_CODE":         EDNS0_CHUNK_OPTION_CODE,
+		"EDNS0_CHUNK_QUERY_ENDPOINT_CODE": EDNS0_CHUNK_QUERY_ENDPOINT_CODE,
+		"EDNS0_PROVIDERSYNC_OPTION_CODE":  EDNS0_PROVIDERSYNC_OPTION_CODE,
+	}
+
+	seen := make(map[uint16]string, len(codes))
+	for name, code := range codes {
+		if other, dup := seen[code]; dup {
+			t.Errorf("option code %d claimed by both %s and %s — one of them must move to a free code point",
+				code, other, name)
+			continue
+		}
+		seen[code] = name
+	}
+
+	// The local range is the private-use space; a code outside it would collide
+	// with an IANA assignment instead.
+	for name, code := range codes {
+		if code < 65001 || code > 65534 {
+			t.Errorf("%s = %d is outside the tdns-local private-use range 65001-65534", name, code)
+		}
+	}
+}
+
+// TestEDECodeValues pins the numeric value of the private EDE codes.
+//
+// These go on the wire and are quoted verbatim in the drafts and design docs,
+// so they are part of the interface, not an implementation detail. They are
+// also unusually easy to break: the block is defined as `513 + iota`, so
+// prepending any constant to it renumbers every code silently. That is exactly
+// what happened — a standard RFC 8914 code was added at the head of the block,
+// pushing EDESig0KeyNotKnown from its documented 513 to 514 and dragging the
+// rest of the block with it. Every existing test asserted symbolically, so
+// nothing caught it.
+//
+// If this test fails, do not "fix" it by updating the numbers: check whether a
+// constant was added to the head of the private block in edns0_ede.go.
+func TestEDECodeValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  uint16
+		want uint16
+	}{
+		// The two codes the delegation-mgmt-via-ddns draft names directly.
+		{"EDESig0KeyNotKnown", EDESig0KeyNotKnown, 513},
+		{"EDESig0KeyKnownButNotTrusted", EDESig0KeyKnownButNotTrusted, 514},
+
+		// Block anchors: these catch a shift introduced anywhere in the middle.
+		{"EDEDelegationSyncNotSupported", EDEDelegationSyncNotSupported, 515},
+		{"EDEZoneFrozen", EDEZoneFrozen, 516},
+		{"EDETsigValidationFailure", EDETsigValidationFailure, 523},
+		{"EDESig0BadTime", EDESig0BadTime, 527},
+		{"EDESig0BadSignature", EDESig0BadSignature, 528},
+		{"EDESig0FormatError", EDESig0FormatError, 529},
+
+		// The standard code must keep its RFC 8914 value and must not be part
+		// of the private sequence.
+		{"EDEDNSSECBogus", EDEDNSSECBogus, 6},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+	}
+}

--- a/v2/edns0/edns0_defs.go
+++ b/v2/edns0/edns0_defs.go
@@ -3,13 +3,22 @@
  */
 package edns0
 
-// Local EDNS(0) options that are defined in TDNS
+// Local EDNS(0) options that are defined in TDNS.
+//
+// EVERY tdns-local option code MUST be declared here and nowhere else. Codes
+// declared next to their implementation drift into collisions that the compiler
+// cannot see: PROVIDERSYNC was defined as 65002 in edns0_providersync.go while
+// KEYSTATE held the same 65002 here, so a ProviderSync option would have been
+// parsed as a KeyState option (both are dns.EDNS0_LOCAL, dispatched purely on
+// Code). Keep them adjacent so the next addition is an obvious next number, and
+// see TestLocalOptionCodesAreUnique.
 const (
-	EDNS0_OTS_OPTION_CODE      = 65001 // TBD: Replace with actual IANA assigned code
-	EDNS0_KEYSTATE_OPTION_CODE = 65002
-	EDNS0_REPORT_OPTION_CODE   = 65003
-	EDNS0_CHUNK_OPTION_CODE           = 65004 // CHUNK EDNS(0) option for payload
-	EDNS0_CHUNK_QUERY_ENDPOINT_CODE   = 65005 // CHUNK query endpoint: where receiver should send CHUNK query (host:port)
+	EDNS0_OTS_OPTION_CODE           = 65001 // TBD: Replace with actual IANA assigned code
+	EDNS0_KEYSTATE_OPTION_CODE      = 65002
+	EDNS0_REPORT_OPTION_CODE        = 65003
+	EDNS0_CHUNK_OPTION_CODE         = 65004 // CHUNK EDNS(0) option for payload
+	EDNS0_CHUNK_QUERY_ENDPOINT_CODE = 65005 // CHUNK query endpoint: where receiver should send CHUNK query (host:port)
+	EDNS0_PROVIDERSYNC_OPTION_CODE  = 65006 // provider-synchronization option (moved off 65002, which KEYSTATE holds)
 )
 
 // Standard EDNS(0) option codes (RFC9567)

--- a/v2/edns0/edns0_ede.go
+++ b/v2/edns0/edns0_ede.go
@@ -9,11 +9,21 @@ import (
 	"github.com/miekg/dns"
 )
 
+// Standard EDE codes (RFC 8914).
+//
+// These MUST stay in their own const block. They were previously declared at
+// the head of the private-code block below, where each additional standard code
+// consumed one iota step and silently shifted EVERY private code up by one:
+// EDESig0KeyNotKnown, documented and specified as 513, was actually compiled as
+// 514, and the whole block after it drifted with it. Adding a standard code
+// here can no longer renumber the private codes. See TestEDECodeValues.
 const (
-	// Standard EDE codes (RFC 8914)
 	EDEDNSSECBogus uint16 = 6 // RFC 8914: DNSSEC Bogus
+)
 
-	// Private EDE codes (above 512)
+// Private EDE codes (above 512). The first entry pins the base; the rest follow
+// by iota, so this block MUST begin at iota == 0 — do not prepend entries.
+const (
 	EDESig0KeyNotKnown uint16 = 513 + iota
 	EDESig0KeyKnownButNotTrusted
 	EDEDelegationSyncNotSupported

--- a/v2/edns0/edns0_providersync.go
+++ b/v2/edns0/edns0_providersync.go
@@ -9,10 +9,12 @@ import (
 	"github.com/miekg/dns"
 )
 
-// EDNS0 Provider-Synchronization option constants
+// EDNS0 Provider-Synchronization option constants.
+//
+// The option CODE lives in edns0_defs.go with every other tdns-local option
+// code, so collisions are visible in one place. It used to be declared here as
+// 65002, colliding with EDNS0_KEYSTATE_OPTION_CODE.
 const (
-	EDNS0_PROVIDERSYNC_OPTION_CODE = 65002 // TBD: Replace with actual IANA assigned code
-
 	// OPERATION field values
 	PROVIDERSYNC_OP_FORBIDDEN = 0
 	PROVIDERSYNC_OP_HELLO     = 1


### PR DESCRIPTION
Two numbering bugs, both invisible to the compiler **and to every existing test**, because everything asserted symbolically.

## 1. Option code 65002 was claimed twice

`EDNS0_KEYSTATE_OPTION_CODE` (`edns0_defs.go:9`) and `EDNS0_PROVIDERSYNC_OPTION_CODE` (`edns0_providersync.go:14`) were **both 65002**. Both options travel as `dns.EDNS0_LOCAL` and are dispatched purely on `Code`, so `ExtractKeyStateOption` would parse a ProviderSync option as a KeyState one, and vice versa. Not currently triggered — the two features aren't used together yet — but it's a live trap.

**Fix:** move PROVIDERSYNC to the next free code, **65006**, and declare it in `edns0_defs.go` alongside every other tdns-local option code. KeyState keeps 65002: it's the code named in draft-berra-dnsop-keystate-03, while ProviderSync is tdns-internal and self-contained (three references). Declaring codes next to their implementation is *how* the collision arose, so the fix is as much about the location as the number.

## 2. Every private EDE code was one higher than documented

The private block is written `EDESig0KeyNotKnown uint16 = 513 + iota`. A standard RFC 8914 code (`EDEDNSSECBogus`) had been added at the head of the **same const block**, so it consumed iota step 0 and the private sequence started at `iota == 1`:

| Constant | Documented | Actually compiled |
|---|---|---|
| `EDESig0KeyNotKnown` | 513 | **514** |
| `EDESig0KeyKnownButNotTrusted` | 514 | **515** |
| `EDESig0BadTime` / `BadSignature` / `FormatError` | 527/528/529 | **528/529/530** |

513 and 514 are the values specified in both `docs/2026-07-20-delsync-test-framework.md` and `docs/2026-07-16-ddns-delegation-keystate-draft-alignment-plan.md`.

**Fix:** split the standard codes into their own const block so the private block begins at `iota == 0` again, restoring the documented numbering. Adding a standard code can no longer renumber the private range.

This is wire-visible, but safe: the codes are private-use (>512), tdns is both ends, and **no caller anywhere hardcodes a numeric value** — every reference is symbolic, which is exactly why the drift went unnoticed. Verified by grep across the tree.

## Tests

Symbolic assertions cannot catch either class of bug, so both are now pinned numerically:

- `TestLocalOptionCodesAreUnique` — cross-checks all six local option codes for duplicates and range.
- `TestEDECodeValues` — pins the numeric EDE values, with anchors through the middle of the block so a shift introduced anywhere is caught, and a comment telling the next reader **not** to "fix" a failure by editing the numbers.

The pre-existing `sig0_validate_phase0_test.go:35` is *named* `"-> REFUSED + EDE514"` but asserts symbolically — which is precisely why it passed against 515 and never caught this.

`go vet` + `go test -race` green across `v2/edns0`, `v2`, `v2/core`, `v2/cache`, `v2/cli`.

## Notes

Found while designing the `tdns-debug delsync` test framework. Base is `feature/ddns-keystate-phase3a` (#304). Independent of #305 (different files); they can merge in either order.