### PR TITLE
updateresponder: relay ValidateUpdate's rcode and EDE instead of discarding them

### DIFF
--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -281,8 +281,25 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	err := zd.ValidateUpdate(r, dur.Status)
 	if err != nil {
 		zd.Logger.Printf("Error from ValidateUpdate(): %v", err)
-		m.SetRcode(m, dns.RcodeServerFailure)
-		edns0.AttachEDEToResponse(m, edns0.EDESig0KeyNotKnown)
+		// Relay the rcode + EDE ValidateUpdate selected, exactly as the
+		// TrustUpdate branch below does. This used to hardcode SERVFAIL +
+		// EDESig0KeyNotKnown, discarding both: an UPDATE carrying no
+		// signature and no OPT sets FORMERR + EDESig0FormatError here, and
+		// was reported on the wire as SERVFAIL + "SIG(0) key not known" --
+		// two wrong answers at once, and it made EDESig0FormatError
+		// unreachable from this path entirely.
+		rcode := int(dur.Status.ValidationRcode)
+		if rcode == dns.RcodeSuccess {
+			// A validation error must never answer NOERROR. ValidateUpdate
+			// defaults ValidationRcode to BADSIG precisely so this cannot
+			// happen; fail closed if some future path forgets to set it.
+			lgHandler.Error("ValidateUpdate returned an error but left ValidationRcode at NOERROR; failing closed with SERVFAIL", "err", err)
+			rcode = dns.RcodeServerFailure
+		}
+		m.SetRcode(m, rcode)
+		if dur.Status.RejectionEDE != 0 {
+			edns0.AttachEDEToResponse(m, dur.Status.RejectionEDE)
+		}
 		w.WriteMsg(m)
 		return err
 	}

--- a/v2/updateresponder_validate_ede_test.go
+++ b/v2/updateresponder_validate_ede_test.go
@@ -1,0 +1,101 @@
+package tdns
+
+import (
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	edns0 "github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// captureWriter is a dns.ResponseWriter that records the message the responder
+// wrote instead of putting it on a wire.
+type captureWriter struct {
+	got *dns.Msg
+}
+
+func (c *captureWriter) LocalAddr() net.Addr  { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53} }
+func (c *captureWriter) RemoteAddr() net.Addr { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 4711} }
+func (c *captureWriter) WriteMsg(m *dns.Msg) error {
+	c.got = m
+	return nil
+}
+func (c *captureWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (c *captureWriter) Close() error                { return nil }
+func (c *captureWriter) TsigStatus() error           { return nil }
+func (c *captureWriter) TsigTimersOnly(bool)         {}
+func (c *captureWriter) Hijack()                     {}
+
+// TestUpdateResponderRelaysValidationRcodeAndEDE asserts that the responder
+// puts ValidateUpdate's chosen rcode and EDE on the wire rather than
+// overwriting them.
+//
+// An UPDATE with no signature and no OPT RR makes ValidateUpdate set
+// FORMERR + EDESig0FormatError. The responder used to discard both and
+// hardcode SERVFAIL + EDESig0KeyNotKnown, which was wrong twice over: the
+// rcode misreported a malformed message as a server failure, the EDE claimed a
+// key problem for a message that carried no key at all, and EDESig0FormatError
+// became unreachable on the wire from this path.
+func TestUpdateResponderRelaysValidationRcodeAndEDE(t *testing.T) {
+	const zone = "parent.example."
+
+	Zones.Set(zone, &ZoneData{
+		ZoneName: zone,
+		Options:  map[ZoneOption]bool{OptAllowUpdates: true},
+		Logger:   log.New(os.Stderr, "", 0),
+	})
+	t.Cleanup(func() { Zones.Remove(zone) })
+
+	// An UPDATE with no SIG(0) and, deliberately, no EDNS0 OPT: that is the
+	// len(r.Extra) == 0 branch in ValidateUpdate.
+	m := new(dns.Msg)
+	m.SetUpdate(zone)
+	rr, err := dns.NewRR("www.parent.example. 3600 IN A 192.0.2.1")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	m.Insert([]dns.RR{rr})
+	if len(m.Extra) != 0 {
+		t.Fatalf("test message must carry no additional records, got %d", len(m.Extra))
+	}
+
+	cw := &captureWriter{}
+	dur := &DnsUpdateRequest{
+		ResponseWriter: cw,
+		Msg:            m,
+		Qname:          zone,
+		Status:         &UpdateStatus{},
+	}
+
+	// An unsigned update is expected to return an error; we assert on the wire
+	// response, not on the error.
+	_ = UpdateResponder(dur, nil)
+
+	if cw.got == nil {
+		t.Fatal("responder wrote no response")
+	}
+
+	if got, want := cw.got.Rcode, dns.RcodeFormatError; got != want {
+		t.Errorf("rcode = %d (%s), want %d (%s) — the responder must relay the rcode ValidateUpdate chose, not substitute SERVFAIL",
+			got, dns.RcodeToString[got], want, dns.RcodeToString[want])
+	}
+
+	found, code, _ := edns0.ExtractEDEFromMsg(cw.got)
+	if !found {
+		t.Fatal("response carries no EDE option")
+	}
+	if code != edns0.EDESig0FormatError {
+		t.Errorf("EDE = %d, want %d (EDESig0FormatError) — a message with no signature at all is a format error, not an unknown key",
+			code, edns0.EDESig0FormatError)
+	}
+
+	// The status the responder acted on must agree with what went on the wire.
+	if dur.Status.ValidationRcode != dns.RcodeFormatError {
+		t.Errorf("Status.ValidationRcode = %d, want %d", dur.Status.ValidationRcode, dns.RcodeFormatError)
+	}
+	if dur.Status.Validated {
+		t.Error("Status.Validated is true for an unsigned update")
+	}
+}


### PR DESCRIPTION
## The bug

The `ValidateUpdate` error branch in `UpdateResponder` hardcoded its wire response:

```go
err := zd.ValidateUpdate(r, dur.Status)
if err != nil {
    m.SetRcode(m, dns.RcodeServerFailure)
    edns0.AttachEDEToResponse(m, edns0.EDESig0KeyNotKnown)
```

throwing away the rcode and EDE `ValidateUpdate` had just selected for the specific failure.

For an UPDATE carrying no signature and no OPT RR, `ValidateUpdate` sets `FORMERR` + `EDESig0FormatError`. The wire answer was **SERVFAIL + "SIG(0) key not known"** — wrong twice over:

- the rcode reports a malformed message as a server-side failure;
- the EDE blames a *key* on a message that carried no key at all, which is actively misleading to a child operator with no access to the parent's logs.

It also made `EDESig0FormatError` unreachable on the wire from this path.

The sibling `TrustUpdate` branch immediately below already does the right thing — that was fixed in the D-8 phase0 work — and this one was simply missed.

## The change

Give the `ValidateUpdate` branch the same treatment, plus a fail-closed guard: a validation error must never answer NOERROR, so if `ValidationRcode` is somehow unset, substitute SERVFAIL rather than sending a success rcode for a rejected update. `ValidateUpdate` defaults `ValidationRcode` to BADSIG precisely so that cannot happen today; the guard keeps it true if a future path forgets.

## A residual difference, deliberately left alone

An unsigned UPDATE that **does** carry an OPT RR reaches `TrustUpdate` with no locatable signer and is answered **BADKEY**, per the draft's deliberate conflation of "unsigned" with "unknown key" so the child re-bootstraps. Only the **no-OPT-at-all** case is a FORMERR.

So matrix case B5 ("unsigned UPDATE → BADKEY") holds for any realistic client — tdns always sets EDNS0 — but not for a bare signature-less message with no OPT. If the conflation should extend there too, that's a change to `ValidateUpdate`, not to the responder, so I left it. Happy to follow up either way.

## Tests

`TestUpdateResponderRelaysValidationRcodeAndEDE` drives `UpdateResponder` end to end with a capturing `dns.ResponseWriter` — **the first test of any kind for the responder's wire output**. Against the previous code it fails with both wrong values:

```
rcode = 2 (SERVFAIL), want 1 (FORMERR)
EDE = 514, want 530 (EDESig0FormatError)
```

Assertions use the EDE *constants*, not literals, so this is unaffected by the renumbering in #306 whichever order they merge.

`go vet` + `go test -race` green across `v2`.

## Notes

Found while designing the `tdns-debug delsync` test framework. Base is `feature/ddns-keystate-phase3a` (#304). Independent of #305 and #306 (different files); any merge order works.