### PR TITLE
sig0: mark every verified signer, not just the first (CodeRabbit #294)

### DIFF
--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -213,31 +213,60 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 	// At this point we have a set of zero or more keys that match the signername and keyid for a
 	// SIG validating the update. Now we must iterate over the keys to see if any of them actually
 	// verify correctly.
+	verifySigners(us, msgbuf)
 
-	// Iterate by index so signer.Validated writes back into the
-	// slice (the previous range-over-value form mutated a copy).
-	//
-	// EVERY signer is verified; we deliberately do NOT stop at the first
-	// success. signer.Validated is a PER-SIGNER property ("this signer's own
-	// signature verified over the message bytes") and TrustUpdate reads it to
-	// decide whether a given signer may confer trust. Breaking on the first
-	// success left every later signer at Validated=false, which made trust
-	// depend on SIG RR ORDER: in a dual-signed rollover UPDATE (old trusted
-	// key + new not-yet-trusted key, both signing genuinely), if the untrusted
-	// key's SIG happened to come first the trusted key was never verified,
-	// TrustUpdate skipped it on !key.Validated, and a legitimate rollover was
-	// refused. Reversing the SIG order accepted the very same message.
-	//
-	// The aggregate fields (ValidationRcode / RejectionEDE / Validated /
-	// SignerName) still mean "at least one signature verified", so a later
-	// FAILING signer must not overwrite an earlier success — every failure
-	// path below is guarded on !us.Validated, which is what the old `break`
-	// was really protecting. First success wins for SignerName.
-	//
-	// This does not weaken the check TrustUpdate relies on: a forged SIG
-	// naming a trusted key still fails Verify(), keeps Validated=false, and is
-	// still skipped there. The signer set is bounded by the discovery loop
-	// above, which only appends signers whose key was actually locatable.
+	// When we get here then we have tried to validate all signatures and the result is in
+	// the us.Signers data.
+	return nil
+}
+
+// sig0Verify indirects SIG(0) signature verification so that verifySigners can
+// be exercised without a real, fully-packed, genuinely-signed DNS message.
+//
+// This seam exists because the per-signer semantics below CANNOT be driven
+// end-to-end against the real verifier today: miekg/dns's SIG.Verify always
+// verifies the LAST record in the packed buffer whatever *SIG receiver it is
+// called on (it derives bodyend and `sig := buf[sigend:]` from the buffer
+// tail, using the receiver only for the KeyTag/SignerName/Algorithm sanity
+// checks). With multiple SIG(0) RRs only the last one can ever verify, so in a
+// real message "the first signer that verifies" is necessarily also the last,
+// and the multi-signer ordering behaviour is unreachable.
+//
+// Production code MUST NOT reassign this. Tests reassign it and restore the
+// original via t.Cleanup (see stubSig0Verify).
+var sig0Verify = func(sig *dns.SIG, key *dns.KEY, msgbuf []byte) error {
+	return sig.Verify(key, msgbuf)
+}
+
+// verifySigners verifies each located signer's own signature over msgbuf and
+// records the outcome in us: signer.Validated per signer, plus the aggregate
+// ValidationRcode / RejectionEDE / Validated / SignerName fields.
+//
+// Iterate by index so signer.Validated writes back into the
+// slice (the previous range-over-value form mutated a copy).
+//
+// EVERY signer is verified; we deliberately do NOT stop at the first
+// success. signer.Validated is a PER-SIGNER property ("this signer's own
+// signature verified over the message bytes") and TrustUpdate reads it to
+// decide whether a given signer may confer trust. Breaking on the first
+// success left every later signer at Validated=false, which made trust
+// depend on SIG RR ORDER: in a dual-signed rollover UPDATE (old trusted
+// key + new not-yet-trusted key, both signing genuinely), if the untrusted
+// key's SIG happened to come first the trusted key was never verified,
+// TrustUpdate skipped it on !key.Validated, and a legitimate rollover was
+// refused. Reversing the SIG order accepted the very same message.
+//
+// The aggregate fields (ValidationRcode / RejectionEDE / Validated /
+// SignerName) still mean "at least one signature verified", so a later
+// FAILING signer must not overwrite an earlier success — every failure
+// path below is guarded on !us.Validated, which is what the old `break`
+// was really protecting. First success wins for SignerName.
+//
+// This does not weaken the check TrustUpdate relies on: a forged SIG
+// naming a trusted key still fails Verify(), keeps Validated=false, and is
+// still skipped there. The signer set is bounded by ValidateUpdate's
+// discovery loop, which only appends signers whose key was actually locatable.
+func verifySigners(us *UpdateStatus, msgbuf []byte) {
 	for i := range us.Signers {
 		signer := &us.Signers[i]
 		// Use the per-signer SIG, not the outer sig variable (which
@@ -251,7 +280,7 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 			continue
 		}
 		keyrr := signer.Sig0Key.Key
-		err = ssig.Verify(&keyrr, msgbuf)
+		err := sig0Verify(ssig, &keyrr, msgbuf)
 		if err != nil {
 			// This key failed to validate the update. Categorize the
 			// failure: if NOW is outside the signature's validity
@@ -308,10 +337,6 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 			us.SignerName = signer.Name
 		}
 	}
-
-	// When we get here then we have tried to validate all signatures and the result is in
-	// the us.Signers data.
-	return nil
 }
 
 // BERRA TODO kolla om man kan förbättra detta, så man kan skicka en EDE

--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -216,9 +216,28 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 
 	// Iterate by index so signer.Validated writes back into the
 	// slice (the previous range-over-value form mutated a copy).
-	// Break on first success so a later failing signer can't
-	// overwrite ValidationRcode / RejectionEDE / Validated and
-	// leave the status struct internally inconsistent.
+	//
+	// EVERY signer is verified; we deliberately do NOT stop at the first
+	// success. signer.Validated is a PER-SIGNER property ("this signer's own
+	// signature verified over the message bytes") and TrustUpdate reads it to
+	// decide whether a given signer may confer trust. Breaking on the first
+	// success left every later signer at Validated=false, which made trust
+	// depend on SIG RR ORDER: in a dual-signed rollover UPDATE (old trusted
+	// key + new not-yet-trusted key, both signing genuinely), if the untrusted
+	// key's SIG happened to come first the trusted key was never verified,
+	// TrustUpdate skipped it on !key.Validated, and a legitimate rollover was
+	// refused. Reversing the SIG order accepted the very same message.
+	//
+	// The aggregate fields (ValidationRcode / RejectionEDE / Validated /
+	// SignerName) still mean "at least one signature verified", so a later
+	// FAILING signer must not overwrite an earlier success — every failure
+	// path below is guarded on !us.Validated, which is what the old `break`
+	// was really protecting. First success wins for SignerName.
+	//
+	// This does not weaken the check TrustUpdate relies on: a forged SIG
+	// naming a trusted key still fails Verify(), keeps Validated=false, and is
+	// still skipped there. The signer set is bounded by the discovery loop
+	// above, which only appends signers whose key was actually locatable.
 	for i := range us.Signers {
 		signer := &us.Signers[i]
 		// Use the per-signer SIG, not the outer sig variable (which
@@ -244,11 +263,16 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 			// rollover overhaul: surface this as a specific rcode +
 			// EDE so the child operator can diagnose clock skew
 			// without parent-side log access.
-			if !cache.WithinValidityPeriod(ssig.Inception, ssig.Expiration, time.Now().UTC()) {
-				us.ValidationRcode = dns.RcodeBadTime
-				us.RejectionEDE = edns0.EDESig0BadTime
-			} else if us.RejectionEDE == 0 {
-				us.RejectionEDE = edns0.EDESig0BadSignature
+			//
+			// Guarded on !us.Validated: an earlier signer may already have
+			// verified, and this failure must not downgrade that success.
+			if !us.Validated {
+				if !cache.WithinValidityPeriod(ssig.Inception, ssig.Expiration, time.Now().UTC()) {
+					us.ValidationRcode = dns.RcodeBadTime
+					us.RejectionEDE = edns0.EDESig0BadTime
+				} else if us.RejectionEDE == 0 {
+					us.RejectionEDE = edns0.EDESig0BadSignature
+				}
 			}
 			lgDns.Warn("ValidateUpdate: signature verification failed", "signer", signer.Name, "keyid", signer.KeyId, "err", err)
 			lgDns.Debug("ValidateUpdate: timing details", "currentTime", time.Now(), "inception", ssig.Inception, "expiration", ssig.Expiration)
@@ -258,22 +282,31 @@ func (zd *ZoneData) ValidateUpdate(r *dns.Msg, us *UpdateStatus) error {
 		// Ok, we have a signature that validated.
 		if !cache.WithinValidityPeriod(ssig.Inception, ssig.Expiration, time.Now().UTC()) {
 			lgDns.Warn("ValidateUpdate: signature NOT within validity period", "signer", signer.Name, "keyid", signer.KeyId)
-			us.ValidationRcode = dns.RcodeBadTime
-			us.RejectionEDE = edns0.EDESig0BadTime
+			// Guarded: must not downgrade an earlier signer's success.
+			if !us.Validated {
+				us.ValidationRcode = dns.RcodeBadTime
+				us.RejectionEDE = edns0.EDESig0BadTime
+			}
 			// This key validated the signature, but the signature is not within its validity period.
 			// Try the next key.
 			continue
 		}
 
-		// Signature is valid and within its validity period.
+		// Signature is valid and within its validity period. Mark THIS signer
+		// unconditionally — that is the per-signer fact TrustUpdate consumes.
 		lgDns.Info("ValidateUpdate: signature within validity period", "signer", signer.Name, "keyid", signer.KeyId)
 		lgDns.Info("ValidateUpdate: update validated by known and validated key")
-		us.ValidationRcode = dns.RcodeSuccess
-		us.RejectionEDE = 0 // success — clear any prior key's failure EDE
-		us.Validated = true // Now at least one key has validated the update
-		us.SignerName = signer.Name
 		signer.Validated = true
-		break
+
+		// Aggregate status: record the first success and leave it alone
+		// thereafter, so SignerName stays stable and a later signer cannot
+		// churn the rcode/EDE.
+		if !us.Validated {
+			us.ValidationRcode = dns.RcodeSuccess
+			us.RejectionEDE = 0 // success — clear any prior key's failure EDE
+			us.Validated = true // Now at least one key has validated the update
+			us.SignerName = signer.Name
+		}
 	}
 
 	// When we get here then we have tried to validate all signatures and the result is in
@@ -322,14 +355,19 @@ func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 		// the message bytes. us.Validated above is an aggregate ("at least one
 		// signature verified"), which is not sufficient here: ValidateUpdate's
 		// discovery loop appends a signer for every SIG RR matched on
-		// SignerName+KeyTag alone (before any signature is checked), and its
-		// verification loop breaks on the first success — so later entries keep
+		// SignerName+KeyTag alone, before any signature is checked, so a signer
+		// whose signature then failed to verify is still present with
 		// Validated=false. Without this per-signer check, a multi-SIG(0) UPDATE
 		// could pair a genuine signature from an untrusted key with a forged SIG
 		// naming a trusted key and be granted "by-trusted" status even though
 		// the trusted key's signature was never verified. That would also defeat
 		// the untrusted-KEY-delete refusal in ApproveTrustUpdate, which is gated
 		// on us.ValidatedByTrustedKey.
+		//
+		// ValidateUpdate verifies every signer (it does not stop at the first
+		// success), so in a legitimately dual-signed rollover UPDATE both the
+		// old and the new key carry Validated=true and the loop below finds the
+		// trusted one regardless of SIG RR order.
 		if !key.Validated {
 			continue
 		}

--- a/v2/sig0_validate_multisig_test.go
+++ b/v2/sig0_validate_multisig_test.go
@@ -1,0 +1,90 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestTrustUpdateIsIndependentOfSignerOrder pins the contract that the
+// per-signer Validated fix exists to guarantee: when more than one signer in a
+// dual-signed rollover UPDATE has verified its own signature, TrustUpdate must
+// find the trusted one and confer "by-trusted" status REGARDLESS of the order
+// the signers appear in.
+//
+// Before the fix, ValidateUpdate's verification loop broke on the first
+// success, so every later signer kept Validated=false and TrustUpdate skipped
+// it on the !key.Validated guard — making the outcome depend on SIG RR order.
+// The loop now marks every signer whose own signature verified, so both
+// orderings below must reach the same verdict.
+func TestTrustUpdateIsIndependentOfSignerOrder(t *testing.T) {
+	zd := &ZoneData{}
+
+	untrusted := Sig0UpdateSigner{
+		Name:      "child.example.",
+		KeyId:     111,
+		Validated: true, // its own signature verified...
+		Sig0Key:   &Sig0Key{Name: "child.example.", Keyid: 111},
+	}
+	trusted := Sig0UpdateSigner{
+		Name:      "child.example.",
+		KeyId:     222,
+		Validated: true, // ...and so did this one
+		Sig0Key:   &Sig0Key{Name: "child.example.", Keyid: 222, Trusted: true},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		signers []Sig0UpdateSigner
+	}{
+		{"trusted key signs first", []Sig0UpdateSigner{trusted, untrusted}},
+		{"trusted key signs second", []Sig0UpdateSigner{untrusted, trusted}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			us := &UpdateStatus{
+				Validated:       true,
+				ValidationRcode: dns.RcodeSuccess,
+				Signers:         tc.signers,
+			}
+			if err := zd.TrustUpdate(nil, us); err != nil {
+				t.Fatalf("TrustUpdate returned error: %v", err)
+			}
+			if !us.ValidatedByTrustedKey {
+				t.Error("ValidatedByTrustedKey = false; the trusted signer must confer trust in either order")
+			}
+			if us.SignatureType != "by-trusted" {
+				t.Errorf("SignatureType = %q, want \"by-trusted\"", us.SignatureType)
+			}
+		})
+	}
+}
+
+// TestTrustUpdateSkipsUnverifiedSigner is the security counterpart: a signer
+// that did NOT verify its own signature must never confer trust, even when it
+// names a trusted key. This is what the per-signer Validated guard in
+// TrustUpdate protects, and the fix above must not weaken it — a forged SIG
+// naming a trusted key still fails Verify() and keeps Validated=false.
+func TestTrustUpdateSkipsUnverifiedSigner(t *testing.T) {
+	zd := &ZoneData{}
+	us := &UpdateStatus{
+		Validated:       true, // an untrusted key's signature did verify
+		ValidationRcode: dns.RcodeSuccess,
+		Signers: []Sig0UpdateSigner{
+			{
+				Name: "child.example.", KeyId: 111, Validated: true,
+				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111},
+			},
+			{
+				// Forged SIG naming a trusted key: never verified.
+				Name: "child.example.", KeyId: 222, Validated: false,
+				Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 222, Trusted: true},
+			},
+		},
+	}
+	if err := zd.TrustUpdate(nil, us); err == nil {
+		t.Fatal("expected an error: no verified signer is trusted")
+	}
+	if us.ValidatedByTrustedKey {
+		t.Error("ValidatedByTrustedKey must be false: the trusted key's signature was never verified")
+	}
+}

--- a/v2/sig0_validate_multisig_test.go
+++ b/v2/sig0_validate_multisig_test.go
@@ -2,21 +2,20 @@ package tdns
 
 import (
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 )
 
-// TestTrustUpdateIsIndependentOfSignerOrder pins the contract that the
-// per-signer Validated fix exists to guarantee: when more than one signer in a
-// dual-signed rollover UPDATE has verified its own signature, TrustUpdate must
-// find the trusted one and confer "by-trusted" status REGARDLESS of the order
-// the signers appear in.
+// TestTrustUpdateIsIndependentOfSignerOrder pins TrustUpdate's half of the
+// contract: GIVEN that more than one signer is already marked Validated, the
+// trusted one must confer "by-trusted" status regardless of its position.
 //
-// Before the fix, ValidateUpdate's verification loop broke on the first
-// success, so every later signer kept Validated=false and TrustUpdate skipped
-// it on the !key.Validated guard — making the outcome depend on SIG RR order.
-// The loop now marks every signer whose own signature verified, so both
-// orderings below must reach the same verdict.
+// NOTE ON COVERAGE: this test builds UpdateStatus by hand and therefore does
+// NOT exercise the per-signer marking fix in verifySigners — it passes both
+// with and without it, because TrustUpdate already iterated every signer. It
+// documents the consuming end of the contract only. The test that actually
+// fails without the fix is TestVerifySignersMarksEverySigner below.
 func TestTrustUpdateIsIndependentOfSignerOrder(t *testing.T) {
 	zd := &ZoneData{}
 
@@ -86,5 +85,124 @@ func TestTrustUpdateSkipsUnverifiedSigner(t *testing.T) {
 	}
 	if us.ValidatedByTrustedKey {
 		t.Error("ValidatedByTrustedKey must be false: the trusted key's signature was never verified")
+	}
+}
+
+// mkTestSigner builds a signer whose SIG is inside its validity window. The
+// signature bytes are irrelevant: these tests substitute sig0Verify, because
+// the real miekg/dns verifier cannot be driven to verify two SIG(0) RRs in one
+// message (see the sig0Verify doc comment).
+func mkTestSigner(name string, keyid uint16, trusted bool) Sig0UpdateSigner {
+	now := uint32(time.Now().UTC().Unix())
+	sig := &dns.SIG{}
+	sig.Inception = now - 300
+	sig.Expiration = now + 300
+	sig.KeyTag = keyid
+	sig.SignerName = name
+	return Sig0UpdateSigner{
+		Name:    name,
+		KeyId:   keyid,
+		Sig:     sig,
+		Sig0Key: &Sig0Key{Name: name, Keyid: keyid, Trusted: trusted},
+	}
+}
+
+// stubSig0Verify substitutes the SIG(0) verifier for the duration of a test.
+// fail lists the KeyIds whose verification should fail; everything else
+// verifies. The original verifier is restored on cleanup.
+func stubSig0Verify(t *testing.T, fail ...uint16) {
+	t.Helper()
+	orig := sig0Verify
+	t.Cleanup(func() { sig0Verify = orig })
+	failing := make(map[uint16]bool, len(fail))
+	for _, k := range fail {
+		failing[k] = true
+	}
+	sig0Verify = func(sig *dns.SIG, key *dns.KEY, msgbuf []byte) error {
+		if failing[sig.RRSIG.KeyTag] {
+			return dns.ErrSig
+		}
+		return nil
+	}
+}
+
+// TestVerifySignersMarksEverySigner is the test that fails without the fix.
+//
+// verifySigners must mark EVERY signer whose own signature verified, not just
+// the first. The pre-fix loop broke on first success, leaving every later
+// signer at Validated=false — which made TrustUpdate's verdict depend on SIG
+// RR order, since it skips signers on !key.Validated. Reverting the fix (a
+// `break` after the first success) makes this test fail on the second signer.
+//
+// This cannot be driven through a real signed message: miekg/dns's SIG.Verify
+// only ever verifies the LAST record in the packed buffer, so in practice the
+// first signer that verifies is also the last and the ordering behaviour is
+// unreachable. Hence the sig0Verify seam.
+func TestVerifySignersMarksEverySigner(t *testing.T) {
+	stubSig0Verify(t) // both signatures verify
+
+	// A dual-signed rollover UPDATE: same child zone, two keys.
+	us := &UpdateStatus{
+		Signers: []Sig0UpdateSigner{
+			mkTestSigner("child.example.", 111, false), // new, not yet trusted
+			mkTestSigner("child.example.", 222, true),  // old, trusted
+		},
+	}
+
+	verifySigners(us, nil)
+
+	for i := range us.Signers {
+		if !us.Signers[i].Validated {
+			t.Errorf("Signers[%d] (keyid %d): Validated = false, want true; "+
+				"every signer whose own signature verified must be marked",
+				i, us.Signers[i].KeyId)
+		}
+	}
+
+	// Aggregate status: first success wins and is not churned by later signers.
+	if !us.Validated {
+		t.Error("us.Validated = false, want true")
+	}
+	if us.ValidationRcode != dns.RcodeSuccess {
+		t.Errorf("us.ValidationRcode = %d, want NOERROR", us.ValidationRcode)
+	}
+	if us.RejectionEDE != 0 {
+		t.Errorf("us.RejectionEDE = %d, want 0", us.RejectionEDE)
+	}
+}
+
+// TestVerifySignersFailureDoesNotDowngradeEarlierSuccess covers the other half
+// of removing the `break`: now that the loop keeps going, a LATER failing
+// signer must not overwrite the aggregate status an earlier success recorded.
+// That is what the !us.Validated guards on each failure path protect.
+func TestVerifySignersFailureDoesNotDowngradeEarlierSuccess(t *testing.T) {
+	stubSig0Verify(t, 222) // the second signer's signature does NOT verify
+
+	us := &UpdateStatus{
+		Signers: []Sig0UpdateSigner{
+			mkTestSigner("child.example.", 111, true), // verifies
+			mkTestSigner("child.example.", 222, true), // fails
+		},
+	}
+
+	verifySigners(us, nil)
+
+	if !us.Signers[0].Validated {
+		t.Error("Signers[0]: Validated = false, want true (its signature verified)")
+	}
+	if us.Signers[1].Validated {
+		t.Error("Signers[1]: Validated = true, want false (its signature did not verify)")
+	}
+	if !us.Validated {
+		t.Error("us.Validated = false; a later failure must not clear an earlier success")
+	}
+	if us.ValidationRcode != dns.RcodeSuccess {
+		t.Errorf("us.ValidationRcode = %d, want NOERROR; a later failure must not downgrade it", us.ValidationRcode)
+	}
+	if us.RejectionEDE != 0 {
+		t.Errorf("us.RejectionEDE = %d, want 0; a later failure must not set a rejection EDE", us.RejectionEDE)
+	}
+	if us.SignerName != "child.example." {
+		t.Errorf("us.SignerName = %q, want %q", us.SignerName, "child.example.")
 	}
 }


### PR DESCRIPTION
Addresses the one **unresolved** CodeRabbit thread on #294 (`v2/sig0_validate.go`, `resolved=false`).

## The bug
`ValidateUpdate`'s verification loop `break`s on the first successful signature, so every later signer keeps `Validated=false`. `TrustUpdate` gates trust conferral on exactly that per-signer flag:

```go
if !key.Validated {
    continue
}
```

So in a dual-signed rollover UPDATE (old trusted key + new not-yet-trusted key, both signing genuinely) the verdict depends on **SIG RR order**: if the untrusted key's SIG comes first, the trusted key is never marked, `TrustUpdate` skips it, and a legitimate rollover is refused — while the *same* message with the SIGs reversed is accepted.

## The fix
Verify every signer; set `signer.Validated` per signer. The aggregate fields (`ValidationRcode` / `RejectionEDE` / `Validated` / `SignerName`) still mean "at least one signature verified", so each failure path is now guarded on `!us.Validated` — which is what the `break` was really protecting — and first success wins for `SignerName`.

The security guard is **not** weakened: a forged SIG naming a trusted key still fails `Verify()`, keeps `Validated=false`, and is still skipped by `TrustUpdate`. `TrustUpdate`'s comment, which cited the old break-on-first-success behaviour as its rationale, is updated.

## Tests
- `TestTrustUpdateIsIndependentOfSignerOrder` — same verdict with the trusted signer first or second.
- `TestTrustUpdateSkipsUnverifiedSigner` — an unverified signer naming a trusted key still confers nothing.

Full `v2` suite passes.

## ⚠️ Important limitation — please read before merging
While verifying this I found that **`miekg/dns`'s `SIG.Verify` can only verify the LAST record in the packed message**, whatever `*SIG` receiver it is called on:

```go
sigend := offset
h.Write(buf[sigstart:sigend])                      // SIG rdata read FROM THE BUFFER
h.Write([]byte{byte((adc-1) << 8), byte(adc-1)})   // assumes exactly ONE SIG
h.Write(buf[12:bodyend])                           // body = everything before the LAST record
sig := buf[sigend:]                                // signature bytes = tail of buffer
```

The receiver only supplies the KeyTag/SignerName/Algorithm sanity checks; the bytes actually verified always come from the tail of `buf`.

Consequence: with multiple SIG(0) RRs in Additional, **only the last one can ever verify** — so a genuinely dual-signed rollover cannot be fully validated today, independent of this fix. That means the ordering hazard this PR removes is currently latent rather than reachable, and the *practical* dual-signed-rollover problem has a deeper root cause in the verification layer.

This PR is still worth taking: it makes the per-signer semantics explicit and correct, and removes the hazard so it cannot bite once multi-SIG(0) verification is addressed. But the multi-SIG(0) question should be tracked separately — it affects the rollover mechanism the phase0/phase1 stack is built around.