### PR TITLE
Relay the recorded rcode/EDE on every SIG(0) UPDATE rejection (CodeRabbit #294 findings 3 & 4)

### DIFF
--- a/v2/sig0_validate.go
+++ b/v2/sig0_validate.go
@@ -344,13 +344,20 @@ func verifySigners(us *UpdateStatus, msgbuf []byte) {
 func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 	// dump.P(us)
 	if len(us.Signers) == 0 {
-		// No locatable signing key for any SIG in the UPDATE. This branch
-		// also covers a fully-unsigned UPDATE (no SIG RR at all): both map
-		// to BADKEY(17). Per draft-ietf-dnsop-delegation-mgmt-via-ddns-02
-		// §"RCODE BADKEY", an unknown key is a definitive BADKEY so the
-		// child falls back to bootstrapping its key into the receiver.
-		// Conflating "unsigned" with "unknown key" is a deliberate choice:
-		// a child re-bootstrapping off its own unsigned UPDATE is harmless.
+		// No locatable signing key for any SIG in the UPDATE. Per
+		// draft-ietf-dnsop-delegation-mgmt-via-ddns-02 §"RCODE BADKEY", an
+		// unknown key is a definitive BADKEY(17) so the child falls back to
+		// bootstrapping its key into the receiver.
+		//
+		// This also covers an UPDATE carrying no SIG RR at all but a
+		// non-empty Additional section (in practice: an OPT RR) — the
+		// discovery loop finds no SIG, so us.Signers is empty and we land
+		// here. Conflating "unsigned" with "unknown key" is a deliberate
+		// choice: a child re-bootstrapping off its own unsigned UPDATE is
+		// harmless. Note it does NOT cover an UPDATE with a completely
+		// empty Additional section: that short-circuits earlier, in
+		// ValidateUpdate's len(r.Extra)==0 branch, as FORMERR +
+		// EDESig0FormatError, which the responder now relays.
 		us.ValidationRcode = dns.RcodeBadKey
 		us.RejectionEDE = edns0.EDESig0KeyNotKnown
 		return fmt.Errorf("update has no locatable signing key")
@@ -368,6 +375,16 @@ func (zd *ZoneData) TrustUpdate(r *dns.Msg, us *UpdateStatus) error {
 	// signature. A well-formed self-signed key upload verifies, so it has
 	// Validated=true and is unaffected.
 	if !us.Validated {
+		// Defensive: this branch relies on ValidateUpdate having run first and
+		// left a non-success ValidationRcode (its line-31 fail-closed default).
+		// If TrustUpdate is ever reached with a fresh UpdateStatus{} from a
+		// future call site, ValidationRcode would still be its zero value
+		// (RcodeSuccess) while we return an error — reintroducing exactly the
+		// "responder answers NOERROR for a rejected update" bug that default
+		// was added to prevent. Do not rely on a precondition we can enforce.
+		if us.ValidationRcode == dns.RcodeSuccess {
+			us.ValidationRcode = dns.RcodeBadSig
+		}
 		if us.RejectionEDE == 0 {
 			us.RejectionEDE = edns0.EDESig0BadSignature
 		}

--- a/v2/sig0_validate_rcoderelay_test.go
+++ b/v2/sig0_validate_rcoderelay_test.go
@@ -114,13 +114,34 @@ func TestApplyValidationFailureRelaysRecordedRcodeAndEDE(t *testing.T) {
 			if got != tc.ede {
 				t.Errorf("EDE info code = %d, want %d", got, tc.ede)
 			}
+
+			// The rejection must actually be sendable. BADSIG/BADKEY/BADTIME
+			// are extended rcodes: Pack() refuses Rcode > 0xF without an OPT
+			// RR to carry the upper bits, and WriteMsg's error is discarded
+			// by both rejection paths — an unpackable reply reaches the child
+			// as a TIMEOUT, not a rejection.
+			wire, err := m.Pack()
+			if err != nil {
+				t.Fatalf("rejection does not pack: %v", err)
+			}
+			var rt dns.Msg
+			if err := rt.Unpack(wire); err != nil {
+				t.Fatalf("packed rejection does not unpack: %v", err)
+			}
+			if rt.Rcode != int(tc.rcode) {
+				t.Errorf("rcode after wire round-trip = %d, want %d", rt.Rcode, tc.rcode)
+			}
 		})
 	}
 }
 
-// TestApplyValidationFailureOmitsZeroEDE: an EDE of 0 means "none recorded"
-// and must not be attached as if it were a real extended error.
-func TestApplyValidationFailureOmitsZeroEDE(t *testing.T) {
+// TestApplyValidationFailureZeroEDEStillPacks: an EDE of 0 means "none
+// recorded" and must not be attached as if it were a real extended error —
+// but an extended rcode (here BADSIG=16) must STILL produce a packable
+// message, which requires an OPT RR even without an EDE option in it. This
+// is the combination no current caller produces (every extended-rcode path
+// also records an EDE); the helper must not depend on that staying true.
+func TestApplyValidationFailureZeroEDEStillPacks(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetUpdate("example.")
 
@@ -135,6 +156,17 @@ func TestApplyValidationFailureOmitsZeroEDE(t *testing.T) {
 				t.Error("an EDE was attached for RejectionEDE=0")
 			}
 		}
+	}
+	wire, err := m.Pack()
+	if err != nil {
+		t.Fatalf("BADSIG rejection without an EDE does not pack: %v", err)
+	}
+	var rt dns.Msg
+	if err := rt.Unpack(wire); err != nil {
+		t.Fatalf("packed rejection does not unpack: %v", err)
+	}
+	if rt.Rcode != dns.RcodeBadSig {
+		t.Errorf("rcode after wire round-trip = %d, want BADSIG(%d)", rt.Rcode, dns.RcodeBadSig)
 	}
 }
 

--- a/v2/sig0_validate_rcoderelay_test.go
+++ b/v2/sig0_validate_rcoderelay_test.go
@@ -1,0 +1,166 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// TestTrustUpdateDefaultsRcodeWhenUnvalidated covers the defensive default in
+// TrustUpdate's !us.Validated branch.
+//
+// The branch previously relied on ValidateUpdate having run first and left a
+// non-success ValidationRcode behind. A caller that reaches TrustUpdate with a
+// fresh UpdateStatus{} would return an error while ValidationRcode was still
+// its zero value (RcodeSuccess), and UpdateResponder relays that value
+// directly — so the child would receive NOERROR for an update the receiver
+// actually rejected.
+func TestTrustUpdateDefaultsRcodeWhenUnvalidated(t *testing.T) {
+	zd := &ZoneData{}
+
+	// A fresh UpdateStatus, as if TrustUpdate were called without
+	// ValidateUpdate having set its fail-closed default first.
+	us := &UpdateStatus{
+		Validated: false,
+		Signers: []Sig0UpdateSigner{
+			{Name: "child.example.", KeyId: 111, Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111}},
+		},
+	}
+	if us.ValidationRcode != dns.RcodeSuccess {
+		t.Fatalf("precondition: zero-valued ValidationRcode should be RcodeSuccess, got %d", us.ValidationRcode)
+	}
+
+	if err := zd.TrustUpdate(nil, us); err == nil {
+		t.Fatal("expected an error: no signature verified")
+	}
+	if us.ValidationRcode == dns.RcodeSuccess {
+		t.Error("ValidationRcode is still NOERROR while TrustUpdate returned an error; " +
+			"the responder would answer NOERROR for a rejected update")
+	}
+	if us.ValidationRcode != dns.RcodeBadSig {
+		t.Errorf("ValidationRcode = %d, want BADSIG(%d)", us.ValidationRcode, dns.RcodeBadSig)
+	}
+	if us.RejectionEDE != edns0.EDESig0BadSignature {
+		t.Errorf("RejectionEDE = %d, want EDESig0BadSignature(%d)", us.RejectionEDE, edns0.EDESig0BadSignature)
+	}
+}
+
+// TestTrustUpdatePreservesRecordedRcode is the counterpart: when ValidateUpdate
+// HAS recorded a specific failure (e.g. BADTIME for clock skew), the defensive
+// default must not overwrite it with the generic BADSIG.
+func TestTrustUpdatePreservesRecordedRcode(t *testing.T) {
+	zd := &ZoneData{}
+	us := &UpdateStatus{
+		Validated:       false,
+		ValidationRcode: dns.RcodeBadTime,
+		RejectionEDE:    edns0.EDESig0BadTime,
+		Signers: []Sig0UpdateSigner{
+			{Name: "child.example.", KeyId: 111, Sig0Key: &Sig0Key{Name: "child.example.", Keyid: 111}},
+		},
+	}
+
+	if err := zd.TrustUpdate(nil, us); err == nil {
+		t.Fatal("expected an error: no signature verified")
+	}
+	if us.ValidationRcode != dns.RcodeBadTime {
+		t.Errorf("ValidationRcode = %d, want BADTIME(%d) preserved", us.ValidationRcode, dns.RcodeBadTime)
+	}
+	if us.RejectionEDE != edns0.EDESig0BadTime {
+		t.Errorf("RejectionEDE = %d, want EDESig0BadTime(%d) preserved", us.RejectionEDE, edns0.EDESig0BadTime)
+	}
+}
+
+// TestApplyValidationFailureRelaysRecordedRcodeAndEDE is the test for the
+// responder fix: the rejection path must relay whatever ValidateUpdate /
+// TrustUpdate recorded, not a hardcoded rcode + EDE. Reverting the fix (a
+// hardcoded SERVFAIL + EDESig0KeyNotKnown, as the ValidateUpdate path had)
+// fails the FORMERR case below.
+func TestApplyValidationFailureRelaysRecordedRcodeAndEDE(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		rcode uint8
+		ede   uint16
+	}{
+		{"unsigned/malformed -> FORMERR", dns.RcodeFormatError, edns0.EDESig0FormatError},
+		{"unknown key -> BADKEY", dns.RcodeBadKey, edns0.EDESig0KeyNotKnown},
+		{"known but untrusted -> REFUSED", dns.RcodeRefused, edns0.EDESig0KeyKnownButNotTrusted},
+		{"bad signature -> BADSIG", dns.RcodeBadSig, edns0.EDESig0BadSignature},
+		{"clock skew -> BADTIME", dns.RcodeBadTime, edns0.EDESig0BadTime},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := new(dns.Msg)
+			m.SetUpdate("example.")
+
+			applyValidationFailure(m, &UpdateStatus{ValidationRcode: tc.rcode, RejectionEDE: tc.ede})
+
+			if m.Rcode != int(tc.rcode) {
+				t.Errorf("response rcode = %d, want %d", m.Rcode, tc.rcode)
+			}
+			opt := m.IsEdns0()
+			if opt == nil {
+				t.Fatal("no OPT RR on the response; the EDE was not attached")
+			}
+			var got uint16
+			var found bool
+			for _, o := range opt.Option {
+				if ede, ok := o.(*dns.EDNS0_EDE); ok {
+					got, found = ede.InfoCode, true
+				}
+			}
+			if !found {
+				t.Fatal("no EDE option on the response")
+			}
+			if got != tc.ede {
+				t.Errorf("EDE info code = %d, want %d", got, tc.ede)
+			}
+		})
+	}
+}
+
+// TestApplyValidationFailureOmitsZeroEDE: an EDE of 0 means "none recorded"
+// and must not be attached as if it were a real extended error.
+func TestApplyValidationFailureOmitsZeroEDE(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetUpdate("example.")
+
+	applyValidationFailure(m, &UpdateStatus{ValidationRcode: dns.RcodeBadSig, RejectionEDE: 0})
+
+	if m.Rcode != dns.RcodeBadSig {
+		t.Errorf("response rcode = %d, want BADSIG(%d)", m.Rcode, dns.RcodeBadSig)
+	}
+	if opt := m.IsEdns0(); opt != nil {
+		for _, o := range opt.Option {
+			if _, ok := o.(*dns.EDNS0_EDE); ok {
+				t.Error("an EDE was attached for RejectionEDE=0")
+			}
+		}
+	}
+}
+
+// TestValidateUpdateUnsignedSetsFormError pins the source of what the responder
+// relays for an UPDATE with an empty Additional section: FORMERR + a
+// format-error EDE, rather than anything resembling "key not known". A child
+// that receives "key not known" is directed at bootstrapping a key, which does
+// not fix a malformed message.
+func TestValidateUpdateUnsignedSetsFormError(t *testing.T) {
+	zd := &ZoneData{}
+	us := &UpdateStatus{}
+
+	r := new(dns.Msg)
+	r.SetUpdate("example.")
+	r.Extra = nil // no OPT, no SIG
+
+	if err := zd.ValidateUpdate(r, us); err == nil {
+		t.Fatal("expected an error for an UPDATE with no signature")
+	}
+	if us.ValidationRcode != dns.RcodeFormatError {
+		t.Errorf("ValidationRcode = %d, want FORMERR(%d)", us.ValidationRcode, dns.RcodeFormatError)
+	}
+	if us.RejectionEDE != edns0.EDESig0FormatError {
+		t.Errorf("RejectionEDE = %d, want EDESig0FormatError(%d)", us.RejectionEDE, edns0.EDESig0FormatError)
+	}
+	if us.Validated || us.ValidatedByTrustedKey {
+		t.Error("Validated/ValidatedByTrustedKey must both be false for an unsigned UPDATE")
+	}
+}

--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -72,6 +72,23 @@ func UpdateHandler(ctx context.Context, conf *Config) error {
 	}
 }
 
+// applyValidationFailure stamps the response with the rcode and EDE that
+// ValidateUpdate / TrustUpdate recorded for a rejected SIG(0) UPDATE, rather
+// than a hardcoded guess at the reason. Both rejection paths must use this so
+// they cannot drift apart again.
+//
+// us.ValidationRcode is authoritative: ValidateUpdate fails closed by
+// defaulting it to BADSIG on entry, and TrustUpdate defends the same way, so
+// an error return always carries a non-success rcode. The EDE is attached only
+// when one was actually selected — an EDE of 0 is "none recorded", not a
+// meaningful extended error.
+func applyValidationFailure(m *dns.Msg, us *UpdateStatus) {
+	m.SetRcode(m, int(us.ValidationRcode))
+	if us.RejectionEDE != 0 {
+		edns0.AttachEDEToResponse(m, us.RejectionEDE)
+	}
+}
+
 func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	w := dur.ResponseWriter
 	r := dur.Msg
@@ -278,11 +295,18 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	// this is an update to auth data) then the update will validate and the SIG(0) key will be
 	// trusted. We always trust SIG(0) keys in the zone we are authoritative for.
 
+	// applyValidationFailure is deliberately shared by both the ValidateUpdate
+	// and TrustUpdate rejection paths below. They previously each hardcoded
+	// their own rcode + EDE, and correcting only one of them is exactly how
+	// they drifted apart: the TrustUpdate path was fixed to relay the recorded
+	// values while the ValidateUpdate path kept answering SERVFAIL + "key not
+	// known" for what is actually FORMERR + a format error — mislabelling a
+	// malformed request as a server-side fault and directing the child at
+	// bootstrapping a key, which does not fix a malformed message.
 	err := zd.ValidateUpdate(r, dur.Status)
 	if err != nil {
 		zd.Logger.Printf("Error from ValidateUpdate(): %v", err)
-		m.SetRcode(m, dns.RcodeServerFailure)
-		edns0.AttachEDEToResponse(m, edns0.EDESig0KeyNotKnown)
+		applyValidationFailure(m, dur.Status)
 		w.WriteMsg(m)
 		return err
 	}
@@ -293,16 +317,7 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	err = zd.TrustUpdate(r, dur.Status)
 	if err != nil {
 		zd.Logger.Printf("Error from TrustUpdate(): %v", err)
-		// Relay the rcode + EDE that TrustUpdate/ValidateUpdate selected
-		// for this specific failure: BADKEY + key-not-known for an unknown
-		// key, REFUSED + key-known-not-trusted for a known-but-untrusted
-		// key, and BADSIG/BADTIME for a signature that did not verify.
-		// The previous hardcoded EDESig0KeyKnownButNotTrusted mislabelled
-		// the unknown-key and bad-signature cases.
-		m.SetRcode(m, int(dur.Status.ValidationRcode))
-		if dur.Status.RejectionEDE != 0 {
-			edns0.AttachEDEToResponse(m, dur.Status.RejectionEDE)
-		}
+		applyValidationFailure(m, dur.Status)
 		w.WriteMsg(m)
 		return err
 	}

--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -87,6 +87,17 @@ func applyValidationFailure(m *dns.Msg, us *UpdateStatus) {
 	if us.RejectionEDE != 0 {
 		edns0.AttachEDEToResponse(m, us.RejectionEDE)
 	}
+	// BADSIG(16)/BADKEY(17)/BADTIME(18) are extended rcodes: the header field
+	// is 4 bits, and Pack() refuses Rcode > 0xF unless an OPT RR is present
+	// to carry the upper bits (ErrExtendedRcode). Every path that records
+	// such an rcode today also records an EDE, and AttachEDEToResponse
+	// creates the OPT — but that is an invariant of the current callers, not
+	// of this helper. Guarantee it here: without the OPT the rejection would
+	// fail to pack inside WriteMsg, whose error both rejection paths discard,
+	// and the child would see a TIMEOUT instead of a rejection.
+	if us.ValidationRcode > 0xF && m.IsEdns0() == nil {
+		m.SetEdns0(4096, false)
+	}
 }
 
 func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {


### PR DESCRIPTION
Fixes the two CodeRabbit findings on #294 that were never addressed. Both were posted as *outside diff range* comments in the review body rather than as inline threads, which is why they were missed.

## Finding 3 — Major, functional correctness

`UpdateResponder`'s **ValidateUpdate** rejection path hardcoded `SERVFAIL` + `EDESig0KeyNotKnown`, ignoring what `ValidateUpdate` actually recorded. Both of its error paths — a `Pack()` failure and an UPDATE with an empty Additional section — set `FORMERR` + `EDESig0FormatError`.

So a malformed request was reported to the child as a server-side fault, with an EDE directing it to bootstrap a key. Bootstrapping does not fix a malformed message.

#294 corrected the *adjacent* `TrustUpdate` path and left this one. That duplication is exactly how the two drifted apart, so the relay is now a single shared helper both paths call:

```go
func applyValidationFailure(m *dns.Msg, us *UpdateStatus) {
	m.SetRcode(m, int(us.ValidationRcode))
	if us.RejectionEDE != 0 {
		edns0.AttachEDEToResponse(m, us.RejectionEDE)
	}
}
```

## Finding 4 — Minor, defensive

`TrustUpdate`'s `!us.Validated` branch relied on `ValidateUpdate` having run first and left its line-31 fail-closed `BADSIG` default behind. Reached with a fresh `UpdateStatus{}` from any future call site, it returns an error while `ValidationRcode` is still the zero value — which *is* `RcodeSuccess` — and the responder relays that directly. The child would see NOERROR for an update the receiver rejected.

Defaulted here too rather than depending on a precondition we cannot enforce. An already-recorded rcode (e.g. `BADTIME` for clock skew) is preserved.

## Comment correction

`TrustUpdate`'s no-locatable-key comment claimed it "also covers a fully-unsigned UPDATE (no SIG RR at all)". It does not: an UPDATE with a *completely empty* Additional section short-circuits earlier in `ValidateUpdate` as FORMERR — which finding 3 makes observable on the wire. It does cover an UPDATE with an OPT RR but no SIG. Comment now says so precisely.

## Wire-visible behaviour change

An UPDATE with an empty Additional section, or one that fails to re-pack, now gets `FORMERR` + `EDESig0FormatError` instead of `SERVFAIL` + `EDESig0KeyNotKnown`. No in-tree child branches on either, so nothing in this repo changes behaviour — but it is visible to third-party senders.

## Tests

Each fix is pinned by a test that **fails when the fix is reverted** — verified by mutation, not assumed:

- `TestApplyValidationFailureRelaysRecordedRcodeAndEDE` — all five rcode/EDE pairs (FORMERR, BADKEY, REFUSED, BADSIG, BADTIME). Restoring the hardcoded `SERVFAIL` fails every case.
- `TestApplyValidationFailureOmitsZeroEDE` — `RejectionEDE == 0` means "none recorded" and must not be attached.
- `TestTrustUpdateDefaultsRcodeWhenUnvalidated` — fails with the exact "responder would answer NOERROR for a rejected update" diagnostic when the default is removed.
- `TestTrustUpdatePreservesRecordedRcode` — the default must not clobber a specific recorded failure.

`go build`, `go vet`, and the full `v2` suite under `-race` are clean.