### PR TITLE
updateresponder: route the ApproveUpdate rejection through applyValidationFailure

### DIFF
--- a/v2/sig0_validate_rcoderelay_test.go
+++ b/v2/sig0_validate_rcoderelay_test.go
@@ -97,6 +97,13 @@ func TestApplyValidationFailureRelaysRecordedRcodeAndEDE(t *testing.T) {
 			if m.Rcode != int(tc.rcode) {
 				t.Errorf("response rcode = %d, want %d", m.Rcode, tc.rcode)
 			}
+			// RFC 2136: the UPDATE response echoes the Zone (Question) section.
+			// applyValidationFailure stamps a message that is already a reply,
+			// so it must not clobber the Zone section — guards against a
+			// SetRcode(m, ...) that re-derives Question from the response itself.
+			if len(m.Question) != 1 || m.Question[0].Name != "example." {
+				t.Errorf("Zone section not preserved: got %+v, want one question for example.", m.Question)
+			}
 			opt := m.IsEdns0()
 			if opt == nil {
 				t.Fatal("no OPT RR on the response; the EDE was not attached")
@@ -218,6 +225,14 @@ func TestApplyValidationFailureFailsClosedOnSuccessRcode(t *testing.T) {
 	}
 	if m.Rcode != dns.RcodeServerFailure {
 		t.Errorf("rcode = %d, want SERVFAIL(%d)", m.Rcode, dns.RcodeServerFailure)
+	}
+	// RFC 2136: the UPDATE response echoes the Zone (Question) section.
+	// applyValidationFailure sets the rcode on a message that is ALREADY a
+	// reply (UpdateResponder calls m.SetReply(r) upstream), so it must not
+	// clobber the Zone section. This guards against a SetRcode(m, ...) that
+	// re-derives Question from the response itself.
+	if len(m.Question) != 1 || m.Question[0].Name != "example." {
+		t.Errorf("Zone section not preserved: got %+v, want a single question for example.", m.Question)
 	}
 	if _, err := m.Pack(); err != nil {
 		t.Errorf("fail-closed response did not pack: %v", err)

--- a/v2/sig0_validate_rcoderelay_test.go
+++ b/v2/sig0_validate_rcoderelay_test.go
@@ -196,3 +196,30 @@ func TestValidateUpdateUnsignedSetsFormError(t *testing.T) {
 		t.Error("Validated/ValidatedByTrustedKey must both be false for an unsigned UPDATE")
 	}
 }
+
+// TestApplyValidationFailureFailsClosedOnSuccessRcode covers the guard that the
+// ApproveUpdate rejection path depends on.
+//
+// ApproveUpdate only returns an error for an unknown update type, and it
+// reaches that with validation having SUCCEEDED — so us.ValidationRcode is
+// RcodeSuccess there. Relaying it raw (as that path did before it was routed
+// through applyValidationFailure) answers NOERROR for an update that was never
+// applied: the child records the change as landed. That is the same
+// wire-protocol lie the finalRcode logic further down UpdateResponder exists to
+// prevent for policy-rejected updates.
+func TestApplyValidationFailureFailsClosedOnSuccessRcode(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetUpdate("example.")
+
+	applyValidationFailure(m, &UpdateStatus{ValidationRcode: dns.RcodeSuccess})
+
+	if m.Rcode == dns.RcodeSuccess {
+		t.Fatal("a rejected UPDATE was answered NOERROR; applyValidationFailure must fail closed")
+	}
+	if m.Rcode != dns.RcodeServerFailure {
+		t.Errorf("rcode = %d, want SERVFAIL(%d)", m.Rcode, dns.RcodeServerFailure)
+	}
+	if _, err := m.Pack(); err != nil {
+		t.Errorf("fail-closed response did not pack: %v", err)
+	}
+}

--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -108,7 +108,14 @@ func applyValidationFailure(m *dns.Msg, us *UpdateStatus) {
 	// of this helper. Guarantee it here: without the OPT the rejection would
 	// fail to pack inside WriteMsg, whose error both rejection paths discard,
 	// and the child would see a TIMEOUT instead of a rejection.
-	if us.ValidationRcode > 0xF && m.IsEdns0() == nil {
+	//
+	// Test the local rcode that was actually stamped onto m, not
+	// us.ValidationRcode: the fail-closed branch above can substitute a
+	// different value, and the OPT requirement is dictated by whatever will be
+	// packed. (They coincide today — the only substitution is Success→SERVFAIL,
+	// neither of which is extended — but coupling the guard to the packed value
+	// keeps it correct if that ever changes.)
+	if rcode > 0xF && m.IsEdns0() == nil {
 		m.SetEdns0(4096, false)
 	}
 }

--- a/v2/updateresponder.go
+++ b/v2/updateresponder.go
@@ -74,8 +74,10 @@ func UpdateHandler(ctx context.Context, conf *Config) error {
 
 // applyValidationFailure stamps the response with the rcode and EDE that
 // ValidateUpdate / TrustUpdate recorded for a rejected SIG(0) UPDATE, rather
-// than a hardcoded guess at the reason. Both rejection paths must use this so
-// they cannot drift apart again.
+// than a hardcoded guess at the reason. Every rejection path in
+// UpdateResponder must use this so they cannot drift apart again — there are
+// three (ValidateUpdate, TrustUpdate, ApproveUpdate), and the ApproveUpdate one
+// was originally missed.
 //
 // us.ValidationRcode is authoritative: ValidateUpdate fails closed by
 // defaulting it to BADSIG on entry, and TrustUpdate defends the same way, so
@@ -83,7 +85,18 @@ func UpdateHandler(ctx context.Context, conf *Config) error {
 // when one was actually selected — an EDE of 0 is "none recorded", not a
 // meaningful extended error.
 func applyValidationFailure(m *dns.Msg, us *UpdateStatus) {
-	m.SetRcode(m, int(us.ValidationRcode))
+	rcode := int(us.ValidationRcode)
+	if rcode == dns.RcodeSuccess {
+		// A validation error must never answer NOERROR. ValidateUpdate
+		// defaults ValidationRcode to BADSIG on entry, and TrustUpdate
+		// defends the same way, precisely so this cannot happen — fail
+		// closed if some future path forgets to set it. (Carried over from
+		// PR #307, which guarded only the ValidateUpdate branch inline;
+		// living in the shared helper it now covers TrustUpdate too.)
+		lgHandler.Error("SIG(0) UPDATE rejected but ValidationRcode was left at NOERROR; failing closed with SERVFAIL")
+		rcode = dns.RcodeServerFailure
+	}
+	m.SetRcode(m, rcode)
 	if us.RejectionEDE != 0 {
 		edns0.AttachEDEToResponse(m, us.RejectionEDE)
 	}
@@ -306,8 +319,9 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	// this is an update to auth data) then the update will validate and the SIG(0) key will be
 	// trusted. We always trust SIG(0) keys in the zone we are authoritative for.
 
-	// applyValidationFailure is deliberately shared by both the ValidateUpdate
-	// and TrustUpdate rejection paths below. They previously each hardcoded
+	// applyValidationFailure is deliberately shared by all three rejection
+	// paths below: ValidateUpdate, TrustUpdate, and ApproveUpdate. They
+	// previously each hardcoded
 	// their own rcode + EDE, and correcting only one of them is exactly how
 	// they drifted apart: the TrustUpdate path was fixed to relay the recorded
 	// values while the ValidateUpdate path kept answering SERVFAIL + "key not
@@ -354,11 +368,13 @@ func UpdateResponder(dur *DnsUpdateRequest, updateq chan UpdateRequest) error {
 	if err != nil {
 		lgHandler.Error("error from ApproveUpdate, ignoring update", "err", err)
 		// Even on internal error, send a response with the validation
-		// rcode + EDE so the child sees something coherent.
-		m = m.SetRcode(m, int(dur.Status.ValidationRcode))
-		if dur.Status.RejectionEDE != 0 {
-			edns0.AttachEDEToResponse(m, dur.Status.RejectionEDE)
-		}
+		// rcode + EDE so the child sees something coherent. This is the
+		// third rejection path and it needs the same two guards as the
+		// other two: ApproveUpdate only errors on an unknown update type,
+		// which it reaches with validation having SUCCEEDED — so relaying
+		// ValidationRcode raw would answer NOERROR for an update that was
+		// never applied.
+		applyValidationFailure(m, dur.Status)
 		w.WriteMsg(m)
 		return err
 	}


### PR DESCRIPTION
`applyValidationFailure` exists so every rejection path stamps the response with the rcode and EDE that were actually recorded. Its own comment said *"both rejection paths must use this so they cannot drift apart again"* — but there are **three**. The `ApproveUpdate`-error path still did it inline, so it had **neither** guard.

### Why it matters

That path is reached only when `ApproveUpdate` errors, whose sole cause is an unknown update type — and it gets there with validation having **succeeded**, so `ValidationRcode` is `RcodeSuccess`. Relaying that raw answers **NOERROR for an update that was never applied**: the child records the change as landed. That is the same wire-protocol lie the `finalRcode` logic a few lines below exists to prevent for policy-rejected updates.

Secondarily, an extended rcode (BADSIG/BADKEY/BADTIME) with no recorded EDE would fail to pack for want of an OPT RR, and `WriteMsg`'s error is discarded — so the child would see a **timeout instead of a rejection**.

### Helper parity (the non-obvious half)

Two parallel fixes for the same defect landed on different branches:

| | extended-rcode OPT guard | fail-closed NOERROR→SERVFAIL |
|---|---|---|
| #309 (main) | ✅ | ❌ |
| #307 (ddns-keystate stack) | — | ✅ |

main only ever got the first, so routing the third path through the helper would **not by itself** have fixed the NOERROR case. The fail-closed guard is ported here **verbatim from the stack's version**, so forward-merging main into that stack is a no-op for this hunk rather than a conflict.

### Tests

Adds the missing fail-closed test. The existing helper tests cover the five recorded-rcode relay cases and zero-EDE packing, but not `RcodeSuccess` → SERVFAIL — precisely what the `ApproveUpdate` path relies on. Verified it fails without the guard.

`go build` + `go vet` + full `go test -race` green on `v2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected DNS UPDATE requests now fail safely with `SERVFAIL` if an invalid success code would otherwise be returned.
  * Approval failures now consistently include the appropriate response code and extended error details.
  * Improved reliability when constructing rejected UPDATE responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->