### PR TITLE
Add `tdns-cli agent config check` and `agent config mwe`

### DIFF
--- a/cmdv2/agent/agent-zones.yaml
+++ b/cmdv2/agent/agent-zones.yaml
@@ -1,30 +1,36 @@
+# Zones and zone templates for tdns-agent.
+#
+# tdns-agent is SECONDARY-only: a zone with `type: primary` is refused at
+# startup and left in config-error state (host primary zones on tdns-auth).
+# The agent also never signs, so online-signing/inline-signing are ignored
+# here.
+
 templates:
    - name:            agent
      type:            secondary
-     primary:         127.0.0.1:5355
-
-   - name: child-agent
      store:           map
+     primaries:
+        - { addr: 127.0.0.1:5355, key: NOKEY }
+
+   - name:            child-agent
      type:            secondary
-     notify:          [ 127.0.0.1:5399 ]
-     options:         [ delegation-sync-child, multisigner ]
-     dnssecpolicy:    none
-     multisigner:     mstest
+     store:           map
+     primaries:
+        - { addr: 127.0.0.1:5355, key: NOKEY }
+     notify:
+        - { addr: 127.0.0.1:5399, key: NOKEY }
+     # delegation-sync-proxy: the agent acts on behalf of a DSYNC-unaware
+     # primary (BIND/Knot), watching inbound transfers for CDS/CSYNC changes
+     # and forwarding to the parent. Valid only on an agent secondary zone.
+     options:         [ delegation-sync-proxy ]
 
 zones:
-   - name:            test.net
-     zonefile:        /etc/tdns/zones/test.net
-     template:        parent-primary
-     notify:	      [ 127.0.0.1:5366 ]
+   - name:            test.net.
+     template:        agent
 
    - name:            johani.org.
-     zonefile:        /etc/tdns/zones/johani.org
-     options:	      [ online-signing ]
-     template:        secondary
+     template:        child-agent
 
    # Commented zones kept for reference
-   # child.test.net:
-   #    name:         child.test.net
-   #    zonefile:     /etc/tdns/zones/child.test.net
-   #    template:     child-primary
-   # ... other commented zones ...
+   # - name:          child.test.net.
+   #   template:      agent

--- a/cmdv2/agent/tdns-agent.sample.yaml
+++ b/cmdv2/agent/tdns-agent.sample.yaml
@@ -1,64 +1,19 @@
-# Main TDNS configuration
+# Main TDNS configuration for tdns-agent.
+#
+# tdns-agent is a SECONDARY-only server: it refuses primary zones (they are
+# put in config-error state at startup) and it never signs, so online-signing
+# and inline-signing are ignored. Host primary and/or signed zones on
+# tdns-auth.
+#
+# There is no `multi-provider:` block here. The multi-provider role is
+# implemented by tdns-mpagent in the tdns-mp repository, which owns that
+# config; a standalone tdns-agent cannot parse it and would silently ignore
+# the whole block. See tdns-mp/cmd/mpagent/tdns-mpagent.sample.yaml.
+#
+# Validate this file with:  tdns-cli agent config check --serverconfig <file>
+
 include:
   - agent-zones.yaml
-
-multi-provider:
-   role:		agent
-   identity:		agent.provider.
-   # Active transport mechanisms: "api" and/or "dns" (default: both if configured)
-   # Use ["api"] to disable DNS transport, ["dns"] to disable API, or ["api", "dns"] for both
-   supported_mechanisms:	[ api, dns ]
-   # Secure CHUNK comms with combiner (no enrollment; configure keys and address)
-   long_term_jose_priv_key:	/etc/tdns/agent.jose.private
-   combiner:
-      address:		1.2.3.4:5678
-      long_term_jose_pub_key:	/etc/tdns/combiner.jose.pub
-      # api_base_url:	https://1.2.3.4:8085/api/v1   # optional; for tdns-cli agent combiner ping --api
-   # Authorized peer agents (identity-only list - addresses and keys discovered via DNS)
-   # authorized_peers:
-   #    - agent2.example.com
-   #    - agent3.example.com
-   # --- agent autozone and secondaries (local) ---
-   local:
-      # Secondaries to send NOTIFY to when the agent autozone changes
-      notify:	[]
-      # Authoritative nameserver hostnames for the agent autozone (normalized to FQDN; no glue; must be outside the autozone)
-      # nameservers:	[ ns1.example.org., ns2.example.org ]
-   # --- discovery and heartbeat (remote) ---
-   remote:
-      LocateInterval:	60    # seconds between locate/discovery runs
-      BeatInterval:	30    # seconds between heartbeats to the same destination
-   # --- zone transfer (xfr): allow AXFR/IXFR to/from listed addresses, optional TSIG ---
-   xfr:
-      outgoing:
-         addresses:	[]   # allow AXFR/IXFR from these addresses
-         auth:	[]   # TSIG key names for outgoing XFR auth
-      incoming:
-         addresses:	[]   # allow AXFR/IXFR to these addresses
-         auth:	[]   # TSIG key names for incoming XFR auth
-   api:
-      addresses:
-         publish:	[ 1.2.3.4 ]
-         listen:	[ 127.0.0.1:8999 ]
-      baseurl:		https://api.{TARGET}:{PORT}/api/v1 # TARGET will be expanded to identity
-      port:		8999
-      certfile:		/etc/tdns/certs/agent.provider..crt
-      keyfile:		/etc/tdns/certs/agent.provider..key
-   dns:
-      addresses:
-         publish:	[ 1.2.3.4 ]
-         listen:	[ 127.0.0.1:8998 ]
-      baseurl:		dns://dns.{TARGET}:{PORT}/ # TARGET will be expanded to identity
-      port:		8998
-      # control_zone:	agent.provider.   # optional; zone used for NOTIFY(CHUNK) QNAMEs (default: agent identity)
-      # chunk_mode:	edns0   # default: send payload in EDNS(0) CHUNK option (code 65004)
-      # chunk_mode:	query   # store payload by qname; send NOTIFY without payload; receiver fetches via CHUNK query (then chunk_query_endpoint is required)
-      # chunk_query_endpoint:	include   # when chunk_mode=query: signal CHUNK query endpoint in NOTIFY (EDNS0 option 65005). Required when chunk_mode=query.
-      # chunk_query_endpoint:	none      # when chunk_mode=query: do not add endpoint to NOTIFY; receiver uses agent_peer.address
-   # --- sync engine (syncengine): always active, manages Hello retries and peer sync ---
-   syncengine:
-      intervals:
-         helloretry:	15    # seconds between Hello retries (range: 15-1800)
 
 service:
    name:		TDNS-AGENT
@@ -73,13 +28,17 @@ service:
 dnsengine:
    addresses:		[ 127.0.0.1:5357, '[::1]:5357']
    transports:		[ doq, dot, do53 ]
+   # The encrypted transports (dot/doq/doh) need their own cert/key; without
+   # them those listeners are silently skipped and only do53 comes up.
+   certfile:		/etc/tdns/certs/localhost.crt
+   keyfile:		/etc/tdns/certs/localhost.key
    # Zone file path comes from zone's zonefile: when set (no filedir/filetmpl needed)
 
 apiserver:
    addresses:     	[ 127.0.0.1:8987 ]
    apikey:         	winter-is-coming-santa-stuck-in-chimney
-   certfile:		/etc/tdns/certs/localhost..crt
-   keyfile:		/etc/tdns/certs/localhost..key
+   certfile:		/etc/tdns/certs/localhost.crt
+   keyfile:		/etc/tdns/certs/localhost.key
 
 server:
    id:			ooga booga boo

--- a/cmdv2/cli/shared_cmds.go
+++ b/cmdv2/cli/shared_cmds.go
@@ -8,25 +8,25 @@ import (
 )
 
 func init() {
-	// From ../tdns/cli/db_cmds.go: per-daemon factory; both auth and agent
+	// From ../../v2/cli/db_cmds.go: per-daemon factory; both auth and agent
 	// have their own SQLite DB so each gets its own 'db init' command.
 	cli.AuthCmd.AddCommand(cli.NewDbCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewDbCmd("agent"))
 
 	// Note: 'auth ping' is already wired in v2/cli/auth_cmds.go init().
 
-	// From ../tdns/cli/report.go: 'auth report' — reports are an
+	// From ../../v2/cli/report.go: 'auth report' — reports are an
 	// auth-daemon concern (CDS/CSYNC/error reports about a zone).
 	cli.AuthCmd.AddCommand(cli.ReportCmd)
 
 	// Note: 'auth daemon' is already wired in v2/cli/auth_cmds.go init().
 	cli.AgentCmd.AddCommand(cli.NewDaemonCmd("agent"))
 
-	// From ../tdns/cli/ddns_cmds.go: 'auth ddns' and 'auth del' —
+	// From ../../v2/cli/ddns_cmds.go: 'auth ddns' and 'auth del' —
 	// DDNS update protocol + delegation-sync are auth-daemon concerns.
 	cli.AuthCmd.AddCommand(cli.DdnsCmd, cli.DelCmd)
 
-	// From ../tdns/cli/debug_cmds.go:
+	// From ../../v2/cli/debug_cmds.go:
 	cli.AuthCmd.AddCommand(cli.NewDebugCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewDebugCmd("agent"))
 
@@ -39,28 +39,29 @@ func init() {
 	cli.AgentCmd.AddCommand(cli.NewKeystoreCmd("agent"))
 	cli.AgentCmd.AddCommand(cli.NewTruststoreCmd("agent"))
 
-	// From ../tdns/cli/dsync_cmds.go: 'imr dsync-query' — DSYNC discovery
+	// From ../../v2/cli/dsync_cmds.go: 'imr dsync-query' — DSYNC discovery
 	// resolves via the IMR resolver, so it sits under the imr daemon parent.
 	cli.ImrCmd.AddCommand(cli.DsyncDiscoveryCmd)
 
-	// From ../tdns/cli/config_cmds.go:
+	// From ../../v2/cli/config_cmds.go:
 	cli.AuthCmd.AddCommand(cli.NewConfigCmd("auth"))
 	cli.AgentCmd.AddCommand(cli.NewConfigCmd("agent"))
 
-	// From ../tdns/cli/generate_cmds.go: daemon-agnostic record syntax helpers
+	// From ../../v2/cli/generate_cmds.go: daemon-agnostic record syntax helpers
 	cli.UtilCmd.AddCommand(cli.GenerateCmd)
 
-	// From ../tdns/cli/notify_cmds.go: 'auth notify' — sends NOTIFY
+	// From ../../v2/cli/notify_cmds.go: 'auth notify' — sends NOTIFY
 	// (CDS/CSYNC/DNSKEY) toward the parent or signer, an auth-daemon op.
 	cli.AuthCmd.AddCommand(cli.NotifyCmd)
 
-	// From ../tdns/cli/commands.go: 'auth stop' (matches 'agent stop' via NewDaemonCmd).
+	// 'auth stop'. Note the trees are asymmetric: the agent has no top-level
+	// 'agent stop', only 'agent daemon stop' (from NewDaemonCmd).
 	cli.AuthCmd.AddCommand(cli.NewStopCmd("auth"))
 
-	// From ../tdns/cli/combiner_cmds.go:
+	// From ../../v2/cli/combiner_cmds.go:
 	//	rootCmd.AddCommand(cli.CombinerCmd)
 
-	// From ../tdns/cli/agent_cmds.go:
+	// From ../../v2/cli/agent_cmds.go:
 	rootCmd.AddCommand(cli.AgentCmd)
 
 	// JOSE/JWT keys CLI moved to tdns-mp/v2/cli and tdns-mp/cmd/mpcli;
@@ -70,16 +71,16 @@ func init() {
 	// Agent uses AgentZoneCmd (wired in cli/agent_zone_cmds.go).
 	// Combiner uses combinerZoneCmd (wired in cli/legacy_combiner_edits_cmds.go).
 
-	// From ../tdns/cli/base32_cmds.go: daemon-agnostic encode/decode helper
+	// From ../../v2/cli/base32_cmds.go: daemon-agnostic encode/decode helper
 	cli.UtilCmd.AddCommand(cli.Base32Cmd)
 
-	// From ../tdns/cli/scanner_cmds.go:
+	// From ../../v2/cli/scanner_cmds.go:
 	rootCmd.AddCommand(cli.ScannerCmd)
 
-	// From ../tdns/cli/imr_cmds.go:
+	// From ../../v2/cli/imr_cmds.go:
 	rootCmd.AddCommand(cli.ImrCmd)
 
-	// From ../tdns/cli/auth_cmds.go:
+	// From ../../v2/cli/auth_cmds.go:
 	rootCmd.AddCommand(cli.AuthCmd)
 
 	// Synthetic 'util' parent itself (must be added once, after children).

--- a/docs/2026-07-20-cli-role-mapping-fallout.md
+++ b/docs/2026-07-20-cli-role-mapping-fallout.md
@@ -1,0 +1,241 @@
+# tdns-cli role-mapping fallout
+
+**Date:** 2026-07-20
+**Status:** open — deferred cleanup, no work started
+**Found while:** implementing `tdns-cli agent config check|mwe` (PR #311)
+
+## Background
+
+`tdns-cli` groups commands per daemon role (`auth`, `agent`, `imr`, `scanner`).
+Many command trees are built by role-parameterized factories
+(`NewConfigCmd(role)`, `NewDaemonCmd(role)`, `NewKeystoreCmd(role)`, …) and
+attached per role in `cmdv2/cli/shared_cmds.go`; others self-wire in
+`v2/cli/*.go` `init()`s.
+
+Adding the agent variants of `config check`/`config mwe` surfaced a class of
+bug: **a command is attached to a role whose daemon cannot serve it.** The
+command exists, `--help` documents it, and it fails only when run — sometimes
+silently.
+
+PR #311 fixed the `config check` instances and, separately, every case where
+help text merely *named* the wrong daemon (commit "Stop CLI help text naming
+the wrong daemon"). Everything below is what remains.
+
+The audit covered the active tree only: repo root, `v2/*`, `cmdv2/*`. Legacy
+`cmd/`, `tdns/`, `music/`, `obe/` were ignored per the standing rule that only
+the active tree is maintained.
+
+---
+
+## A. Broken at runtime
+
+### A1. `agent parentsync` — the API bridge is missing (RESURRECT, do not delete)
+
+**This functionality is needed in tdns for the agent.** It is *not* a tdns-mp
+concern, despite the `/agent` endpoint comment in `apirouters.go` pointing at
+tdns-mp. It must be restored, not removed.
+
+Affected: `agent parentsync status | bootstrap | inquire update | election`
+(`v2/cli/parentsync_cmds.go:28,53,81,108,151`).
+
+Current state — the two halves exist and the bridge between them does not:
+
+- **CLI half exists.** The commands build an `AgentMgmtPost` with
+  `Command: "parentsync-status"` / `-bootstrap` / `-inquire` / `-election`
+  and POST it to `/agent`.
+- **Engine half exists.** `v2/parentsync_bootstrap.go` provides
+  `ParentSyncAfterKeyPublication`, `QueryParentKeyState`,
+  `QueryParentKeyStateDetailed`, `UpdateParentState`, `BootstrapWithParent`,
+  `ZoneHasParentSyncAgent`.
+- **Bridge missing.** There is no `HandleFunc("/agent", …)` anywhere in `v2/`
+  or `cmdv2/`, and no handler for any of the four `parentsync-*` command
+  strings outside `v2/cli/`. Verified by grep and by live test.
+
+Two independent defects, both must be fixed:
+
+1. **The request struct is not serializable.** `AgentMgmtPost`
+   (`v2/structs.go:967`) carries `Response chan *AgentMgmtResponse` — an
+   in-process channel — yet is used as an HTTP POST body. It fails in the
+   client before any network I/O:
+
+   ```
+   $ tdns-cli agent parentsync status --zone example.com
+   api.RequestNG: Error from json.NewEncoder: json: unsupported type: chan *tdns.AgentMgmtResponse
+   ```
+
+   `AgentMgmtPost` is doing double duty as both an in-process message and a
+   wire type. The fix pattern already exists next door: `ImrMgmtPost`
+   (`v2/structs.go:996`) has an explicit comment that it *"deliberately does
+   NOT reuse AgentMgmtPost, whose agent/RR fields are unrelated ... and whose
+   overloading here would be a future footgun."* Either split out a wire-only
+   request type, or tag the channel `json:"-"`.
+
+2. **The route and handler must be (re)introduced** for `AppTypeAgent` in
+   `SetupAPIRouter`, dispatching the four `parentsync-*` commands to the
+   engine functions above. Worth reconsidering the endpoint name: `/agent` on
+   a daemon that *is* an agent is uninformative, and the name currently
+   carries a comment reserving it for tdns-mp. Something like
+   `/parentsync` would not collide.
+
+Also blocked on this: `agent zone addrr` / `delrr`
+(`v2/cli/agent_zone_cmds.go:314,388`) POST to the same `/agent`. They are
+currently defused — the attachment is commented out at
+`agent_zone_cmds.go:437` — so they are dead code today, but re-enabling them
+before the bridge exists would reintroduce the same failure.
+
+### A2. `tdns-cli imr {query,stats,show,flush,set,zone}` — daemon-only commands attached to the CLI
+
+`ImrQueryCmd`, `ImrStatsCmd`, `ImrShowCmd`, `ImrFlushCmd`, `ImrSetCmd` and
+`ImrZoneCmd` are the **tdns-imr daemon's own in-process REPL commands**, wired
+onto the daemon's `rootCmd` at `cmdv2/imr/shared_cmds.go:12-25`, where
+`Conf.Internal.RecursorCh` / `RRsetCache` are populated.
+
+`v2/cli/imr_cmds.go:528` re-attaches those same `*cobra.Command` values under
+tdns-cli's `ImrCmd`, where `Conf.Internal.*` is always nil:
+
+```
+$ tdns-cli imr query example.com A
+Querying example.com for A records (verbose mode: false)
+No active channel to RecursorEngine. Terminating.
+```
+
+Affected leaves: `imr query`; `imr stats`, `stats auth-transports`,
+`stats auth-servers`; `imr show config`, `show options`; `imr flush common`,
+`flush all`; `imr set linewidth`, `set server transport`.
+(`imr stats transport-stats` is the exception — it goes over `/imr` and works.)
+
+**The fix already exists in-tree.** `addImrLeafCmds(parent, role)`
+(`v2/cli/agent_imr_cmds.go:270-279`) builds API-based equivalents that POST to
+`/imr`, and is called for `agent` and `auth` but never for `imr`. So
+`tdns-cli agent imr query` works while `tdns-cli imr query` does not. Call it
+for `imr` and stop re-attaching the daemon REPL commands.
+
+Note `/imr` *is* registered for `AppTypeImr` (`apirouters.go:72-74`), so the
+server side needs nothing.
+
+### A3. `imr zone list` / `imr zone check` are stubs
+
+`imr zone list` only prints `Listing records for zone: %s`
+(`v2/cli/imr_cmds.go:179`); `imr zone check` prints `[NYI]`
+(`imr_cmds.go:205`). Implement or remove.
+
+### A4. `<role> daemon reload` silently pretends to succeed
+
+`daemon reload` (`v2/cli/daemon_cmds.go:84`) sends command `"reload"` to
+`/command`, but `APIcommand` (`v2/apihandler_funcs.go:276-308`) only handles
+`status`, `stop` and `api`. The request falls to `default:` and the CLI prints
+an empty success line:
+
+```
+$ tdns-cli agent daemon reload
+Reload:  Message:
+```
+
+Nothing reloaded, no error shown. Affects every role. `config reload` already
+does the real work, so the likely resolution is to delete `daemon reload`
+rather than implement it — but that is a user-visible interface change.
+
+---
+
+## B. Commands offered where they make no sense
+
+### B1. `agent keystore dnssec *`
+
+Offered on a daemon that never signs: `SetupZoneSigning` returns early for
+`AppTypeAgent`, and no `ResignerEngine` / `KeyStateWorker` is started. The
+`/keystore` endpoint is registered for the agent and the handler has no
+app-type gate, so the commands "work" — they just manage keys nothing will
+ever use. Consider gating the `dnssec` subtree to auth, or documenting why an
+agent keystore holds DNSSEC keys. (`agent keystore sig0|tsig` are legitimate.)
+
+---
+
+## C. Coverage gaps — the daemon serves it, the CLI does not offer it
+
+| Endpoint | Registered for | Missing CLI |
+|---|---|---|
+| `/imr` | imr (`apirouters.go:72-74`) | see A2 — `addImrLeafCmds(ImrCmd, "imr")` |
+| `/config` | imr (`apirouters.go:66`) | `imr config reload` / `reload-zones` / `status`. `NewImrConfigCmd` wires only `check`+`mwe`, and its comment justifies this with "tdns-imr has no zone/tsig/keystore state" — true, but `APIconfig` serves reload/status regardless of app type. |
+| `/debug` | imr (`apirouters.go:67`) | no `imr debug`; `NewDebugCmd` is wired for auth and agent only |
+| `/catalog` | agent (`apirouters.go:96`, unconditional) | `CatalogCmd` is auth-only (`cmdv2/cli/root.go:93`) |
+| `/delegation` | agent (`apirouters.go:103`) | agent reaches it only via `parentsync delta|sync`; the fuller `DelCmd` (`del status|sync|export`) is auth-only |
+
+---
+
+## D. Adjacent findings (not CLI, found in the same pass)
+
+### D1. `GET /config/paths` is auth-only, probably by accident
+
+`apirouters.go:117` registers it inside the `if Globals.App.Type ==
+AppTypeAuth` block, alongside the `/rollover/*` routes. It is generic
+config-path discovery with nothing rollover-specific about it. Because of
+this, `agent config check` cannot ask the daemon which config file it loaded
+and falls back to the compiled-in default.
+
+This also caused a real bug, fixed in PR #311: `/config/paths` was doubling as
+the liveness probe, so its 404 was read as "daemon is down" and disabled *all*
+running-config correlation for non-auth roles. Liveness is now an API ping and
+path discovery is gated on `roleHasConfigPaths(role)`.
+
+Moving the registration into the auth-or-agent block would let the agent do
+path discovery; `roleHasConfigPaths` is then the single line to update.
+
+### D2. The unknown-config-key warning has false positives
+
+`parseconfig.go:346` warns:
+
+```
+unknown config keys ignored (possible misspellings)
+keys=[keybootstrap delegationsync common server resolver delegationbackends validator]
+```
+
+The detector uses mapstructure's unused-key set, so it flags every block read
+directly through viper rather than decoded into `Config`. Of those seven,
+**five are live**: `delegationsync` (26 viper reads), `common`, `server`,
+`validator` (3 each), and `delegationbackends`
+(`viper.UnmarshalKey`, `v2/delegation_backend.go:63`).
+
+The noise has a real cost: a genuinely dead `multi-provider:` block sat in the
+shipped agent sample config unnoticed, because it looked exactly like the five
+false positives. Suggested: an allowlist of known viper-direct top-level keys,
+so the warning only fires on actual unknowns.
+
+Related: adding a `deprecatedConfigKeys` entry (`parseconfig.go:209`) for
+`multi-provider` would give operators real advice ("moved to tdns-mp; use
+tdns-mpagent") instead of "possible misspellings".
+
+### D3. `resolver:` and `keybootstrap:` look dead everywhere
+
+Both are still present as top-level blocks in
+`cmdv2/agent/tdns-agent.sample.yaml` (lines 59 and 118) and in
+`tdns-mp/cmd/mpagent/tdns-mpagent.sample.yaml`, but no reader was found in
+either repo. The `KeyBootstrap` that does exist is a *zone-level*
+`updatepolicy` field (`v2/structs.go:362`), unrelated to the top-level
+`keybootstrap:` block.
+
+Deliberately **not** removed: "no reader found" is weaker evidence than the
+`multi-provider` case (which was positively confirmed to live in tdns-mp).
+Confirm before deleting.
+
+---
+
+## Suggested sequencing
+
+1. **A1 (`agent parentsync`)** — restores needed agent functionality. Wire
+   struct + route + handler. Independent of everything else.
+2. **A2/A3 (`imr` subtree)** — largest user-visible cleanup; the fix is mostly
+   deletion plus one existing call, so it is cheaper than it looks.
+3. **D1** — one line server-side, plus one line in `roleHasConfigPaths`.
+4. **A4, B1, C** — interface changes; batch them so the CLI surface changes
+   once rather than repeatedly.
+5. **D2** — quality-of-life, but it is what let this class of rot hide.
+
+## Root cause, for whoever does the cleanup
+
+There is no declaration anywhere of *which roles a command is valid for*. A
+factory takes a `role string` and the caller decides where to attach it;
+nothing checks that the daemon behind that role serves the endpoint. Both A1
+and A2 are instances of that. A small per-role capability table — consulted at
+attach time, or asserted in a test that walks the command tree against the
+routes `SetupAPIRouter` registers per app type — would turn this whole class of
+bug into a compile-or-test-time failure instead of a runtime surprise.

--- a/v2/cli/config_agent_cmds.go
+++ b/v2/cli/config_agent_cmds.go
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Agent-specific parts of `tdns-cli agent config check` and the tdns-agent
+ * variant of `tdns-cli agent config mwe`.
+ *
+ * The bulk of `config check` is shared with auth (config_check_cmds.go): the
+ * agent uses the same Config struct, the same required-field validation
+ * (ValidateConfig treats AppTypeAgent exactly like AppTypeAuth), the same
+ * dnsengine/apiserver/zone/TSIG machinery, and the same mgmt-API endpoints
+ * minus GET /config/paths. What lives here is only what genuinely differs:
+ * config this binary silently ignores, and options the agent rejects.
+ */
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/johanix/tdns/v2"
+	"github.com/spf13/viper"
+)
+
+// ---------------------------------------------------------------------------
+// Agent-specific static checks
+// ---------------------------------------------------------------------------
+
+// checkAgentSpecifics reports the ways a tdns-agent config differs from the
+// auth config it otherwise shares a schema with. Each check predicts a concrete
+// startup behaviour: a block this binary cannot parse, a subsystem the
+// required-field validator does not cover, or an option the agent refuses.
+func checkAgentSpecifics(cfg *tdns.Config, v *viper.Viper, rep *ccReport) {
+	checkAgentInertConfig(cfg, v, rep)
+	checkAgentImrEngine(cfg, v, rep)
+	checkAgentZoneOptions(cfg, v, rep)
+}
+
+// checkAgentInertConfig flags config blocks that a standalone tdns-agent parses
+// into nothing. These are the highest-surprise findings: the YAML is well
+// formed and the daemon starts, but the block has no effect whatsoever.
+func checkAgentInertConfig(cfg *tdns.Config, v *viper.Viper, rep *ccReport) {
+	const g = "Agent-specific"
+
+	// multi-provider: has no field in tdns.Config in this repo — the struct is
+	// owned by tdns-mp. A standalone tdns-agent drops the whole subtree into
+	// mapstructure's Unused set, where it surfaces only as a generic "unknown
+	// config keys ignored (possible misspellings)" warning in the log.
+	if v.Get("multi-provider") != nil {
+		rep.warn(g, "multi-provider",
+			"a multi-provider: block is present, but standalone tdns-agent cannot parse it — the entire block is ignored",
+			"remove it, or run tdns-mpagent (tdns-mp) if you need the multi-provider role")
+	}
+
+	// The agent never signs: SetupZoneSigning returns early for AppTypeAgent
+	// and no ResignerEngine/KeyStateWorker is started. A dnssec: block is still
+	// parsed (and a malformed one is startup-fatal), so this is INFO, not WARN:
+	// the policies are validated above, they just never sign anything.
+	if len(cfg.Dnssec.Policies) > 0 {
+		rep.info(g, "dnssec",
+			fmt.Sprintf("%d DNSSEC policy definition(s) present; tdns-agent never signs, so these only gate zone dnssecpolicy: references",
+				len(cfg.Dnssec.Policies)))
+	}
+}
+
+// checkAgentImrEngine sanity-checks imrengine:. The agent starts an in-process
+// IMR, but ValidateConfig only enforces imrengine for AppTypeImr — so for the
+// agent this block is entirely unvalidated and a bad one fails at engine start.
+func checkAgentImrEngine(cfg *tdns.Config, v *viper.Viper, rep *ccReport) {
+	const g = "Agent-specific"
+
+	if v.Get("imrengine") == nil {
+		rep.info(g, "imrengine", "no imrengine: block; the agent runs with IMR defaults")
+		return
+	}
+	// Tri-state: nil or true means active, matching the daemon
+	// (imrActive := conf.Imr.Active == nil || *conf.Imr.Active).
+	if !(cfg.Imr.Active == nil || *cfg.Imr.Active) {
+		rep.info(g, "imrengine", "imrengine.active is false; the in-process resolver is disabled")
+		return
+	}
+	if len(cfg.Imr.Addresses) == 0 {
+		rep.warn(g, "imrengine",
+			"imrengine is active but has no addresses: — the resolver listener will not be started",
+			"set imrengine.addresses (e.g. [ 127.0.0.1:5453, '[::1]:5453' ]) or set active: false")
+	}
+	if rh := v.GetString("imrengine.root-hints"); rh != "" {
+		if _, err := os.Stat(rh); err != nil {
+			rep.fail(g, "imrengine",
+				fmt.Sprintf("imrengine.root-hints %s not found: %v", rh, err),
+				"create the file or fix the path")
+			return
+		}
+	}
+	if len(cfg.Imr.Addresses) > 0 {
+		rep.pass(g, "imrengine",
+			fmt.Sprintf("in-process resolver active on %d address(es)", len(cfg.Imr.Addresses)))
+	}
+}
+
+// checkAgentZoneOptions checks the two zone options whose validity depends on
+// the app being an agent. Both put the zone in ConfigError state at startup
+// when misapplied, so both are predictable statically.
+func checkAgentZoneOptions(cfg *tdns.Config, v *viper.Viper, rep *ccReport) {
+	const g = "Agent-specific"
+
+	templates := map[string]tdns.ZoneConf{}
+	for _, t := range cfg.Templates {
+		templates[lc(t.Name)] = t
+	}
+	childSchemes := v.GetStringSlice("delegationsync.child.schemes")
+
+	for i := range cfg.Zones {
+		eff := effectiveZone(cfg.Zones[i], templates)
+		zname := cfg.Zones[i].Name
+		if zname == "" {
+			continue
+		}
+		opts := map[string]bool{}
+		for _, o := range eff.OptionsStrs {
+			opts[lc(o)] = true
+		}
+
+		// delegation-sync-proxy is valid ONLY on an agent secondary.
+		if opts["delegation-sync-proxy"] && lc(eff.Type) != "secondary" {
+			rep.fail(g, zname,
+				fmt.Sprintf("delegation-sync-proxy requires a secondary zone (this zone is %q) — it will be quarantined at startup",
+					eff.Type),
+				"set type: secondary, or drop the delegation-sync-proxy option")
+		}
+
+		// On an agent, delegation-sync-child only engages when the zone also
+		// carries multi-provider; otherwise the setup block is skipped and the
+		// option is silently inert.
+		if opts["delegation-sync-child"] {
+			switch {
+			case !opts["multi-provider"]:
+				rep.warn(g, zname,
+					"delegation-sync-child without multi-provider is inert on tdns-agent — child delegation sync will not run",
+					"add the multi-provider option, or host the zone on tdns-auth where delegation-sync-child works standalone")
+			case len(childSchemes) == 0:
+				rep.fail(g, zname,
+					"delegation-sync-child is enabled but delegationsync.child.schemes is empty — the zone will be quarantined",
+					"set delegationsync.child.schemes (e.g. [ notify, update ])")
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Agent MWE
+// ---------------------------------------------------------------------------
+
+// runAgentConfigMwe generates a minimal working tdns-agent tree. It differs
+// from the auth MWE in what it can legally contain: tdns-agent refuses primary
+// zones and never signs, so there are no zone files and no dnssec: block to
+// generate. The result is a zone-less agent that starts clean; two secondary
+// templates and a commented-out secondary zone show how to add one.
+func runAgentConfigMwe(role, dir string) {
+	dir = filepath.Clean(dir)
+	cfgPath := filepath.Join(dir, "tdns-"+role+".yaml")
+	if _, err := os.Stat(cfgPath); err == nil {
+		cfgPath += ".mwe"
+		fmt.Printf("Config %s already exists; writing MWE to %s instead.\n",
+			filepath.Join(dir, "tdns-"+role+".yaml"), cfgPath)
+	}
+
+	certsDir := filepath.Join(dir, "certs")
+	for _, d := range []string{dir, certsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			cliFatalf("could not create directory %s: %v", d, err)
+		}
+	}
+
+	certFile := filepath.Join(certsDir, "localhost.crt")
+	keyFile := filepath.Join(certsDir, "localhost.key")
+	certCreated, err := ensureSelfSignedCert(certFile, keyFile)
+	if err != nil {
+		cliFatalf("could not generate certificate: %v", err)
+	}
+
+	apiKey, err := randomAPIKey()
+	if err != nil {
+		cliFatalf("could not generate api key: %v", err)
+	}
+
+	apiPort := "8987"
+	dnsPort := "5356"
+	content := renderAgentMweConfig(role, dir, certFile, keyFile, apiKey, apiPort, dnsPort)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		cliFatalf("could not write config %s: %v", cfgPath, err)
+	}
+
+	fmt.Printf("\nWrote MWE config:  %s\n", cfgPath)
+	if certCreated {
+		fmt.Printf("Generated cert:    %s\n", certFile)
+		fmt.Printf("Generated key:     %s\n", keyFile)
+	} else {
+		fmt.Printf("Reused cert/key:   %s , %s\n", certFile, keyFile)
+	}
+
+	fmt.Printf("\nTo let `tdns-cli %s ...` reach this server, add to your tdns-cli.yaml:\n\n", role)
+	fmt.Printf("  apiservers:\n")
+	fmt.Printf("     - name:       tdns-%s\n", role)
+	fmt.Printf("       baseurl:    https://127.0.0.1:%s/api/v1\n", apiPort)
+	fmt.Printf("       apikey:     %s\n", apiKey)
+	fmt.Printf("       authmethod: X-API-Key\n")
+	fmt.Printf("\nNext steps:\n")
+	fmt.Printf("  tdns-%s --config %s        # start the server\n", role, cfgPath)
+	fmt.Printf("  tdns-cli %s config check --serverconfig %s   # validate\n", role, cfgPath)
+}
+
+func renderAgentMweConfig(role, dir, certFile, keyFile, apiKey, apiPort, dnsPort string) string {
+	r := strings.NewReplacer(
+		"{{ROLE}}", role,
+		"{{DIR}}", dir,
+		"{{CERT}}", certFile,
+		"{{KEY}}", keyFile,
+		"{{APIKEY}}", apiKey,
+		"{{APIPORT}}", apiPort,
+		"{{DNSPORT}}", dnsPort,
+	)
+	return r.Replace(agentMweConfigTemplate)
+}
+
+// agentMweConfigTemplate is the single-file agent MWE. Placeholders in {{...}}
+// form are substituted by renderAgentMweConfig (the template contains a literal
+// %s zonefile pattern in a comment, so fmt verbs are unusable here).
+const agentMweConfigTemplate = `# Minimal Working Example — tdns-{{ROLE}}
+#
+# Generated by ` + "`tdns-cli {{ROLE}} config mwe`" + `. Self-contained: one file plus a
+# self-signed cert. Validate it any time with:
+#   tdns-cli {{ROLE}} config check --serverconfig <this file>
+#
+# NOTE: tdns-agent is a SECONDARY-only server. It refuses primary zones
+# (they are quarantined at startup) and it never signs — online-signing and
+# inline-signing are ignored. Host primary and/or signed zones on tdns-auth,
+# or use tdns-mpagent (tdns-mp) for multi-provider roles.
+
+service:
+   name:  TDNS-AGENT
+
+dnsengine:
+   # Listen on IPv4 and IPv6 localhost. Port {{DNSPORT}} is used so the server
+   # runs unprivileged; use 53 for a real deployment (needs root/capabilities).
+   addresses:   [ 127.0.0.1:{{DNSPORT}}, '[::1]:{{DNSPORT}}' ]
+   # Add more listen addresses by uncommenting/extending, e.g.:
+   #   addresses: [ 127.0.0.1:{{DNSPORT}}, '[::1]:{{DNSPORT}}', 192.0.2.53:53, '[2001:db8::53]:53' ]
+   transports:  [ do53 ]
+   # For encrypted transports, add them here and the cert/key are already set:
+   #   transports: [ do53, dot, doh, doq ]
+   certfile:  {{CERT}}
+   keyfile:   {{KEY}}
+
+apiserver:
+   addresses:  [ 127.0.0.1:{{APIPORT}} ]
+   apikey:     {{APIKEY}}
+   certfile:   {{CERT}}
+   keyfile:    {{KEY}}
+   usetls:     true
+
+db:
+   file:  {{DIR}}/tdns-{{ROLE}}.db
+
+# The log: block must live in THIS file. Logging is set up from the main
+# config file before include: is resolved, so a log: block in an included
+# file is not found and startup fails.
+log:
+   file:   {{DIR}}/tdns-{{ROLE}}.log
+   level:  info
+
+# The agent runs an in-process iterative resolver, used e.g. to look up peer
+# records. Disable it with active: false if the host has a resolver already.
+imrengine:
+   active:      true
+   addresses:   [ 127.0.0.1:5453, '[::1]:5453' ]
+   transports:  [ do53 ]
+   # In a lab without a complete DNSSEC chain, relax validation:
+   #   require_dnssec_validation: false
+
+# Zone templates. Both are SECONDARY templates — see the note at the top.
+# The commented-out zone below uses the first one.
+templates:
+   - name:   basic-secondary
+     type:   secondary
+     store:  map
+
+   - name:   proxy-secondary
+     type:   secondary
+     store:  map
+     # delegation-sync-proxy: act on behalf of a DSYNC-unaware primary
+     # (BIND/Knot) by watching transfers for CDS/CSYNC changes. Valid only
+     # on an agent secondary.
+     options: [ delegation-sync-proxy ]
+
+# No zones are configured, so this agent starts clean. To serve a zone, point
+# primaries: at your real primary and uncomment. A template may instead carry
+# a zonefile pattern like  zonefile: {{DIR}}/zones/%szone  to derive the path.
+zones: []
+   # - name:      secondary.example.
+   #   template:  basic-secondary
+   #   zonefile:  {{DIR}}/zones/secondary.example.zone
+   #   primaries:
+   #      - { addr: "192.0.2.1:53", key: NOKEY }
+   #   allow-notify:
+   #      - { prefix: "192.0.2.1", key: NOKEY }
+`

--- a/v2/cli/config_agent_test.go
+++ b/v2/cli/config_agent_test.go
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Tests for the agent-specific config checks and the role plumbing shared by
+ * the auth/agent `config check`.
+ */
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/johanix/tdns/v2"
+	"github.com/spf13/viper"
+)
+
+// levelsFor returns the levels recorded under group for the given check name.
+func levelsFor(rep *ccReport, group, check string) []ccLevel {
+	var out []ccLevel
+	for _, r := range rep.byGroup[group] {
+		if r.check == check {
+			out = append(out, r.level)
+		}
+	}
+	return out
+}
+
+func hasLevel(rep *ccReport, group, check string, want ccLevel) bool {
+	for _, l := range levelsFor(rep, group, check) {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRolePlumbing(t *testing.T) {
+	tests := []struct {
+		role        string
+		wantCfg     string
+		wantType    tdns.AppType
+		wantHasPath bool
+	}{
+		{"auth", tdns.DefaultAuthCfgFile, tdns.AppTypeAuth, true},
+		{"agent", tdns.DefaultAgentCfgFile, tdns.AppTypeAgent, false},
+		{"imr", tdns.DefaultImrCfgFile, tdns.AppTypeImr, false},
+		// Unknown roles fall back to auth rather than producing an empty path.
+		{"nosuchrole", tdns.DefaultAuthCfgFile, tdns.AppTypeAuth, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.role, func(t *testing.T) {
+			if got := defaultCfgFileForRole(tc.role); got != tc.wantCfg {
+				t.Errorf("defaultCfgFileForRole(%q) = %q, want %q", tc.role, got, tc.wantCfg)
+			}
+			if got := appTypeForRole(tc.role); got != tc.wantType {
+				t.Errorf("appTypeForRole(%q) = %v, want %v", tc.role, got, tc.wantType)
+			}
+			if got := roleHasConfigPaths(tc.role); got != tc.wantHasPath {
+				t.Errorf("roleHasConfigPaths(%q) = %v, want %v", tc.role, got, tc.wantHasPath)
+			}
+		})
+	}
+}
+
+// A standalone tdns-agent cannot parse multi-provider:, so its presence must be
+// reported rather than silently ignored.
+func TestCheckAgentInertConfig_MultiProvider(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		v := viper.New()
+		v.Set("multi-provider", map[string]interface{}{"role": "agent"})
+		rep := newCCReport()
+		checkAgentInertConfig(&tdns.Config{}, v, rep)
+		if !hasLevel(rep, "Agent-specific", "multi-provider", ccWARN) {
+			t.Fatalf("expected a WARN for an inert multi-provider block, got %+v", rep.byGroup["Agent-specific"])
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		rep := newCCReport()
+		checkAgentInertConfig(&tdns.Config{}, viper.New(), rep)
+		if len(levelsFor(rep, "Agent-specific", "multi-provider")) != 0 {
+			t.Fatalf("expected no multi-provider finding, got %+v", rep.byGroup["Agent-specific"])
+		}
+	})
+}
+
+// The agent parses dnssec: but never signs; that is INFO, not a warning.
+func TestCheckAgentInertConfig_DnssecIsInfo(t *testing.T) {
+	cfg := &tdns.Config{}
+	cfg.Dnssec.Policies = map[string]tdns.DnssecPolicyConf{"default": {}}
+	rep := newCCReport()
+	checkAgentInertConfig(cfg, viper.New(), rep)
+	if !hasLevel(rep, "Agent-specific", "dnssec", ccINFO) {
+		t.Fatalf("expected INFO for dnssec policies on agent, got %+v", rep.byGroup["Agent-specific"])
+	}
+	if fails, warns := rep.counts(); fails != 0 || warns != 0 {
+		t.Fatalf("dnssec policies on an agent must not FAIL or WARN, got %d/%d", fails, warns)
+	}
+}
+
+func TestCheckAgentZoneOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		zone       tdns.ZoneConf
+		schemes    []string
+		wantLevel  ccLevel
+		wantNoFind bool
+	}{
+		{
+			name:       "proxy on secondary is fine",
+			zone:       tdns.ZoneConf{Name: "ok.example.", Type: "secondary", OptionsStrs: []string{"delegation-sync-proxy"}},
+			wantNoFind: true,
+		},
+		{
+			name:      "proxy on primary is quarantined",
+			zone:      tdns.ZoneConf{Name: "bad.example.", Type: "primary", OptionsStrs: []string{"delegation-sync-proxy"}},
+			wantLevel: ccFAIL,
+		},
+		{
+			// On the agent the delegation-sync-child setup block only runs when
+			// the zone also carries multi-provider; without it the option is
+			// silently inert, which is a warning rather than a failure.
+			name:      "child without multi-provider is inert",
+			zone:      tdns.ZoneConf{Name: "inert.example.", Type: "secondary", OptionsStrs: []string{"delegation-sync-child"}},
+			schemes:   []string{"notify"},
+			wantLevel: ccWARN,
+		},
+		{
+			name:      "child with multi-provider but no schemes is quarantined",
+			zone:      tdns.ZoneConf{Name: "noschemes.example.", Type: "secondary", OptionsStrs: []string{"delegation-sync-child", "multi-provider"}},
+			schemes:   nil,
+			wantLevel: ccFAIL,
+		},
+		{
+			name:       "child with multi-provider and schemes is fine",
+			zone:       tdns.ZoneConf{Name: "good.example.", Type: "secondary", OptionsStrs: []string{"delegation-sync-child", "multi-provider"}},
+			schemes:    []string{"notify", "update"},
+			wantNoFind: true,
+		},
+		{
+			name:       "unrelated options are ignored",
+			zone:       tdns.ZoneConf{Name: "plain.example.", Type: "secondary", OptionsStrs: []string{"fold-case"}},
+			wantNoFind: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			if tc.schemes != nil {
+				v.Set("delegationsync.child.schemes", tc.schemes)
+			}
+			cfg := &tdns.Config{Zones: []tdns.ZoneConf{tc.zone}}
+			rep := newCCReport()
+			checkAgentZoneOptions(cfg, v, rep)
+
+			got := levelsFor(rep, "Agent-specific", tc.zone.Name)
+			if tc.wantNoFind {
+				if len(got) != 0 {
+					t.Fatalf("expected no finding, got %+v", rep.byGroup["Agent-specific"])
+				}
+				return
+			}
+			if len(got) != 1 || got[0] != tc.wantLevel {
+				t.Fatalf("expected one %v, got %v (%+v)", tc.wantLevel.label(), got, rep.byGroup["Agent-specific"])
+			}
+		})
+	}
+}
+
+// A zone with no name must not produce a phantom finding.
+func TestCheckAgentZoneOptions_SkipsUnnamedZone(t *testing.T) {
+	cfg := &tdns.Config{Zones: []tdns.ZoneConf{{Type: "primary", OptionsStrs: []string{"delegation-sync-proxy"}}}}
+	rep := newCCReport()
+	checkAgentZoneOptions(cfg, viper.New(), rep)
+	if fails, warns := rep.counts(); fails != 0 || warns != 0 {
+		t.Fatalf("unnamed zone should be skipped, got %d FAIL / %d WARN", fails, warns)
+	}
+}
+
+// SetupLogging reads the main config file before include: is resolved, so a
+// log: block reachable only through an include is a startup failure even though
+// the merged view looks complete.
+func TestCheckLogSection(t *testing.T) {
+	write := func(t *testing.T, dir, name, content string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("log in main file passes", func(t *testing.T) {
+		dir := t.TempDir()
+		main := write(t, dir, "tdns-agent.yaml", "log:\n   file: /tmp/x.log\n")
+		v := viper.New()
+		v.SetConfigFile(main)
+		if err := v.ReadInConfig(); err != nil {
+			t.Fatal(err)
+		}
+		rep := newCCReport()
+		checkLogSection(v, main, rep)
+		if fails, _ := rep.counts(); fails != 0 {
+			t.Fatalf("top-level log: must not FAIL, got %+v", rep.byGroup["Config file"])
+		}
+	})
+
+	t.Run("log only in include fails", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, dir, "logging.yaml", "log:\n   file: /tmp/x.log\n")
+		main := write(t, dir, "tdns-agent.yaml", "include:\n  - logging.yaml\nservice:\n   name: TDNS-AGENT\n")
+
+		// Merged view (what loadConfigViper produces) does see log.file.
+		v := viper.New()
+		v.SetConfigFile(main)
+		if err := v.ReadInConfig(); err != nil {
+			t.Fatal(err)
+		}
+		v.SetConfigFile(filepath.Join(dir, "logging.yaml"))
+		if err := v.MergeInConfig(); err != nil {
+			t.Fatal(err)
+		}
+		if v.GetString("log.file") == "" {
+			t.Fatal("test setup: merged view should see log.file")
+		}
+
+		rep := newCCReport()
+		checkLogSection(v, main, rep)
+		if !hasLevel(rep, "Config file", "log", ccFAIL) {
+			t.Fatalf("expected FAIL for include-only log:, got %+v", rep.byGroup["Config file"])
+		}
+	})
+
+	t.Run("no log anywhere is left to the required-field check", func(t *testing.T) {
+		dir := t.TempDir()
+		main := write(t, dir, "tdns-agent.yaml", "service:\n   name: TDNS-AGENT\n")
+		v := viper.New()
+		v.SetConfigFile(main)
+		if err := v.ReadInConfig(); err != nil {
+			t.Fatal(err)
+		}
+		rep := newCCReport()
+		checkLogSection(v, main, rep)
+		if fails, warns := rep.counts(); fails != 0 || warns != 0 {
+			t.Fatalf("missing log: is the required-field check's job, got %d/%d", fails, warns)
+		}
+	})
+}

--- a/v2/cli/config_check_cmds.go
+++ b/v2/cli/config_check_cmds.go
@@ -154,6 +154,15 @@ func newConfigCheckCmd(role string) *cobra.Command {
 		serverConfig string
 		offline      bool
 	)
+	// Only tdns-auth serves GET /config/paths, so only there can the target
+	// config file be discovered from the running daemon.
+	resolution := "  1. an explicit path (positional arg or --serverconfig)\n" +
+		"  2. otherwise the compiled-in default (/etc/tdns/tdns-" + role + ".yaml)"
+	if roleHasConfigPaths(role) {
+		resolution = "  1. an explicit path (positional arg or --serverconfig)\n" +
+			"  2. otherwise, online, the path the daemon reports via GET /config/paths\n" +
+			"  3. otherwise the compiled-in default (/etc/tdns/tdns-" + role + ".yaml)"
+	}
 	c := &cobra.Command{
 		Use:   "check [config-file]",
 		Short: "Validate the tdns-" + role + " config and correlate it with the running daemon",
@@ -162,9 +171,7 @@ consistency, and (unless --offline) correlate it against the running daemon to
 report drift between the file on disk and what the server actually loaded.
 
 Target config resolution:
-  1. an explicit path (positional arg or --serverconfig)
-  2. otherwise, online, the path the daemon reports via GET /config/paths
-  3. otherwise the compiled-in default (/etc/tdns/tdns-` + role + `.yaml)
+` + resolution + `
 
 Exit status is non-zero if any check FAILs (WARNs do not fail the run).`,
 		Args: cobra.MaximumNArgs(1),
@@ -178,6 +185,61 @@ Exit status is non-zero if any check FAILs (WARNs do not fail the run).`,
 	c.Flags().StringVar(&serverConfig, "serverconfig", "", "path to the tdns-"+role+" config file to check (default: ask the daemon, else the compiled-in default)")
 	c.Flags().BoolVar(&offline, "offline", false, "do not contact the daemon; run static checks only")
 	return c
+}
+
+// ---------------------------------------------------------------------------
+// Role plumbing
+//
+// `config check` is shared by the auth and agent roles (imr has its own
+// implementation in config_imr_cmds.go). The three things that genuinely differ
+// per role are collected here rather than sprinkled through the checks.
+// ---------------------------------------------------------------------------
+
+// defaultCfgFileForRole returns the compiled-in default config path used when
+// neither an explicit path nor daemon path-discovery yields one.
+func defaultCfgFileForRole(role string) string {
+	switch role {
+	case "agent":
+		return tdns.DefaultAgentCfgFile
+	case "imr":
+		return tdns.DefaultImrCfgFile
+	default:
+		return tdns.DefaultAuthCfgFile
+	}
+}
+
+// appTypeForRole maps a CLI role to the tdns app type, which selects the
+// sections tdns.ValidateConfig enforces.
+func appTypeForRole(role string) tdns.AppType {
+	switch role {
+	case "agent":
+		return tdns.AppTypeAgent
+	case "imr":
+		return tdns.AppTypeImr
+	default:
+		return tdns.AppTypeAuth
+	}
+}
+
+// roleHasConfigPaths reports whether the daemon serves GET /config/paths.
+// Only tdns-auth registers it (see SetupAPIRouter) — so for every other role
+// the target config file cannot be discovered from the running daemon, and
+// crucially a 404 there must NOT be read as "the daemon is down".
+func roleHasConfigPaths(role string) bool { return role == "auth" }
+
+// daemonReachable probes the daemon with an API ping. This is deliberately
+// separate from fetchDaemonPaths: /config/paths is auth-only, so using it as
+// the liveness probe would silently disable ALL running-config correlation for
+// every other role, even against a perfectly healthy daemon.
+func daemonReachable(role string) bool {
+	api, err := GetApiClient(role, false)
+	if err != nil {
+		return false
+	}
+	if _, err := api.SendPing(0, false); err != nil {
+		return false
+	}
+	return true
 }
 
 // ---------------------------------------------------------------------------
@@ -196,13 +258,18 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 	online := !offline
 	var daemonCfgPath, daemonDBPath string
 	if online {
-		if p, db, ok := fetchDaemonPaths(role); ok {
-			daemonCfgPath, daemonDBPath = p, db
-		} else {
+		// Liveness is probed with a ping, NOT with /config/paths: that route is
+		// auth-only, so treating its absence as "daemon down" would disable all
+		// correlation for a healthy agent.
+		if !daemonReachable(role) {
 			online = false
 			rep.warn("Daemon", "reachability",
 				fmt.Sprintf("could not reach the %s daemon; running static checks only", role),
 				"start the daemon (or pass --offline) to enable running-config correlation")
+		} else if roleHasConfigPaths(role) {
+			if p, db, ok := fetchDaemonPaths(role); ok {
+				daemonCfgPath, daemonDBPath = p, db
+			}
 		}
 	}
 
@@ -213,7 +280,7 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 	case daemonCfgPath != "":
 		cfgPath = daemonCfgPath
 	default:
-		cfgPath = tdns.DefaultAuthCfgFile
+		cfgPath = defaultCfgFileForRole(role)
 	}
 	cfgPath = absClean(cfgPath)
 
@@ -237,10 +304,11 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 		return
 	}
 	rep.pass("Config file", "load", "config file (and includes) parsed as YAML")
+	checkLogSection(v, cfgPath, rep)
 
 	// Required-field validation via the exported tdns validator (drives the
 	// `validate:"required"` struct tags AND the cert/key pair validation).
-	checkRequiredFields(v, cfgPath, rep, tdns.AppTypeAuth)
+	checkRequiredFields(v, cfgPath, rep, appTypeForRole(role))
 
 	// Decode into a typed Config for the structural checks. Best-effort: the
 	// legacy bare-string primary/ACL decode hooks live in the tdns package and
@@ -254,9 +322,15 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 
 	checkDnsEngine(&cfg, rep)
 	checkApiServer(&cfg, cfgPath, rep)
-	checkDnssecPolicies(v, rep)
+	checkDnssecPolicies(v, rep, role)
 	checkZones(&cfg, rep, online, role)
 	checkApiServerCorrelation(role, &cfg, rep)
+
+	// Agent-only: config that this binary silently ignores, and options the
+	// agent rejects at startup. See config_agent_cmds.go.
+	if role == "agent" {
+		checkAgentSpecifics(&cfg, v, rep)
+	}
 
 	// Running-config correlation.
 	if online {
@@ -265,8 +339,11 @@ func runConfigCheck(role, explicitPath string, offline bool) {
 
 	// Signed-zone policy-algorithm vs active-key dry-run (predicts a
 	// would-break-on-reload algorithm change). Handles the offline info-skip
-	// itself.
-	checkPolicyAlgVsActiveKeys(&cfg, v, rep, online, role)
+	// itself. Skipped for the agent, which never signs (SetupZoneSigning
+	// returns early for AppTypeAgent), so no policy can break a reload there.
+	if role != "agent" {
+		checkPolicyAlgVsActiveKeys(&cfg, v, rep, online, role)
+	}
 
 	finishCheckconf(rep)
 }
@@ -325,6 +402,31 @@ func loadConfigViper(path string, rep *ccReport) (*viper.Viper, error) {
 // ---------------------------------------------------------------------------
 // Static checks
 // ---------------------------------------------------------------------------
+
+// checkLogSection verifies that log: is reachable the way the daemon reads it.
+// SetupLogging parses the MAIN config file directly and runs BEFORE include:
+// resolution, so a log: block that lives only in an included file satisfies
+// every merged-view check here and still aborts startup. Applies to every role.
+func checkLogSection(v *viper.Viper, cfgPath string, rep *ccReport) {
+	// Nothing to add if the merged view has no log.file at all: the
+	// required-field validator already FAILs on that.
+	if v.GetString("log.file") == "" {
+		return
+	}
+
+	mainOnly := viper.New()
+	mainOnly.SetConfigFile(cfgPath)
+	if err := mainOnly.ReadInConfig(); err != nil {
+		// The main file already parsed once in loadConfigViper; a failure here
+		// is not worth a second complaint.
+		return
+	}
+	if mainOnly.GetString("log.file") == "" {
+		rep.fail("Config file", "log",
+			"log: is only set in an included file — logging is set up from the main config file, before include: is resolved, so the daemon will refuse to start",
+			fmt.Sprintf("move the log: block into %s", cfgPath))
+	}
+}
 
 // checkRequiredFields runs the exported required-field validator for the given
 // app type (which selects the sections tdns.ValidateConfig checks: auth →
@@ -418,10 +520,16 @@ func checkApiServer(cfg *tdns.Config, cfgPath string, rep *ccReport) {
 // does (template expansion + split-algorithm gating + role-capability + key
 // lifetimes) by handing the merged dnssec: subtree to the exported
 // tdns.ValidateDnssecPoliciesFromFile.
-func checkDnssecPolicies(v *viper.Viper, rep *ccReport) {
+func checkDnssecPolicies(v *viper.Viper, rep *ccReport, role string) {
 	const g = "DNSSEC policies"
 	sub := v.Get("dnssec")
 	if sub == nil {
+		if role == "agent" {
+			// The agent never signs, so a missing dnssec: block is simply
+			// normal rather than a fallback-to-default situation.
+			rep.info(g, "policies", "no dnssec: block (tdns-agent never signs)")
+			return
+		}
 		rep.info(g, "policies", "no dnssec: block; zones needing signing fall back to the built-in default policy")
 		return
 	}
@@ -537,16 +645,36 @@ func checkZones(cfg *tdns.Config, rep *ccReport, online bool, role string) {
 				"define it under multisigner: or fix the name")
 		}
 
-		// Signing option requires a policy.
-		if hasSigningOption(eff.OptionsStrs) && lc(eff.DnssecPolicy) == "" {
-			rep.fail(g, zname, "online-signing/inline-signing set but no dnssecpolicy — the zone will be quarantined",
-				"set dnssecpolicy: on the zone or its template")
+		// Signing option requires a policy — except on the agent, which never
+		// signs: it rejects the option outright at parse time rather than
+		// quarantining the zone, so the missing policy is not the problem.
+		if hasSigningOption(eff.OptionsStrs) {
+			switch {
+			case role == "agent":
+				rep.warn(g, zname, "online-signing/inline-signing is ignored on tdns-agent — the agent never signs",
+					"drop the option, or host the zone on tdns-auth if it needs signing")
+			case lc(eff.DnssecPolicy) == "":
+				rep.fail(g, zname, "online-signing/inline-signing set but no dnssecpolicy — the zone will be quarantined",
+					"set dnssecpolicy: on the zone or its template")
+			}
 		}
 
 		switch lc(eff.Type) {
-		case "primary", "":
-			if lc(eff.Type) == "" {
-				rep.warn(g, zname, "no zone type (and none inherited from a template)", "set type: primary or secondary")
+		case "primary":
+			// tdns-agent refuses primary zones outright (parseconfig.go): the
+			// zone is put in ConfigError state at startup, so predict it here.
+			if role == "agent" {
+				rep.fail(g, zname, "tdns-agent does not serve primary zones — this zone will be quarantined at startup",
+					"make it a secondary, or host it on tdns-auth (or tdns-mpagent for multi-provider roles)")
+				continue
+			}
+			checkPrimaryZone(rep, g, zname, eff)
+		case "":
+			rep.warn(g, zname, "no zone type (and none inherited from a template)", "set type: primary or secondary")
+			if role == "agent" {
+				// Don't fall through to the primary-zone checks on the agent;
+				// an untyped agent zone is never a primary.
+				continue
 			}
 			checkPrimaryZone(rep, g, zname, eff)
 		case "secondary":

--- a/v2/cli/config_check_cmds.go
+++ b/v2/cli/config_check_cmds.go
@@ -1,8 +1,10 @@
 /*
  * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
  *
- * `tdns-cli auth config check` — validate a tdns-auth configuration file and
- * correlate it against the running daemon.
+ * `tdns-cli <role> config check` — validate a tdns-auth or tdns-agent
+ * configuration file and correlate it against the running daemon. The
+ * agent-specific checks live in config_agent_cmds.go; tdns-imr has its own
+ * implementation in config_imr_cmds.go.
  *
  * The command is deliberately CLI-side and self-contained: it re-reads the
  * YAML the same way the daemon's loader does (main file + single-level
@@ -147,8 +149,9 @@ func (r *ccReport) render(verbose bool) {
 // Command
 // ---------------------------------------------------------------------------
 
-// newConfigCheckCmd builds the `config check` command for the given role. Only
-// wired for "auth" today; the role parameter keeps the door open for imr/agent.
+// newConfigCheckCmd builds the `config check` command for the given role.
+// Wired for "auth" and "agent" (via NewConfigCmd); "imr" has its own
+// implementation in config_imr_cmds.go.
 func newConfigCheckCmd(role string) *cobra.Command {
 	var (
 		serverConfig string

--- a/v2/cli/config_cmds.go
+++ b/v2/cli/config_cmds.go
@@ -26,7 +26,7 @@ func NewConfigCmd(role string) *cobra.Command {
 
 	reload := &cobra.Command{
 		Use:   "reload",
-		Short: "Send config reload command to tdns-auth",
+		Short: "Send config reload command to tdns-" + role,
 		Run: func(cmd *cobra.Command, args []string) {
 			runConfigCmd(role, "reload", false)
 		},
@@ -34,7 +34,7 @@ func NewConfigCmd(role string) *cobra.Command {
 
 	reloadZones := &cobra.Command{
 		Use:   "reload-zones",
-		Short: "Send reload-zones command to tdns-auth",
+		Short: "Send reload-zones command to tdns-" + role,
 		Run: func(cmd *cobra.Command, args []string) {
 			runConfigCmd(role, "reload-zones", false)
 		},
@@ -56,7 +56,7 @@ overwrite all conflicts, or --interactive to prompt per conflict.`,
 
 	status := &cobra.Command{
 		Use:   "status",
-		Short: "Send config status command to tdns-auth",
+		Short: "Send config status command to tdns-" + role,
 		Run: func(cmd *cobra.Command, args []string) {
 			runConfigCmd(role, "status", true)
 		},
@@ -251,7 +251,9 @@ func SendConfigCommand(api *tdns.ApiClient, data tdns.ConfigPost) (tdns.ConfigRe
 	}
 
 	if cr.Error {
-		return cr, fmt.Errorf("error from tdns-auth: %s", cr.ErrorMsg)
+		// Generic: this helper is shared by every role (auth/agent/imr), so it
+		// must not name a specific daemon.
+		return cr, fmt.Errorf("error from the daemon: %s", cr.ErrorMsg)
 	}
 
 	return cr, nil

--- a/v2/cli/config_imr_cmds.go
+++ b/v2/cli/config_imr_cmds.go
@@ -115,6 +115,7 @@ func runImrConfigCheck(explicitPath string, offline bool) {
 		return
 	}
 	rep.pass("Config file", "load", "config file (and includes) parsed as YAML")
+	checkLogSection(v, cfgPath, rep)
 
 	checkRequiredFields(v, cfgPath, rep, tdns.AppTypeImr)
 

--- a/v2/cli/config_mwe_cmds.go
+++ b/v2/cli/config_mwe_cmds.go
@@ -29,9 +29,27 @@ import (
 )
 
 // newConfigMweCmd builds the `config mwe` subcommand for the given role.
-// Only tdns-auth is supported today.
+// auth and agent generate different trees — see runConfigMwe /
+// runAgentConfigMwe — because tdns-agent serves no primary zones and never
+// signs, so it has no zone files or dnssec: block to generate.
 func newConfigMweCmd(role string) *cobra.Command {
 	var dir string
+
+	generates := `  - a self-signed cert/key pair under <dir>/certs (for the API server and the
+    encrypted DNS transports)
+  - two example primary zones — one unsigned, one signed — using two different
+    zone templates, with generated zone files under <dir>/zones
+  - a commented-out secondary zone using a third template`
+	if role == "agent" {
+		generates = `  - a self-signed cert/key pair under <dir>/certs (for the API server and the
+    encrypted DNS transports)
+  - two secondary zone templates and a commented-out secondary zone
+
+tdns-agent is secondary-only and never signs, so the generated config declares
+no zones and no dnssec: block; the agent starts clean and you add secondaries
+by uncommenting the example.`
+	}
+
 	c := &cobra.Command{
 		Use:   "mwe",
 		Short: "Generate a minimal working example config (+ certs, zones) for tdns-" + role,
@@ -41,20 +59,20 @@ Writes a single self-contained YAML to <dir>/tdns-` + role + `.yaml (or, if that
 file already exists, to <dir>/tdns-` + role + `.yaml.mwe so nothing is
 clobbered). Also generates, unless already present:
 
-  - a self-signed cert/key pair under <dir>/certs (for the API server and the
-    encrypted DNS transports)
-  - two example primary zones — one unsigned, one signed — using two different
-    zone templates, with generated zone files under <dir>/zones
-  - a commented-out secondary zone using a third template
+` + generates + `
 
 The DNS engine listens on IPv4 and IPv6 localhost; extra listen addresses are
 shown commented out. The generated tree is designed to pass
 ` + "`tdns-cli " + role + " config check`" + `.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if role != "auth" {
-				cliFatalf("config mwe is currently only implemented for auth")
+			switch role {
+			case "auth":
+				runConfigMwe(role, dir)
+			case "agent":
+				runAgentConfigMwe(role, dir)
+			default:
+				cliFatalf("config mwe is not implemented for %s", role)
 			}
-			runConfigMwe(role, dir)
 		},
 	}
 	c.Flags().StringVar(&dir, "dir", "/etc/tdns", "base directory for the generated config, certs and zones")

--- a/v2/cli/daemon_cmds.go
+++ b/v2/cli/daemon_cmds.go
@@ -88,8 +88,8 @@ Right now this doesn't do much, but later on various services will be able to re
 
 	start := &cobra.Command{
 		Use:   "start",
-		Short: "Start the axfr-statusd daemon",
-		Long:  `Start the axfr-statusd daemon. If it was already running, then this is a no-op.`,
+		Short: "Start the tdns-" + role + " daemon",
+		Long:  `Start the tdns-` + role + ` daemon. If it was already running, then this is a no-op.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			api, _ := GetApiClient(role, true)
 
@@ -219,8 +219,8 @@ Right now this doesn't do much, but later on various services will be able to re
 
 	apiCmd := &cobra.Command{
 		Use:   "api",
-		Short: "request a statusd api summary",
-		Long: `The daemon api queries the statusd for the provided API
+		Short: "request an API summary from the tdns-" + role + " daemon",
+		Long: `The daemon api command queries tdns-` + role + ` for the provided API
 and prints that out in a (hopefully) comprehensible fashion.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			api, _ := GetApiClient(role, true)

--- a/v2/cli/ddns_cmds.go
+++ b/v2/cli/ddns_cmds.go
@@ -30,7 +30,7 @@ var DelCmd = &cobra.Command{
 
 var delStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Make an API call to request TDNSD to analyse whether delegation is in sync or not",
+	Short: "Make an API call to request the daemon to analyse whether delegation is in sync or not",
 	Run: func(cmd *cobra.Command, args []string) {
 		PrepArgs("zonename")
 		if schemestr != "" {
@@ -96,7 +96,7 @@ var scheme uint8
 
 var delSyncCmd = &cobra.Command{
 	Use:   "sync",
-	Short: "Make an API call to request TDNSD to send a DDNS update to sync parent delegation info with child data",
+	Short: "Make an API call to request the daemon to send a DDNS update to sync parent delegation info with child data",
 	Run: func(cmd *cobra.Command, args []string) {
 		PrepArgs("zonename")
 		if schemestr != "" {

--- a/v2/cli/keystore_cmds.go
+++ b/v2/cli/keystore_cmds.go
@@ -544,7 +544,7 @@ KEY RR). The resulting pair is directly consumable by commands accepting
 
 	delete := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete SIG(0) key pair from TDNSD keystore",
+		Short: "Delete SIG(0) key pair from the keystore",
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("keyid", "childzone")
 			sig0KeyMgmt(role, "delete")
@@ -554,7 +554,7 @@ KEY RR). The resulting pair is directly consumable by commands accepting
 
 	setstate := &cobra.Command{
 		Use:   "setstate",
-		Short: "Set the state of and existing SIG(0) key pair in the TDNSD keystore",
+		Short: "Set the state of and existing SIG(0) key pair in the keystore",
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("keyid", "zonename", "state")
 			sig0KeyMgmt(role, "setstate")
@@ -668,7 +668,7 @@ DNSKEY RR). The resulting pair is directly consumable by 'keystore dnssec import
 
 	delete := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete DNSSEC key pair from TDNSD keystore",
+		Short: "Delete DNSSEC key pair from the keystore",
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("keyid", "zonename")
 			dnssecKeyMgmt(role, "delete")
@@ -678,7 +678,7 @@ DNSKEY RR). The resulting pair is directly consumable by 'keystore dnssec import
 
 	setstate := &cobra.Command{
 		Use:   "setstate",
-		Short: "Set the state of and existing DNSSEC key pair in the TDNSD keystore",
+		Short: "Set the state of and existing DNSSEC key pair in the keystore",
 		Run: func(cmd *cobra.Command, args []string) {
 			PrepArgs("keyid", "zonename", "state")
 			dnssecKeyMgmt(role, "setstate")
@@ -878,7 +878,7 @@ func sig0KeyMgmt(role, cmd string) {
 	}
 
 	if tr.Error {
-		fmt.Printf("Error from TDNSD: %s\n", tr.ErrorMsg)
+		fmt.Printf("Error from the daemon: %s\n", tr.ErrorMsg)
 		os.Exit(1)
 	}
 
@@ -1062,7 +1062,7 @@ func dnssecKeyMgmt(role, cmd string) {
 	}
 
 	if tr.Error {
-		fmt.Printf("Error from TDNSD: %s\n", tr.ErrorMsg)
+		fmt.Printf("Error from the daemon: %s\n", tr.ErrorMsg)
 		os.Exit(1)
 	}
 
@@ -1174,7 +1174,7 @@ func dnssecKeyPurgeCmd(role string, cmd *cobra.Command) {
 		os.Exit(1)
 	}
 	if tr.Error {
-		fmt.Printf("Error from TDNSD: %s\n", tr.ErrorMsg)
+		fmt.Printf("Error from the daemon: %s\n", tr.ErrorMsg)
 		os.Exit(1)
 	}
 

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -117,7 +117,7 @@ failing. Does not change anything; read-only.`,
 
 	bump := &cobra.Command{
 		Use:   "bump",
-		Short: "Bump SOA serial and epoch (if any) in tdns-auth version of zone",
+		Short: "Bump SOA serial and epoch (if any) in the daemon's version of the zone",
 		Run:   func(cmd *cobra.Command, args []string) { RunZoneBump(role, args) },
 	}
 


### PR DESCRIPTION
Completes the `config check` / `config mwe` set: `auth` and `imr` landed in #303, this adds `agent`.

## Not just a gap — the existing commands were wrong

`cmdv2/cli/shared_cmds.go` already wires `NewConfigCmd("agent")`, and that unconditionally attaches `check` and `mwe`. So both commands were reachable today: `mwe` refused with "only implemented for auth", and `check` **ran, with auth semantics**.

Three things in the shared driver were hardcoded to auth:

| | before | after |
|---|---|---|
| target config | `DefaultAuthCfgFile` — a bare `agent config check` inspected **tdns-auth.yaml** | `DefaultAgentCfgFile` |
| liveness probe | `GET /config/paths` | API ping |
| validator app type | `AppTypeAuth` | `AppTypeAgent` |

The liveness one is the interesting bug. `/config/paths` is registered **only** for `AppTypeAuth` (`apirouters.go`), so for agent it always 404s — which the driver read as "daemon is down" and used to silently disable *all* running-config correlation against a perfectly healthy daemon. Liveness is now a ping; path discovery stays auth-only (`roleHasConfigPaths`).

## Agent-specific checks

The agent shares auth's config schema and `ValidateConfig` treats the two identically, so most checks are reused as-is. What differs is collected in `config_agent_cmds.go` — each predicts a concrete startup behaviour:

- **primary zones** — the agent refuses them outright and quarantines the zone → FAIL (and auth's zonefile checks are skipped)
- **online-signing / inline-signing** — rejected at option-parse time; the agent never signs → WARN. This *replaces* auth's "online-signing but no dnssecpolicy" FAIL, which is the wrong diagnosis here: adding a policy would not help.
- **`multi-provider:`** — this binary has no struct for it (it lives in `tdns-mp`), so the whole block lands in mapstructure's unused set and surfaces only as a generic "possible misspellings" log line → WARN pointing at `tdns-mpagent`
- **`imrengine:`** — `ValidateConfig` does not cover it for the agent even though `StartAgent` runs an IMR, so a bad block fails at engine start instead
- **`delegation-sync-proxy`** off a secondary → FAIL; **`delegation-sync-child`** without `multi-provider` (inert on the agent) → WARN, or with it but no `delegationsync.child.schemes` → FAIL

The policy-alg vs active-key dry-run is skipped for the agent — it never signs, so no policy can break a reload there.

## One generic fix, found while testing the agent

`log:` must be top level in the **main** config file: `SetupLogging` runs before `include:` is resolved. An include-only `log:` block passes every merged-view check and still aborts startup with a hard error. Now a FAIL for **all** roles (auth/agent/imr), not just agent.

## `agent config mwe`

Generates a secondary-only tree: no zone files and no `dnssec:` block, because the agent can host neither. Two secondary templates and a commented-out secondary zone show how to add one; the agent starts clean with zero zones.

## Validation

Every prediction was checked against a real `tdns-agent` built from this branch, on unique ports so no running daemon was disturbed.

The generated MWE starts and listens (DNS 15356 v4+v6, API 18987, IMR 15453), `agent ping` succeeds over TLS, and `agent config check` reports `all checks passed` while genuinely correlating (3 API calls, all 200) — which is itself the proof of the liveness fix.

Running the daemon on a deliberately broken config confirms each finding:

```
[WARN/config]  unknown config keys ignored (possible misspellings) keys=[multi-provider]
[ERROR/config] tdns-agent does not support primary zones, zone in error state zone=prim.example.
[ERROR/zones]  option ignored: agent does not allow signing zone=signme.example. option=online-signing
[INFO/config]  zones parsed ... broken=[prim.example. proxy.example.]
[ERROR/config] engine error engine=ImrEngine err=... Root hints file ... not found
```

`broken=[...]` is exactly the set the check FAILed on. The include-only `log:` case was confirmed startup-fatal, with the daemon's own error matching the check's wording.

- `go build`, `go vet`, `go test ./...` green in both `v2` and `v2/cli`
- New table-driven tests for the role plumbing, the agent zone-option gating, the inert-config detection and the log-section check; **mutation-tested** (disabling the proxy check and the multi-provider warn each fail their test)
- `auth` and `imr` re-checked for regressions — byte-identical behaviour apart from the intended `log:` addition

## Follow-up (not in this PR)

`cmdv2/agent/tdns-agent.sample.yaml` ships a large `multi-provider:` block that this binary cannot parse, and `cmdv2/agent/agent-zones.yaml` references two templates (`parent-primary`, `secondary`) that it does not define. `agent config check` now flags both. Cleaning up the samples felt out of scope here.