### PR TITLE
XoT (XFR-over-TLS, RFC 9103): verified secondary pull, dog support, opt-in primary mTLS

### DIFF
--- a/cmdv2/auth/auth-zones.sample.yaml
+++ b/cmdv2/auth/auth-zones.sample.yaml
@@ -125,6 +125,40 @@ zones:
         - delegation-sync-child    # Push DS/NS updates to parent
 
    # ===========================================================================
+   # EXAMPLE 2b: SECONDARY zone pulling over XoT (XFR-over-TLS, RFC 9103)
+   # ===========================================================================
+   # Per-primary transport selection: transport: dot moves the SOA probe and
+   # the transfer itself to TLS (default port 853). Every dot primary MUST
+   # declare how the server certificate is authenticated (tls-auth):
+   #
+   #   pin   Static SPKI pinning. pins: lists base64 SHA-256 digests of the
+   #         server cert's SubjectPublicKeyInfo (get it from the primary
+   #         operator, or from the cert: dog +showpin, or
+   #         openssl x509 -in cert.pem -pubkey -noout | openssl pkey -pubin \
+   #           -outform der | openssl dgst -sha256 -binary | base64
+   #   dane  TLSA lookup at _<port>._tcp.<name>, DNSSEC-validated through the
+   #         built-in IMR. <name> is the primary's hostname (or tls-name when
+   #         the primary is configured as an IP literal).
+   #   pkix  WebPKI-style chain verification against ca-file (or the system
+   #         roots when ca-file is omitted).
+   #
+   # TSIG stays orthogonal: key: is still honored (RFC 9103 allows TSIG+TLS).
+   #- name:            example.com.
+   #  type:            secondary
+   #  primaries:
+   #     - addr: "ns1.example.net"        # hostname primary: port defaults to 853,
+   #       key:  NOKEY                    # the name doubles as SNI + TLSA base
+   #       transport: dot
+   #       tls-auth: dane
+   #     - addr: "203.0.113.1:853"        # IP-literal primary: tls-name required
+   #       key:  xfr-key-2026             # for dane (and used as SNI)
+   #       transport: dot
+   #       tls-auth: pin
+   #       tls-name: ns2.example.net
+   #       pins:
+   #          - "base64-spki-sha256-digest-here="
+
+   # ===========================================================================
    # EXAMPLE 3: Zone using a TEMPLATE (with overrides)
    # ===========================================================================
    - name:            example.org.

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -40,6 +40,14 @@ dnsengine:
    # those listeners are not started (do53 is unaffected).
    certfile:  /etc/tdns/certs/servers/localhost..crt
    keyfile:   /etc/tdns/certs/servers/localhost..key
+   # Optional XoT mTLS (RFC 9103): authenticate downstream secondaries at the
+   # TLS layer on the DoT listener. Opt-in; absent = no client certificate
+   # requested. TSIG + the per-zone downstreams: ACL keep working either way.
+   # See docs/2026-07-21-xot-operations.md.
+   #downstream-auth: pin        # pin | ca
+   #downstream-pins:            # base64 SPKI SHA-256 of each secondary's cert
+   #   - "sec1-spki-sha256-base64="
+   #downstream-ca: /etc/tdns/certs/downstream-ca.pem   # for downstream-auth: ca
    # outbound_soa_serial controls the SOA serial advertised to secondaries:
    #   keep      — outbound = inbound serial (default; current behavior)
    #   unixtime  — outbound = time.Now().Unix() at zone load

--- a/cmdv2/dog/dog.go
+++ b/cmdv2/dog/dog.go
@@ -250,6 +250,13 @@ var rootCmd = &cobra.Command{
 			switch rrtype {
 			case dns.TypeAXFR, dns.TypeIXFR:
 				upstream := net.JoinHostPort(options["server"], options["port"])
+				// Verify flags only take effect over an encrypted transport;
+				// refuse rather than silently ignore them on plain Do53 (else
+				// +pin/+cafile/+tlsa give a false sense of a verified transfer).
+				if verifyFlagsGiven(options) && dogtransport.PlainDo53(options["transport"]) {
+					fmt.Fprintf(os.Stderr, "Error: +pin/+cafile/+tlsa require an encrypted transport (+dot); refusing to ignore them over Do53\n")
+					os.Exit(1)
+				}
 				var xferTLS *tls.Config
 				switch {
 				case dogtransport.PlainDo53(options["transport"]):
@@ -337,7 +344,17 @@ var rootCmd = &cobra.Command{
 				}
 
 				var tlsConfig *tls.Config
-				if transport, ok := options["transport"]; ok && transport != "do53" {
+				// Verify flags only take effect over an encrypted transport;
+				// refuse rather than silently ignore them on plain Do53 (else
+				// +pin/+cafile/+tlsa give a false sense of a verified transfer).
+				if verifyFlagsGiven(options) && dogtransport.PlainDo53(options["transport"]) {
+					fmt.Fprintf(os.Stderr, "Error: +pin/+cafile/+tlsa require an encrypted transport (+dot/+doh/+doq); refusing to ignore them over Do53\n")
+					os.Exit(1)
+				}
+				// PlainDo53 is case-insensitive and also covers Do53-TCP/tcp;
+				// a bare transport != "do53" mishandles the canonical "Do53"
+				// spelling and would wrap a plain query in a TLS config.
+				if transport, ok := options["transport"]; ok && !dogtransport.PlainDo53(transport) {
 					if verifyFlagsGiven(options) {
 						var terr error
 						tlsConfig, terr = buildDogTLSConfig(options)

--- a/cmdv2/dog/dog.go
+++ b/cmdv2/dog/dog.go
@@ -117,7 +117,7 @@ var rootCmd = &cobra.Command{
 			}
 
 			if strings.HasPrefix(ucarg, "+") {
-				options, err = ProcessOptions(options, ucarg)
+				options, err = ProcessOptions(options, ucarg, arg)
 				if err != nil {
 					fmt.Printf("Error: %v\n", err)
 					os.Exit(1)
@@ -199,6 +199,14 @@ var rootCmd = &cobra.Command{
 				options["opcode"], options["server"], options["transport"], options["port"])
 		}
 
+		// +showpin needs no qname: connect, print the server cert's SPKI pin
+		// (and TLSA 3-1-1 record) and exit. Bootstrap helper for pins: config
+		// and TLSA publication.
+		if options["showpin"] == "true" {
+			showServerPin(options)
+			return
+		}
+
 		for _, qname := range cleanArgs {
 			qname = dns.Fqdn(qname)
 			if tdns.Globals.Verbose {
@@ -216,29 +224,7 @@ var rootCmd = &cobra.Command{
 					os.Exit(1)
 				}
 				chaserClient := core.NewDNSClient(chaserTransport, options["port"], nil)
-				// Resolve trust anchors via the standard priority chain:
-				//   --trust-anchor flag → IMR config → compiled-in.
-				taLogf := func(format string, args ...any) {
-					if tdns.Globals.Verbose {
-						fmt.Fprintf(os.Stderr, format+"\n", args...)
-					}
-				}
-				dss, keys, taSource := tdns.LoadDefaultTrustAnchors(trustAnchorFile, taLogf)
-				// Some TA files (autotrust / RFC 5011 managed) hold DNSKEY
-				// records rather than DS. Convert each KSK DNSKEY to its
-				// SHA-256 DS equivalent so the chaser, which keys off DS,
-				// can anchor the root regardless of file format.
-				for _, k := range keys {
-					if k.Flags&dns.SEP == 0 {
-						continue
-					}
-					if ds := k.ToDS(dns.SHA256); ds != nil {
-						dss = append(dss, ds)
-					}
-				}
-				if tdns.Globals.Verbose {
-					fmt.Fprintf(os.Stderr, ";; trust anchor source: %s (%d DS records, %d DNSKEYs)\n", taSource, len(dss), len(keys))
-				}
+				dss := loadChaserAnchors()
 				chaser := tdns.NewChaser(chaserClient, options["server"], dss)
 				result, err := chaser.Chase(qname, rrtype)
 				if err != nil {
@@ -263,13 +249,23 @@ var rootCmd = &cobra.Command{
 
 			switch rrtype {
 			case dns.TypeAXFR, dns.TypeIXFR:
-				if dogtransport.PlainDo53(options["transport"]) {
-					upstream := net.JoinHostPort(options["server"], options["port"])
-					if err := tdns.ZoneTransferPrint(qname, upstream, serial, rrtype, options, tsigName, tsigAlgo, tsigSecret); err != nil {
+				upstream := net.JoinHostPort(options["server"], options["port"])
+				var xferTLS *tls.Config
+				switch {
+				case dogtransport.PlainDo53(options["transport"]):
+					// nil TLS config: plain TCP, unchanged.
+				case strings.EqualFold(options["transport"], "DoT"):
+					var terr error
+					xferTLS, terr = buildDogTLSConfig(options)
+					if terr != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", terr)
 						os.Exit(1)
 					}
-				} else {
-					fmt.Printf("Zone transfer only supported over Do53/TCP, not %s\n", options["transport"])
+				default:
+					fmt.Printf("Zone transfer only supported over Do53/TCP and DoT, not %s\n", options["transport"])
+					os.Exit(1)
+				}
+				if err := tdns.ZoneTransferPrint(qname, upstream, serial, rrtype, options, tsigName, tsigAlgo, tsigSecret, xferTLS); err != nil {
 					os.Exit(1)
 				}
 
@@ -342,13 +338,30 @@ var rootCmd = &cobra.Command{
 
 				var tlsConfig *tls.Config
 				if transport, ok := options["transport"]; ok && transport != "do53" {
-					tlsConfig = &tls.Config{
-						InsecureSkipVerify: true,
-						MinVersion:         tls.VersionTLS12,
-					}
-					// Add ALPN for DoQ
-					if transport == "DoQ" {
-						tlsConfig.NextProtos = []string{"doq"}
+					if verifyFlagsGiven(options) {
+						var terr error
+						tlsConfig, terr = buildDogTLSConfig(options)
+						if terr != nil {
+							fmt.Fprintf(os.Stderr, "Error: %v\n", terr)
+							os.Exit(1)
+						}
+						// ALPN is per-transport; the builder assumes DoT.
+						switch transport {
+						case "DoQ":
+							tlsConfig.NextProtos = []string{"doq"}
+						case "DoH":
+							tlsConfig.NextProtos = nil // http client negotiates
+						}
+					} else {
+						fmt.Fprintf(os.Stderr, ";; WARNING: server certificate NOT verified; use +tlsa, +pin=<spki-b64> or +cafile=<pem>\n")
+						tlsConfig = &tls.Config{
+							InsecureSkipVerify: true,
+							MinVersion:         tls.VersionTLS12,
+						}
+						// Add ALPN for DoQ
+						if transport == "DoQ" {
+							tlsConfig.NextProtos = []string{"doq"}
+						}
 					}
 				}
 
@@ -531,9 +544,215 @@ func showDNSMessageTrace() bool {
 	return tdns.Globals.Verbose || tdns.Globals.Debug
 }
 
-func ProcessOptions(options map[string]string, ucarg string) (map[string]string, error) {
+// loadChaserAnchors resolves DS trust anchors via the standard priority
+// chain (--trust-anchor flag -> IMR config -> compiled-in). Some TA files
+// (autotrust / RFC 5011 managed) hold DNSKEY records rather than DS; each
+// KSK DNSKEY is converted to its SHA-256 DS equivalent so the chaser, which
+// keys off DS, can anchor the root regardless of file format.
+func loadChaserAnchors() []*dns.DS {
+	taLogf := func(format string, args ...any) {
+		if tdns.Globals.Verbose {
+			fmt.Fprintf(os.Stderr, format+"\n", args...)
+		}
+	}
+	dss, keys, taSource := tdns.LoadDefaultTrustAnchors(trustAnchorFile, taLogf)
+	for _, k := range keys {
+		if k.Flags&dns.SEP == 0 {
+			continue
+		}
+		if ds := k.ToDS(dns.SHA256); ds != nil {
+			dss = append(dss, ds)
+		}
+	}
+	if tdns.Globals.Verbose {
+		fmt.Fprintf(os.Stderr, ";; trust anchor source: %s (%d DS records, %d DNSKEYs)\n", taSource, len(dss), len(keys))
+	}
+	return dss
+}
+
+// verifyFlagsGiven reports whether any of the certificate-verification
+// options (+tlsa, +pin=, +cafile=) was requested.
+func verifyFlagsGiven(options map[string]string) bool {
+	return options["tlsa"] == "true" || options["pins"] != "" || options["cafile"] != ""
+}
+
+// buildDogTLSConfig returns the TLS config for an encrypted-transport dog
+// operation. With +pin/+cafile it builds a verifying config through
+// tdns.ClientTLSConfigForPeer (a synthetic PeerConf from the flags); with
+// +tlsa it chase-validates the server's TLSA RRset from the root trust
+// anchors and pins the handshake to it. Without any verify flag it keeps
+// dog's historical InsecureSkipVerify behavior, with a warning.
+func buildDogTLSConfig(options map[string]string) (*tls.Config, error) {
+	server := options["server"]
+	port := options["port"]
+
+	nVerify := 0
+	if options["tlsa"] == "true" {
+		nVerify++
+	}
+	if options["pins"] != "" {
+		nVerify++
+	}
+	if options["cafile"] != "" {
+		nVerify++
+	}
+	switch nVerify {
+	case 0:
+		fmt.Fprintf(os.Stderr, ";; WARNING: server certificate NOT verified; use +tlsa, +pin=<spki-b64> or +cafile=<pem>\n")
+		return &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, nil
+	case 1:
+	default:
+		return nil, fmt.Errorf("choose ONE of +tlsa, +pin=, +cafile=")
+	}
+
+	if options["tlsa"] == "true" {
+		return dogDaneTLSConfig(server, port)
+	}
+
+	peer := tdns.PeerConf{
+		Addr:      net.JoinHostPort(server, port),
+		Key:       tdns.NOKEY,
+		Transport: tdns.TransportDoT,
+	}
+	if options["pins"] != "" {
+		peer.TLSAuth = tdns.TLSAuthPin
+		peer.Pins = strings.Split(options["pins"], ",")
+	} else {
+		peer.TLSAuth = tdns.TLSAuthPKIX
+		peer.CAFile = options["cafile"]
+	}
+	conf := &tdns.Config{}
+	return conf.ClientTLSConfigForPeer(peer)
+}
+
+// dogDaneTLSConfig implements +tlsa: fetch and chain-validate (from the root
+// trust anchors, via the system resolver) the TLSA RRset at
+// _<port>._tcp.<server>, then pin the TLS handshake to it. Fails closed when
+// the chain is not provably secure. The lookup goes through the system
+// resolver rather than @server because @server is typically the
+// authoritative primary being transferred from, not a recursive.
+func dogDaneTLSConfig(server, port string) (*tls.Config, error) {
+	if net.ParseIP(server) != nil {
+		return nil, fmt.Errorf("+tlsa needs a server NAME for the TLSA base; got IP literal %s (use +pin= or +cafile=)", server)
+	}
+	resolver, err := ParseResolvConf()
+	if err != nil {
+		return nil, fmt.Errorf("+tlsa: cannot determine system resolver: %v", err)
+	}
+	client := core.NewDNSClient(core.TransportDo53, "53", nil)
+	chaser := tdns.NewChaser(client, resolver, loadChaserAnchors())
+	owner := fmt.Sprintf("_%s._tcp.%s", port, dns.Fqdn(server))
+	res, err := chaser.Chase(owner, dns.TypeTLSA)
+	if err != nil {
+		return nil, fmt.Errorf("+tlsa: TLSA chase for %s failed: %v", owner, err)
+	}
+	if res.Status != tdns.ChainStatusSecure || res.Leaf.RRset == nil || len(res.Leaf.RRset.RRs) == 0 {
+		return nil, fmt.Errorf("+tlsa: TLSA RRset for %s is not provably secure; refusing (fail closed)", owner)
+	}
+	tlsaRRs := res.Leaf.RRset.RRs
+	if tdns.Globals.Verbose {
+		for _, rr := range tlsaRRs {
+			fmt.Fprintf(os.Stderr, ";; validated TLSA: %s\n", rr.String())
+		}
+	}
+	return &tls.Config{
+		ServerName: server,
+		MinVersion: tls.VersionTLS13,
+		NextProtos: []string{"dot"},
+		// DANE-EE replaces PKIX chain building; VerifyConnection is the gate.
+		InsecureSkipVerify: true,
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return fmt.Errorf("server presented no certificate")
+			}
+			for _, rr := range tlsaRRs {
+				if tlsa, ok := rr.(*dns.TLSA); ok {
+					if err := tdns.VerifyCertAgainstTlsaRR(tlsa, cs.PeerCertificates[0]); err == nil {
+						return nil
+					}
+				}
+			}
+			return fmt.Errorf("no validated TLSA record at %s matches the server certificate", owner)
+		},
+	}, nil
+}
+
+// showServerPin implements +showpin: connect over TLS (unverified — this IS
+// the bootstrap step), print the server certificate's SPKI SHA-256 pin and
+// the equivalent TLSA 3-1-1 record, then move on. A plain-Do53 transport
+// implies DoT on port 853.
+func showServerPin(options map[string]string) {
+	server := options["server"]
+	port := options["port"]
+	if dogtransport.PlainDo53(options["transport"]) {
+		port = "853"
+		fmt.Fprintf(os.Stderr, ";; +showpin: assuming DoT on port %s (use +dot with -p to override)\n", port)
+	}
+	addr := net.JoinHostPort(server, port)
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", addr,
+		&tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12, NextProtos: []string{"dot"}})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: cannot fetch server certificate from %s: %v\n", addr, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: %s presented no certificate\n", addr)
+		os.Exit(1)
+	}
+	leaf := certs[0]
+	fmt.Printf(";; server:  %s\n", addr)
+	fmt.Printf(";; subject: %s\n", leaf.Subject)
+	fmt.Printf(";; SPKI pin (for pins: / +pin=): %s\n", tdns.SPKISHA256(leaf))
+	if portNum, perr := strconv.ParseUint(port, 10, 16); perr == nil {
+		if tlsa, terr := tdns.NewTlsaRR(dns.Fqdn(server), uint16(portNum), leaf); terr == nil {
+			fmt.Printf(";; TLSA:    %s\n", tlsa.String())
+		}
+	}
+}
+
+// ProcessOptions interprets one +option argument. ucarg is the uppercased
+// form (used for matching); arg is the original argument, needed whenever the
+// option value is case-sensitive (base64 pins, file paths).
+func ProcessOptions(options map[string]string, ucarg, arg string) (map[string]string, error) {
 	if options == nil {
 		options = make(map[string]string)
+	}
+
+	// XoT/TLS verification options (case-sensitive values -> parse from arg).
+	if strings.HasPrefix(ucarg, "+PIN=") {
+		pin := arg[len("+pin="):]
+		if pin == "" {
+			return nil, fmt.Errorf("+pin= requires a base64 SPKI SHA-256 digest")
+		}
+		// Repeatable; base64 std alphabet never contains ',' so join on it.
+		if options["pins"] != "" {
+			options["pins"] += ","
+		}
+		options["pins"] += pin
+		return options, nil
+	}
+	if strings.HasPrefix(ucarg, "+CAFILE=") {
+		path := arg[len("+cafile="):]
+		if path == "" {
+			return nil, fmt.Errorf("+cafile= requires a path to a PEM cert bundle")
+		}
+		options["cafile"] = path
+		return options, nil
+	}
+
+	switch ucarg {
+	case "+TLSA":
+		// DANE-verify the server cert: TLSA at _<port>._tcp.<server>,
+		// chase-validated from the root trust anchors.
+		options["tlsa"] = "true"
+		return options, nil
+	case "+SHOWPIN":
+		// Connect, print the server cert's SPKI pin (and TLSA 3-1-1 rdata),
+		// and exit. For bootstrapping pins: / TLSA records.
+		options["showpin"] = "true"
+		return options, nil
 	}
 
 	switch ucarg {

--- a/docs/2026-07-21-xot-operations.md
+++ b/docs/2026-07-21-xot-operations.md
@@ -1,0 +1,188 @@
+# XoT (XFR-over-TLS) Operations Guide
+
+**Date:** 2026-07-21
+**Standards:** RFC 9103 (DNS Zone Transfer over TLS). Implemented by the
+`feature/xot` work; design in `docs/2026-07-20-xot-implementation-plan.md`.
+
+tdns supports XoT in both roles:
+
+- **Primary (serve):** the DoT listener serves AXFR/IXFR through the same
+  handler as Do53, with full TSIG parity and the same `downstreams:` ACL.
+  Optional mTLS lets the primary authenticate secondaries at the TLS layer.
+- **Secondary (pull):** per-primary `transport: dot` moves the SOA probe and
+  the transfer to TLS. Every DoT primary must declare how its certificate is
+  authenticated (`tls-auth`): static SPKI pinning, DANE, or PKIX.
+
+TSIG stays orthogonal throughout: RFC 9103 explicitly allows TSIG and TLS
+together, and `key:` keeps working unchanged on both sides. tdns-auth and
+tdns-agent share the secondary pull code, so both daemons get XoT.
+
+---
+
+## 1. Secondary: pulling a zone over XoT
+
+Per-primary configuration in the zone's `primaries:` list:
+
+```yaml
+zones:
+   - name: example.com.
+     type: secondary
+     primaries:
+        # Hostname primary, DANE-authenticated. Port defaults to 853 for
+        # transport: dot. The hostname doubles as SNI and the TLSA base.
+        - addr: ns1.example.net
+          key:  NOKEY
+          transport: dot
+          tls-auth: dane
+
+        # IP-literal primary, static pin + TSIG. tls-name provides the SNI
+        # (and would provide the TLSA base for dane).
+        - addr: 192.0.2.53:853
+          key:  xfr-key-2026
+          transport: dot
+          tls-auth: pin
+          tls-name: ns2.example.net
+          pins:
+             - "spki-sha256-digest-in-base64="
+
+        # PKIX against a private CA (omit ca-file to use the system roots).
+        - addr: ns3.example.net
+          key:  NOKEY
+          transport: dot
+          tls-auth: pkix
+          ca-file: /etc/tdns/certs/xfr-ca.pem
+```
+
+Rules enforced at config load (violations quarantine the zone):
+
+- `transport: dot` requires `tls-auth: pin | dane | pkix`.
+- `tls-auth: pin` requires at least one well-formed pin (base64 SHA-256 of
+  the server certificate's SubjectPublicKeyInfo).
+- `tls-auth: dane` with an IP-literal `addr` requires `tls-name` (no name,
+  no TLSA base). Hostname primaries use the hostname automatically — a
+  multi-address hostname keeps the same name on every resolved address.
+- `tls-auth: pkix`: `ca-file`, when set, must be a readable PEM bundle;
+  when empty the system roots are used. An IP-literal primary without
+  `tls-name` is verified against the certificate's IP SANs.
+- The TLS fields on a `do53` primary, or on a `notify:` target, are
+  rejected loudly rather than silently ignored.
+
+### DANE specifics
+
+The TLSA lookup (`_<port>._tcp.<name>`) goes through the built-in validating
+IMR and **fails closed**: no IMR, a failed lookup, or a not-provably-secure
+RRset all abort the transfer. The `imrengine.require_dnssec_validation:
+false` lab-mode escape hatch is honored (with a loud warning), consistent
+with how tdns treats TLSA elsewhere.
+
+### Getting a pin
+
+Ask the primary operator, or bootstrap from the live cert:
+
+```
+dog +showpin @ns1.example.net           # prints SPKI pin + TLSA 3-1-1 record
+openssl x509 -in cert.pem -pubkey -noout \
+  | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64
+```
+
+Pin rotation: list the old and the new pin simultaneously (any match
+admits), roll the cert, then drop the old pin.
+
+## 2. Primary: serving XoT
+
+Already works with a DoT listener + transfer ACL — no new config needed:
+
+```yaml
+dnsengine:
+   addresses:  [ 192.0.2.53:53 ]
+   transports: [ do53, dot ]
+   certfile:   /etc/tdns/certs/ns1.crt
+   keyfile:    /etc/tdns/certs/ns1.key
+
+zones:
+   - name: example.com.
+     type: primary
+     zonefile: /var/lib/tdns/example.com
+     downstreams:              # provide-xfr ACL, same as over Do53
+        - prefix: 198.51.100.0/24
+          key:    xfr-key-2026
+```
+
+The DoT listener runs the same handler as Do53: the `downstreams:` ACL and
+TSIG verification apply unchanged to transfer requests arriving over TLS.
+
+### Optional: authenticate secondaries with mTLS
+
+`dnsengine.downstream-auth` gates every **auth** DoT connection (the IMR's
+DoT front end never requests client certificates):
+
+```yaml
+dnsengine:
+   # pin: each secondary's client-cert SPKI digest is listed explicitly
+   downstream-auth: pin
+   downstream-pins:
+      - "sec1-spki-sha256-base64="
+      - "sec2-spki-sha256-base64="
+
+   # ...or ca: standard mTLS against a CA bundle
+   #downstream-auth: ca
+   #downstream-ca:   /etc/tdns/certs/downstream-ca.pem
+```
+
+Notes:
+
+- RFC 9103 treats mTLS as one of several valid policies; TSIG + IP ACL
+  remains fully supported without it.
+- There is deliberately no `dane` mode here: the server cannot know which
+  downstream is connecting before the handshake, so it has no name to base
+  a TLSA lookup on. Pins cover that case statically.
+- Misconfiguration (missing/malformed pins, unreadable CA) fails at
+  startup, not at the first transfer.
+
+### Advertising DoT
+
+A primary that serves DoT participates in the existing transport-signaling
+machinery (OOTS SVCB, `draft-johani-dnsop-transport-signaling`) when that is
+configured; XoT adds no separate advertisement.
+
+### Publishing TLSA for your own cert
+
+`PublishTlsaRR` emits a true **3-1-1** record (DANE-EE / SPKI / SHA-256) as
+of this branch — the hash is over the SubjectPublicKeyInfo, matching the
+advertised selector, and `dog +showpin` prints the same record for manual
+publication. (Before this branch the selector said SPKI but the hash was
+over the whole cert; verifiers were consistently wrong in the same way, so
+pairs of old daemons agreed. A mixed old/new pair will disagree until both
+sides run the fixed code — the records are TTL 120, so re-convergence after
+upgrade is quick.)
+
+## 3. dog
+
+```
+dog AXFR example.com @ns1.example.net                      # Do53, unchanged
+dog +dot AXFR example.com @ns1.example.net                 # XoT, UNVERIFIED (warns)
+dog +dot +tlsa AXFR example.com @ns1.example.net           # XoT, DANE-validated
+dog +dot +pin=<spki-b64> AXFR example.com @ns1.example.net # XoT, pinned
+dog +dot +cafile=ca.pem AXFR example.com @ns1.example.net  # XoT, PKIX
+dog +showpin @ns1.example.net                              # print server pin/TLSA
+```
+
+- `+tlsa` chase-validates the TLSA RRset from the root trust anchors
+  (`--trust-anchor` / IMR config / compiled-in) through the **system
+  resolver** — `@server` is the authoritative being transferred from, not a
+  recursive — and fails closed unless the chain is provably secure.
+- `+pin`/`+cafile` also verify plain DoT/DoQ/DoH queries, not just
+  transfers.
+- Without a verify flag, encrypted transports keep dog's historical
+  unverified behavior but print a warning.
+
+## 4. Limitations / notes
+
+- IXFR: the secondary always requests AXFR today, and `ZoneTransferOut`
+  answers IXFR requests with a full zone (AXFR-style response, which RFC
+  1995 permits). XoT changes nothing here; incremental transfer is tracked
+  separately (`docs/2026-07-02-*` project C).
+- DoQ/DoH zone transfer is out of scope (RFC 9103 defines XoT over TLS;
+  dog refuses transfer over non-DoT encrypted transports).
+- The TLS minimum version on both sides is 1.3, per the RFC 9103
+  recommendation.

--- a/v2/cache/authserver.go
+++ b/v2/cache/authserver.go
@@ -55,9 +55,8 @@ type AuthServer struct {
 	TransportWeights map[core.Transport]uint8 // independent oots weights [0,100]; Do53 is ultimate fallback
 	// Optional config-only field for stubs: colon-separated transport weights, e.g. "doq:30,dot:70"
 	// When provided in config, this overrides Alpn for building Transports/TransportWeights.
-	TransportSignal string                  `yaml:"transport" mapstructure:"transport"`
-	ConnMode        ConnMode                `yaml:"connmode" mapstructure:"connmode"`
-	TLSARecords     map[string]*CachedRRset // keyed by owner (_port._proto.name.), validated RRsets only
+	TransportSignal string   `yaml:"transport" mapstructure:"transport"`
+	ConnMode        ConnMode `yaml:"connmode" mapstructure:"connmode"`
 	// Stats (guarded by mu)
 	mu                sync.Mutex
 	TransportCounters map[core.Transport]uint64 // queries ATTEMPTED per transport (transport chosen)
@@ -98,7 +97,6 @@ func NewAuthServer(name string) *AuthServer {
 		// Addrs: nil
 		// TransportWeights: nil
 		// TransportSignal: ""
-		// TLSARecords: nil
 		// TransportCounters: nil (will be initialized on first use)
 		// Expire: zero time
 		// Debug: false
@@ -394,22 +392,6 @@ func (as *AuthServer) SetTransportWeights(weights map[core.Transport]uint8) {
 	for k, v := range weights {
 		as.TransportWeights[k] = v
 	}
-}
-
-func (as *AuthServer) SnapshotTLSARecords() map[string]*CachedRRset {
-	if as == nil {
-		return nil
-	}
-	as.mu.Lock()
-	defer as.mu.Unlock()
-	if len(as.TLSARecords) == 0 {
-		return nil
-	}
-	snap := make(map[string]*CachedRRset, len(as.TLSARecords))
-	for owner, rec := range as.TLSARecords {
-		snap[owner] = rec
-	}
-	return snap
 }
 
 // SnapshotCounters returns a copy of the per-transport counters.

--- a/v2/cache/cache_structs.go
+++ b/v2/cache/cache_structs.go
@@ -51,6 +51,7 @@ type RRsetCacheT struct {
 	ServerMap     *core.ConcurrentMap[string, map[string]*AuthServer] // map[zone]map[nsname]*AuthServer
 	AuthServerMap *core.ConcurrentMap[string, *AuthServer]            // Global map: nsname -> *AuthServer (ensures single instance per nameserver)
 	ZoneMap       *core.ConcurrentMap[string, *Zone]                  // map[zone]*Zone
+	ServerTLSA    *core.ConcurrentMap[string, *ServerTLSARecords]     // nsname -> validated TLSA cache, decoupled from AuthServer instances
 	DnskeyCache   *DnskeyCacheT
 	DNSClient     map[core.Transport]core.DNSClienter
 	//Options                map[ImrOption]string
@@ -62,6 +63,17 @@ type RRsetCacheT struct {
 	Quiet                bool // if true, suppress informational logging (useful for CLI tools)
 	nsRevalidateMu       sync.Mutex
 	nsRevalidateInFlight map[string]struct{}
+}
+
+// ServerTLSARecords is the validated TLSA cache for one nameserver, keyed by
+// owner (_port._proto.name.). It lives at cache level (RRsetCacheT.ServerTLSA,
+// keyed by the server's base name) rather than on the AuthServer instance, so a
+// stub's private AuthServer and a discovery-shared instance for the same name
+// share the TLSA cache WITHOUT sharing — and clobbering — address/transport
+// state. Guarded by its own mutex.
+type ServerTLSARecords struct {
+	mu   sync.RWMutex
+	recs map[string]*CachedRRset // keyed by owner
 }
 
 type Zone struct {

--- a/v2/cache/rrset_cache.go
+++ b/v2/cache/rrset_cache.go
@@ -619,11 +619,14 @@ func (rrcache *RRsetCacheT) StoreTLSAForServer(base, owner string, rrset *core.R
 	if rrcache == nil || rrset == nil || len(rrset.RRs) == 0 {
 		return
 	}
-	base = dns.Fqdn(strings.TrimSpace(base))
+	// Canonicalize (lowercase + fqdn) so mixed-case names key the same bucket;
+	// DNS names are case-insensitive (ASCII, RFC 4343) and dns.Fqdn alone
+	// preserves case, which would split NS1.Example. from ns1.example.
+	base = dns.CanonicalName(strings.TrimSpace(base))
 	if base == "." || base == "" {
 		return
 	}
-	owner = dns.Fqdn(strings.TrimSpace(owner))
+	owner = dns.CanonicalName(strings.TrimSpace(owner))
 	if owner == "." || owner == "" {
 		return
 	}
@@ -665,8 +668,9 @@ func (rrcache *RRsetCacheT) LookupTLSAForServer(base, owner string) *CachedRRset
 	if rrcache == nil {
 		return nil
 	}
-	base = dns.Fqdn(strings.TrimSpace(base))
-	owner = dns.Fqdn(strings.TrimSpace(owner))
+	// Canonicalize to match StoreTLSAForServer's keying (case-insensitive).
+	base = dns.CanonicalName(strings.TrimSpace(base))
+	owner = dns.CanonicalName(strings.TrimSpace(owner))
 	st, ok := rrcache.ServerTLSA.Get(base)
 	if !ok || st == nil {
 		return nil
@@ -687,7 +691,7 @@ func (rrcache *RRsetCacheT) SnapshotTLSAForServer(base string) map[string]*Cache
 	if rrcache == nil {
 		return nil
 	}
-	st, ok := rrcache.ServerTLSA.Get(dns.Fqdn(strings.TrimSpace(base)))
+	st, ok := rrcache.ServerTLSA.Get(dns.CanonicalName(strings.TrimSpace(base)))
 	if !ok || st == nil {
 		return nil
 	}

--- a/v2/cache/rrset_cache.go
+++ b/v2/cache/rrset_cache.go
@@ -70,6 +70,7 @@ func NewRRsetCache(lg *log.Logger, verbose, debug bool) *RRsetCacheT {
 		ServerMap:            core.NewCmap[map[string]*AuthServer](), // servers stored as map[nsname]*AuthServer{}
 		AuthServerMap:        core.NewCmap[*AuthServer](),            // Global map: nsname -> *AuthServer (ensures single instance per nameserver)
 		ZoneMap:              core.NewCmap[*Zone](),                  // zone -> *Zone
+		ServerTLSA:           core.NewCmap[*ServerTLSARecords](),     // nsname -> validated TLSA cache
 		DnskeyCache:          DnskeyCache,
 		Logger:               lg,
 		LineWidth:            130, // default line width for truncating long lines in logging and output
@@ -376,12 +377,14 @@ func (rrcache *RRsetCacheT) AddStub(zone string, servers []AuthServer) error {
 	authservers := map[string]*AuthServer{}
 	for i := range servers {
 		server := &servers[i]
-		// Use the shared per-nameserver instance (as AddServers does), so this
-		// stub server is also registered in AuthServerMap. A private NewAuthServer
-		// here would live only in ServerMap: StoreTLSAForServer writes TLSA onto
-		// the ServerMap instance, but LookupTLSAForServer reads AuthServerMap, so
-		// a stub upstream's cached TLSA would be invisible on the XoT DANE path.
-		tmpauthserver := rrcache.GetOrCreateAuthServer(server.Name)
+		// A stub gets a PRIVATE AuthServer instance (ServerMap only), never the
+		// shared AuthServerMap one: the setters below (SetAddrs/SetTransports/
+		// ForceSetSrc) would otherwise clobber the address/transport state that
+		// IMR discovery maintains for the same nameserver name, skewing ordinary
+		// recursion. TLSA visibility does NOT require sharing — it is cached at
+		// cache level (rrcache.ServerTLSA), keyed by name, independent of which
+		// AuthServer instance answered.
+		tmpauthserver := NewAuthServer(server.Name)
 		if tmpauthserver == nil {
 			continue // Skip invalid server names
 		}
@@ -606,6 +609,12 @@ func cloneRRs(rrs []dns.RR) []dns.RR {
 	return out
 }
 
+// StoreTLSAForServer caches a validated TLSA RRset for the nameserver base
+// (SVCB/TSYNC discovery and direct TLSA answers). The cache is keyed by the
+// server's base name at cache level (rrcache.ServerTLSA), NOT on the AuthServer
+// instance — so a stub's private AuthServer and a discovery-shared instance for
+// the same name observe the same TLSA cache without co-mingling their
+// address/transport state.
 func (rrcache *RRsetCacheT) StoreTLSAForServer(base, owner string, rrset *core.RRset, vstate ValidationState) {
 	if rrcache == nil || rrset == nil || len(rrset.RRs) == 0 {
 		return
@@ -618,32 +627,33 @@ func (rrcache *RRsetCacheT) StoreTLSAForServer(base, owner string, rrset *core.R
 	if owner == "." || owner == "" {
 		return
 	}
-	for zone, sm := range rrcache.ServerMap.Items() {
-		server, ok := sm[base]
-		if !ok {
-			continue
+	st, ok := rrcache.ServerTLSA.Get(base)
+	if !ok {
+		st = &ServerTLSARecords{recs: make(map[string]*CachedRRset)}
+		if !rrcache.ServerTLSA.SetIfAbsent(base, st) {
+			// Lost the race; adopt the instance that won.
+			st, _ = rrcache.ServerTLSA.Get(base)
 		}
-		server.mu.Lock()
-		if server.TLSARecords == nil {
-			server.TLSARecords = make(map[string]*CachedRRset)
-		}
-		server.TLSARecords[owner] = &CachedRRset{
-			Name:   owner,
-			RRtype: dns.TypeTLSA,
-			RRset: &core.RRset{
-				Name:   owner,
-				Class:  dns.ClassINET,
-				RRtype: dns.TypeTLSA,
-				RRs:    cloneRRs(rrset.RRs),
-				RRSIGs: cloneRRs(rrset.RRSIGs),
-			},
-			Context:    ContextAnswer,
-			State:      vstate,
-			Expiration: time.Now().Add(GetMinTTL(rrset.RRs)),
-		}
-		server.mu.Unlock()
-		rrcache.ServerMap.Set(zone, sm)
 	}
+	if st == nil {
+		return
+	}
+	st.mu.Lock()
+	st.recs[owner] = &CachedRRset{
+		Name:   owner,
+		RRtype: dns.TypeTLSA,
+		RRset: &core.RRset{
+			Name:   owner,
+			Class:  dns.ClassINET,
+			RRtype: dns.TypeTLSA,
+			RRs:    cloneRRs(rrset.RRs),
+			RRSIGs: cloneRRs(rrset.RRSIGs),
+		},
+		Context:    ContextAnswer,
+		State:      vstate,
+		Expiration: time.Now().Add(GetMinTTL(rrset.RRs)),
+	}
+	st.mu.Unlock()
 }
 
 // LookupTLSAForServer returns the cached TLSA RRset for owner (a
@@ -657,15 +667,40 @@ func (rrcache *RRsetCacheT) LookupTLSAForServer(base, owner string) *CachedRRset
 	}
 	base = dns.Fqdn(strings.TrimSpace(base))
 	owner = dns.Fqdn(strings.TrimSpace(owner))
-	server, ok := rrcache.AuthServerMap.Get(base)
-	if !ok || server == nil {
+	st, ok := rrcache.ServerTLSA.Get(base)
+	if !ok || st == nil {
 		return nil
 	}
-	rec := server.SnapshotTLSARecords()[owner]
+	st.mu.RLock()
+	rec := st.recs[owner]
+	st.mu.RUnlock()
 	if rec == nil || time.Now().After(rec.Expiration) {
 		return nil
 	}
 	return rec
+}
+
+// SnapshotTLSAForServer returns a copy of the cached TLSA records for the
+// nameserver base (owner -> CachedRRset), or nil if none. Used by the IMR cache
+// dump; expiry is not filtered here (the dump shows all cached entries).
+func (rrcache *RRsetCacheT) SnapshotTLSAForServer(base string) map[string]*CachedRRset {
+	if rrcache == nil {
+		return nil
+	}
+	st, ok := rrcache.ServerTLSA.Get(dns.Fqdn(strings.TrimSpace(base)))
+	if !ok || st == nil {
+		return nil
+	}
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	if len(st.recs) == 0 {
+		return nil
+	}
+	snap := make(map[string]*CachedRRset, len(st.recs))
+	for owner, rec := range st.recs {
+		snap[owner] = rec
+	}
+	return snap
 }
 
 func (rrcache *RRsetCacheT) SetPrimed(primed bool) {

--- a/v2/cache/rrset_cache.go
+++ b/v2/cache/rrset_cache.go
@@ -376,7 +376,12 @@ func (rrcache *RRsetCacheT) AddStub(zone string, servers []AuthServer) error {
 	authservers := map[string]*AuthServer{}
 	for i := range servers {
 		server := &servers[i]
-		tmpauthserver := NewAuthServer(server.Name)
+		// Use the shared per-nameserver instance (as AddServers does), so this
+		// stub server is also registered in AuthServerMap. A private NewAuthServer
+		// here would live only in ServerMap: StoreTLSAForServer writes TLSA onto
+		// the ServerMap instance, but LookupTLSAForServer reads AuthServerMap, so
+		// a stub upstream's cached TLSA would be invisible on the XoT DANE path.
+		tmpauthserver := rrcache.GetOrCreateAuthServer(server.Name)
 		if tmpauthserver == nil {
 			continue // Skip invalid server names
 		}

--- a/v2/cache/rrset_cache.go
+++ b/v2/cache/rrset_cache.go
@@ -641,6 +641,28 @@ func (rrcache *RRsetCacheT) StoreTLSAForServer(base, owner string, rrset *core.R
 	}
 }
 
+// LookupTLSAForServer returns the cached TLSA RRset for owner (a
+// _port._proto.name. label) on the nameserver base, or nil when absent or
+// expired. Entries are written by StoreTLSAForServer (SVCB/TSYNC discovery and
+// direct TLSA answers), which records the DNSSEC validation state the caller
+// should check (XoT DANE requires ValidationStateSecure).
+func (rrcache *RRsetCacheT) LookupTLSAForServer(base, owner string) *CachedRRset {
+	if rrcache == nil {
+		return nil
+	}
+	base = dns.Fqdn(strings.TrimSpace(base))
+	owner = dns.Fqdn(strings.TrimSpace(owner))
+	server, ok := rrcache.AuthServerMap.Get(base)
+	if !ok || server == nil {
+		return nil
+	}
+	rec := server.SnapshotTLSARecords()[owner]
+	if rec == nil || time.Now().After(rec.Expiration) {
+		return nil
+	}
+	return rec
+}
+
 func (rrcache *RRsetCacheT) SetPrimed(primed bool) {
 	rrcache.Primed = primed
 }

--- a/v2/cache/rrset_tlsa_stub_test.go
+++ b/v2/cache/rrset_tlsa_stub_test.go
@@ -1,0 +1,62 @@
+package cache
+
+import (
+	"log"
+	"testing"
+
+	"github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+// TestStubServerTLSAVisibleToLookup guards the fix for the #314 review finding:
+// AddStub must register its servers as the shared per-nameserver instance
+// (AuthServerMap), not a private ServerMap-only one. Otherwise a TLSA record
+// stored via StoreTLSAForServer (which walks ServerMap) is invisible to
+// LookupTLSAForServer (which reads AuthServerMap), defeating the server-scoped
+// TLSA cache for stub upstreams on the XoT DANE path.
+func TestStubServerTLSAVisibleToLookup(t *testing.T) {
+	rrcache := NewRRsetCache(log.Default(), false, false)
+
+	const (
+		zone  = "example."
+		nsFQ  = "ns1.example."
+		owner = "_853._tcp.ns1.example."
+	)
+
+	if err := rrcache.AddStub(zone, []AuthServer{
+		{Name: nsFQ, Addrs: []string{"192.0.2.1"}, Alpn: []string{"dot"}},
+	}); err != nil {
+		t.Fatalf("AddStub: %v", err)
+	}
+
+	// Sanity: the stub server is reachable through the shared global map, not
+	// only through the per-zone ServerMap.
+	if s, ok := rrcache.AuthServerMap.Get(nsFQ); !ok || s == nil {
+		t.Fatalf("stub server %s not registered in AuthServerMap (shared instance missing)", nsFQ)
+	}
+
+	tlsa, err := dns.NewRR(owner + " 120 IN TLSA 3 1 1 " +
+		"0000000000000000000000000000000000000000000000000000000000000000")
+	if err != nil {
+		t.Fatalf("build TLSA RR: %v", err)
+	}
+	rrset := &core.RRset{
+		Name:   owner,
+		Class:  dns.ClassINET,
+		RRtype: dns.TypeTLSA,
+		RRs:    []dns.RR{tlsa},
+	}
+
+	rrcache.StoreTLSAForServer(nsFQ, owner, rrset, ValidationStateSecure)
+
+	got := rrcache.LookupTLSAForServer(nsFQ, owner)
+	if got == nil {
+		t.Fatal("LookupTLSAForServer returned nil for a stub server: TLSA stored via ServerMap is invisible to the AuthServerMap-backed lookup")
+	}
+	if got.State != ValidationStateSecure {
+		t.Fatalf("unexpected validation state: got %v, want secure", got.State)
+	}
+	if got.RRset == nil || len(got.RRset.RRs) != 1 {
+		t.Fatalf("unexpected cached RRset: %+v", got.RRset)
+	}
+}

--- a/v2/cache/rrset_tlsa_stub_test.go
+++ b/v2/cache/rrset_tlsa_stub_test.go
@@ -8,12 +8,20 @@ import (
 	"github.com/miekg/dns"
 )
 
-// TestStubServerTLSAVisibleToLookup guards the fix for the #314 review finding:
-// AddStub must register its servers as the shared per-nameserver instance
-// (AuthServerMap), not a private ServerMap-only one. Otherwise a TLSA record
-// stored via StoreTLSAForServer (which walks ServerMap) is invisible to
-// LookupTLSAForServer (which reads AuthServerMap), defeating the server-scoped
-// TLSA cache for stub upstreams on the XoT DANE path.
+func tlsaRRset(t *testing.T, owner string) *core.RRset {
+	t.Helper()
+	rr, err := dns.NewRR(owner + " 120 IN TLSA 3 1 1 " +
+		"0000000000000000000000000000000000000000000000000000000000000000")
+	if err != nil {
+		t.Fatalf("build TLSA RR: %v", err)
+	}
+	return &core.RRset{Name: owner, Class: dns.ClassINET, RRtype: dns.TypeTLSA, RRs: []dns.RR{rr}}
+}
+
+// TestStubServerTLSAVisibleToLookup: a stub upstream's TLSA is retrievable via
+// LookupTLSAForServer. TLSA is cached at cache level (ServerTLSA), decoupled
+// from the AuthServer instance — so this works even though AddStub keeps a
+// PRIVATE instance and never registers the stub in the shared AuthServerMap.
 func TestStubServerTLSAVisibleToLookup(t *testing.T) {
 	rrcache := NewRRsetCache(log.Default(), false, false)
 
@@ -29,34 +37,70 @@ func TestStubServerTLSAVisibleToLookup(t *testing.T) {
 		t.Fatalf("AddStub: %v", err)
 	}
 
-	// Sanity: the stub server is reachable through the shared global map, not
-	// only through the per-zone ServerMap.
-	if s, ok := rrcache.AuthServerMap.Get(nsFQ); !ok || s == nil {
-		t.Fatalf("stub server %s not registered in AuthServerMap (shared instance missing)", nsFQ)
+	// The stub must NOT leak into the shared AuthServerMap: sharing that
+	// instance is exactly what let AddStub clobber discovered NS state.
+	if _, ok := rrcache.AuthServerMap.Get(nsFQ); ok {
+		t.Fatalf("stub server %s leaked into AuthServerMap (should be a private ServerMap-only instance)", nsFQ)
 	}
 
-	tlsa, err := dns.NewRR(owner + " 120 IN TLSA 3 1 1 " +
-		"0000000000000000000000000000000000000000000000000000000000000000")
-	if err != nil {
-		t.Fatalf("build TLSA RR: %v", err)
-	}
-	rrset := &core.RRset{
-		Name:   owner,
-		Class:  dns.ClassINET,
-		RRtype: dns.TypeTLSA,
-		RRs:    []dns.RR{tlsa},
-	}
-
-	rrcache.StoreTLSAForServer(nsFQ, owner, rrset, ValidationStateSecure)
+	rrcache.StoreTLSAForServer(nsFQ, owner, tlsaRRset(t, owner), ValidationStateSecure)
 
 	got := rrcache.LookupTLSAForServer(nsFQ, owner)
 	if got == nil {
-		t.Fatal("LookupTLSAForServer returned nil for a stub server: TLSA stored via ServerMap is invisible to the AuthServerMap-backed lookup")
+		t.Fatal("LookupTLSAForServer returned nil for a stub server: decoupled TLSA cache not consulted")
 	}
 	if got.State != ValidationStateSecure {
 		t.Fatalf("unexpected validation state: got %v, want secure", got.State)
 	}
-	if got.RRset == nil || len(got.RRset.RRs) != 1 {
-		t.Fatalf("unexpected cached RRset: %+v", got.RRset)
+	// Snapshot (used by the IMR dump) sees it too.
+	if snap := rrcache.SnapshotTLSAForServer(nsFQ); len(snap) != 1 || snap[owner] == nil {
+		t.Fatalf("SnapshotTLSAForServer missing the record: %+v", snap)
+	}
+}
+
+// TestDiscoverThenStubKeepsGlue is the F2 regression: a stub sharing an NS name
+// with IMR discovery must NOT overwrite the discovered addresses on the shared
+// AuthServerMap instance (which ordinary recursion dials). Before the decoupling
+// fix, AddStub used the shared instance + SetAddrs and clobbered the glue.
+func TestDiscoverThenStubKeepsGlue(t *testing.T) {
+	rrcache := NewRRsetCache(log.Default(), false, false)
+	const nsFQ = "ns1.example."
+
+	// IMR discovery registers ns1 with glue in the shared AuthServerMap.
+	disc := NewAuthServer(nsFQ)
+	disc.SetAddrs([]string{"192.0.2.10", "192.0.2.11"})
+	if err := rrcache.AddServers("child.example.", map[string]*AuthServer{nsFQ: disc}); err != nil {
+		t.Fatalf("AddServers: %v", err)
+	}
+	shared, ok := rrcache.AuthServerMap.Get(nsFQ)
+	if !ok || len(shared.Addrs) != 2 {
+		t.Fatalf("discovery did not register glue: %+v", shared)
+	}
+
+	// A stub for the SAME name with a different address.
+	if err := rrcache.AddStub("stub.example.", []AuthServer{
+		{Name: nsFQ, Addrs: []string{"203.0.113.1"}, Alpn: []string{"do53"}},
+	}); err != nil {
+		t.Fatalf("AddStub: %v", err)
+	}
+
+	// The shared/discovered instance must be untouched (glue intact, no stub addr).
+	shared2, _ := rrcache.AuthServerMap.Get(nsFQ)
+	if len(shared2.Addrs) != 2 || shared2.Addrs[0] != "192.0.2.10" || shared2.Addrs[1] != "192.0.2.11" {
+		t.Fatalf("stub clobbered discovered glue on the shared instance: %v", shared2.Addrs)
+	}
+	for _, a := range shared2.Addrs {
+		if a == "203.0.113.1" {
+			t.Fatalf("stub address leaked onto the shared discovery instance: %v", shared2.Addrs)
+		}
+	}
+
+	// The stub's own private instance carries the stub address.
+	sm, ok := rrcache.ServerMap.Get("stub.example.")
+	if !ok || sm[nsFQ] == nil {
+		t.Fatalf("stub zone server map missing %s", nsFQ)
+	}
+	if len(sm[nsFQ].Addrs) != 1 || sm[nsFQ].Addrs[0] != "203.0.113.1" {
+		t.Fatalf("stub private instance has wrong addrs: %v", sm[nsFQ].Addrs)
 	}
 }

--- a/v2/cache/rrset_tlsa_stub_test.go
+++ b/v2/cache/rrset_tlsa_stub_test.go
@@ -104,3 +104,29 @@ func TestDiscoverThenStubKeepsGlue(t *testing.T) {
 		t.Fatalf("stub private instance has wrong addrs: %v", sm[nsFQ].Addrs)
 	}
 }
+
+// TestServerTLSACaseInsensitive: DNS names are case-insensitive (ASCII, RFC
+// 4343), so a TLSA stored under one letter case must be retrievable under
+// another. The cache keys are canonicalized (dns.CanonicalName); a plain
+// dns.Fqdn would split NS1.Example. from ns1.example. into separate buckets.
+func TestServerTLSACaseInsensitive(t *testing.T) {
+	rrcache := NewRRsetCache(log.Default(), false, false)
+	const ownerLC = "_853._tcp.ns1.example."
+
+	// Store under UPPER/mixed case...
+	rrcache.StoreTLSAForServer("NS1.Example.", "_853._TCP.NS1.Example.", tlsaRRset(t, ownerLC), ValidationStateSecure)
+
+	// ...look up under lower case.
+	if got := rrcache.LookupTLSAForServer("ns1.example.", ownerLC); got == nil {
+		t.Fatal("lookup missed a record stored under different letter case (keys not canonicalized)")
+	}
+	// ...and with a mixed-case owner too.
+	if got := rrcache.LookupTLSAForServer("ns1.example.", "_853._Tcp.NS1.example."); got == nil {
+		t.Fatal("lookup missed under mixed-case owner")
+	}
+	// Snapshot canonicalizes the base and keys by the canonical owner.
+	snap := rrcache.SnapshotTLSAForServer("Ns1.Example.")
+	if len(snap) != 1 || snap[ownerLC] == nil {
+		t.Fatalf("snapshot missed the record under different base case: %+v", snap)
+	}
+}

--- a/v2/cli/imr_dump_cmds.go
+++ b/v2/cli/imr_dump_cmds.go
@@ -139,7 +139,7 @@ var dumpAuthServersCmd = &cobra.Command{
 					if counters := formatTransportCounters(server); counters != "" {
 						fmt.Printf("    Transport usage: %s\n", counters)
 					}
-					if tlsaSnapshot := server.SnapshotTLSARecords(); len(tlsaSnapshot) > 0 {
+					if tlsaSnapshot := Conf.Internal.RRsetCache.SnapshotTLSAForServer(server.Name); len(tlsaSnapshot) > 0 {
 						fmt.Printf("    TLSA records:\n")
 						var owners []string
 						for owner := range tlsaSnapshot {
@@ -824,7 +824,7 @@ func printAuthServerVerbose(name string, server *cache.AuthServer) {
 	if counters := formatTransportCounters(server); counters != "" {
 		fmt.Printf("    Transport usage: %s\n", counters)
 	}
-	if tlsaSnapshot := server.SnapshotTLSARecords(); len(tlsaSnapshot) > 0 {
+	if tlsaSnapshot := Conf.Internal.RRsetCache.SnapshotTLSAForServer(server.Name); len(tlsaSnapshot) > 0 {
 		fmt.Printf("    TLSA records:\n")
 		var owners []string
 		for owner := range tlsaSnapshot {

--- a/v2/config.go
+++ b/v2/config.go
@@ -187,6 +187,16 @@ type DnsEngineConf struct {
 	Transports  []string              `yaml:"transports" validate:"required,min=1,dive,oneof=do53 dot doh doq"` // "do53", "dot", "doh", "doq"
 	OptionsStrs []string              `yaml:"options" mapstructure:"options"`
 	Options     map[AuthOption]string `yaml:"-" mapstructure:"-"`
+	// Downstream (secondary) client-certificate authentication on the DoT
+	// listener — the primary side of XoT mTLS (RFC 9103 §9.3 lists mTLS as
+	// one valid policy; TSIG + IP ACL remain valid without it). Opt-in:
+	// empty = no client certificate requested (previous behavior). Applies
+	// only to the auth DoT listener, not the IMR's DoT front end.
+	//   pin  require a client cert whose SPKI SHA-256 is in downstream-pins
+	//   ca   standard mTLS chain verification against the downstream-ca PEM
+	DownstreamAuth string   `yaml:"downstream-auth,omitempty" mapstructure:"downstream-auth" validate:"omitempty,oneof=pin ca"`
+	DownstreamPins []string `yaml:"downstream-pins,omitempty" mapstructure:"downstream-pins"`
+	DownstreamCA   string   `yaml:"downstream-ca,omitempty" mapstructure:"downstream-ca"`
 	// OutboundSoaSerial controls the SOA serial advertised on outbound zone
 	// transfers and NOTIFYs. One of:
 	//   keep     — outbound = inbound serial (default; current behavior).

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -50,8 +50,11 @@ func clarifyXfrError(zone, upstream string, err error) error {
 	return err
 }
 
-func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype, keyName string, conf *Config) (uint32, error) {
-
+// ZoneTransferIn pulls the zone from the upstream primary described by up:
+// AXFR/IXFR over Do53, or over TLS (XoT, RFC 9103) when up.Transport is dot.
+// TSIG (up.Key) and TLS are independent layers and may be combined.
+func (zd *ZoneData) ZoneTransferIn(up PeerConf, serial uint32, ttype string, conf *Config) (uint32, error) {
+	upstream := up.Addr
 	if upstream == "" {
 		Fatal("ZoneTransfer: upstream not set")
 	}
@@ -67,12 +70,19 @@ func (zd *ZoneData) ZoneTransferIn(upstream string, serial uint32, ttype, keyNam
 	if zd.ZoneStore == MapZone {
 		zd.Data = core.NewCmap[OwnerData]()
 	}
-	lgDns.Info("ZoneTransferIn", "zone", zd.ZoneName, "store", ZoneStoreToString[zd.ZoneStore])
+	lgDns.Info("ZoneTransferIn", "zone", zd.ZoneName, "store", ZoneStoreToString[zd.ZoneStore], "transport", transportLabel(up))
 
 	transfer := new(dns.Transfer)
+	// XoT: a DoT peer gets a verifying TLS config (pin/dane/pkix) and the
+	// fork's Transfer.In dials tcp-tls with it. nil => plain TCP (Do53).
+	tlsCfg, terr := conf.ClientTLSConfigForPeer(up)
+	if terr != nil {
+		return 0, fmt.Errorf("ZoneTransferIn %s: TLS setup for %s: %w", zd.ZoneName, upstream, terr)
+	}
+	transfer.TLS = tlsCfg
 	// Sign the AXFR/IXFR request under this upstream's key (NOKEY => unsigned).
 	// The provider also verifies the TSIG on the inbound envelopes.
-	provider, serr := SignForPeer(msg, keyName, conf)
+	provider, serr := SignForPeer(msg, up.Key, conf)
 	if serr != nil {
 		return 0, fmt.Errorf("ZoneTransferIn %s: TSIG sign setup: %w", zd.ZoneName, serr)
 	}

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -184,7 +184,7 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 		addresses = tmp
 
 		if CaseFoldContains(conf.DnsEngine.Transports, "dot") {
-			err := DnsDoTEngine(ctx, conf, addresses, &cert, authDNSHandler)
+			err := DnsDoTEngine(ctx, conf, addresses, &cert, authDNSHandler, true)
 			if err != nil {
 				lgDns.Error("Failed to setup the DoT server", "err", err)
 			}

--- a/v2/dot.go
+++ b/v2/dot.go
@@ -16,21 +16,25 @@ import (
 	"github.com/spf13/viper"
 )
 
+// DnsDoTEngine starts the DoT listeners. applyDownstreamAuth selects whether
+// the dnsengine.downstream-auth mTLS policy applies: true for the auth
+// listener (the XoT primary side), false for the IMR's DoT front end, which
+// serves arbitrary clients and must never demand client certificates.
 func DnsDoTEngine(ctx context.Context, conf *Config, dotaddrs []string, cert *tls.Certificate,
-	ourDNSHandler func(w dns.ResponseWriter, r *dns.Msg)) error {
+	ourDNSHandler func(w dns.ResponseWriter, r *dns.Msg), applyDownstreamAuth bool) error {
 
 	if cert == nil {
 		return fmt.Errorf("DnsDoTEngine:DoT certificate is not set")
 	}
 
 	lgDns.Info("DnsEngine: DoT addresses", "addrs", dotaddrs)
-	// tlsConfig := DoTTLSConfig(certFile, keyFile)
 
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{*cert},
-		MinVersion:   tls.VersionTLS13, // or TLS12 if you need broader support
-		// ClientAuth: tls.NoClientCert, // optional: change if you want client certs
-		NextProtos: []string{"dot"}, // important for DoT
+	tlsConfig, err := ServerTLSConfigForDoT(conf, cert, applyDownstreamAuth)
+	if err != nil {
+		return fmt.Errorf("DnsDoTEngine: %v", err)
+	}
+	if tlsConfig.ClientAuth != tls.NoClientCert {
+		lgDns.Info("DnsEngine: DoT downstream mTLS enabled", "mode", conf.DnsEngine.DownstreamAuth)
 	}
 
 	// Wrap the DNS handler to add logging

--- a/v2/imrengine.go
+++ b/v2/imrengine.go
@@ -1357,7 +1357,7 @@ func (imr *Imr) StartImrEngineListeners(ctx context.Context, conf *Config) error
 		addresses = tmp
 
 		if CaseFoldContains(conf.Imr.Transports, "dot") {
-			err := DnsDoTEngine(ctx, conf, addresses, &cert, ImrHandler)
+			err := DnsDoTEngine(ctx, conf, addresses, &cert, ImrHandler, false)
 			if err != nil {
 				lgImr.Error("failed to setup DoT server", "err", err)
 			}

--- a/v2/ops_tlsa.go
+++ b/v2/ops_tlsa.go
@@ -25,22 +25,14 @@ func (zd *ZoneData) PublishTlsaRR(name string, port uint16, certPEM string) erro
 		return fmt.Errorf("PublishTlsaRR: name %q is not a subdomain of %q", name, zd.ZoneName)
 	}
 
-	certData, err := parseCertificate(certPEM)
+	cert, err := parseCertificate(certPEM)
 	if err != nil {
 		return err
 	}
 
-	tlsa := dns.TLSA{
-		Usage:        3, // DANE-EE
-		Selector:     1, // SPKI
-		MatchingType: 1, // SHA-256
-		Certificate:  certData,
-	}
-	tlsa.Hdr = dns.RR_Header{
-		Name:   fmt.Sprintf("_%d._tcp.%s", port, name),
-		Rrtype: dns.TypeTLSA,
-		Class:  dns.ClassINET,
-		Ttl:    120,
+	tlsa, err := NewTlsaRR(name, port, cert)
+	if err != nil {
+		return err
 	}
 
 	lgHandler.Info("PublishTlsaRR: publishing TLSA RR", "rr", tlsa.String())
@@ -52,31 +44,65 @@ func (zd *ZoneData) PublishTlsaRR(name string, port uint16, certPEM string) erro
 	zd.KeyDB.UpdateQ <- UpdateRequest{
 		Cmd:            "ZONE-UPDATE",
 		ZoneName:       zd.ZoneName,
-		Actions:        []dns.RR{&tlsa},
+		Actions:        []dns.RR{tlsa},
 		InternalUpdate: true,
 	}
 
 	return nil
 }
 
-func parseCertificate(certPEM string) (string, error) {
+// NewTlsaRR builds a DANE-EE / SPKI / SHA-256 ("3 1 1") TLSA record for the
+// given service name and port. The certificate association data is the SHA-256
+// digest of the SubjectPublicKeyInfo, per the advertised Selector.
+func NewTlsaRR(name string, port uint16, cert *x509.Certificate) (*dns.TLSA, error) {
+	data, err := tlsaSelectorBytes(cert, 1)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(data)
+
+	tlsa := &dns.TLSA{
+		Usage:        3, // DANE-EE
+		Selector:     1, // SPKI
+		MatchingType: 1, // SHA-256
+		Certificate:  hex.EncodeToString(hash[:]),
+	}
+	tlsa.Hdr = dns.RR_Header{
+		Name:   fmt.Sprintf("_%d._tcp.%s", port, name),
+		Rrtype: dns.TypeTLSA,
+		Class:  dns.ClassINET,
+		Ttl:    120,
+	}
+	return tlsa, nil
+}
+
+func parseCertificate(certPEM string) (*x509.Certificate, error) {
 	block, _ := pem.Decode([]byte(certPEM))
 	if block == nil {
-		return "", fmt.Errorf("failed to decode PEM data")
+		return nil, fmt.Errorf("failed to decode PEM data")
 	}
 	if block.Type != "CERTIFICATE" {
-		return "", fmt.Errorf("unexpected PEM block type: %s (expected CERTIFICATE)", block.Type)
+		return nil, fmt.Errorf("unexpected PEM block type: %s (expected CERTIFICATE)", block.Type)
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse certificate: %v", err)
+		return nil, fmt.Errorf("failed to parse certificate: %v", err)
 	}
+	return cert, nil
+}
 
-	// Use the entire certificate for hashing instead of just the public key
-	hash := sha256.Sum256(cert.Raw)
-	// log.Printf("parseCertificate: hash: %s", hex.EncodeToString(hash[:]))
-	return hex.EncodeToString(hash[:]), nil
+// tlsaSelectorBytes returns the certificate bytes that a TLSA record's
+// Selector field says the association data is computed over.
+func tlsaSelectorBytes(cert *x509.Certificate, selector uint8) ([]byte, error) {
+	switch selector {
+	case 0: // full certificate
+		return cert.Raw, nil
+	case 1: // SubjectPublicKeyInfo
+		return cert.RawSubjectPublicKeyInfo, nil
+	default:
+		return nil, fmt.Errorf("unsupported TLSA selector: %d", selector)
+	}
 }
 
 func (zd *ZoneData) UnpublishTlsaRR(port uint16) error {
@@ -111,29 +137,36 @@ func LookupTlsaRR(name string) (*core.RRset, error) {
 	return rrset, nil
 }
 
-func VerifyCertAgainstTlsaRR(tlsarr *dns.TLSA, rawcert []byte) error {
+// VerifyCertAgainstTlsaRR checks a presented certificate against one TLSA
+// record. Only usage 3 (DANE-EE) is supported. The Selector field decides
+// which certificate bytes the association data is computed over (0 = full
+// cert, 1 = SPKI); taking the parsed certificate (rather than raw bytes)
+// ensures the caller cannot hash the wrong form.
+func VerifyCertAgainstTlsaRR(tlsarr *dns.TLSA, cert *x509.Certificate) error {
 	decodedCert, err := hex.DecodeString(tlsarr.Certificate)
 	if err != nil {
 		return fmt.Errorf("failed to decode TLSA certificate: %v", err)
 	}
-	switch tlsarr.Usage {
-	case 3:
-		switch tlsarr.MatchingType {
-		case 1: // SHA-256
-			hash := sha256.Sum256(rawcert)
-			if subtle.ConstantTimeCompare(hash[:], decodedCert) == 1 {
-				return nil
-			}
-		case 2: // SHA-512
-			hash := sha512.Sum512(rawcert)
-			if subtle.ConstantTimeCompare(hash[:], decodedCert) == 1 {
-				return nil
-			}
-		default:
-			return fmt.Errorf("unsupported TLSA matching type: %d", tlsarr.MatchingType)
+	if tlsarr.Usage != 3 {
+		return fmt.Errorf("only TLSA usage 3 is supported (this TLSA has usage %d)", tlsarr.Usage)
+	}
+	data, err := tlsaSelectorBytes(cert, tlsarr.Selector)
+	if err != nil {
+		return err
+	}
+	switch tlsarr.MatchingType {
+	case 1: // SHA-256
+		hash := sha256.Sum256(data)
+		if subtle.ConstantTimeCompare(hash[:], decodedCert) == 1 {
+			return nil
+		}
+	case 2: // SHA-512
+		hash := sha512.Sum512(data)
+		if subtle.ConstantTimeCompare(hash[:], decodedCert) == 1 {
+			return nil
 		}
 	default:
-		return fmt.Errorf("only TLSA usage 3 is supported (this TLSA has usage %d)", tlsarr.Usage)
+		return fmt.Errorf("unsupported TLSA matching type: %d", tlsarr.MatchingType)
 	}
 	return fmt.Errorf("TLSA RR %s did not match cert", tlsarr.String())
 }

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -694,10 +694,16 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 					secondaryOK = false
 					break
 				}
+				if err := validatePeerXoT(p); err != nil {
+					lgConfig.Error("secondary zone primary has invalid XoT config, zone in error state", "zone", zname, "primary", p.Addr, "err", err)
+					zd.SetError(ConfigError, "primary %s: %v", p.Addr, err)
+					secondaryOK = false
+					break
+				}
 				origPrimary := p.Addr
-				p.Addr = NormalizeAddress(p.Addr)
+				p.Addr = NormalizeAddressPort(p.Addr, defaultPortForPeer(*p))
 				if origPrimary != p.Addr {
-					lgConfig.Warn("primary has no port specified, using default :53", "zone", zname, "primary", origPrimary)
+					lgConfig.Warn("primary has no port specified, using transport default", "zone", zname, "primary", origPrimary, "port", defaultPortForPeer(*p))
 				}
 			}
 			if !secondaryOK {
@@ -745,6 +751,15 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 			if n.Legacy != "" {
 				lgConfig.Error("zone uses legacy bare-string notify entry, zone in error state", "zone", zname, "notify", n.Legacy)
 				zd.SetError(ConfigError, "notify now requires {addr, key} (got bare string %q)", n.Legacy)
+				legacyNotify = true
+				break
+			}
+			// The XoT fields only apply to the transfer path (primaries:).
+			// NOTIFY goes out over Do53; reject rather than silently ignore
+			// a configured security setting.
+			if n.Transport != "" || n.TLSAuth != "" || n.TLSName != "" || len(n.Pins) > 0 || n.CAFile != "" {
+				lgConfig.Error("zone notify entry carries XoT fields, zone in error state", "zone", zname, "notify", n.Addr)
+				zd.SetError(ConfigError, "notify %s: transport/tls-* not supported for notify targets", n.Addr)
 				legacyNotify = true
 				break
 			}
@@ -1645,6 +1660,12 @@ func GenKeyLifetime(lifetime string) (KeyLifetime, error) {
 // This allows users to specify addresses as either "IP" or "IP:port" in config.
 // Returns empty string if input is empty.
 func NormalizeAddress(addr string) string {
+	return NormalizeAddressPort(addr, "53")
+}
+
+// NormalizeAddressPort is NormalizeAddress with a caller-chosen default port
+// (DoT peers default to 853, everything else to 53).
+func NormalizeAddressPort(addr, defaultPort string) string {
 	if addr == "" {
 		return ""
 	}
@@ -1653,8 +1674,7 @@ func NormalizeAddress(addr string) string {
 	_, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		// If SplitHostPort fails, it means no port is present
-		// Add default DNS port :53
-		return net.JoinHostPort(addr, "53")
+		return net.JoinHostPort(addr, defaultPort)
 	}
 	// Address already has a port, use as-is
 	return addr

--- a/v2/resolve_primaries.go
+++ b/v2/resolve_primaries.go
@@ -50,9 +50,11 @@ func resolvePrimaries(ctx context.Context, imr *Imr, primaries []PeerConf) Prima
 }
 
 func expandPrimaryEntry(ctx context.Context, imr *Imr, p PeerConf) ([]PeerConf, bool) {
-	host, port := splitHostPortDefault(p.Addr)
+	host, port := splitHostPortDefault(p.Addr, defaultPortForPeer(p))
 	if ip := net.ParseIP(host); ip != nil {
-		return []PeerConf{{Addr: net.JoinHostPort(host, port), Key: p.Key}}, true
+		out := p // carry Key + the XoT fields (Transport/TLSAuth/TLSName/Pins/CAFile)
+		out.Addr = net.JoinHostPort(host, port)
+		return []PeerConf{out}, true
 	}
 
 	// Hostname. Resolution is the IMR's job; without one (e.g. imr disabled)
@@ -65,7 +67,7 @@ func expandPrimaryEntry(ctx context.Context, imr *Imr, p PeerConf) ([]PeerConf, 
 		return nil, false
 	}
 	lg.Debug("resolved hostname primary", "hostname", host, "addresses", addrs)
-	return buildUpstreams(addrs, port, p.Key), true
+	return buildUpstreams(addrs, port, p, host), true
 }
 
 // imrLookupAddrs returns host's A and AAAA addresses resolved through the IMR,
@@ -109,19 +111,27 @@ func sortV4First(addrs []string) []string {
 }
 
 // buildUpstreams turns resolved IP literals into addr:port PeerConfs, copying
-// key to each and preserving input order.
-func buildUpstreams(addrs []string, port, key string) []PeerConf {
+// the source entry's key and XoT fields to each and preserving input order.
+// For a DoT peer the source hostname is recorded as TLSName (unless the config
+// set one explicitly) so every produced tuple keeps the name needed for SNI
+// and the DANE TLSA base — the resolved Addr is an IP and no longer has it.
+func buildUpstreams(addrs []string, port string, src PeerConf, srcHost string) []PeerConf {
 	out := make([]PeerConf, 0, len(addrs))
 	for _, a := range addrs {
-		out = append(out, PeerConf{Addr: net.JoinHostPort(a, port), Key: key})
+		up := src
+		up.Addr = net.JoinHostPort(a, port)
+		if peerUsesDoT(up) && up.TLSName == "" {
+			up.TLSName = srcHost
+		}
+		out = append(out, up)
 	}
 	return out
 }
 
-func splitHostPortDefault(addr string) (host, port string) {
+func splitHostPortDefault(addr, defaultPort string) (host, port string) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		return addr, "53"
+		return addr, defaultPort
 	}
 	return host, port
 }

--- a/v2/resolve_primaries_test.go
+++ b/v2/resolve_primaries_test.go
@@ -91,7 +91,8 @@ func TestSortV4First(t *testing.T) {
 }
 
 func TestBuildUpstreams(t *testing.T) {
-	got := buildUpstreams([]string{"192.0.2.1", "2001:db8::1"}, "5353", "K1")
+	src := PeerConf{Addr: "ns.example.net", Key: "K1"}
+	got := buildUpstreams([]string{"192.0.2.1", "2001:db8::1"}, "5353", src, "ns.example.net")
 	if len(got) != 2 {
 		t.Fatalf("want 2, got %+v", got)
 	}
@@ -100,5 +101,70 @@ func TestBuildUpstreams(t *testing.T) {
 	}
 	if got[1].Addr != "[2001:db8::1]:5353" || got[1].Key != "K1" {
 		t.Fatalf("v6 tuple wrong: %+v", got[1])
+	}
+	// Do53 source: the resolved tuples must be identical to pre-XoT output —
+	// in particular TLSName stays empty.
+	if got[0].TLSName != "" || got[0].Transport != "" {
+		t.Fatalf("do53 tuple gained XoT fields: %+v", got[0])
+	}
+}
+
+func TestBuildUpstreams_DoTCarriesTLSNameAndAuth(t *testing.T) {
+	src := PeerConf{
+		Addr:      "ns.example.net",
+		Key:       NOKEY,
+		Transport: TransportDoT,
+		TLSAuth:   TLSAuthDANE,
+	}
+	got := buildUpstreams([]string{"192.0.2.1", "2001:db8::1"}, "853", src, "ns.example.net")
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %+v", got)
+	}
+	for i, up := range got {
+		if up.Transport != TransportDoT || up.TLSAuth != TLSAuthDANE {
+			t.Fatalf("tuple %d lost XoT fields: %+v", i, up)
+		}
+		// The source hostname must survive resolution on every tuple
+		// (multi-address primaries all share the same SNI/DANE name).
+		if up.TLSName != "ns.example.net" {
+			t.Fatalf("tuple %d lost the hostname: %+v", i, up)
+		}
+	}
+}
+
+func TestBuildUpstreams_ExplicitTLSNameWins(t *testing.T) {
+	src := PeerConf{
+		Addr:      "xfr.example.net",
+		Key:       NOKEY,
+		Transport: TransportDoT,
+		TLSAuth:   TLSAuthPin,
+		Pins:      []string{"AAAA"},
+		TLSName:   "ns2.example.net",
+	}
+	got := buildUpstreams([]string{"192.0.2.1"}, "853", src, "xfr.example.net")
+	if len(got) != 1 || got[0].TLSName != "ns2.example.net" {
+		t.Fatalf("explicit tls-name must not be overwritten: %+v", got)
+	}
+}
+
+func TestResolvePrimaries_DoTIPLiteral(t *testing.T) {
+	// An IP-literal DoT primary defaults to port 853 and keeps its XoT fields.
+	res := resolvePrimaries(context.Background(), nil, []PeerConf{{
+		Addr:      "192.0.2.1",
+		Key:       NOKEY,
+		Transport: TransportDoT,
+		TLSAuth:   TLSAuthPin,
+		Pins:      []string{"AAAA"},
+		TLSName:   "ns1.example.net",
+	}})
+	if len(res.Resolved) != 1 {
+		t.Fatalf("want 1 resolved, got %+v", res)
+	}
+	up := res.Resolved[0]
+	if up.Addr != "192.0.2.1:853" {
+		t.Fatalf("DoT default port should be 853: %+v", up)
+	}
+	if up.Transport != TransportDoT || up.TLSAuth != TLSAuthPin || up.TLSName != "ns1.example.net" || len(up.Pins) != 1 {
+		t.Fatalf("XoT fields lost through resolution: %+v", up)
 	}
 }

--- a/v2/rr_print.go
+++ b/v2/rr_print.go
@@ -4,6 +4,7 @@
 package tdns
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strconv"
@@ -311,10 +312,12 @@ func xfrErrorRcode(errstr string) (string, bool) {
 // tsigSecret) and the response envelope MACs are verified -- so a transfer gated
 // by a downstreams ACL that requires a key is accepted. tsigName == "" means an
 // unsigned transfer.
-func ZoneTransferPrint(zname, upstream string, serial uint32, ttype uint16, options map[string]string, tsigName, tsigAlgo, tsigSecret string) error {
+// ZoneTransferPrint runs an AXFR/IXFR and pretty-prints the result. A non-nil
+// tlsConfig moves the transfer to TLS (XoT); nil keeps plain TCP.
+func ZoneTransferPrint(zname, upstream string, serial uint32, ttype uint16, options map[string]string, tsigName, tsigAlgo, tsigSecret string, tlsConfig *tls.Config) error {
 	msg := new(dns.Msg)
 	if ttype == dns.TypeIXFR {
-		// msg.SetIxfr(zname, serial, soa.Ns, soa.Mbox)
+		// msg.SetIxfr(zone, serial, soa.Ns, soa.Mbox)
 		msg.SetIxfr(zname, serial, "", "")
 	} else {
 		msg.SetAxfr(zname)
@@ -332,6 +335,7 @@ func ZoneTransferPrint(zname, upstream string, serial uint32, ttype uint16, opti
 	}
 
 	transfer := new(dns.Transfer)
+	transfer.TLS = tlsConfig
 	// TSIG-sign the transfer request (dog -y) so a downstreams ACL that requires
 	// a key accepts it; miekg base64-decodes the secret and verifies the
 	// per-envelope response MACs.

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -255,6 +255,16 @@ type PeerConf struct {
 	Addr   string `yaml:"addr" mapstructure:"addr"`
 	Key    string `yaml:"key" mapstructure:"key"`
 	Legacy string `yaml:"-" mapstructure:"-"` // bare-string marker; not config
+
+	// XoT (XFR-over-TLS, RFC 9103) fields. All optional; an empty Transport
+	// means Do53 and preserves pre-XoT behavior exactly. TSIG (Key) remains
+	// orthogonal: RFC 9103 allows TSIG and TLS together, so a peer may have
+	// both a TLS auth mode and a TSIG key. Validated by validatePeerXoT.
+	Transport string   `yaml:"transport" mapstructure:"transport"` // "" | do53 | dot
+	TLSAuth   string   `yaml:"tls-auth" mapstructure:"tls-auth"`   // pin | dane | pkix (required for dot)
+	TLSName   string   `yaml:"tls-name" mapstructure:"tls-name"`   // SNI + DANE base name; defaults to the Addr hostname
+	Pins      []string `yaml:"pins" mapstructure:"pins"`           // base64 SPKI SHA-256 pins (tls-auth: pin)
+	CAFile    string   `yaml:"ca-file" mapstructure:"ca-file"`     // PEM bundle (tls-auth: pkix); empty = system roots
 }
 
 // ZoneConf represents the external config for a zone; it contains no zone data

--- a/v2/xot.go
+++ b/v2/xot.go
@@ -53,6 +53,14 @@ func peerUsesDoT(p PeerConf) bool {
 	return p.Transport == TransportDoT
 }
 
+// transportLabel names the peer's transport for logging.
+func transportLabel(p PeerConf) string {
+	if peerUsesDoT(p) {
+		return TransportDoT
+	}
+	return TransportDo53
+}
+
 // peerHostIsIPLiteral reports whether the host part of p.Addr is an IP
 // literal (as opposed to a DNS name).
 func peerHostIsIPLiteral(p PeerConf) bool {

--- a/v2/xot.go
+++ b/v2/xot.go
@@ -7,7 +7,10 @@
 package tdns
 
 import (
+	"context"
 	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -15,6 +18,11 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
+
+	cache "github.com/johanix/tdns/v2/cache"
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
 )
 
 // PeerConf.Transport values.
@@ -124,6 +132,164 @@ func checkPEMCertFile(path string) error {
 		}
 	}
 	return fmt.Errorf("no CERTIFICATE PEM block found")
+}
+
+// daneLookupTimeout bounds the TLSA lookup performed inside the TLS handshake
+// callback so a slow resolver cannot hang an outbound transfer indefinitely.
+const daneLookupTimeout = 5 * time.Second
+
+// ClientTLSConfigForPeer builds the *tls.Config for an outbound XoT connection
+// to peer, dispatching certificate verification to the configured tls-auth
+// mode. Returns (nil, nil) when the peer is not configured for DoT: the
+// caller stays on plain TCP/Do53 (a nil *tls.Config is the Do53 signal
+// throughout the transfer path).
+func (conf *Config) ClientTLSConfigForPeer(peer PeerConf) (*tls.Config, error) {
+	if !peerUsesDoT(peer) {
+		return nil, nil
+	}
+
+	host, port := splitHostPortDefault(peer.Addr, defaultPortForPeer(peer))
+	serverName := peer.TLSName
+	if serverName == "" && net.ParseIP(host) == nil {
+		serverName = host
+	}
+
+	tlsCfg := &tls.Config{
+		// SNI: with DANE-EE the name match is not strictly required, but we
+		// send it for interop with primaries that vhost on SNI. For an
+		// IP-literal peer with no tls-name it stays empty and crypto/tls
+		// fills it from the dial address.
+		ServerName: serverName,
+		MinVersion: tls.VersionTLS13,
+		NextProtos: []string{"dot"},
+	}
+
+	switch peer.TLSAuth {
+	case TLSAuthPin:
+		// Pinning replaces PKIX chain building entirely: InsecureSkipVerify
+		// disables the default chain+hostname verification and
+		// VerifyConnection (which still runs) becomes the sole gate.
+		pins := append([]string(nil), peer.Pins...)
+		tlsCfg.InsecureSkipVerify = true
+		tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+			return verifyPeerCertPins(cs, pins)
+		}
+	case TLSAuthDANE:
+		if serverName == "" {
+			// validatePeerXoT enforces this at config load; kept as a
+			// backstop for PeerConfs built programmatically.
+			return nil, fmt.Errorf("xot: dane peer %s has no DNS name for the TLSA base (set tls-name)", peer.Addr)
+		}
+		name, lookupPort := serverName, port
+		tlsCfg.InsecureSkipVerify = true // DANE-EE replaces PKIX; VerifyConnection is the gate
+		tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+			return conf.verifyPeerCertDANE(cs, name, lookupPort)
+		}
+	case TLSAuthPKIX:
+		if peer.CAFile != "" {
+			data, err := os.ReadFile(peer.CAFile)
+			if err != nil {
+				return nil, fmt.Errorf("xot: peer %s: reading ca-file: %v", peer.Addr, err)
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(data) {
+				return nil, fmt.Errorf("xot: peer %s: no usable certificates in ca-file %s", peer.Addr, peer.CAFile)
+			}
+			tlsCfg.RootCAs = pool
+		}
+		// RootCAs nil = system roots. Standard chain + hostname/IP-SAN
+		// verification; no callback needed.
+	default:
+		return nil, fmt.Errorf("xot: peer %s: unsupported tls-auth %q", peer.Addr, peer.TLSAuth)
+	}
+	return tlsCfg, nil
+}
+
+// verifyPeerCertPins is the VerifyConnection gate for tls-auth: pin. The
+// leaf certificate's SPKI SHA-256 must match one of the configured pins.
+func verifyPeerCertPins(cs tls.ConnectionState, pins []string) error {
+	if len(cs.PeerCertificates) == 0 {
+		return fmt.Errorf("xot: peer presented no certificate")
+	}
+	got := SPKISHA256(cs.PeerCertificates[0])
+	for _, want := range pins {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1 {
+			return nil
+		}
+	}
+	return fmt.Errorf("xot: peer SPKI digest %s matches none of the %d configured pin(s)", got, len(pins))
+}
+
+// verifyPeerCertDANE is the VerifyConnection gate for tls-auth: dane: the
+// leaf certificate must match a TLSA record at _<port>._tcp.<name> obtained
+// through a DNSSEC-validated lookup.
+func (conf *Config) verifyPeerCertDANE(cs tls.ConnectionState, name, port string) error {
+	if len(cs.PeerCertificates) == 0 {
+		return fmt.Errorf("xot: peer presented no certificate")
+	}
+	leaf := cs.PeerCertificates[0]
+	rrset, err := conf.lookupTLSAValidated(name, port)
+	if err != nil {
+		return err
+	}
+	for _, rr := range rrset.RRs {
+		tlsa, ok := rr.(*dns.TLSA)
+		if !ok {
+			continue
+		}
+		if err := VerifyCertAgainstTlsaRR(tlsa, leaf); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("xot: no TLSA record at _%s._tcp.%s matches the peer certificate", port, name)
+}
+
+// lookupTLSAValidated returns the TLSA RRset at _<port>._tcp.<name>. DANE over
+// an unvalidated lookup is meaningless, so this fails closed: no IMR, lookup
+// failure, or a not-secure validation state are all errors. The per-server
+// TLSA cache (populated, with validation state, by SVCB/TSYNC discovery and
+// direct TLSA answers) is consulted first; otherwise the RRset is fetched and
+// validated through the in-process IMR. The imr.RequireDnssecValidation
+// lab-mode escape hatch (config: imrengine.require_dnssec_validation) is
+// honored, with a loud warning, to match how the rest of tdns treats TLSA.
+func (conf *Config) lookupTLSAValidated(name, port string) (*core.RRset, error) {
+	imr := conf.Internal.ImrEngine
+	if imr == nil {
+		return nil, fmt.Errorf("xot: tls-auth dane requires the built-in IMR to be active")
+	}
+	fqdn := dns.Fqdn(name)
+	owner := fmt.Sprintf("_%s._tcp.%s", port, fqdn)
+
+	requireSecure := imr.RequireDnssecValidation
+	acceptState := func(state cache.ValidationState) bool {
+		if state == cache.ValidationStateSecure {
+			return true
+		}
+		if !requireSecure {
+			lg.Warn("xot: accepting non-secure TLSA RRset because require_dnssec_validation is disabled (lab mode)", "owner", owner, "state", cache.ValidationStateToString[state])
+			return true
+		}
+		return false
+	}
+
+	if cr := imr.Cache.LookupTLSAForServer(fqdn, owner); cr != nil && cr.RRset != nil && len(cr.RRset.RRs) > 0 && acceptState(cr.State) {
+		return cr.RRset, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), daneLookupTimeout)
+	defer cancel()
+	rrset, err := imr.DefaultRRsetFetcher(ctx, owner, dns.TypeTLSA)
+	if err != nil {
+		return nil, fmt.Errorf("xot: TLSA lookup for %s failed: %v", owner, err)
+	}
+	vstate, err := imr.Cache.ValidateRRsetWithParentZone(ctx, rrset, imr.IterativeDNSQueryFetcher(), imr.ParentZone)
+	if err != nil {
+		return nil, fmt.Errorf("xot: TLSA validation for %s failed: %v", owner, err)
+	}
+	if !acceptState(vstate) {
+		return nil, fmt.Errorf("xot: TLSA RRset for %s is not DNSSEC-secure (state %s); refusing DANE (fail closed)", owner, cache.ValidationStateToString[vstate])
+	}
+	return rrset, nil
 }
 
 // SPKISHA256 returns the base64 (standard encoding) SHA-256 digest of the

--- a/v2/xot.go
+++ b/v2/xot.go
@@ -10,7 +10,121 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"strings"
 )
+
+// PeerConf.Transport values.
+const (
+	TransportDo53 = "do53"
+	TransportDoT  = "dot"
+)
+
+// PeerConf.TLSAuth values (how the peer's certificate is authenticated).
+const (
+	TLSAuthPin  = "pin"  // static SPKI SHA-256 pin(s)
+	TLSAuthDANE = "dane" // TLSA at _<port>._tcp.<tls-name>, DNSSEC-validated
+	TLSAuthPKIX = "pkix" // CA chain (ca-file, or system roots if empty)
+)
+
+// defaultPortForPeer returns the default port implied by the peer's transport:
+// 853 for DoT (RFC 7858/9103), 53 otherwise.
+func defaultPortForPeer(p PeerConf) string {
+	if p.Transport == TransportDoT {
+		return "853"
+	}
+	return "53"
+}
+
+// peerUsesDoT reports whether this peer is configured for XFR-over-TLS.
+// (Transport is normalized to lowercase by validatePeerXoT at config load.)
+func peerUsesDoT(p PeerConf) bool {
+	return p.Transport == TransportDoT
+}
+
+// peerHostIsIPLiteral reports whether the host part of p.Addr is an IP
+// literal (as opposed to a DNS name).
+func peerHostIsIPLiteral(p PeerConf) bool {
+	host := p.Addr
+	if h, _, err := net.SplitHostPort(p.Addr); err == nil {
+		host = h
+	}
+	return net.ParseIP(host) != nil
+}
+
+// validatePeerXoT validates (and normalizes in place) the XoT fields of one
+// primary entry. Called from the secondary-zone config validation loop; an
+// error quarantines the zone. The empty/do53 case must stay cheap and always
+// succeed for a plain {addr, key} entry, so pre-XoT configs parse unchanged.
+func validatePeerXoT(p *PeerConf) error {
+	p.Transport = strings.ToLower(strings.TrimSpace(p.Transport))
+	p.TLSAuth = strings.ToLower(strings.TrimSpace(p.TLSAuth))
+
+	switch p.Transport {
+	case "", TransportDo53:
+		// Plain Do53: the TLS-only knobs are meaningless there — reject
+		// loudly rather than silently ignoring a security setting.
+		if p.TLSAuth != "" || p.TLSName != "" || len(p.Pins) > 0 || p.CAFile != "" {
+			return fmt.Errorf("tls-auth/tls-name/pins/ca-file require transport: dot")
+		}
+		return nil
+	case TransportDoT:
+		// validated below
+	default:
+		return fmt.Errorf("unknown transport %q (supported: do53, dot)", p.Transport)
+	}
+
+	switch p.TLSAuth {
+	case TLSAuthPin:
+		if len(p.Pins) == 0 {
+			return fmt.Errorf("tls-auth: pin requires at least one pin in pins:")
+		}
+		for _, pin := range p.Pins {
+			raw, err := base64.StdEncoding.DecodeString(pin)
+			if err != nil || len(raw) != sha256.Size {
+				return fmt.Errorf("pin %q is not a base64 SHA-256 SPKI digest", pin)
+			}
+		}
+	case TLSAuthDANE:
+		// DANE needs a DNS name to form the TLSA base (_<port>._tcp.<name>).
+		// A hostname primary provides it implicitly; an IP literal cannot.
+		if peerHostIsIPLiteral(*p) && p.TLSName == "" {
+			return fmt.Errorf("tls-auth: dane with an IP-literal primary requires tls-name")
+		}
+	case TLSAuthPKIX:
+		// Empty ca-file means system roots. An IP-literal primary without
+		// tls-name is allowed: the cert must then carry an IP SAN.
+		if p.CAFile != "" {
+			if err := checkPEMCertFile(p.CAFile); err != nil {
+				return fmt.Errorf("ca-file %q: %v", p.CAFile, err)
+			}
+		}
+	case "":
+		return fmt.Errorf("transport: dot requires tls-auth (pin | dane | pkix)")
+	default:
+		return fmt.Errorf("unknown tls-auth %q (supported: pin, dane, pkix)", p.TLSAuth)
+	}
+	return nil
+}
+
+// checkPEMCertFile verifies that path is readable and contains at least one
+// CERTIFICATE PEM block, so a broken ca-file is caught at config load rather
+// than at the first transfer attempt.
+func checkPEMCertFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	for block, rest := pem.Decode(data); block != nil; block, rest = pem.Decode(rest) {
+		if block.Type == "CERTIFICATE" {
+			return nil
+		}
+	}
+	return fmt.Errorf("no CERTIFICATE PEM block found")
+}
 
 // SPKISHA256 returns the base64 (standard encoding) SHA-256 digest of the
 // certificate's SubjectPublicKeyInfo. This is the value used for static

--- a/v2/xot.go
+++ b/v2/xot.go
@@ -252,6 +252,67 @@ func (conf *Config) verifyPeerCertDANE(cs tls.ConnectionState, name, port string
 	return fmt.Errorf("xot: no TLSA record at _%s._tcp.%s matches the peer certificate", port, name)
 }
 
+// ServerTLSConfigForDoT builds the DoT listener's tls.Config. With
+// applyDownstreamAuth false (the IMR's DoT front end) or no downstream-auth
+// configured, the result matches the historical config: server cert only, no
+// client certificate requested. With dnsengine.downstream-auth set, the auth
+// listener enforces mTLS on every DoT connection:
+//   - pin: the client must present a certificate and its SPKI SHA-256 must
+//     match one of dnsengine.downstream-pins (chain building skipped — the
+//     mirror of the client-side pin mode).
+//   - ca: standard mTLS chain verification against dnsengine.downstream-ca.
+//
+// Client-side DANE (TLSA per downstream) is deliberately not offered: the
+// server cannot know which downstream is connecting before the handshake, so
+// there is no name to base a TLSA lookup on. Pins cover that case statically.
+func ServerTLSConfigForDoT(conf *Config, cert *tls.Certificate, applyDownstreamAuth bool) (*tls.Config, error) {
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{*cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{"dot"},
+	}
+	if !applyDownstreamAuth {
+		return tlsCfg, nil
+	}
+	de := conf.DnsEngine
+	switch de.DownstreamAuth {
+	case "":
+		// No client-cert policy configured — serve exactly as before.
+	case "pin":
+		if len(de.DownstreamPins) == 0 {
+			return nil, fmt.Errorf("dnsengine: downstream-auth pin requires downstream-pins")
+		}
+		for _, pin := range de.DownstreamPins {
+			raw, err := base64.StdEncoding.DecodeString(pin)
+			if err != nil || len(raw) != sha256.Size {
+				return nil, fmt.Errorf("dnsengine: downstream pin %q is not a base64 SHA-256 SPKI digest", pin)
+			}
+		}
+		pins := append([]string(nil), de.DownstreamPins...)
+		tlsCfg.ClientAuth = tls.RequireAnyClientCert
+		tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+			return verifyPeerCertPins(cs, pins)
+		}
+	case "ca":
+		if de.DownstreamCA == "" {
+			return nil, fmt.Errorf("dnsengine: downstream-auth ca requires downstream-ca")
+		}
+		data, err := os.ReadFile(de.DownstreamCA)
+		if err != nil {
+			return nil, fmt.Errorf("dnsengine: reading downstream-ca: %v", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(data) {
+			return nil, fmt.Errorf("dnsengine: no usable certificates in downstream-ca %s", de.DownstreamCA)
+		}
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	default:
+		return nil, fmt.Errorf("dnsengine: unknown downstream-auth %q (supported: pin, ca)", de.DownstreamAuth)
+	}
+	return tlsCfg, nil
+}
+
 // lookupTLSAValidated returns the TLSA RRset at _<port>._tcp.<name>. DANE over
 // an unvalidated lookup is meaningless, so this fails closed: no IMR, lookup
 // failure, or a not-secure validation state are all errors. The per-server

--- a/v2/xot.go
+++ b/v2/xot.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * XoT (XFR-over-TLS, RFC 9103) support: SPKI pinning helpers and the
+ * client-side verifying TLS configuration builder.
+ */
+package tdns
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+)
+
+// SPKISHA256 returns the base64 (standard encoding) SHA-256 digest of the
+// certificate's SubjectPublicKeyInfo. This is the value used for static
+// certificate pinning (tls-auth: pin) and matches the digest carried in a
+// TLSA 3-1-1 record (which encodes the same bytes in hex).
+func SPKISHA256(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return base64.StdEncoding.EncodeToString(sum[:])
+}

--- a/v2/xot_test.go
+++ b/v2/xot_test.go
@@ -45,7 +45,7 @@ func newTestTLSCert(t *testing.T, dnsNames []string, ips []net.IP) (tls.Certific
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		DNSNames:     dnsNames,
 		IPAddresses:  ips,
 		BasicConstraintsValid: true,
@@ -66,15 +66,22 @@ func newTestTLSCert(t *testing.T, dnsNames []string, ips []net.IP) (tls.Certific
 // same AXFR-out handler behind a TLS listener, optionally with TSIG.
 func startTestAXFRServerTLS(t *testing.T, zd *ZoneData, tsigProvider dns.TsigProvider, cert tls.Certificate) *axfrTestServer {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	tlsLn := tls.NewListener(ln, &tls.Config{
+	return startTestAXFRServerTLSConfig(t, zd, tsigProvider, &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   tls.VersionTLS13,
 		NextProtos:   []string{"dot"},
 	})
+}
+
+// startTestAXFRServerTLSConfig serves AXFR behind a caller-supplied TLS
+// listener config (used by the mTLS tests, which need ClientAuth set).
+func startTestAXFRServerTLSConfig(t *testing.T, zd *ZoneData, tsigProvider dns.TsigProvider, tlsCfg *tls.Config) *axfrTestServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	tlsLn := tls.NewListener(ln, tlsCfg)
 
 	srv := &axfrTestServer{addr: ln.Addr().String()}
 	zone := dns.Fqdn(zd.ZoneName)
@@ -740,6 +747,141 @@ func TestXoT_DoTransferSOAProbeOverDoT(t *testing.T) {
 	if _, _, err := secBad.DoTransfer(conf); err == nil {
 		t.Fatal("SOA probe with wrong pin must fail")
 	}
+}
+
+// --- Phase 5: primary-side downstream mTLS -----------------------------------
+
+// mtlsServerConf builds a Config with the given downstream-auth settings and
+// returns the DoT listener tls.Config via the production builder.
+func mtlsServerTLS(t *testing.T, serverCert tls.Certificate, auth string, pins []string, caFile string) *tls.Config {
+	t.Helper()
+	conf := &Config{}
+	conf.DnsEngine.DownstreamAuth = auth
+	conf.DnsEngine.DownstreamPins = pins
+	conf.DnsEngine.DownstreamCA = caFile
+	cfg, err := ServerTLSConfigForDoT(conf, &serverCert, true)
+	if err != nil {
+		t.Fatalf("ServerTLSConfigForDoT: %v", err)
+	}
+	return cfg
+}
+
+// TestXoT_ServerMTLSPin: with downstream-auth pin, only a client presenting a
+// pinned certificate can transfer; unpinned and cert-less clients fail.
+func TestXoT_ServerMTLSPin(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	serverCert, serverLeaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	clientCert, clientLeaf := newTestTLSCert(t, []string{"sec1.test"}, nil)
+	otherCert, _ := newTestTLSCert(t, []string{"rogue.test"}, nil)
+
+	srvTLS := mtlsServerTLS(t, serverCert, "pin", []string{SPKISHA256(clientLeaf)}, "")
+	srv := startTestAXFRServerTLSConfig(t, zd, nil, srvTLS)
+	defer srv.shutdown()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(serverLeaf)
+	base := &tls.Config{RootCAs: pool, ServerName: "ns1.test", MinVersion: tls.VersionTLS13}
+
+	// Pinned client: admitted.
+	good := base.Clone()
+	good.Certificates = []tls.Certificate{clientCert}
+	rrs, err := axfrClientTLS(t, srv.addr, zd.ZoneName, good, nil)
+	if err != nil {
+		t.Fatalf("pinned client transfer failed: %v", err)
+	}
+	if len(rrs) < 4 {
+		t.Fatalf("expected full zone, got %d RRs", len(rrs))
+	}
+
+	// Unpinned client cert: refused.
+	bad := base.Clone()
+	bad.Certificates = []tls.Certificate{otherCert}
+	if _, err := axfrClientTLS(t, srv.addr, zd.ZoneName, bad, nil); err == nil {
+		t.Fatal("unpinned client must be refused")
+	}
+
+	// No client cert at all: refused.
+	if _, err := axfrClientTLS(t, srv.addr, zd.ZoneName, base.Clone(), nil); err == nil {
+		t.Fatal("cert-less client must be refused")
+	}
+}
+
+// TestXoT_ServerMTLSCA: with downstream-auth ca, chain verification against
+// the configured CA bundle gates the transfer.
+func TestXoT_ServerMTLSCA(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	serverCert, serverLeaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	clientCert, clientLeaf := newTestTLSCert(t, []string{"sec1.test"}, nil)
+	otherCert, _ := newTestTLSCert(t, []string{"rogue.test"}, nil)
+
+	caPath := t.TempDir() + "/downstream-ca.pem"
+	if err := writeCertPEM(caPath, clientLeaf.Raw); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	srvTLS := mtlsServerTLS(t, serverCert, "ca", nil, caPath)
+	srv := startTestAXFRServerTLSConfig(t, zd, nil, srvTLS)
+	defer srv.shutdown()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(serverLeaf)
+	base := &tls.Config{RootCAs: pool, ServerName: "ns1.test", MinVersion: tls.VersionTLS13}
+
+	good := base.Clone()
+	good.Certificates = []tls.Certificate{clientCert}
+	if _, err := axfrClientTLS(t, srv.addr, zd.ZoneName, good, nil); err != nil {
+		t.Fatalf("CA-verified client transfer failed: %v", err)
+	}
+
+	bad := base.Clone()
+	bad.Certificates = []tls.Certificate{otherCert}
+	if _, err := axfrClientTLS(t, srv.addr, zd.ZoneName, bad, nil); err == nil {
+		t.Fatal("client outside the CA must be refused")
+	}
+}
+
+// TestXoT_ServerMTLSConfigValidation: bad downstream-auth configs fail at
+// listener build (startup), not at the first connection.
+func TestXoT_ServerMTLSConfigValidation(t *testing.T) {
+	serverCert, _ := newTestTLSCert(t, []string{"ns1.test"}, nil)
+	mk := func(auth string, pins []string, ca string) error {
+		conf := &Config{}
+		conf.DnsEngine.DownstreamAuth = auth
+		conf.DnsEngine.DownstreamPins = pins
+		conf.DnsEngine.DownstreamCA = ca
+		_, err := ServerTLSConfigForDoT(conf, &serverCert, true)
+		return err
+	}
+	if err := mk("pin", nil, ""); err == nil {
+		t.Fatal("pin without pins must fail")
+	}
+	if err := mk("pin", []string{"junk"}, ""); err == nil {
+		t.Fatal("malformed pin must fail")
+	}
+	if err := mk("ca", nil, ""); err == nil {
+		t.Fatal("ca without downstream-ca must fail")
+	}
+	if err := mk("ca", nil, "/nonexistent.pem"); err == nil {
+		t.Fatal("unreadable downstream-ca must fail")
+	}
+	if err := mk("bogus", nil, ""); err == nil {
+		t.Fatal("unknown mode must fail")
+	}
+	// The IMR front end never applies downstream auth even when configured.
+	conf := &Config{}
+	conf.DnsEngine.DownstreamAuth = "pin"
+	conf.DnsEngine.DownstreamPins = []string{SPKISHA256FromB64Test()}
+	cfg, err := ServerTLSConfigForDoT(conf, &serverCert, false)
+	if err != nil {
+		t.Fatalf("imr-side build: %v", err)
+	}
+	if cfg.ClientAuth != tls.NoClientCert {
+		t.Fatal("imr-side listener must not request client certs")
+	}
+}
+
+// SPKISHA256FromB64Test returns a syntactically valid pin for config tests.
+func SPKISHA256FromB64Test() string {
+	return base64.StdEncoding.EncodeToString(make([]byte, sha256.Size))
 }
 
 // TestXoT_TransferRejectsUntrustedCert: the same server, but the client does

--- a/v2/xot_test.go
+++ b/v2/xot_test.go
@@ -85,6 +85,17 @@ func startTestAXFRServerTLS(t *testing.T, zd *ZoneData, tsigProvider dns.TsigPro
 			record:         srv.recordSize,
 		}
 		serve := func(w2 dns.ResponseWriter, req *dns.Msg) {
+			// Answer SOA probes (the DoTransfer path) from the zone apex;
+			// AXFR/IXFR goes through the real transfer-out path.
+			if len(req.Question) == 1 && req.Question[0].Qtype == dns.TypeSOA {
+				m := new(dns.Msg)
+				m.SetReply(req)
+				if apex, ok := zd.Data.Get(zd.ZoneName); ok {
+					m.Answer = append(m.Answer, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs...)
+				}
+				_ = w2.WriteMsg(m)
+				return
+			}
 			_, _ = zd.ZoneTransferOut(w2, req)
 		}
 		if tsigProvider != nil {
@@ -639,6 +650,95 @@ func TestXoT_PKIXModeEndToEnd(t *testing.T) {
 	badName.TLSName = "ns2.test"
 	if _, err := xotTransfer(t, conf, badName, srv, zd.ZoneName); err == nil {
 		t.Fatal("pkix with wrong tls-name must fail")
+	}
+}
+
+// --- Phase 3: the real secondary pull path (ZoneTransferIn / DoTransfer) ----
+
+// newTestSecondary builds a secondary ZoneData pulling from the given peer.
+func newTestSecondary(t *testing.T, up PeerConf) *ZoneData {
+	t.Helper()
+	return &ZoneData{
+		ZoneName:  "example.test.",
+		ZoneStore: MapZone,
+		ZoneType:  Secondary,
+		Logger:    log.Default(),
+		Upstreams: []PeerConf{up},
+	}
+}
+
+// TestXoT_ZoneTransferInOverDoT: the production inbound-transfer function
+// pulls a zone over verified TLS (pin) with TSIG on the envelopes; a wrong
+// pin aborts; DANE mode works against an injected validated TLSA.
+func TestXoT_ZoneTransferInOverDoT(t *testing.T) {
+	conf := testXfrConf(t)
+	primary := loadTestTransferZone(t, basicZone)
+	primary.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, primary, conf.tsigProvider(), cert)
+	defer srv.shutdown()
+
+	pinPeer := PeerConf{Addr: srv.addr, Key: "tkey", Transport: TransportDoT,
+		TLSAuth: TLSAuthPin, Pins: []string{SPKISHA256(leaf)}}
+	sec := newTestSecondary(t, pinPeer)
+	serial, err := sec.ZoneTransferIn(pinPeer, 0, "axfr", conf)
+	if err != nil {
+		t.Fatalf("XoT pull (pin+tsig) failed: %v", err)
+	}
+	if serial != 1 {
+		t.Fatalf("expected serial 1, got %d", serial)
+	}
+	if sec.Data.IsEmpty() {
+		t.Fatal("secondary has no zone data after transfer")
+	}
+
+	// Tampered/wrong pin: the transfer must abort at the handshake.
+	badPeer := pinPeer
+	badPeer.Pins = []string{base64.StdEncoding.EncodeToString(make([]byte, sha256.Size))}
+	secBad := newTestSecondary(t, badPeer)
+	if _, err := secBad.ZoneTransferIn(badPeer, 0, "axfr", conf); err == nil {
+		t.Fatal("XoT pull with wrong pin must fail")
+	}
+
+	// DANE mode through the same production path.
+	danePeer := PeerConf{Addr: srv.addr, Key: "tkey", Transport: TransportDoT,
+		TLSAuth: TLSAuthDANE, TLSName: "ns1.test"}
+	daneConf := testXfrConf(t)
+	daneConf.Internal.ImrEngine = daneTestConf(t, leaf, serverPort(t, srv), cache.ValidationStateSecure, true).Internal.ImrEngine
+	secDane := newTestSecondary(t, danePeer)
+	if _, err := secDane.ZoneTransferIn(danePeer, 0, "axfr", daneConf); err != nil {
+		t.Fatalf("XoT pull (dane+tsig) failed: %v", err)
+	}
+}
+
+// TestXoT_DoTransferSOAProbeOverDoT: the SOA probe uses the same verified TLS
+// channel (and TSIG) as the transfer; a wrong pin makes the upstream count as
+// unreachable.
+func TestXoT_DoTransferSOAProbeOverDoT(t *testing.T) {
+	conf := testXfrConf(t)
+	primary := loadTestTransferZone(t, basicZone)
+	primary.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, primary, conf.tsigProvider(), cert)
+	defer srv.shutdown()
+
+	pinPeer := PeerConf{Addr: srv.addr, Key: "tkey", Transport: TransportDoT,
+		TLSAuth: TLSAuthPin, Pins: []string{SPKISHA256(leaf)}}
+	sec := newTestSecondary(t, pinPeer)
+	should, serial, err := sec.DoTransfer(conf)
+	if err != nil {
+		t.Fatalf("SOA probe over DoT failed: %v", err)
+	}
+	if !should || serial != 1 {
+		t.Fatalf("expected (transfer=true, serial=1), got (%v, %d)", should, serial)
+	}
+
+	// Wrong pin: handshake fails -> all upstreams unreachable -> hard error.
+	badPeer := pinPeer
+	badPeer.Pins = []string{base64.StdEncoding.EncodeToString(make([]byte, sha256.Size))}
+	secBad := newTestSecondary(t, badPeer)
+	if _, _, err := secBad.DoTransfer(conf); err == nil {
+		t.Fatal("SOA probe with wrong pin must fail")
 	}
 }
 

--- a/v2/xot_test.go
+++ b/v2/xot_test.go
@@ -16,13 +16,17 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
+	"log"
 	"math/big"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	cache "github.com/johanix/tdns/v2/cache"
+	core "github.com/johanix/tdns/v2/core"
 	"github.com/miekg/dns"
 )
 
@@ -400,6 +404,241 @@ func TestNormalizeAddressPort(t *testing.T) {
 	}
 	if got := NormalizeAddress("192.0.2.1"); got != "192.0.2.1:53" {
 		t.Fatalf("NormalizeAddress default unchanged: %q", got)
+	}
+}
+
+// --- ClientTLSConfigForPeer -------------------------------------------------
+
+func TestClientTLSConfigForPeer_Do53ReturnsNil(t *testing.T) {
+	conf := &Config{}
+	for _, p := range []PeerConf{
+		{Addr: "192.0.2.1:53", Key: NOKEY},
+		{Addr: "192.0.2.1:53", Key: NOKEY, Transport: "do53"},
+	} {
+		cfg, err := conf.ClientTLSConfigForPeer(p)
+		if err != nil || cfg != nil {
+			t.Fatalf("do53 peer must yield (nil, nil), got (%v, %v)", cfg, err)
+		}
+	}
+}
+
+func TestClientTLSConfigForPeer_ServerNameSelection(t *testing.T) {
+	conf := &Config{}
+	// Hostname primary: hostname becomes SNI.
+	cfg, err := conf.ClientTLSConfigForPeer(PeerConf{Addr: "ns1.test:853", Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthPKIX})
+	if err != nil || cfg.ServerName != "ns1.test" {
+		t.Fatalf("hostname SNI: cfg=%+v err=%v", cfg, err)
+	}
+	// Explicit tls-name wins.
+	cfg, err = conf.ClientTLSConfigForPeer(PeerConf{Addr: "192.0.2.1:853", Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthPKIX, TLSName: "ns2.test"})
+	if err != nil || cfg.ServerName != "ns2.test" {
+		t.Fatalf("tls-name SNI: cfg=%+v err=%v", cfg, err)
+	}
+	// IP literal without tls-name: empty (crypto/tls fills from dial addr).
+	cfg, err = conf.ClientTLSConfigForPeer(PeerConf{Addr: "192.0.2.1:853", Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthPKIX})
+	if err != nil || cfg.ServerName != "" {
+		t.Fatalf("ip-literal SNI: cfg=%+v err=%v", cfg, err)
+	}
+	// DANE without any name is refused (backstop; config validation catches it earlier).
+	if _, err = conf.ClientTLSConfigForPeer(PeerConf{Addr: "192.0.2.1:853", Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthDANE}); err == nil {
+		t.Fatal("dane without name must error")
+	}
+	// Unknown auth mode is refused.
+	if _, err = conf.ClientTLSConfigForPeer(PeerConf{Addr: "ns1.test:853", Key: NOKEY, Transport: TransportDoT, TLSAuth: "nope"}); err == nil {
+		t.Fatal("unknown tls-auth must error")
+	}
+}
+
+// xotTransfer runs an AXFR against srv using the tls.Config built for peer.
+func xotTransfer(t *testing.T, conf *Config, peer PeerConf, srv *axfrTestServer, zone string) ([]dns.RR, error) {
+	t.Helper()
+	tlsCfg, err := conf.ClientTLSConfigForPeer(peer)
+	if err != nil {
+		return nil, err
+	}
+	if tlsCfg == nil {
+		t.Fatal("expected a TLS config for a dot peer")
+	}
+	return axfrClientTLS(t, srv.addr, zone, tlsCfg, nil)
+}
+
+// TestXoT_PinModeEndToEnd: pin match transfers; pin mismatch aborts the
+// handshake (and thus the transfer).
+func TestXoT_PinModeEndToEnd(t *testing.T) {
+	conf := &Config{}
+	zd := loadTestTransferZone(t, basicZone)
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, zd, nil, cert)
+	defer srv.shutdown()
+
+	good := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthPin,
+		Pins: []string{SPKISHA256(leaf)}}
+	rrs, err := xotTransfer(t, conf, good, srv, zd.ZoneName)
+	if err != nil {
+		t.Fatalf("pin-match transfer failed: %v", err)
+	}
+	if len(rrs) < 4 {
+		t.Fatalf("expected full zone, got %d RRs", len(rrs))
+	}
+
+	wrongPin := base64.StdEncoding.EncodeToString(make([]byte, sha256.Size))
+	bad := good
+	bad.Pins = []string{wrongPin}
+	if _, err := xotTransfer(t, conf, bad, srv, zd.ZoneName); err == nil {
+		t.Fatal("pin-mismatch transfer must fail")
+	}
+	// Second pin in the list may be the matching one.
+	multi := good
+	multi.Pins = []string{wrongPin, SPKISHA256(leaf)}
+	if _, err := xotTransfer(t, conf, multi, srv, zd.ZoneName); err != nil {
+		t.Fatalf("any-pin-matches transfer failed: %v", err)
+	}
+}
+
+// daneTestConf builds a Config whose IMR has a pre-populated, validated TLSA
+// cache entry for ns1.test. at the given port: the injected-validated-TLSA
+// seam from the plan (the network fetch path needs a live resolver and is
+// exercised in the manual/testbed runs instead).
+func daneTestConf(t *testing.T, leafCert *x509.Certificate, port uint16, vstate cache.ValidationState, requireSecure bool) *Config {
+	t.Helper()
+	rrcache := cache.NewRRsetCache(log.Default(), false, false)
+	as := rrcache.GetOrCreateAuthServer("ns1.test.")
+	rrcache.ServerMap.Set("test.", map[string]*cache.AuthServer{"ns1.test.": as})
+
+	tlsa, err := NewTlsaRR("ns1.test.", port, leafCert)
+	if err != nil {
+		t.Fatalf("NewTlsaRR: %v", err)
+	}
+	rrset := &core.RRset{Name: tlsa.Hdr.Name, Class: dns.ClassINET, RRtype: dns.TypeTLSA, RRs: []dns.RR{tlsa}}
+	rrcache.StoreTLSAForServer("ns1.test.", tlsa.Hdr.Name, rrset, vstate)
+
+	conf := &Config{}
+	conf.Internal.ImrEngine = &Imr{Cache: rrcache, RequireDnssecValidation: requireSecure}
+	return conf
+}
+
+func serverPort(t *testing.T, srv *axfrTestServer) uint16 {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(srv.addr)
+	if err != nil {
+		t.Fatalf("split server addr: %v", err)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	return uint16(port)
+}
+
+// TestXoT_DANEModeEndToEnd: a secure cached TLSA matching the server cert
+// admits the transfer; a TLSA for a different cert aborts it.
+func TestXoT_DANEModeEndToEnd(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, zd, nil, cert)
+	defer srv.shutdown()
+	port := serverPort(t, srv)
+
+	peer := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthDANE, TLSName: "ns1.test"}
+
+	conf := daneTestConf(t, leaf, port, cache.ValidationStateSecure, true)
+	rrs, err := xotTransfer(t, conf, peer, srv, zd.ZoneName)
+	if err != nil {
+		t.Fatalf("dane-match transfer failed: %v", err)
+	}
+	if len(rrs) < 4 {
+		t.Fatalf("expected full zone, got %d RRs", len(rrs))
+	}
+
+	_, otherLeaf := newTestTLSCert(t, []string{"ns1.test"}, nil)
+	confMismatch := daneTestConf(t, otherLeaf, port, cache.ValidationStateSecure, true)
+	if _, err := xotTransfer(t, confMismatch, peer, srv, zd.ZoneName); err == nil {
+		t.Fatal("dane-mismatch transfer must fail")
+	}
+}
+
+// TestXoT_DANEFailsClosedOnUnvalidated: an unvalidated TLSA is refused when
+// validation is required (the default), and accepted only in explicit lab mode
+// (require_dnssec_validation: false).
+func TestXoT_DANEFailsClosedOnUnvalidated(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, zd, nil, cert)
+	defer srv.shutdown()
+	port := serverPort(t, srv)
+
+	peer := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthDANE, TLSName: "ns1.test"}
+
+	for _, state := range []cache.ValidationState{cache.ValidationStateNone, cache.ValidationStateInsecure, cache.ValidationStateBogus} {
+		conf := daneTestConf(t, leaf, port, state, true)
+		if _, err := xotTransfer(t, conf, peer, srv, zd.ZoneName); err == nil {
+			t.Fatalf("state %s: transfer must fail closed", cache.ValidationStateToString[state])
+		}
+	}
+
+	// Lab mode: insecure state is accepted (with a warning), matching the
+	// imrengine.require_dnssec_validation escape hatch semantics.
+	confLab := daneTestConf(t, leaf, port, cache.ValidationStateInsecure, false)
+	if _, err := xotTransfer(t, confLab, peer, srv, zd.ZoneName); err != nil {
+		t.Fatalf("lab-mode transfer failed: %v", err)
+	}
+}
+
+// TestXoT_DANEWithoutIMRFails: tls-auth dane with no IMR engine must refuse
+// the connection (fail closed), not fall back to unverified TLS.
+func TestXoT_DANEWithoutIMRFails(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	cert, _ := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, zd, nil, cert)
+	defer srv.shutdown()
+
+	conf := &Config{} // no ImrEngine
+	peer := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthDANE, TLSName: "ns1.test"}
+	if _, err := xotTransfer(t, conf, peer, srv, zd.ZoneName); err == nil {
+		t.Fatal("dane without IMR must fail")
+	}
+}
+
+// TestXoT_PKIXModeEndToEnd: chain verification against a ca-file; a CA that
+// did not issue the server cert aborts the handshake.
+func TestXoT_PKIXModeEndToEnd(t *testing.T) {
+	conf := &Config{}
+	zd := loadTestTransferZone(t, basicZone)
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, zd, nil, cert)
+	defer srv.shutdown()
+
+	caPath := t.TempDir() + "/ca.pem"
+	if err := writeCertPEM(caPath, leaf.Raw); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	good := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT, TLSAuth: TLSAuthPKIX,
+		TLSName: "ns1.test", CAFile: caPath}
+	rrs, err := xotTransfer(t, conf, good, srv, zd.ZoneName)
+	if err != nil {
+		t.Fatalf("pkix transfer failed: %v", err)
+	}
+	if len(rrs) < 4 {
+		t.Fatalf("expected full zone, got %d RRs", len(rrs))
+	}
+
+	// A different (wrong) CA must not admit the server.
+	_, otherCA := newTestTLSCert(t, []string{"other-ca.test"}, nil)
+	wrongCAPath := t.TempDir() + "/wrong-ca.pem"
+	if err := writeCertPEM(wrongCAPath, otherCA.Raw); err != nil {
+		t.Fatalf("write wrong ca: %v", err)
+	}
+	bad := good
+	bad.CAFile = wrongCAPath
+	if _, err := xotTransfer(t, conf, bad, srv, zd.ZoneName); err == nil {
+		t.Fatal("pkix with wrong CA must fail")
+	}
+
+	// Wrong hostname expectation must fail too (SNI/hostname check).
+	badName := good
+	badName.TLSName = "ns2.test"
+	if _, err := xotTransfer(t, conf, badName, srv, zd.ZoneName); err == nil {
+		t.Fatal("pkix with wrong tls-name must fail")
 	}
 }
 

--- a/v2/xot_test.go
+++ b/v2/xot_test.go
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package tdns
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// newTestTLSCert generates an in-memory self-signed server certificate for the
+// given names/IPs and returns both the tls.Certificate (server side) and the
+// parsed x509 leaf (for pin/TLSA computation on the client side).
+func newTestTLSCert(t *testing.T, dnsNames []string, ips []net.IP) (tls.Certificate, *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "xot-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     dnsNames,
+		IPAddresses:  ips,
+		BasicConstraintsValid: true,
+		IsCA:                  true, // self-signed: lets the client use it as its own root
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}, leaf
+}
+
+// startTestAXFRServerTLS is the DoT variant of startTestAXFRServerCore: the
+// same AXFR-out handler behind a TLS listener, optionally with TSIG.
+func startTestAXFRServerTLS(t *testing.T, zd *ZoneData, tsigProvider dns.TsigProvider, cert tls.Certificate) *axfrTestServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	tlsLn := tls.NewListener(ln, &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{"dot"},
+	})
+
+	srv := &axfrTestServer{addr: ln.Addr().String()}
+	zone := dns.Fqdn(zd.ZoneName)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(zone, func(w dns.ResponseWriter, r *dns.Msg) {
+		rec := &recordingResponseWriter{
+			ResponseWriter: w,
+			record:         srv.recordSize,
+		}
+		serve := func(w2 dns.ResponseWriter, req *dns.Msg) {
+			_, _ = zd.ZoneTransferOut(w2, req)
+		}
+		if tsigProvider != nil {
+			TsigSigningHandler(serve)(rec, r)
+		} else {
+			serve(rec, r)
+		}
+	})
+
+	started := make(chan struct{})
+	dnsSrv := &dns.Server{
+		Listener:          tlsLn,
+		Handler:           mux,
+		TsigProvider:      tsigProvider,
+		NotifyStartedFunc: func() { close(started) },
+	}
+	go func() { _ = dnsSrv.ActivateAndServe() }()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test DoT AXFR server did not start")
+	}
+	srv.shutdown = func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = dnsSrv.ShutdownContext(ctx)
+	}
+	return srv
+}
+
+// axfrClientTLS runs an AXFR through the fork's dns.Transfer with the TLS
+// field set (the XoT client path), optionally with TSIG.
+func axfrClientTLS(t *testing.T, addr, zone string, tlsCfg *tls.Config, provider dns.TsigProvider) ([]dns.RR, error) {
+	t.Helper()
+	msg := new(dns.Msg)
+	msg.SetAxfr(zone)
+	tr := &dns.Transfer{TLS: tlsCfg, TsigProvider: provider}
+	ch, err := tr.In(msg, addr)
+	if err != nil {
+		return nil, err
+	}
+	var rrs []dns.RR
+	for env := range ch {
+		if env.Error != nil {
+			return rrs, env.Error
+		}
+		rrs = append(rrs, env.RR...)
+	}
+	return rrs, nil
+}
+
+// TestXoT_TransferTSIGInsideTLS is the fork-risk spike (plan §6.1): AXFR over
+// TLS with TSIG on both request and response envelopes, TSIG signed/verified
+// inside the TLS stream, PKIX-verified against the server's self-signed cert.
+func TestXoT_TransferTSIGInsideTLS(t *testing.T) {
+	conf := testXfrConf(t)
+	zd := loadTestTransferZone(t, basicZone)
+	zd.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, zd, conf.tsigProvider(), cert)
+	defer srv.shutdown()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+
+	msg := new(dns.Msg)
+	msg.SetAxfr(zd.ZoneName)
+	provider, err := SignForPeer(msg, "tkey", conf)
+	if err != nil {
+		t.Fatalf("SignForPeer: %v", err)
+	}
+
+	tlsCfg := &tls.Config{
+		RootCAs:    pool,
+		ServerName: "ns1.test",
+		MinVersion: tls.VersionTLS13,
+		NextProtos: []string{"dot"},
+	}
+	tr := &dns.Transfer{TLS: tlsCfg, TsigProvider: provider}
+	ch, err := tr.In(msg, srv.addr)
+	if err != nil {
+		t.Fatalf("Transfer.In over TLS: %v", err)
+	}
+	var rrs []dns.RR
+	for env := range ch {
+		if env.Error != nil {
+			t.Fatalf("envelope error (TSIG-inside-TLS broken?): %v", env.Error)
+		}
+		rrs = append(rrs, env.RR...)
+	}
+	if len(rrs) < 4 {
+		t.Fatalf("expected at least 4 RRs (SOA bookends + data), got %d", len(rrs))
+	}
+	if _, ok := rrs[0].(*dns.SOA); !ok {
+		t.Fatalf("first RR should be SOA, got %T", rrs[0])
+	}
+	if _, ok := rrs[len(rrs)-1].(*dns.SOA); !ok {
+		t.Fatalf("last RR should be SOA, got %T", rrs[len(rrs)-1])
+	}
+}
+
+// TestTLSA_GenerateVerifyRoundTrip: a TLSA record generated by NewTlsaRR
+// (true 3-1-1: the hash really is over the SPKI) must verify against the same
+// certificate, and must NOT verify against a different certificate.
+func TestTLSA_GenerateVerifyRoundTrip(t *testing.T) {
+	_, cert := newTestTLSCert(t, []string{"ns1.test"}, nil)
+	_, other := newTestTLSCert(t, []string{"ns2.test"}, nil)
+
+	tlsa, err := NewTlsaRR("ns1.test.", 853, cert)
+	if err != nil {
+		t.Fatalf("NewTlsaRR: %v", err)
+	}
+	if tlsa.Usage != 3 || tlsa.Selector != 1 || tlsa.MatchingType != 1 {
+		t.Fatalf("expected 3-1-1 TLSA, got %d-%d-%d", tlsa.Usage, tlsa.Selector, tlsa.MatchingType)
+	}
+	if tlsa.Hdr.Name != "_853._tcp.ns1.test." {
+		t.Fatalf("unexpected owner name %q", tlsa.Hdr.Name)
+	}
+	// The association data must be the SPKI hash (selector 1 semantics), not
+	// the full-cert hash (the old bug).
+	spkiHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	if tlsa.Certificate != hex.EncodeToString(spkiHash[:]) {
+		t.Fatalf("TLSA data is not the SPKI SHA-256: got %s", tlsa.Certificate)
+	}
+	if err := VerifyCertAgainstTlsaRR(tlsa, cert); err != nil {
+		t.Fatalf("verify against own cert: %v", err)
+	}
+	if err := VerifyCertAgainstTlsaRR(tlsa, other); err == nil {
+		t.Fatal("verify against a different cert should fail")
+	}
+}
+
+// TestTLSA_VerifyHonorsSelector: selector 0 (full cert) and selector 1 (SPKI)
+// must be hashed over different bytes, and each must verify only when the
+// association data matches its own selector semantics.
+func TestTLSA_VerifyHonorsSelector(t *testing.T) {
+	_, cert := newTestTLSCert(t, []string{"ns1.test"}, nil)
+
+	fullHash := sha256.Sum256(cert.Raw)
+	spkiHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	if fullHash == spkiHash {
+		t.Fatal("test is vacuous: full-cert and SPKI hashes are identical")
+	}
+
+	mk := func(selector uint8, data [32]byte) *dns.TLSA {
+		return &dns.TLSA{
+			Hdr:          dns.RR_Header{Name: "_853._tcp.ns1.test.", Rrtype: dns.TypeTLSA, Class: dns.ClassINET, Ttl: 120},
+			Usage:        3,
+			Selector:     selector,
+			MatchingType: 1,
+			Certificate:  hex.EncodeToString(data[:]),
+		}
+	}
+
+	if err := VerifyCertAgainstTlsaRR(mk(0, fullHash), cert); err != nil {
+		t.Fatalf("selector 0 with full-cert hash should verify: %v", err)
+	}
+	if err := VerifyCertAgainstTlsaRR(mk(1, spkiHash), cert); err != nil {
+		t.Fatalf("selector 1 with SPKI hash should verify: %v", err)
+	}
+	// Crossed: selector says one thing, data is the other -> must fail.
+	if err := VerifyCertAgainstTlsaRR(mk(0, spkiHash), cert); err == nil {
+		t.Fatal("selector 0 with SPKI hash must not verify")
+	}
+	if err := VerifyCertAgainstTlsaRR(mk(1, fullHash), cert); err == nil {
+		t.Fatal("selector 1 with full-cert hash must not verify")
+	}
+}
+
+// TestTLSA_VerifySHA512AndRejects: matching type 2 (SHA-512) works per
+// selector; unsupported usage/selector/matching-type are rejected.
+func TestTLSA_VerifySHA512AndRejects(t *testing.T) {
+	_, cert := newTestTLSCert(t, []string{"ns1.test"}, nil)
+
+	spki512 := sha512.Sum512(cert.RawSubjectPublicKeyInfo)
+	tlsa := &dns.TLSA{
+		Hdr:          dns.RR_Header{Name: "_853._tcp.ns1.test.", Rrtype: dns.TypeTLSA, Class: dns.ClassINET, Ttl: 120},
+		Usage:        3,
+		Selector:     1,
+		MatchingType: 2,
+		Certificate:  hex.EncodeToString(spki512[:]),
+	}
+	if err := VerifyCertAgainstTlsaRR(tlsa, cert); err != nil {
+		t.Fatalf("selector 1 + SHA-512 should verify: %v", err)
+	}
+
+	bad := *tlsa
+	bad.Usage = 1 // PKIX-EE, unsupported
+	if err := VerifyCertAgainstTlsaRR(&bad, cert); err == nil {
+		t.Fatal("usage 1 must be rejected")
+	}
+	bad = *tlsa
+	bad.Selector = 7
+	if err := VerifyCertAgainstTlsaRR(&bad, cert); err == nil {
+		t.Fatal("unknown selector must be rejected")
+	}
+	bad = *tlsa
+	bad.MatchingType = 0 // exact match, unsupported
+	if err := VerifyCertAgainstTlsaRR(&bad, cert); err == nil {
+		t.Fatal("matching type 0 must be rejected")
+	}
+}
+
+// TestSPKISHA256_PinRoundTrip: the pin helper hashes the SPKI (not the whole
+// cert), is stable, and two different keys yield different pins.
+func TestSPKISHA256_PinRoundTrip(t *testing.T) {
+	_, cert := newTestTLSCert(t, []string{"ns1.test"}, nil)
+	_, other := newTestTLSCert(t, []string{"ns1.test"}, nil)
+
+	pin := SPKISHA256(cert)
+	want := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	if pin != base64.StdEncoding.EncodeToString(want[:]) {
+		t.Fatalf("pin mismatch: got %s", pin)
+	}
+	if pin != SPKISHA256(cert) {
+		t.Fatal("pin not stable")
+	}
+	if pin == SPKISHA256(other) {
+		t.Fatal("different keys must yield different pins")
+	}
+	// A TLSA 3-1-1 record and a pin are the same digest in different encodings.
+	tlsa, err := NewTlsaRR("ns1.test.", 853, cert)
+	if err != nil {
+		t.Fatalf("NewTlsaRR: %v", err)
+	}
+	rawPin, err := base64.StdEncoding.DecodeString(pin)
+	if err != nil {
+		t.Fatalf("decode pin: %v", err)
+	}
+	if hex.EncodeToString(rawPin) != tlsa.Certificate {
+		t.Fatal("pin and TLSA 3-1-1 association data disagree")
+	}
+}
+
+// TestXoT_TransferRejectsUntrustedCert: the same server, but the client does
+// not trust the server cert -> the handshake (and thus the transfer) must fail.
+func TestXoT_TransferRejectsUntrustedCert(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+
+	cert, _ := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, zd, nil, cert)
+	defer srv.shutdown()
+
+	tlsCfg := &tls.Config{
+		// Empty root pool: nothing is trusted.
+		RootCAs:    x509.NewCertPool(),
+		ServerName: "ns1.test",
+		MinVersion: tls.VersionTLS13,
+	}
+	_, err := axfrClientTLS(t, srv.addr, zd.ZoneName, tlsCfg, nil)
+	if err == nil {
+		t.Fatal("expected transfer to fail against an untrusted cert")
+	}
+	if !strings.Contains(err.Error(), "certificate") && !strings.Contains(err.Error(), "x509") {
+		t.Logf("note: failure was not an x509 error (still acceptable): %v", err)
+	}
+}

--- a/v2/xot_test.go
+++ b/v2/xot_test.go
@@ -15,8 +15,10 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/pem"
 	"math/big"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -311,6 +313,93 @@ func TestSPKISHA256_PinRoundTrip(t *testing.T) {
 	}
 	if hex.EncodeToString(rawPin) != tlsa.Certificate {
 		t.Fatal("pin and TLSA 3-1-1 association data disagree")
+	}
+}
+
+// TestValidatePeerXoT covers the config-load validation matrix for the XoT
+// fields on a primary entry.
+func TestValidatePeerXoT(t *testing.T) {
+	// A valid pin: base64 of 32 bytes.
+	goodPin := base64.StdEncoding.EncodeToString(make([]byte, sha256.Size))
+
+	// A readable CA file with a CERTIFICATE block.
+	certTLS, _ := newTestTLSCert(t, []string{"ca.test"}, nil)
+	caPath := t.TempDir() + "/ca.pem"
+	if err := writeCertPEM(caPath, certTLS.Certificate[0]); err != nil {
+		t.Fatalf("write ca file: %v", err)
+	}
+	junkPath := t.TempDir() + "/junk.pem"
+	if err := os.WriteFile(junkPath, []byte("not a pem"), 0o600); err != nil {
+		t.Fatalf("write junk file: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		peer PeerConf
+		ok   bool
+	}{
+		{"plain do53 untouched", PeerConf{Addr: "192.0.2.1:53", Key: NOKEY}, true},
+		{"explicit do53", PeerConf{Addr: "192.0.2.1:53", Key: NOKEY, Transport: "do53"}, true},
+		{"do53 with tls-auth", PeerConf{Addr: "192.0.2.1:53", Key: NOKEY, TLSAuth: "pin"}, false},
+		{"do53 with pins", PeerConf{Addr: "192.0.2.1:53", Key: NOKEY, Pins: []string{goodPin}}, false},
+		{"unknown transport", PeerConf{Addr: "192.0.2.1", Key: NOKEY, Transport: "doq"}, false},
+		{"dot without tls-auth", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot"}, false},
+		{"dot unknown tls-auth", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "spki"}, false},
+		{"pin ok", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pin", Pins: []string{goodPin}}, true},
+		{"pin without pins", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pin"}, false},
+		{"pin bad base64", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pin", Pins: []string{"!!!"}}, false},
+		{"pin wrong digest size", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pin", Pins: []string{"AAAA"}}, false},
+		{"dane hostname ok", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "dane"}, true},
+		{"dane ip needs tls-name", PeerConf{Addr: "192.0.2.1:853", Key: NOKEY, Transport: "dot", TLSAuth: "dane"}, false},
+		{"dane ip with tls-name", PeerConf{Addr: "192.0.2.1:853", Key: NOKEY, Transport: "dot", TLSAuth: "dane", TLSName: "ns1.test"}, true},
+		{"pkix system roots", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pkix"}, true},
+		{"pkix ca file ok", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pkix", CAFile: caPath}, true},
+		{"pkix ca file missing", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pkix", CAFile: "/nonexistent/ca.pem"}, false},
+		{"pkix ca file junk", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "dot", TLSAuth: "pkix", CAFile: junkPath}, false},
+		{"case-insensitive DoT/DANE", PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "DoT", TLSAuth: "DANE"}, true},
+	}
+	for _, tc := range cases {
+		p := tc.peer
+		err := validatePeerXoT(&p)
+		if tc.ok && err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("%s: expected error, got none", tc.name)
+		}
+	}
+
+	// Normalization: transport/tls-auth are lowercased in place.
+	p := PeerConf{Addr: "ns1.test", Key: NOKEY, Transport: "DOT", TLSAuth: "PKIX"}
+	if err := validatePeerXoT(&p); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if p.Transport != TransportDoT || p.TLSAuth != TLSAuthPKIX {
+		t.Fatalf("expected normalized transport/tls-auth, got %+v", p)
+	}
+}
+
+func writeCertPEM(path string, der []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestNormalizeAddressPort(t *testing.T) {
+	if got := NormalizeAddressPort("192.0.2.1", "853"); got != "192.0.2.1:853" {
+		t.Fatalf("got %q", got)
+	}
+	if got := NormalizeAddressPort("192.0.2.1:53", "853"); got != "192.0.2.1:53" {
+		t.Fatalf("explicit port must win: %q", got)
+	}
+	if got := NormalizeAddressPort("2001:db8::1", "853"); got != "[2001:db8::1]:853" {
+		t.Fatalf("v6 literal: %q", got)
+	}
+	if got := NormalizeAddress("192.0.2.1"); got != "192.0.2.1:53" {
+		t.Fatalf("NormalizeAddress default unchanged: %q", got)
 	}
 }
 

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -128,14 +128,24 @@ func (zd *ZoneData) DoTransfer(conf *Config) (bool, uint32, error) {
 		upstream := up.Addr
 		if _, _, err := net.SplitHostPort(upstream); err != nil {
 			// If error, assume no port was specified
-			upstream = net.JoinHostPort(upstream, "53")
-			lg.Debug("DoTransfer: no port specified for upstream, using default port 53", "zone", zd.ZoneName, "upstream", upstream)
+			upstream = net.JoinHostPort(upstream, defaultPortForPeer(up))
+			lg.Debug("DoTransfer: no port specified for upstream, using transport default", "zone", zd.ZoneName, "upstream", upstream)
 		}
 		// Fresh message per attempt: TSIG signing adds an RR with a per-attempt
 		// timestamp and this upstream's key.
 		m := new(dns.Msg)
 		m.SetQuestion(zd.ZoneName, dns.TypeSOA)
 		c := new(dns.Client)
+		// XoT peer: probe the SOA over the same verified-TLS channel the
+		// transfer itself will use (same pin/dane/pkix gate).
+		if tlsCfg, terr := conf.ClientTLSConfigForPeer(up); terr != nil {
+			lg.Error("DoTransfer: TLS setup failed, trying next upstream", "zone", zd.ZoneName, "upstream", upstream, "err", terr)
+			lastErr = terr
+			continue
+		} else if tlsCfg != nil {
+			c.Net = "tcp-tls"
+			c.TLSConfig = tlsCfg
+		}
 		provider, serr := SignForPeer(m, up.Key, conf)
 		if serr != nil {
 			lg.Error("DoTransfer: TSIG sign setup failed, trying next upstream", "zone", zd.ZoneName, "upstream", upstream, "key", up.Key, "err", serr)
@@ -286,7 +296,7 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 			Ready:          true, // this is only used by the checks for changes to DNSKEYs, HSYNC, etc.
 			// FoldCase:       zd.FoldCase, // Must be here, as this is an instruction to the zone reader
 		}
-		if _, err := new_zd.ZoneTransferIn(upstream, zd.IncomingSerial, "axfr", up.Key, conf); err != nil {
+		if _, err := new_zd.ZoneTransferIn(up, zd.IncomingSerial, "axfr", conf); err != nil {
 			lg.Warn("FetchFromUpstream: AXFR from upstream failed, trying next", "zone", zd.ZoneName, "upstream", upstream, "err", err)
 			lastErr = err
 			continue


### PR DESCRIPTION
Implements docs/2026-07-20-xot-implementation-plan.md end to end. One commit per plan phase, each independently green.

## What this adds

**Secondary pull over XoT (tdns-auth + tdns-agent, shared path):** per-primary `transport: dot` moves both the SOA probe and the transfer itself onto TLS, gated by a mandatory per-peer `tls-auth`:

- `pin` — static SPKI SHA-256 pinning (constant-time, any-of-list)
- `dane` — TLSA at `_<port>._tcp.<name>`, DNSSEC-validated through the in-process IMR, **fail closed** (honors the pre-existing `require_dnssec_validation` lab escape hatch, loudly)
- `pkix` — CA bundle or system roots

TSIG stays fully orthogonal (RFC 9103 allows TSIG+TLS; the fork applies TSIG inside the TLS stream — proven by the phase-0 spike test).

**Config/resolution:** five new optional `PeerConf` fields; empty `transport` is byte-for-byte today's Do53 behavior. Validation quarantines the zone on misconfig (dot without tls-auth, malformed pins, dane on an IP literal without `tls-name`, TLS fields on do53/notify peers). Hostname primaries keep their name through resolution (SNI + DANE base on every resolved address); DoT defaults to port 853.

**dog:** `AXFR/IXFR` now allowed over DoT; new `+pin=`, `+cafile=`, `+tlsa` (chase-validated DANE from the root trust anchors via the system resolver), and `+showpin` (pin/TLSA bootstrap helper). Unverified encrypted transports still work but warn.

**Primary side:** already served XoT via the DoT listener; this adds opt-in mTLS (`dnsengine.downstream-auth: pin | ca`) applying only to the auth listener — the IMR DoT front end never requests client certs. Plus an operations guide (docs/2026-07-21-xot-operations.md).

**TLSA primitive fixes (pre-existing bugs):** `VerifyCertAgainstTlsaRR` ignored the Selector field; `PublishTlsaRR` advertised 3-1-1 but hashed the full cert. Generation is now true 3-1-1 over the SPKI and verification honors the selector, taking `*x509.Certificate` so callers cannot hash the wrong bytes.

## Decisions made (Johan was AFK)

- Single branch with per-phase commits rather than the plan's six PRs (as requested).
- dog `+tlsa` validates via the existing sigchase `Chaser` + system resolver instead of booting an IMR — `@server` on a transfer is the authoritative, not a recursive.
- DANE lookups: per-server validated-TLSA cache consulted first, direct IMR fetch + `ValidateRRsetWithParentZone` as mainline; strict fail-closed except the pre-existing lab-mode knob.
- No client-cert DANE on the primary (no client name exists pre-handshake); pins cover it.
- SVCB advertisement rides the existing OOTS machinery — no new code.

## Heads-up for tdns-mp

At its next tdns/v2 pin bump, the `VerifyCertAgainstTlsaRR(tlsaRR, clientCert.Raw)` call in apirouter_sync.go must pass the parsed cert instead of `.Raw` (compile error will point at it). Mixed fleets (old verifier / new publisher) will fail TLSA verification until both sides upgrade; records are TTL 120 so re-convergence is quick.

## Testing

- 25+ new unit/integration tests: TLSA selector matrix, pin round-trips, all three auth modes end-to-end against an in-process DoT AXFR server (match + mismatch aborts), DANE fail-closed on none/insecure/bogus, no-IMR refusal, production `ZoneTransferIn`/`DoTransfer` over DoT with TSIG, server mTLS pin/ca (pinned/unpinned/cert-less clients), config-validation failures.
- Full `go test -race` green across v2, v2/cache, v2/core, v2/edns0; all cmdv2 binaries build.
- Live smoke: two local tdns-auth instances — secondary pulled `unsigned.example` from the primary over DoT with a pinned cert (SOA probe + AXFR over TLS, zone served correctly); dog `+showpin` bootstrap → pinned AXFR → wrong-pin refusal against the live daemon; dog `+pin` verified DoT query + wrong-pin abort against 1.1.1.1.
- Not done: interop against BIND/nsd (no non-disruptive target available — the foffe/pq testbed is live and was left untouched). Suggest a lab interop pass before wide rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XFR-over-TLS (AXFR/IXFR) with per-peer TLS authentication (pins, DANE/TLSA, or PKIX CA validation).
  * Added opt-in downstream mTLS for DoT listeners.
  * Added `+showpin` to display a server’s SPKI pin and matching TLSA.
* **Bug Fixes**
  * Improved TLSA handling for selector semantics and certificate verification.
  * Made TLS verification behavior fail-closed for DANE/TLSA unless explicitly relaxed in lab mode.
  * Refreshed TLSA caching and verbose TLSA reporting, including a regression fix for discovered NS glue vs stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->