### PR TITLE
PKIX cert tooling: tdns-cli cert (minimal internal CA) + cert init + PKIX loose ends

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 language: "en-US"
 
 reviews:
-  profile: "chill"
+  profile: "assertive"
 
   # Only review Go source under v2/ and cmdv2/
   path_filters:

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -48,6 +48,7 @@ dnsengine:
    #downstream-pins:            # base64 SPKI SHA-256 of each secondary's cert
    #   - "sec1-spki-sha256-base64="
    #downstream-ca: /etc/tdns/certs/downstream-ca.pem   # for downstream-auth: ca
+   #downstream-names: [ sec1.example.net ]  # ca mode + shared CA: also require an allowlisted DNS SAN
    # outbound_soa_serial controls the SOA serial advertised to secondaries:
    #   keep      — outbound = inbound serial (default; current behavior)
    #   unixtime  — outbound = time.Now().Unix() at zone load

--- a/cmdv2/cli/root.go
+++ b/cmdv2/cli/root.go
@@ -32,9 +32,11 @@ var rootCmd = &cobra.Command{
 			tdns.PrintVersionAndExit()
 		}
 		tdns.SetupCliLogging()
-		// keys generate (root-level) and gen-docs (offline doc generator) do
-		// not need config or API.
-		if isRootKeysCommand(cmd) || cmd.Name() == "gen-docs" {
+		// keys generate (root-level), gen-docs (offline doc generator) and
+		// the cert PKI subtree (offline provisioning; cert init reads the
+		// server config via its own --serverconfig flag) do not need
+		// config or API.
+		if isRootKeysCommand(cmd) || cmd.Name() == "gen-docs" || isCertCommand(cmd) {
 			return
 		}
 		initConfig()
@@ -67,6 +69,18 @@ func ExecuteContext(ctx context.Context) {
 //   - legacy: tdns-cli keys ...
 //   - current: tdns-cli util keys ...   (moved under 'util' in the
 //     CLI restructure; same no-config semantics).
+// isCertCommand returns true inside the root-level "cert" subtree — the
+// offline PKI provisioning commands, which must work with no daemon, no
+// tdns-cli config, and no API.
+func isCertCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "cert" && c.Parent() != nil && c.Parent().Name() == "tdns-cli" {
+			return true
+		}
+	}
+	return false
+}
+
 func isRootKeysCommand(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
 		if c.Name() != "keys" {

--- a/cmdv2/cli/shared_cmds.go
+++ b/cmdv2/cli/shared_cmds.go
@@ -50,6 +50,11 @@ func init() {
 	// From ../../v2/cli/generate_cmds.go: daemon-agnostic record syntax helpers
 	cli.UtilCmd.AddCommand(cli.GenerateCmd)
 
+	// Offline PKI provisioning for XoT/TLS (docs/2026-07-21-pkix-cert-
+	// tooling-design.md). Top-level: it is daemon-agnostic and needs no
+	// config or API (root.go skips init for the cert subtree).
+	rootCmd.AddCommand(cli.CertCmd)
+
 	// From ../../v2/cli/notify_cmds.go: 'auth notify' — sends NOTIFY
 	// (CDS/CSYNC/DNSKEY) toward the parent or signer, an auth-daemon op.
 	cli.AuthCmd.AddCommand(cli.NotifyCmd)

--- a/cmdv2/dog/dog.go
+++ b/cmdv2/dog/dog.go
@@ -620,6 +620,11 @@ func buildDogTLSConfig(options map[string]string) (*tls.Config, error) {
 	} else {
 		peer.TLSAuth = tdns.TLSAuthPKIX
 		peer.CAFile = options["cafile"]
+		if net.ParseIP(server) != nil {
+			// PKIX against an IP literal matches the cert's IP SANs; a
+			// verify failure here is usually a missing IP SAN, not a bad CA.
+			fmt.Fprintf(os.Stderr, ";; note: server %s is an IP literal — PKIX will match the certificate's IP SANs (a name-mismatch failure usually means the cert lacks this IP SAN)\n", server)
+		}
 	}
 	conf := &tdns.Config{}
 	return conf.ClientTLSConfigForPeer(peer)

--- a/docs/2026-07-21-xot-operations.md
+++ b/docs/2026-07-21-xot-operations.md
@@ -180,6 +180,9 @@ dnsengine:
    # ...or ca: standard mTLS against a CA bundle
    #downstream-auth: ca
    #downstream-ca:   /etc/tdns/certs/downstream-ca.pem
+   # optional with a SHARED ca: additionally require an allowlisted DNS SAN
+   # in the client cert (empty = any cert chaining to downstream-ca)
+   #downstream-names: [ sec1.example.net, sec2.example.net ]
 ```
 
 Notes:

--- a/docs/2026-07-21-xot-operations.md
+++ b/docs/2026-07-21-xot-operations.md
@@ -94,7 +94,10 @@ admits), roll the cert, then drop the old pin.
 You do not need an external CA. `tdns-cli cert` is a deliberately minimal
 internal PKI (no CRL/OCSP/renewal, no cert database — just PEM files plus an
 append-only `issued.log` audit trail next to the CA key, default home
-`/etc/tdns/ca/`).
+`/etc/tdns/ca/`). **Full operator how-to — including upgrading existing
+self-signed certs to CA-signed (keeping the key, so pins/TLSA stay valid)
+and building the `ca-file` for each kind of cert — in
+[guide/cert-provisioning.md](../guide/cert-provisioning.md).**
 
 **Just testing tdns?** You don't need any of this: `config mwe` generates a
 self-signed cert, and `pin`/`dane` (and dog `+showpin`) work fine against it.

--- a/docs/2026-07-21-xot-operations.md
+++ b/docs/2026-07-21-xot-operations.md
@@ -81,12 +81,65 @@ Ask the primary operator, or bootstrap from the live cert:
 
 ```
 dog +showpin @ns1.example.net           # prints SPKI pin + TLSA 3-1-1 record
+tdns-cli cert pin cert.pem              # same, from a PEM file
 openssl x509 -in cert.pem -pubkey -noout \
   | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64
 ```
 
 Pin rotation: list the old and the new pin simultaneously (any match
 admits), roll the cert, then drop the old pin.
+
+## 1b. Provisioning certificates: `tdns-cli cert`
+
+You do not need an external CA. `tdns-cli cert` is a deliberately minimal
+internal PKI (no CRL/OCSP/renewal, no cert database — just PEM files plus an
+append-only `issued.log` audit trail next to the CA key, default home
+`/etc/tdns/ca/`).
+
+**Just testing tdns?** You don't need any of this: `config mwe` generates a
+self-signed cert, and `pin`/`dane` (and dog `+showpin`) work fine against it.
+
+**Single host, one command** — provision the local tdns-auth:
+
+```
+tdns-cli cert init [--serverconfig /etc/tdns/tdns-auth.yaml]
+```
+
+This creates the CA if absent (reuses it otherwise), derives SANs from the
+config's listen addresses + this host's name, writes cert/key to the exact
+`dnsengine.certfile`/`keyfile` paths the config already names, drops a CA
+copy next to them, and prints ready-to-paste secondary config for all three
+auth modes. Restart the daemon and you serve verified XoT. Re-running is
+safe; `--force` is needed to replace existing files.
+
+**Fleet / cross-org** — the primitives:
+
+```
+tdns-cli cert ca   --name xot-ca                                   # once
+tdns-cli cert leaf --ca .../xot-ca.crt --ca-key .../xot-ca.key \
+    --name ns1.example.net --dns ns1.example.net --ip 192.0.2.53 \
+    --emit-pin --emit-tlsa ns1.example.net                         # per server
+# remote secondary (key never leaves its host):
+tdns-cli cert csr  --name ns2.example.net --dns ns2.example.net    # on ns2
+tdns-cli cert sign --ca ... --ca-key ... --csr ns2.example.net.csr --client
+tdns-cli cert show cert.pem   # inspect; cert pin cert.pem for the pin only
+```
+
+One issuance feeds all three modes: the CA cert is the `ca-file` (pkix), the
+`--emit-pin` output is the `pins:` value, the `--emit-tlsa` output is the
+DANE record. Keys are written 0600 and never overwritten without `--force`.
+The CA is hard-coded pathlen-0 (it can only sign leaves, never a sub-CA)
+and its key is never auto-loaded by any daemon — keep it access-controlled,
+ideally on an admin host rather than the DNS servers.
+
+### Intermediate chains (external CAs)
+
+`dnsengine.certfile` may hold the full presented chain: **leaf first, then
+intermediates**, concatenated PEM — `tls.LoadX509KeyPair` presents every
+block. A CA-signed leaf without its intermediates makes secondaries fail
+chain building (the server logs an informational note at startup for the
+single-CA-signed-cert shape). Certs from `tdns-cli cert` need no bundling:
+secondaries trust the root directly.
 
 ## 2. Primary: serving XoT
 
@@ -177,6 +230,13 @@ dog +showpin @ns1.example.net                              # print server pin/TL
   unverified behavior but print a warning.
 
 ## 4. Limitations / notes
+
+- tdns-agent inherits the whole secondary XoT feature unchanged — both
+  daemons drive the same `FetchFromUpstream`/`DoTransfer` path (guarded by
+  `TestXoT_FetchFromUpstreamPKIX`).
+- dog `+cafile` against an IP-literal server verifies the cert's IP SANs
+  (dog prints a note); a name-mismatch failure there usually means the cert
+  lacks that IP SAN, not a bad CA.
 
 - IXFR: the secondary always requests AXFR today, and `ZoneTransferOut`
   answers IXFR requests with a full zone (AXFR-style response, which RFC

--- a/guide/README.md
+++ b/guide/README.md
@@ -41,6 +41,17 @@ companion [tdns-mp Guide](../../tdns-mp/guide/README.md).
   support (ML-DSA / SLH-DSA / Falcon / MAYO / SNOVA for both
   SIG(0) and DNSSEC).
 
+- [Certificate Provisioning: the tdns Minimal CA](cert-provisioning.md)
+  -- Operator how-to for `tdns-cli cert`: the one-shot
+  `cert init` for the local tdns-auth, upgrading existing
+  self-signed certificates to CA-signed ones (locally and
+  on remote hosts, keeping the key so pins and TLSA records
+  stay valid), creating the `ca-file` for each kind of
+  certificate, renewal/rotation, and what the deliberately
+  minimal scope (no CRL/OCSP/renewal automation) means in
+  practice. Companion to the XoT transfer configuration in
+  the tdns-auth config guide.
+
 - [Agent as a DSYNC proxy](agent-dsync-proxy.md)
   -- Operator how-to for running tdns-agent as a secondary
   that forwards delegation-sync (NOTIFY and/or signed DNS

--- a/guide/cert-provisioning.md
+++ b/guide/cert-provisioning.md
@@ -1,0 +1,215 @@
+# Certificate Provisioning: the tdns Minimal CA
+
+tdns ships a deliberately small built-in certificate authority,
+`tdns-cli cert`, so that TLS between tdns components (XoT zone transfer,
+DoT/DoH/DoQ service, mutual TLS) never *requires* an external CA. It is a
+provisioning convenience for a **private trust domain** — your own primaries
+and secondaries — not general CA tooling: there is no CRL, no OCSP, no
+renewal automation and no certificate database. The only persistent state
+is plain PEM files plus a human-readable audit log.
+
+**Do you need it at all?** Not for kicking the tires. `tdns-cli auth config
+mwe` generates a self-signed certificate, and both the `pin` and `dane`
+authentication modes (and `dog +showpin`) work fine against self-signed
+certs. Reach for the CA when you want `tls-auth: pkix` (one trusted file on
+every secondary instead of per-server pins), or mutual TLS.
+
+## The pieces
+
+| Path | What | Notes |
+|---|---|---|
+| `/etc/tdns/ca/` | the CA's home (dir mode 0700) | default when running as root; otherwise the cwd is used — override with `--out-dir`/`--ca-dir` |
+| `/etc/tdns/ca/<name>.crt` | the CA certificate (public) | distribute freely — this **is** the `ca-file` |
+| `/etc/tdns/ca/<name>.key` | the CA signing key (mode 0600) | guard it; no tdns daemon ever reads it |
+| `/etc/tdns/ca/issued.log` | append-only audit trail | one line per issuance; nothing reads it programmatically |
+| `/etc/tdns/certs/` | where daemons' certs/keys live | the existing convention (`dnsengine.certfile`/`keyfile`) |
+
+Key files are always written mode 0600 and never overwritten without
+`--force`. The CA is hard-coded to only ever sign end-entity certificates
+(pathlen 0) — it cannot mint sub-CAs, and no flag can change that.
+
+## Quick start: one host, one command
+
+```
+tdns-cli cert init [--serverconfig /etc/tdns/tdns-auth.yaml]
+```
+
+`cert init` creates the CA if it does not exist yet (and reuses it on every
+later run), issues a server certificate whose SANs are derived from the
+config's `dnsengine.addresses` plus this host's name and loopback, writes
+cert and key to the **exact `dnsengine.certfile`/`keyfile` paths the config
+already names** (no config editing needed), drops a copy of the CA cert
+next to them, and prints ready-to-paste secondary configuration for all
+three XoT auth modes. Restart `tdns-auth` and you are serving CA-signed
+TLS.
+
+The rest of this page is the manual toolbox behind that one-shot.
+
+## Creating the CA (once)
+
+```
+tdns-cli cert ca --name tdns-ca --out-dir /etc/tdns/ca
+```
+
+produces `/etc/tdns/ca/tdns-ca.crt` (the trust anchor) and
+`/etc/tdns/ca/tdns-ca.key` (the signing key). Default validity 3650 days,
+default algorithm ed25519 (`--algorithm ecdsa-p256|rsa2048` for interop
+with older peers).
+
+## Upgrading a LOCAL self-signed cert to a CA-signed cert
+
+Scenario: this host already runs tdns-auth with a self-signed certificate
+(from `config mwe` or `utils/gen-cert.sh`), e.g.
+`/etc/tdns/certs/servers/ns1.example.net.crt` + `.key`, and you want the
+same server to present a CA-signed certificate instead.
+
+The important idea: you do not replace the *key*, only the *certificate*.
+`cert csr --key` re-certifies the existing key, which keeps the public key
+(SPKI) identical — so any `pins:` entries and published TLSA records that
+point at this server **remain valid** across the upgrade.
+
+```
+cd /etc/tdns/certs/servers
+
+# 1. CSR from the existing cert + key: --from-cert copies the CN and all
+#    SANs, --key reuses the existing private key (nothing new generated).
+tdns-cli cert csr --from-cert ns1.example.net.crt --key ns1.example.net.key
+
+# 2. Sign it with the CA (same host, so no file shipping involved):
+tdns-cli cert sign --ca /etc/tdns/ca/tdns-ca.crt --ca-key /etc/tdns/ca/tdns-ca.key \
+    --csr ns1.example.net.csr --server --force
+#    -> ns1.example.net.crt is now CA-signed (--force: it replaces the
+#       self-signed one; the .key file is untouched)
+
+# 3. Restart tdns-auth. Done — certfile/keyfile paths in the config never
+#    changed, and neither did the SPKI:
+tdns-cli cert pin ns1.example.net.crt      # same pin as before the upgrade
+```
+
+(`--server` is the default EKU; add `--client` too if this daemon will also
+present the cert as a *client* under mutual XoT.)
+
+If you do not care about keeping the key (no pins/TLSA published yet), skip
+the CSR dance entirely: `tdns-cli cert leaf --ca … --ca-key … --name
+ns1.example.net --dns ns1.example.net --ip 192.0.2.53 --force` mints a
+fresh key + cert in one step.
+
+## Upgrading a REMOTE self-signed cert
+
+Scenario: a secondary (or another primary) elsewhere runs with a
+self-signed cert; you operate the CA. Same flow — the only difference is
+*where* each command runs, and that the CSR/cert travel between hosts while
+**the private key never leaves the remote host**:
+
+```
+# --- on the REMOTE host (ns2) ---
+cd /etc/tdns/certs/servers
+tdns-cli cert csr --from-cert ns2.example.net.crt --key ns2.example.net.key
+scp ns2.example.net.csr ca-host:
+
+# --- on the CA host ---
+tdns-cli cert sign --ca /etc/tdns/ca/tdns-ca.crt --ca-key /etc/tdns/ca/tdns-ca.key \
+    --csr ns2.example.net.csr --server --client
+scp ns2.example.net.crt tdns-ca.crt ns2:/etc/tdns/certs/servers/
+
+# --- back on the REMOTE host ---
+# ns2.example.net.crt replaces the self-signed cert (same key, same paths);
+# tdns-ca.crt is there for when ns2 needs a ca-file itself (see below).
+# Restart the daemon.
+```
+
+A CSR is public data — it can travel by scp, mail, or ticket attachment.
+The CA operator can inspect it before signing; `cert sign` refuses a CSR
+whose signature does not verify. `--client` on the sign step gives the cert
+the clientAuth EKU too, which a secondary needs if the primary enforces
+mutual TLS (`downstream-auth: ca`).
+
+## Creating the ca-file (for each kind of cert)
+
+A "ca-file" is nothing more than the PEM certificate(s) a verifier should
+trust as roots. What goes in it depends on how the *server's* cert was
+made:
+
+- **Cert signed by the tdns CA** → the ca-file is a **copy of the CA
+  certificate**:
+
+  ```
+  scp ca-host:/etc/tdns/ca/tdns-ca.crt /etc/tdns/certs/tdns-ca.crt
+  ```
+
+  One file covers every cert that CA ever signs — that is the point of
+  pkix mode: new servers need no per-server configuration on the clients.
+
+- **Self-signed cert** → the ca-file is **the certificate itself** (a
+  self-signed cert is its own root). Copy the server's `.crt` (never the
+  `.key`!) to the verifying side and point `ca-file` at it. This works
+  today, before any CA exists — it is per-server pinning by file instead
+  of by digest.
+
+- **External CA** (corporate PKI, etc.) → the ca-file is that CA's root
+  certificate (concatenate roots if there are several). If the server's
+  cert was issued via an intermediate, the *server* must present the
+  intermediate: concatenate leaf-first into `dnsengine.certfile`
+  (see [XoT operations](../docs/2026-07-21-xot-operations.md)). Certs from
+  the tdns CA never need this — there are no intermediates by design.
+
+Where a ca-file is consumed:
+
+```yaml
+# secondary: verify the primary's cert when pulling over XoT
+zones:
+   - name: example.com.
+     type: secondary
+     primaries:
+        - addr: ns1.example.net:853
+          key: NOKEY
+          transport: dot
+          tls-auth: pkix
+          ca-file: /etc/tdns/certs/tdns-ca.crt
+
+# primary: verify SECONDARIES' client certs (mutual TLS, optional)
+dnsengine:
+   downstream-auth: ca
+   downstream-ca:   /etc/tdns/certs/tdns-ca.crt
+   #downstream-names: [ ns2.example.net ]   # optional SAN allowlist
+```
+
+and on the command line: `dog +dot +cafile=/etc/tdns/certs/tdns-ca.crt
+AXFR example.com @ns1.example.net`.
+
+## Verifying what you built
+
+```
+tdns-cli cert show ns1.example.net.crt    # subject, issuer, SANs, EKU, validity, pin
+tdns-cli cert pin  ns1.example.net.crt    # just the SPKI pin
+dog +dot +cafile=tdns-ca.crt SOA example.com @ns1.example.net   # live PKIX check
+dog +dot +showpin @ns1.example.net                              # what the server presents
+cat /etc/tdns/ca/issued.log               # what the CA has signed, when
+```
+
+## Renewal, rotation and the ugly cases
+
+- **Renewal** (cert expiring, default leaf validity 397 days): re-run the
+  same `csr --key` + `sign --force` flow (or `cert leaf --force` /
+  `cert init --force`). Reusing the key keeps pins/TLSA valid; the server
+  logs a warning 30 days before expiry.
+- **Key rotation** (you *want* a new key): mint a fresh leaf, and if pins
+  or TLSA are in play, publish old + new side by side first — `pins:`
+  accepts a list and any match admits; TLSA RRsets can hold both digests —
+  then remove the old one after the switch.
+- **Compromise**: there is no revocation (no CRL/OCSP — deliberate scope).
+  If a *server* key leaks: issue a new key+cert and update pins/TLSA; pkix
+  clients are only safe once the attacker can no longer use the cert, so
+  treat a leaked server key in a pkix setup as urgent. If the **CA key**
+  leaks: create a new CA and re-issue everything; the small size of a
+  private trust domain is what makes this feasible — which is also why the
+  CA key belongs on an access-controlled (ideally offline/admin) host, not
+  on the DNS servers.
+
+## Relation to pin and dane
+
+One issuance feeds all three auth modes: `--emit-pin` prints the `pins:` /
+`+pin=` value and `--emit-tlsa <owner> [--tlsa-port 853]` prints the TLSA
+3-1-1 record for DANE. pkix is about *not* having to manage those
+per-server values — but nothing stops you from mixing modes per primary in
+`primaries:`.

--- a/guide/config-tdns-auth.md
+++ b/guide/config-tdns-auth.md
@@ -202,6 +202,69 @@ downstreams:
      key:    BLOCKED          # denied even with a valid key
 ```
 
+### The TLS layer: authenticating secondaries by certificate (XoT)
+
+When the primary serves zone transfer over TLS (XoT — `dot` in
+`dnsengine.transports`), a second, independent gate is available in front
+of the `downstreams:` ACL: **mutual TLS**. It is configured in the
+`dnsengine:` block, not per zone, and it applies to **every connection on
+the auth DoT listener** (the IMR's DoT front end never requests client
+certificates):
+
+```yaml
+dnsengine:
+   transports: [ do53, dot ]
+   certfile:   /etc/tdns/certs/servers/ns1.example.net.crt
+   keyfile:    /etc/tdns/certs/servers/ns1.example.net.key
+
+   # EITHER: pin each secondary's client certificate explicitly
+   downstream-auth: pin
+   downstream-pins:
+      - "sec1-spki-sha256-base64="      # tdns-cli cert pin sec1.crt
+      - "sec2-spki-sha256-base64="
+
+   # OR: standard mTLS against a CA (see guide/cert-provisioning.md)
+   #downstream-auth: ca
+   #downstream-ca:   /etc/tdns/certs/tdns-ca.crt
+   ## optional, for a CA shared beyond the transfer trust domain: the
+   ## client cert must ALSO carry one of these DNS SANs
+   #downstream-names: [ sec2.example.net, sec3.example.net ]
+```
+
+- `pin` — the connecting secondary must present a certificate whose SPKI
+  SHA-256 digest is in `downstream-pins` (any match admits; list old +
+  new during rotation). No CA involved; get each pin with
+  `tdns-cli cert pin <cert.pem>` or `dog +showpin`.
+- `ca` — the client certificate must chain to `downstream-ca` (the same
+  CA file secondaries use to verify *us* — one file both ways when using
+  the tdns minimal CA). `downstream-names` optionally narrows which
+  chain-valid subjects count, which matters when the CA also signs certs
+  for hosts that should *not* be able to transfer.
+- Absent `downstream-auth` — no client certificate is requested; the DoT
+  listener behaves as before.
+
+**How the two layers compose.** They are ANDed, in order: the TLS
+handshake (including `downstream-auth`, if set) must succeed before any
+DNS message is read, and then the per-zone `downstreams:` prefix+TSIG ACL
+decides the transfer exactly as over Do53. TSIG remains fully meaningful
+inside TLS (RFC 9103 allows both), so the strongest configuration is
+mTLS + per-zone TSIG. Note the granularity difference: `downstream-auth`
+is one policy for the whole listener, while `downstreams:` is per zone —
+there is currently no per-zone certificate requirement inside a
+`downstreams:` entry.
+
+**Verifying the secondary's cert via TLSA/DANE is not currently offered**
+on the primary side (client-cert DANE would mean validating the presented
+certificate against the DNSSEC-signed TLSA record of the name it claims —
+feasible, but not implemented; `pin` covers the no-shared-files case
+today). The `dane` mode exists on the *secondary* side, where the
+secondary verifies the primary's server certificate (`tls-auth: dane` in
+`primaries:`).
+
+Provisioning the certificates for all of this — including the one-shot
+`tdns-cli cert init` and upgrading existing self-signed certs — is
+covered in [Certificate Provisioning](cert-provisioning.md).
+
 ## Zone declarations
 
 A zone is one entry in the top-level `zones:` list.
@@ -371,6 +434,10 @@ dnsengine:
 | `ports.doh` | `443` | listen ports for DoH |
 | `ports.doq` | `853` | listen ports for DoQ (only 853 is truly supported) |
 | `outbound_soa_serial` | `keep` | `keep`, `unixtime` or `persist` |
+| `downstream-auth` | — | opt-in mTLS on the DoT listener: `pin` or `ca` (see [the TLS layer](#the-tls-layer-authenticating-secondaries-by-certificate-xot)) |
+| `downstream-pins` | — | SPKI pins for `downstream-auth: pin` |
+| `downstream-ca` | — | CA bundle for `downstream-auth: ca` |
+| `downstream-names` | — | optional SAN allowlist for `ca` mode |
 | `options` | — | server-wide options, below |
 
 `ports.do53` is **not read**. Do53 always listens on the ports embedded in

--- a/v2/cli/cert_cmds.go
+++ b/v2/cli/cert_cmds.go
@@ -50,21 +50,22 @@ Typical flows:
 }
 
 var (
-	certName      string
-	certOutDir    string
-	certValidity  int
-	certAlgorithm string
-	certForce     bool
-	certCAFile    string
-	certCAKeyFile string
-	certDNSNames  []string
-	certIPs       []string
-	certServer    bool
-	certClient    bool
-	certCSRFile   string
-	certEmitPin   bool
-	certEmitTlsa  string
-	certTlsaPort  uint16
+	certName       string
+	certOutDir     string
+	certValidity   int
+	certCAValidity int // separate backing var: certValidity is shared/rebound by addCommonLeafFlags
+	certAlgorithm  string
+	certForce      bool
+	certCAFile     string
+	certCAKeyFile  string
+	certDNSNames   []string
+	certIPs        []string
+	certServer     bool
+	certClient     bool
+	certCSRFile    string
+	certEmitPin    bool
+	certEmitTlsa   string
+	certTlsaPort   uint16
 )
 
 var certCaCmd = &cobra.Command{
@@ -74,7 +75,7 @@ var certCaCmd = &cobra.Command{
 		outDir := certOutDirDefault()
 		ca, err := tdns.CreateCA(tdns.CAOptions{
 			Name:     certName,
-			Validity: time.Duration(certValidity) * 24 * time.Hour,
+			Validity: time.Duration(certCAValidity) * 24 * time.Hour,
 			Alg:      tdns.CertAlgorithm(certAlgorithm),
 		})
 		if err != nil {
@@ -429,7 +430,10 @@ func init() {
 	}
 	certCsrCmd.Flags().StringVar(&certKeyFile, "key", "", "reuse this EXISTING private key (PKCS#8 or legacy openssl EC/RSA PEM) instead of generating one — keeps the SPKI, so pins/TLSA stay valid")
 	certCsrCmd.Flags().StringVar(&certFromCert, "from-cert", "", "copy CN and SANs from this existing certificate (PEM)")
-	certCaCmd.Flags().IntVar(&certValidity, "validity", 3650, "validity in days")
+	// Own backing variable: certValidity is shared with (and rebound to 397 by)
+	// addCommonLeafFlags below, which would otherwise leave `cert ca` minting a
+	// 397-day root instead of 3650.
+	certCaCmd.Flags().IntVar(&certCAValidity, "validity", 3650, "validity in days")
 
 	addCommonLeafFlags(certLeafCmd)
 	addCommonLeafFlags(certSignCmd)

--- a/v2/cli/cert_cmds.go
+++ b/v2/cli/cert_cmds.go
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * `tdns-cli cert …` — a deliberately minimal internal PKI for provisioning
+ * XoT/TLS certificates in a *private* trust domain (docs/2026-07-21-pkix-
+ * cert-tooling-design.md). Not public-PKI tooling: no CRL, no OCSP, no
+ * renewal automation, no cert database. The only persistent artifacts are
+ * the PEM files themselves plus an append-only, human-readable issued.log
+ * next to the CA. The crypto lives in v2/pki.go; this file is flag
+ * handling, file I/O, and output.
+ */
+package cli
+
+import (
+	"crypto"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tdns "github.com/johanix/tdns/v2"
+	"github.com/miekg/dns"
+	"github.com/spf13/cobra"
+)
+
+// DefaultCADir is where `cert ca` (and `cert init`) put CA material when
+// running as root; non-root runs default to the current directory so the
+// tool never surprises a user with writes into /etc.
+const DefaultCADir = "/etc/tdns/ca"
+
+var CertCmd = &cobra.Command{
+	Use:   "cert",
+	Short: "Minimal internal PKI for XoT/TLS provisioning (private trust domains only)",
+	Long: `Minimal internal PKI for provisioning XoT/TLS certificates.
+
+Scope: a provisioning convenience for a PRIVATE trust domain (your own
+primaries and secondaries) — not general CA tooling. No CRL, no OCSP, no
+renewal automation, no certificate database. State is plain PEM files plus
+an append-only issued.log next to the CA key.
+
+Typical flows:
+  cert init  — one command: CA (if absent) + a server cert for the local
+               tdns-auth, written to the paths its config already names.
+  cert ca / cert leaf — mint the CA and individual certs by hand.
+  cert csr / cert sign — split provisioning: the remote side generates the
+               key+CSR locally (key never travels), the CA side signs.`,
+}
+
+var (
+	certName      string
+	certOutDir    string
+	certValidity  int
+	certAlgorithm string
+	certForce     bool
+	certCAFile    string
+	certCAKeyFile string
+	certDNSNames  []string
+	certIPs       []string
+	certServer    bool
+	certClient    bool
+	certCSRFile   string
+	certEmitPin   bool
+	certEmitTlsa  string
+	certTlsaPort  uint16
+)
+
+var certCaCmd = &cobra.Command{
+	Use:   "ca",
+	Short: "Create a self-signed CA (pathlen 0: signs leaves only)",
+	Run: func(cmd *cobra.Command, args []string) {
+		outDir := certOutDirDefault()
+		ca, err := tdns.CreateCA(tdns.CAOptions{
+			Name:     certName,
+			Validity: time.Duration(certValidity) * 24 * time.Hour,
+			Alg:      tdns.CertAlgorithm(certAlgorithm),
+		})
+		if err != nil {
+			cliFatalf("cert ca: %v", err)
+		}
+		base := filepath.Join(outDir, safeFileName(certName))
+		writeCertAndKey(base, ca, 0o700)
+		appendIssuedLog(outDir, "ca-created", ca.Cert)
+		fmt.Printf("CA certificate: %s.crt\nCA signing key: %s.key (mode 0600 — guard it; nothing in tdns ever auto-loads it)\n", base, base)
+	},
+}
+
+var certLeafCmd = &cobra.Command{
+	Use:   "leaf",
+	Short: "Generate a key and a CA-signed end-entity certificate",
+	Run: func(cmd *cobra.Command, args []string) {
+		caCert, caKey := loadCA()
+		leaf, err := tdns.IssueLeaf(caCert, caKey, tdns.LeafOptions{
+			Name:     certName,
+			DNSNames: certDNSNames,
+			IPs:      parseIPFlags(),
+			Server:   certServer,
+			Client:   certClient,
+			Validity: time.Duration(certValidity) * 24 * time.Hour,
+			Alg:      tdns.CertAlgorithm(certAlgorithm),
+		})
+		if err != nil {
+			cliFatalf("cert leaf: %v", err)
+		}
+		base := filepath.Join(certOutDirDefaultCwd(), safeFileName(certName))
+		writeCertAndKey(base, leaf, 0o755)
+		appendIssuedLog(filepath.Dir(certCAFile), "leaf", leaf.Cert)
+		fmt.Printf("certificate: %s.crt\nprivate key: %s.key\n", base, base)
+		emitPinAndTlsa(leaf.Cert)
+	},
+}
+
+var certCsrCmd = &cobra.Command{
+	Use:   "csr",
+	Short: "Generate a key + certificate signing request (key never leaves this host)",
+	Run: func(cmd *cobra.Command, args []string) {
+		csrPEM, keyPEM, err := tdns.CreateCSR(tdns.CSROptions{
+			Name:     certName,
+			DNSNames: certDNSNames,
+			IPs:      parseIPFlags(),
+			Alg:      tdns.CertAlgorithm(certAlgorithm),
+		})
+		if err != nil {
+			cliFatalf("cert csr: %v", err)
+		}
+		base := filepath.Join(certOutDirDefaultCwd(), safeFileName(certName))
+		writeFileSafe(base+".key", keyPEM, 0o600)
+		writeFileSafe(base+".csr", csrPEM, 0o644)
+		fmt.Printf("CSR:         %s.csr  (send this to the CA operator)\nprivate key: %s.key  (stays here)\n", base, base)
+	},
+}
+
+var certSignCmd = &cobra.Command{
+	Use:   "sign",
+	Short: "Sign a CSR with the CA (SANs are taken from the CSR)",
+	Run: func(cmd *cobra.Command, args []string) {
+		caCert, caKey := loadCA()
+		csrPEM, err := os.ReadFile(certCSRFile)
+		if err != nil {
+			cliFatalf("cert sign: reading CSR: %v", err)
+		}
+		signed, err := tdns.SignCSR(caCert, caKey, csrPEM, tdns.SignOptions{
+			Server:   certServer,
+			Client:   certClient,
+			Validity: time.Duration(certValidity) * 24 * time.Hour,
+		})
+		if err != nil {
+			cliFatalf("cert sign: %v", err)
+		}
+		name := signed.Cert.Subject.CommonName
+		if name == "" {
+			name = strings.TrimSuffix(filepath.Base(certCSRFile), ".csr")
+		}
+		out := filepath.Join(certOutDirDefaultCwd(), safeFileName(name)+".crt")
+		writeFileSafe(out, signed.CertPEM, 0o644)
+		appendIssuedLog(filepath.Dir(certCAFile), "csr-signed", signed.Cert)
+		fmt.Printf("certificate: %s  (return this to the requester)\n", out)
+		emitPinAndTlsa(signed.Cert)
+	},
+}
+
+var certPinCmd = &cobra.Command{
+	Use:   "pin <cert.pem>",
+	Short: "Print the base64 SPKI SHA-256 pin of a certificate",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(tdns.SPKISHA256(readCertArg(args[0])))
+	},
+}
+
+var certShowCmd = &cobra.Command{
+	Use:   "show <cert.pem>",
+	Short: "Human-readable certificate summary (subject, SANs, EKU, validity, pin)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cert := readCertArg(args[0])
+		fmt.Printf("subject:  %s\nissuer:   %s\nserial:   %x\nvalidity: %s — %s\nis-ca:    %v\n",
+			cert.Subject, cert.Issuer, cert.SerialNumber,
+			cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339), cert.IsCA)
+		if sans := sanStrings(cert); len(sans) > 0 {
+			fmt.Printf("sans:     %s\n", strings.Join(sans, ", "))
+		}
+		if ekus := ekuStrings(cert); len(ekus) > 0 {
+			fmt.Printf("eku:      %s\n", strings.Join(ekus, ", "))
+		}
+		fmt.Printf("spki pin: %s\n", tdns.SPKISHA256(cert))
+	},
+}
+
+// --- shared helpers ---------------------------------------------------------
+
+// certOutDirDefault: CA material goes to /etc/tdns/ca when running as root,
+// else the cwd (never surprise-write into /etc without privileges).
+func certOutDirDefault() string {
+	if certOutDir != "" {
+		return certOutDir
+	}
+	if os.Geteuid() == 0 {
+		return DefaultCADir
+	}
+	return "."
+}
+
+func certOutDirDefaultCwd() string {
+	if certOutDir != "" {
+		return certOutDir
+	}
+	return "."
+}
+
+func loadCA() (*x509.Certificate, crypto.Signer) {
+	certData, err := os.ReadFile(certCAFile)
+	if err != nil {
+		cliFatalf("cert: reading CA cert: %v", err)
+	}
+	caCert, err := tdns.ParseCertPEM(certData)
+	if err != nil {
+		cliFatalf("cert: parsing CA cert %s: %v", certCAFile, err)
+	}
+	keyData, err := os.ReadFile(certCAKeyFile)
+	if err != nil {
+		cliFatalf("cert: reading CA key: %v", err)
+	}
+	caKey, err := tdns.ParsePrivateKeyPEM(keyData)
+	if err != nil {
+		cliFatalf("cert: parsing CA key %s: %v", certCAKeyFile, err)
+	}
+	return caCert, caKey
+}
+
+func safeFileName(name string) string {
+	name = strings.TrimSuffix(name, ".")
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, name)
+}
+
+// writeFileSafe writes data, creating parent dirs, refusing to overwrite an
+// existing file unless --force was given.
+func writeFileSafe(path string, data []byte, mode os.FileMode) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		cliFatalf("cert: mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if _, err := os.Stat(path); err == nil && !certForce {
+		cliFatalf("cert: %s already exists (use --force to overwrite)", path)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		cliFatalf("cert: write %s: %v", path, err)
+	}
+	// os.WriteFile does not chmod an existing file; enforce the mode.
+	if err := os.Chmod(path, mode); err != nil {
+		cliFatalf("cert: chmod %s: %v", path, err)
+	}
+}
+
+// writeCertAndKey writes <base>.crt (0644) and <base>.key (0600), ensuring
+// the containing directory exists with dirMode (0700 for the CA home).
+func writeCertAndKey(base string, pc *tdns.PKICert, dirMode os.FileMode) {
+	dir := filepath.Dir(base)
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		cliFatalf("cert: mkdir %s: %v", dir, err)
+	}
+	writeFileSafe(base+".crt", pc.CertPEM, 0o644)
+	writeFileSafe(base+".key", pc.KeyPEM, 0o600)
+}
+
+// appendIssuedLog appends one human-readable line per issuance next to the
+// CA. Nothing ever reads this programmatically — it is an operator audit
+// trail, not a certificate database. Failure to write it is a warning, not
+// an abort (the cert already exists on disk).
+func appendIssuedLog(caDir, kind string, cert *x509.Certificate) {
+	line := fmt.Sprintf("%s  kind=%s  serial=%x  cn=%q  sans=%s  eku=%s\n",
+		time.Now().UTC().Format(time.RFC3339), kind, cert.SerialNumber,
+		cert.Subject.CommonName,
+		strings.Join(sanStrings(cert), ","), strings.Join(ekuStrings(cert), ","))
+	path := filepath.Join(caDir, "issued.log")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not append to %s: %v\n", path, err)
+		return
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not append to %s: %v\n", path, err)
+	}
+}
+
+func sanStrings(cert *x509.Certificate) []string {
+	out := append([]string(nil), cert.DNSNames...)
+	for _, ip := range cert.IPAddresses {
+		out = append(out, ip.String())
+	}
+	return out
+}
+
+func ekuStrings(cert *x509.Certificate) []string {
+	var out []string
+	for _, eku := range cert.ExtKeyUsage {
+		switch eku {
+		case x509.ExtKeyUsageServerAuth:
+			out = append(out, "server")
+		case x509.ExtKeyUsageClientAuth:
+			out = append(out, "client")
+		default:
+			out = append(out, fmt.Sprintf("eku-%d", eku))
+		}
+	}
+	return out
+}
+
+func parseIPFlags() []net.IP {
+	var ips []net.IP
+	for _, s := range certIPs {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			cliFatalf("cert: --ip %q is not a valid IP address", s)
+		}
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+func readCertArg(path string) *x509.Certificate {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		cliFatalf("cert: reading %s: %v", path, err)
+	}
+	cert, err := tdns.ParseCertPEM(data)
+	if err != nil {
+		cliFatalf("cert: parsing %s: %v", path, err)
+	}
+	return cert
+}
+
+// emitPinAndTlsa prints the SPKI pin and/or the TLSA 3-1-1 record for a
+// freshly issued certificate, so one provisioning step feeds all three XoT
+// auth modes (pkix via the CA file, pin via the digest, dane via the RR).
+func emitPinAndTlsa(cert *x509.Certificate) {
+	if certEmitPin {
+		fmt.Printf("spki pin (for pins: / +pin=): %s\n", tdns.SPKISHA256(cert))
+	}
+	if certEmitTlsa != "" {
+		tlsa, err := tdns.NewTlsaRR(dns.Fqdn(certEmitTlsa), certTlsaPort, cert)
+		if err != nil {
+			cliFatalf("cert: building TLSA record: %v", err)
+		}
+		fmt.Printf("TLSA (publish for dane):     %s\n", tlsa.String())
+	}
+}
+
+func addCommonLeafFlags(c *cobra.Command) {
+	c.Flags().StringVar(&certCAFile, "ca", "", "path to the CA certificate (PEM)")
+	c.Flags().StringVar(&certCAKeyFile, "ca-key", "", "path to the CA signing key (PEM)")
+	c.Flags().BoolVar(&certServer, "server", true, "include serverAuth EKU (default true; use --server=false for a client-only cert)")
+	c.Flags().BoolVar(&certClient, "client", false, "include clientAuth EKU (a mutual-XoT downstream wants both)")
+	c.Flags().IntVar(&certValidity, "validity", 397, "validity in days")
+	c.Flags().BoolVar(&certEmitPin, "emit-pin", false, "print the SPKI pin after issuing")
+	c.Flags().StringVar(&certEmitTlsa, "emit-tlsa", "", "print a TLSA 3-1-1 RR for this owner name after issuing")
+	c.Flags().Uint16Var(&certTlsaPort, "tlsa-port", 853, "port for the --emit-tlsa owner name")
+	_ = c.MarkFlagRequired("ca")
+	_ = c.MarkFlagRequired("ca-key")
+}
+
+func init() {
+	CertCmd.AddCommand(certCaCmd, certLeafCmd, certCsrCmd, certSignCmd, certPinCmd, certShowCmd, certInitCmd)
+
+	for _, c := range []*cobra.Command{certCaCmd, certLeafCmd, certCsrCmd, certSignCmd} {
+		c.Flags().StringVar(&certOutDir, "out-dir", "", "output directory (default: cwd; cert ca as root: "+DefaultCADir+")")
+		c.Flags().StringVar(&certAlgorithm, "algorithm", "ed25519", "key algorithm: ed25519 | ecdsa-p256 | rsa2048")
+		c.Flags().BoolVar(&certForce, "force", false, "overwrite existing files")
+	}
+	for _, c := range []*cobra.Command{certCaCmd, certLeafCmd, certCsrCmd} {
+		c.Flags().StringVar(&certName, "name", "", "subject CN (and default file base name)")
+		_ = c.MarkFlagRequired("name")
+	}
+	for _, c := range []*cobra.Command{certLeafCmd, certCsrCmd} {
+		c.Flags().StringSliceVar(&certDNSNames, "dns", nil, "DNS SANs (comma-separated or repeated)")
+		c.Flags().StringSliceVar(&certIPs, "ip", nil, "IP SANs (comma-separated or repeated)")
+	}
+	certCaCmd.Flags().IntVar(&certValidity, "validity", 3650, "validity in days")
+
+	addCommonLeafFlags(certLeafCmd)
+	addCommonLeafFlags(certSignCmd)
+	certSignCmd.Flags().StringVar(&certCSRFile, "csr", "", "path to the CSR (PEM) to sign")
+	_ = certSignCmd.MarkFlagRequired("csr")
+}

--- a/v2/cli/cert_cmds.go
+++ b/v2/cli/cert_cmds.go
@@ -112,23 +112,64 @@ var certLeafCmd = &cobra.Command{
 	},
 }
 
+var (
+	certKeyFile  string
+	certFromCert string
+)
+
 var certCsrCmd = &cobra.Command{
 	Use:   "csr",
-	Short: "Generate a key + certificate signing request (key never leaves this host)",
+	Short: "Generate a certificate signing request (key never leaves this host)",
+	Long: `Generate a certificate signing request. By default a fresh key is
+generated next to the CSR. With --key an EXISTING private key (PKCS#8, or
+legacy openssl EC/RSA PEM) signs the CSR instead — the upgrade-in-place
+path for turning a self-signed cert into a CA-signed one: the key (and so
+the SPKI) is unchanged, which keeps configured pins and published TLSA
+records valid. --from-cert copies CN and SANs from an existing
+certificate so the replacement matches what it replaces.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		csrPEM, keyPEM, err := tdns.CreateCSR(tdns.CSROptions{
+		opts := tdns.CSROptions{
 			Name:     certName,
 			DNSNames: certDNSNames,
 			IPs:      parseIPFlags(),
 			Alg:      tdns.CertAlgorithm(certAlgorithm),
-		})
+		}
+		if certFromCert != "" {
+			old := readCertArg(certFromCert)
+			if opts.Name == "" {
+				opts.Name = old.Subject.CommonName
+			}
+			opts.DNSNames = append(append([]string(nil), old.DNSNames...), opts.DNSNames...)
+			for _, ip := range old.IPAddresses {
+				opts.IPs = append(opts.IPs, ip)
+			}
+		}
+		if opts.Name == "" {
+			cliFatalf("cert csr: need --name (or --from-cert with a CN)")
+		}
+		if certKeyFile != "" {
+			keyData, err := os.ReadFile(certKeyFile)
+			if err != nil {
+				cliFatalf("cert csr: reading --key: %v", err)
+			}
+			key, err := tdns.ParsePrivateKeyPEM(keyData)
+			if err != nil {
+				cliFatalf("cert csr: %v", err)
+			}
+			opts.Key = key
+		}
+		csrPEM, keyPEM, err := tdns.CreateCSR(opts)
 		if err != nil {
 			cliFatalf("cert csr: %v", err)
 		}
-		base := filepath.Join(certOutDirDefaultCwd(), safeFileName(certName))
-		writeFileSafe(base+".key", keyPEM, 0o600)
+		base := filepath.Join(certOutDirDefaultCwd(), safeFileName(opts.Name))
 		writeFileSafe(base+".csr", csrPEM, 0o644)
-		fmt.Printf("CSR:         %s.csr  (send this to the CA operator)\nprivate key: %s.key  (stays here)\n", base, base)
+		if keyPEM != nil {
+			writeFileSafe(base+".key", keyPEM, 0o600)
+			fmt.Printf("CSR:         %s.csr  (send this to the CA operator)\nprivate key: %s.key  (stays here)\n", base, base)
+		} else {
+			fmt.Printf("CSR:         %s.csr  (send this to the CA operator)\nreusing key: %s  (unchanged — existing pins and TLSA records stay valid)\n", base, certKeyFile)
+		}
 	},
 }
 
@@ -378,12 +419,16 @@ func init() {
 	}
 	for _, c := range []*cobra.Command{certCaCmd, certLeafCmd, certCsrCmd} {
 		c.Flags().StringVar(&certName, "name", "", "subject CN (and default file base name)")
-		_ = c.MarkFlagRequired("name")
 	}
+	// csr may take its name from --from-cert instead (validated in Run).
+	_ = certCaCmd.MarkFlagRequired("name")
+	_ = certLeafCmd.MarkFlagRequired("name")
 	for _, c := range []*cobra.Command{certLeafCmd, certCsrCmd} {
 		c.Flags().StringSliceVar(&certDNSNames, "dns", nil, "DNS SANs (comma-separated or repeated)")
 		c.Flags().StringSliceVar(&certIPs, "ip", nil, "IP SANs (comma-separated or repeated)")
 	}
+	certCsrCmd.Flags().StringVar(&certKeyFile, "key", "", "reuse this EXISTING private key (PKCS#8 or legacy openssl EC/RSA PEM) instead of generating one — keeps the SPKI, so pins/TLSA stay valid")
+	certCsrCmd.Flags().StringVar(&certFromCert, "from-cert", "", "copy CN and SANs from this existing certificate (PEM)")
 	certCaCmd.Flags().IntVar(&certValidity, "validity", 3650, "validity in days")
 
 	addCommonLeafFlags(certLeafCmd)

--- a/v2/cli/cert_cmds_test.go
+++ b/v2/cli/cert_cmds_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package cli
+
+import "testing"
+
+// TestCertValidityFlagBindings guards the shared-backing-variable footgun:
+// every cobra flag registered against &certValidity writes its default to
+// that one variable at registration time, so `cert ca` must use its own
+// backing variable (certCAValidity) or it silently inherits the leaf/sign
+// default (397) instead of 3650. This test would have caught that bug.
+func TestCertValidityFlagBindings(t *testing.T) {
+	caFlag := certCaCmd.Flags().Lookup("validity")
+	if caFlag == nil {
+		t.Fatal("cert ca has no --validity flag")
+	}
+	if caFlag.DefValue != "3650" {
+		t.Fatalf("cert ca --validity default = %q, want 3650", caFlag.DefValue)
+	}
+	// The CA flag must NOT share the leaf/sign backing variable, or
+	// addCommonLeafFlags rebinds it to 397.
+	if certCAValidity != 3650 {
+		t.Fatalf("certCAValidity = %d after init, want 3650 (shared-variable regression)", certCAValidity)
+	}
+	if certValidity != 397 {
+		t.Fatalf("certValidity = %d after init, want 397 (leaf/sign default)", certValidity)
+	}
+
+	for _, cmd := range []string{"leaf", "sign"} {
+		var f = certLeafCmd.Flags().Lookup("validity")
+		if cmd == "sign" {
+			f = certSignCmd.Flags().Lookup("validity")
+		}
+		if f == nil || f.DefValue != "397" {
+			t.Fatalf("cert %s --validity default = %v, want 397", cmd, f)
+		}
+	}
+}

--- a/v2/cli/cert_cmds_test.go
+++ b/v2/cli/cert_cmds_test.go
@@ -36,4 +36,20 @@ func TestCertValidityFlagBindings(t *testing.T) {
 			t.Fatalf("cert %s --validity default = %v, want 397", cmd, f)
 		}
 	}
+
+	// Verify the binding DIRECTLY, not just the default: setting the CA
+	// --validity value must land in certCAValidity and must NOT leak into
+	// certValidity (the shared leaf/sign backing var). Defaults alone would
+	// miss a mis-binding if the two defaults ever coincided. Restore both.
+	origCA, origLeaf := certCAValidity, certValidity
+	t.Cleanup(func() { certCAValidity, certValidity = origCA, origLeaf })
+	if err := caFlag.Value.Set("1234"); err != nil {
+		t.Fatalf("set cert ca --validity: %v", err)
+	}
+	if certCAValidity != 1234 {
+		t.Fatalf("cert ca --validity wrote the wrong variable: certCAValidity = %d, want 1234", certCAValidity)
+	}
+	if certValidity != origLeaf {
+		t.Fatalf("cert ca --validity leaked into certValidity (= %d, want %d): shared backing variable", certValidity, origLeaf)
+	}
 }

--- a/v2/cli/cert_init_cmds.go
+++ b/v2/cli/cert_init_cmds.go
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * `tdns-cli cert init` — the one-shot local provisioning path: create the
+ * CA if absent, mint a server certificate for the local tdns-auth with SANs
+ * derived from its own config, and write cert/key to the exact paths the
+ * config already names. After this + a daemon restart, the primary serves
+ * verified XoT; the command prints everything a secondary needs (ca-file,
+ * pin, TLSA) for each of the three auth modes.
+ */
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+
+	tdns "github.com/johanix/tdns/v2"
+	"github.com/miekg/dns"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	certInitServerConfig string
+	certInitCADir        string
+	certInitCAName       string
+)
+
+var certInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "One-shot local provisioning: CA (if absent) + server cert for the local tdns-auth",
+	Long: `Reads the local tdns-auth config, creates a private CA if one does not
+exist yet, and issues a server certificate written to the exact
+dnsengine.certfile/keyfile paths the config already names — no config
+editing needed, just restart the daemon. SANs are derived from the
+config's listen addresses plus this host's name (and loopback). The leaf
+carries both serverAuth and clientAuth EKU so the same daemon can also
+present it as a client certificate under mutual XoT.
+
+Re-running is safe: an existing CA is reused; existing cert/key files are
+only replaced with --force.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runCertInit()
+	},
+}
+
+func runCertInit() {
+	cfgPath := certInitServerConfig
+	if cfgPath == "" {
+		cfgPath = tdns.DefaultAuthCfgFile
+	}
+	v := viper.New()
+	v.SetConfigFile(cfgPath)
+	if err := v.ReadInConfig(); err != nil {
+		cliFatalf("cert init: reading server config %s: %v", cfgPath, err)
+	}
+	// Single-level include: merge, same as the daemon loader.
+	for _, inc := range v.GetStringSlice("include") {
+		if !filepath.IsAbs(inc) {
+			inc = filepath.Join(filepath.Dir(cfgPath), inc)
+		}
+		if _, err := os.Stat(inc); err == nil {
+			v.SetConfigFile(inc)
+			if err := v.MergeInConfig(); err != nil {
+				cliFatalf("cert init: merging include %s: %v", inc, err)
+			}
+		}
+	}
+
+	certFile := v.GetString("dnsengine.certfile")
+	keyFile := v.GetString("dnsengine.keyfile")
+	if certFile == "" || keyFile == "" {
+		cliFatalf("cert init: %s does not set dnsengine.certfile/keyfile — set both (they are where the new cert/key will be written), then re-run", cfgPath)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		cliFatalf("cert init: cannot determine hostname: %v", err)
+	}
+	leafName := certName
+	if leafName == "" {
+		leafName = hostname
+	}
+	dnsSANs, ipSANs := initSANs(leafName, hostname, v.GetStringSlice("dnsengine.addresses"))
+
+	// CA: reuse when present, mint when absent, refuse a half-present pair.
+	caDir := certInitCADir
+	if caDir == "" {
+		if os.Geteuid() == 0 {
+			caDir = DefaultCADir
+		} else {
+			caDir = "."
+		}
+	}
+	caBase := filepath.Join(caDir, safeFileName(certInitCAName))
+	caCertPath, caKeyPath := caBase+".crt", caBase+".key"
+	_, certErr := os.Stat(caCertPath)
+	_, keyErr := os.Stat(caKeyPath)
+	var created bool
+	switch {
+	case certErr == nil && keyErr == nil:
+		// reuse
+	case os.IsNotExist(certErr) && os.IsNotExist(keyErr):
+		ca, err := tdns.CreateCA(tdns.CAOptions{Name: certInitCAName, Alg: tdns.CertAlgorithm(certAlgorithm)})
+		if err != nil {
+			cliFatalf("cert init: creating CA: %v", err)
+		}
+		writeCertAndKey(caBase, ca, 0o700)
+		appendIssuedLog(caDir, "ca-created", ca.Cert)
+		created = true
+	default:
+		cliFatalf("cert init: inconsistent CA state in %s (found one of %s / %s but not both) — repair or remove before re-running", caDir, caCertPath, caKeyPath)
+	}
+	certCAFile, certCAKeyFile = caCertPath, caKeyPath
+	caCert, caKey := loadCA()
+	if created {
+		fmt.Printf("created CA:      %s (+ .key, mode 0600 — guard it)\n", caCertPath)
+	} else {
+		fmt.Printf("reusing CA:      %s\n", caCertPath)
+	}
+
+	leaf, err := tdns.IssueLeaf(caCert, caKey, tdns.LeafOptions{
+		Name:     leafName,
+		DNSNames: dnsSANs,
+		IPs:      ipSANs,
+		Server:   true,
+		Client:   true, // mutual-XoT ready: the daemon can present it as a client cert too
+		Validity: time.Duration(certValidity) * 24 * time.Hour,
+		Alg:      tdns.CertAlgorithm(certAlgorithm),
+	})
+	if err != nil {
+		cliFatalf("cert init: issuing server cert: %v", err)
+	}
+	writeFileSafe(certFile, leaf.CertPEM, 0o644)
+	writeFileSafe(keyFile, leaf.KeyPEM, 0o600)
+	appendIssuedLog(caDir, "init-server-leaf", leaf.Cert)
+	fmt.Printf("server cert:     %s\nserver key:      %s\n", certFile, keyFile)
+
+	// Drop a copy of the CA cert next to the server cert for use as
+	// ca-file / downstream-ca on this host. Idempotent: identical content
+	// is left alone; a different file needs --force.
+	caCopy := filepath.Join(filepath.Dir(certFile), safeFileName(certInitCAName)+".crt")
+	if existing, err := os.ReadFile(caCopy); err != nil || !bytes.Equal(existing, mustReadFile(caCertPath)) {
+		writeFileSafe(caCopy, mustReadFile(caCertPath), 0o644)
+	}
+	fmt.Printf("CA cert copy:    %s\n\n", caCopy)
+
+	dotPort := initDotPort(v)
+	fmt.Printf("Restart tdns-auth to serve the new certificate. Secondaries can then use any of:\n\n")
+	fmt.Printf("  # pkix — copy %s to the secondary:\n", filepath.Base(caCopy))
+	fmt.Printf("  primaries:\n     - addr: %s:%s\n       key: NOKEY\n       transport: dot\n       tls-auth: pkix\n       ca-file: /etc/tdns/certs/%s\n\n", leafName, dotPort, filepath.Base(caCopy))
+	fmt.Printf("  # pin — no file distribution needed:\n")
+	fmt.Printf("  #    tls-auth: pin\n  #    pins: [ %q ]\n\n", tdns.SPKISHA256(leaf.Cert))
+	tlsa, terr := tdns.NewTlsaRR(dns.Fqdn(leafName), initPortNum(dotPort), leaf.Cert)
+	if terr == nil {
+		fmt.Printf("  # dane — publish this record (zone must be DNSSEC-signed):\n  #    %s\n", tlsa.String())
+	}
+}
+
+// initSANs derives the certificate SANs: the leaf name, the hostname,
+// localhost, loopback, and every listen address from the config (skipping
+// wildcard binds).
+func initSANs(leafName, hostname string, addresses []string) ([]string, []net.IP) {
+	dnsSet := map[string]bool{leafName: true, hostname: true, "localhost": true}
+	ipSet := map[string]net.IP{
+		"127.0.0.1": net.ParseIP("127.0.0.1"),
+		"::1":       net.ParseIP("::1"),
+	}
+	for _, addr := range addresses {
+		host := addr
+		if h, _, err := net.SplitHostPort(addr); err == nil {
+			host = h
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			if !ip.IsUnspecified() {
+				ipSet[ip.String()] = ip
+			}
+		} else if host != "" {
+			dnsSet[host] = true
+		}
+	}
+	var dnsSANs []string
+	for name := range dnsSet {
+		if ip := net.ParseIP(name); ip == nil {
+			dnsSANs = append(dnsSANs, name)
+		}
+	}
+	sort.Strings(dnsSANs)
+	var ipKeys []string
+	for k := range ipSet {
+		ipKeys = append(ipKeys, k)
+	}
+	sort.Strings(ipKeys)
+	ips := make([]net.IP, 0, len(ipKeys))
+	for _, k := range ipKeys {
+		ips = append(ips, ipSet[k])
+	}
+	return dnsSANs, ips
+}
+
+// initDotPort returns the DoT port the config implies: dnsengine.ports.dot
+// when set, else 853.
+func initDotPort(v *viper.Viper) string {
+	if ports := v.GetStringSlice("dnsengine.ports.dot"); len(ports) > 0 {
+		return ports[0]
+	}
+	if ports := v.GetIntSlice("dnsengine.ports.dot"); len(ports) > 0 {
+		return strconv.Itoa(ports[0])
+	}
+	return "853"
+}
+
+func initPortNum(s string) uint16 {
+	n, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return 853
+	}
+	return uint16(n)
+}
+
+func mustReadFile(path string) []byte {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		cliFatalf("cert init: reading %s: %v", path, err)
+	}
+	return data
+}
+
+func init() {
+	certInitCmd.Flags().StringVar(&certInitServerConfig, "serverconfig", "", "path to the tdns-auth config (default: "+tdns.DefaultAuthCfgFile+")")
+	certInitCmd.Flags().StringVar(&certInitCADir, "ca-dir", "", "CA directory (default: "+DefaultCADir+" as root, else cwd)")
+	certInitCmd.Flags().StringVar(&certInitCAName, "ca-name", "tdns-ca", "CA name (CN and file base name)")
+	certInitCmd.Flags().StringVar(&certName, "name", "", "server cert CN and primary SAN (default: hostname)")
+	certInitCmd.Flags().IntVar(&certValidity, "validity", 397, "server cert validity in days")
+	certInitCmd.Flags().StringVar(&certAlgorithm, "algorithm", "ed25519", "key algorithm: ed25519 | ecdsa-p256 | rsa2048")
+	certInitCmd.Flags().BoolVar(&certForce, "force", false, "overwrite existing cert/key files")
+}

--- a/v2/config.go
+++ b/v2/config.go
@@ -197,6 +197,11 @@ type DnsEngineConf struct {
 	DownstreamAuth string   `yaml:"downstream-auth,omitempty" mapstructure:"downstream-auth" validate:"omitempty,oneof=pin ca"`
 	DownstreamPins []string `yaml:"downstream-pins,omitempty" mapstructure:"downstream-pins"`
 	DownstreamCA   string   `yaml:"downstream-ca,omitempty" mapstructure:"downstream-ca"`
+	// DownstreamNames (optional, ca mode only): with a shared CA, restrict
+	// which chain-valid client certs are accepted to those carrying one of
+	// these DNS SANs. Empty = any cert that chains to downstream-ca (the
+	// BIND model, fine for a dedicated CA).
+	DownstreamNames []string `yaml:"downstream-names,omitempty" mapstructure:"downstream-names"`
 	// OutboundSoaSerial controls the SOA serial advertised on outbound zone
 	// transfers and NOTIFYs. One of:
 	//   keep     — outbound = inbound serial (default; current behavior).

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -127,39 +127,55 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 		lgDns.Info("DnsEngine: no certificate file or key file provided. Not starting DoT, DoH or DoQ service.")
 		certKey = false
 		certReason = "certfile/keyfile not configured"
-	} else if _, err := os.Stat(certFile); os.IsNotExist(err) {
-		lgDns.Info("DnsEngine: certificate file does not exist. Not starting DoT, DoH or DoQ service.", "file", certFile)
+	} else if _, err := os.Stat(certFile); err != nil {
+		// Any stat failure (missing, permission, not-a-directory, …) disables
+		// encrypted transports AND is recorded, so `config status` sees it —
+		// not only os.IsNotExist.
+		lgDns.Info("DnsEngine: certificate file not accessible. Not starting DoT, DoH or DoQ service.", "file", certFile, "err", err)
 		certKey = false
-		certReason = fmt.Sprintf("certfile %s does not exist", certFile)
-	} else if _, err := os.Stat(keyFile); os.IsNotExist(err) {
-		lgDns.Info("DnsEngine: key file does not exist. Not starting DoT, DoH or DoQ service.", "file", keyFile)
+		if os.IsNotExist(err) {
+			certReason = fmt.Sprintf("certfile %s does not exist", certFile)
+		} else {
+			certReason = fmt.Sprintf("certfile %s not accessible: %v", certFile, err)
+		}
+	} else if _, err := os.Stat(keyFile); err != nil {
+		lgDns.Info("DnsEngine: key file not accessible. Not starting DoT, DoH or DoQ service.", "file", keyFile, "err", err)
 		certKey = false
-		certReason = fmt.Sprintf("keyfile %s does not exist", keyFile)
+		if os.IsNotExist(err) {
+			certReason = fmt.Sprintf("keyfile %s does not exist", keyFile)
+		} else {
+			certReason = fmt.Sprintf("keyfile %s not accessible: %v", keyFile, err)
+		}
 	}
 
 	var certPEM []byte
 	var keyPEM []byte
+	var cert tls.Certificate
 	var err error
 
 	if certKey {
-		certPEM, err = os.ReadFile(certFile)
-		if err != nil {
-			return fmt.Errorf("DnsEngine: error reading cert file: %v", err)
-		}
-
-		keyPEM, err = os.ReadFile(keyFile)
-		if err != nil {
-			return fmt.Errorf("DnsEngine: error reading key file: %v", err)
-		}
-
-		conf.Internal.CertData = string(certPEM)
-		conf.Internal.KeyData = string(keyPEM)
-
-		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-		if err != nil {
-			lgDns.Error("DnsEngine: failed to load certificate, not starting DoT/DoH/DoQ service", "err", err)
+		// A cert/key access failure (unreadable file, a directory, a race
+		// after the stat above, …) is non-fatal, exactly like a missing file:
+		// disable encrypted transports and record certReason so `config status`
+		// reports it (via SetTransportCertError below), rather than aborting the
+		// whole DnsEngine and taking Do53 down with it.
+		if certPEM, err = os.ReadFile(certFile); err != nil {
+			lgDns.Error("DnsEngine: error reading cert file, not starting DoT/DoH/DoQ service", "file", certFile, "err", err)
 			certKey = false
-			certReason = fmt.Sprintf("loading certfile/keyfile: %v", err)
+			certReason = fmt.Sprintf("reading certfile %s: %v", certFile, err)
+		} else if keyPEM, err = os.ReadFile(keyFile); err != nil {
+			lgDns.Error("DnsEngine: error reading key file, not starting DoT/DoH/DoQ service", "file", keyFile, "err", err)
+			certKey = false
+			certReason = fmt.Sprintf("reading keyfile %s: %v", keyFile, err)
+		} else {
+			conf.Internal.CertData = string(certPEM)
+			conf.Internal.KeyData = string(keyPEM)
+
+			if cert, err = tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+				lgDns.Error("DnsEngine: failed to load certificate, not starting DoT/DoH/DoQ service", "err", err)
+				certKey = false
+				certReason = fmt.Sprintf("loading certfile/keyfile: %v", err)
+			}
 		}
 
 		// Check certificate expiry at startup

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -168,13 +168,17 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 					lgDns.Info("DnsEngine: TLS certificate expiry check passed", "expiry", x509Cert.NotAfter, "file", certFile)
 				}
 				// XoT chain-presentation note: LoadX509KeyPair presents every
-				// CERTIFICATE block in certfile, so a CA-signed leaf that
-				// needs intermediates must have them bundled (leaf first).
-				// A single CA-signed cert is also the normal shape for a
-				// two-tier PKI (e.g. tdns-cli cert init, where secondaries
-				// trust the root directly), hence Info, not Warn.
+				// CERTIFICATE block in certfile. The condition below fires for a
+				// single certificate that is NOT a self-signed CA — i.e. a leaf,
+				// whether CA-signed (cert init, two-tier PKI) or self-signed. A
+				// self-signed CA root (the mwe default) is exempt: CheckSignature-
+				// From(self) succeeds for it, so no note. Info, not Warn: presenting
+				// a single leaf is fine when peers trust it (or its issuing CA)
+				// directly; it only breaks if the leaf was issued via CA
+				// intermediates that were not bundled. Rewording avoids calling a
+				// self-signed leaf "CA-signed".
 				if parseErr == nil && len(cert.Certificate) == 1 && x509Cert.CheckSignatureFrom(x509Cert) != nil {
-					lgDns.Info("DnsEngine: certfile holds a single CA-signed certificate — fine when peers trust the issuing CA directly; if the CA uses intermediates, bundle them into certfile (leaf first) or secondaries will fail chain building", "file", certFile)
+					lgDns.Info("DnsEngine: certfile holds a single leaf certificate (no chain bundled) — fine when peers trust it, or its issuing CA, directly; but if it was issued via CA intermediates, bundle them into certfile (leaf first) or secondaries will fail chain building", "file", certFile)
 				}
 			}
 		}

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -171,7 +171,10 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 			conf.Internal.CertData = string(certPEM)
 			conf.Internal.KeyData = string(keyPEM)
 
-			if cert, err = tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+			// Parse from the bytes already read, not LoadX509KeyPair(file,file):
+			// re-reading the files could parse a cert that no longer matches the
+			// CertData/KeyData captured above if the files changed in between.
+			if cert, err = tls.X509KeyPair(certPEM, keyPEM); err != nil {
 				lgDns.Error("DnsEngine: failed to load certificate, not starting DoT/DoH/DoQ service", "err", err)
 				certKey = false
 				certReason = fmt.Sprintf("loading certfile/keyfile: %v", err)

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -167,6 +167,15 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 				} else {
 					lgDns.Info("DnsEngine: TLS certificate expiry check passed", "expiry", x509Cert.NotAfter, "file", certFile)
 				}
+				// XoT chain-presentation note: LoadX509KeyPair presents every
+				// CERTIFICATE block in certfile, so a CA-signed leaf that
+				// needs intermediates must have them bundled (leaf first).
+				// A single CA-signed cert is also the normal shape for a
+				// two-tier PKI (e.g. tdns-cli cert init, where secondaries
+				// trust the root directly), hence Info, not Warn.
+				if parseErr == nil && len(cert.Certificate) == 1 && x509Cert.CheckSignatureFrom(x509Cert) != nil {
+					lgDns.Info("DnsEngine: certfile holds a single CA-signed certificate — fine when peers trust the issuing CA directly; if the CA uses intermediates, bundle them into certfile (leaf first) or secondaries will fail chain building", "file", certFile)
+				}
 			}
 		}
 

--- a/v2/pki.go
+++ b/v2/pki.go
@@ -73,6 +73,11 @@ type CSROptions struct {
 	DNSNames []string
 	IPs      []net.IP
 	Alg      CertAlgorithm
+	// Key, when set, is used to sign the CSR instead of generating a fresh
+	// key. This is the upgrade-in-place path: re-certifying an existing
+	// (e.g. self-signed) key keeps the SPKI, so published TLSA records and
+	// configured pins remain valid across the switch to a CA-signed cert.
+	Key crypto.Signer
 }
 
 type SignOptions struct {
@@ -144,16 +149,22 @@ func IssueLeaf(caCert *x509.Certificate, caKey crypto.Signer, opts LeafOptions) 
 	return assemblePKICert(der, key)
 }
 
-// CreateCSR generates a fresh key plus a certificate signing request — the
-// split-provisioning path where the private key never leaves the requesting
-// host.
+// CreateCSR builds a certificate signing request — the split-provisioning
+// path where the private key never leaves the requesting host. With
+// opts.Key set the existing key signs the CSR and keyPEM is nil (the key
+// already lives on disk); otherwise a fresh key is generated and returned.
 func CreateCSR(opts CSROptions) (csrPEM, keyPEM []byte, err error) {
 	if opts.Name == "" {
 		return nil, nil, fmt.Errorf("pki: CSR needs a name")
 	}
-	key, err := generateKey(opts.Alg)
-	if err != nil {
-		return nil, nil, err
+	key := opts.Key
+	generated := false
+	if key == nil {
+		key, err = generateKey(opts.Alg)
+		if err != nil {
+			return nil, nil, err
+		}
+		generated = true
 	}
 	tmpl := x509.CertificateRequest{
 		Subject:     pkix.Name{CommonName: opts.Name},
@@ -164,12 +175,15 @@ func CreateCSR(opts CSROptions) (csrPEM, keyPEM []byte, err error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("pki: create CSR: %v", err)
 	}
+	csrPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+	if !generated {
+		return csrPEM, nil, nil
+	}
 	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
 	if err != nil {
 		return nil, nil, fmt.Errorf("pki: marshal key: %v", err)
 	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der}),
-		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), nil
+	return csrPEM, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), nil
 }
 
 // SignCSR signs a parsed-and-verified CSR with the CA, copying the CSR's
@@ -221,15 +235,26 @@ func ParseCertPEM(data []byte) (*x509.Certificate, error) {
 	return nil, fmt.Errorf("pki: no CERTIFICATE block found")
 }
 
-// ParsePrivateKeyPEM parses a PKCS#8 PRIVATE KEY block into a crypto.Signer.
+// ParsePrivateKeyPEM parses the first private-key block into a crypto.Signer.
+// Accepts PKCS#8 ("PRIVATE KEY", what this PKI writes) plus the legacy
+// openssl shapes ("EC PRIVATE KEY" SEC1, "RSA PRIVATE KEY" PKCS#1), so an
+// existing self-signed key from gen-cert.sh/openssl can be re-certified.
 func ParsePrivateKeyPEM(data []byte) (crypto.Signer, error) {
 	for block, rest := pem.Decode(data); block != nil; block, rest = pem.Decode(rest) {
-		if block.Type != "PRIVATE KEY" {
+		var key any
+		var err error
+		switch block.Type {
+		case "PRIVATE KEY":
+			key, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+		case "EC PRIVATE KEY":
+			key, err = x509.ParseECPrivateKey(block.Bytes)
+		case "RSA PRIVATE KEY":
+			key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		default:
 			continue
 		}
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
-			return nil, fmt.Errorf("pki: parse PKCS#8 key: %v", err)
+			return nil, fmt.Errorf("pki: parse %s: %v", block.Type, err)
 		}
 		signer, ok := key.(crypto.Signer)
 		if !ok {
@@ -237,7 +262,7 @@ func ParsePrivateKeyPEM(data []byte) (crypto.Signer, error) {
 		}
 		return signer, nil
 	}
-	return nil, fmt.Errorf("pki: no PRIVATE KEY block found")
+	return nil, fmt.Errorf("pki: no private-key PEM block found")
 }
 
 func leafTemplate(name string, dnsNames []string, ips []net.IP, server, client bool, validity time.Duration) (*x509.Certificate, error) {

--- a/v2/pki.go
+++ b/v2/pki.go
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Minimal internal PKI for XoT provisioning (docs/2026-07-21-pkix-cert-
+ * tooling-design.md): mint a private root, sign server/client leaves, and
+ * round-trip CSRs. Deliberately tiny scope — no CRL/OCSP/renewal, no CA
+ * database (serials are random 128-bit), hard-coded safe constraints
+ * (pathlen 0 on the CA, IsCA=false on leaves). File handling and the
+ * issued.log live in the CLI layer (v2/cli/cert_cmds.go); this file is
+ * pure crypto so the XoT tests can verify the tool's output directly.
+ */
+package tdns
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// CertAlgorithm selects the key algorithm for CA and leaf keys.
+type CertAlgorithm string
+
+const (
+	CertAlgEd25519   CertAlgorithm = "ed25519" // default: smallest/fastest, fine for TLS 1.3
+	CertAlgECDSAP256 CertAlgorithm = "ecdsa-p256"
+	CertAlgRSA2048   CertAlgorithm = "rsa2048"
+)
+
+const (
+	// DefaultCAValidity: a private root can be long-lived.
+	DefaultCAValidity = 3650 * 24 * time.Hour
+	// DefaultLeafValidity: 397 days, the CA/Browser cap — a sane habit even
+	// for a private CA.
+	DefaultLeafValidity = 397 * 24 * time.Hour
+)
+
+// PKICert bundles the PEM artifacts and parsed certificate produced by
+// CreateCA / IssueLeaf.
+type PKICert struct {
+	CertPEM []byte
+	KeyPEM  []byte // PKCS#8; empty for SignCSR results (the key stays remote)
+	Cert    *x509.Certificate
+}
+
+type CAOptions struct {
+	Name     string // Subject CN
+	Validity time.Duration
+	Alg      CertAlgorithm
+}
+
+type LeafOptions struct {
+	Name     string // Subject CN
+	DNSNames []string
+	IPs      []net.IP
+	Server   bool // ExtKeyUsage serverAuth
+	Client   bool // ExtKeyUsage clientAuth
+	Validity time.Duration
+	Alg      CertAlgorithm
+}
+
+type CSROptions struct {
+	Name     string
+	DNSNames []string
+	IPs      []net.IP
+	Alg      CertAlgorithm
+}
+
+type SignOptions struct {
+	Server   bool
+	Client   bool
+	Validity time.Duration
+}
+
+// CreateCA mints a self-signed root: pathlen 0 (signs leaves only, never a
+// sub-CA), KeyUsage CertSign|CRLSign.
+func CreateCA(opts CAOptions) (*PKICert, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("pki: CA needs a name")
+	}
+	if opts.Validity == 0 {
+		opts.Validity = DefaultCAValidity
+	}
+	key, err := generateKey(opts.Alg)
+	if err != nil {
+		return nil, err
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: opts.Name},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(opts.Validity),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, key.Public(), key)
+	if err != nil {
+		return nil, fmt.Errorf("pki: create CA certificate: %v", err)
+	}
+	return assemblePKICert(der, key)
+}
+
+// IssueLeaf signs an end-entity certificate (freshly generated key) with the
+// CA. At least one of Server/Client must be set; a daemon that both serves
+// DoT and presents a client cert for mutual XoT wants both.
+func IssueLeaf(caCert *x509.Certificate, caKey crypto.Signer, opts LeafOptions) (*PKICert, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("pki: leaf needs a name")
+	}
+	if !opts.Server && !opts.Client {
+		return nil, fmt.Errorf("pki: leaf needs at least one of server/client usage")
+	}
+	if opts.Validity == 0 {
+		opts.Validity = DefaultLeafValidity
+	}
+	key, err := generateKey(opts.Alg)
+	if err != nil {
+		return nil, err
+	}
+	tmpl, err := leafTemplate(opts.Name, opts.DNSNames, opts.IPs, opts.Server, opts.Client, opts.Validity)
+	if err != nil {
+		return nil, err
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, fmt.Errorf("pki: sign leaf certificate: %v", err)
+	}
+	return assemblePKICert(der, key)
+}
+
+// CreateCSR generates a fresh key plus a certificate signing request — the
+// split-provisioning path where the private key never leaves the requesting
+// host.
+func CreateCSR(opts CSROptions) (csrPEM, keyPEM []byte, err error) {
+	if opts.Name == "" {
+		return nil, nil, fmt.Errorf("pki: CSR needs a name")
+	}
+	key, err := generateKey(opts.Alg)
+	if err != nil {
+		return nil, nil, err
+	}
+	tmpl := x509.CertificateRequest{
+		Subject:     pkix.Name{CommonName: opts.Name},
+		DNSNames:    opts.DNSNames,
+		IPAddresses: opts.IPs,
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, &tmpl, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pki: create CSR: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pki: marshal key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), nil
+}
+
+// SignCSR signs a parsed-and-verified CSR with the CA, copying the CSR's
+// subject and SANs. The resulting PKICert carries no key (it stayed with the
+// requester).
+func SignCSR(caCert *x509.Certificate, caKey crypto.Signer, csrPEM []byte, opts SignOptions) (*PKICert, error) {
+	block, _ := pem.Decode(csrPEM)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, fmt.Errorf("pki: no CERTIFICATE REQUEST block found")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("pki: parse CSR: %v", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		return nil, fmt.Errorf("pki: CSR signature check failed: %v", err)
+	}
+	if !opts.Server && !opts.Client {
+		return nil, fmt.Errorf("pki: sign needs at least one of server/client usage")
+	}
+	if opts.Validity == 0 {
+		opts.Validity = DefaultLeafValidity
+	}
+	tmpl, err := leafTemplate(csr.Subject.CommonName, csr.DNSNames, csr.IPAddresses, opts.Server, opts.Client, opts.Validity)
+	if err != nil {
+		return nil, err
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, csr.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("pki: sign CSR: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	return &PKICert{
+		CertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		Cert:    cert,
+	}, nil
+}
+
+// ParseCertPEM parses the first CERTIFICATE block in data.
+func ParseCertPEM(data []byte) (*x509.Certificate, error) {
+	for block, rest := pem.Decode(data); block != nil; block, rest = pem.Decode(rest) {
+		if block.Type == "CERTIFICATE" {
+			return x509.ParseCertificate(block.Bytes)
+		}
+	}
+	return nil, fmt.Errorf("pki: no CERTIFICATE block found")
+}
+
+// ParsePrivateKeyPEM parses a PKCS#8 PRIVATE KEY block into a crypto.Signer.
+func ParsePrivateKeyPEM(data []byte) (crypto.Signer, error) {
+	for block, rest := pem.Decode(data); block != nil; block, rest = pem.Decode(rest) {
+		if block.Type != "PRIVATE KEY" {
+			continue
+		}
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("pki: parse PKCS#8 key: %v", err)
+		}
+		signer, ok := key.(crypto.Signer)
+		if !ok {
+			return nil, fmt.Errorf("pki: key type %T is not a signer", key)
+		}
+		return signer, nil
+	}
+	return nil, fmt.Errorf("pki: no PRIVATE KEY block found")
+}
+
+func leafTemplate(name string, dnsNames []string, ips []net.IP, server, client bool, validity time.Duration) (*x509.Certificate, error) {
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	var ekus []x509.ExtKeyUsage
+	if server {
+		ekus = append(ekus, x509.ExtKeyUsageServerAuth)
+	}
+	if client {
+		ekus = append(ekus, x509.ExtKeyUsageClientAuth)
+	}
+	return &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: name},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(validity),
+		IsCA:                  false,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           ekus,
+		DNSNames:              dnsNames,
+		IPAddresses:           ips,
+	}, nil
+}
+
+func generateKey(alg CertAlgorithm) (crypto.Signer, error) {
+	switch alg {
+	case "", CertAlgEd25519:
+		_, key, err := ed25519.GenerateKey(rand.Reader)
+		return key, err
+	case CertAlgECDSAP256:
+		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case CertAlgRSA2048:
+		return rsa.GenerateKey(rand.Reader, 2048)
+	default:
+		return nil, fmt.Errorf("pki: unknown algorithm %q (supported: ed25519, ecdsa-p256, rsa2048)", alg)
+	}
+}
+
+// randomSerial returns a random 128-bit serial — the reason this CA needs no
+// serial-file state.
+func randomSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("pki: generate serial: %v", err)
+	}
+	return serial, nil
+}
+
+func assemblePKICert(der []byte, key crypto.Signer) (*PKICert, error) {
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("pki: marshal key: %v", err)
+	}
+	return &PKICert{
+		CertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		KeyPEM:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+		Cert:    cert,
+	}, nil
+}

--- a/v2/pki_test.go
+++ b/v2/pki_test.go
@@ -4,8 +4,14 @@
 package tdns
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"net"
 	"os"
 	"testing"
@@ -158,6 +164,75 @@ func TestPKI_CSRRoundTrip(t *testing.T) {
 	broken := append([]byte(nil), csrPEM...)
 	if _, err := SignCSR(ca.Cert, caKey, broken[:len(broken)/2], SignOptions{Client: true}); err == nil {
 		t.Fatal("truncated CSR must be refused")
+	}
+}
+
+// TestPKI_CSRWithExistingKey is the upgrade-in-place path: re-certifying an
+// existing (self-signed) key must keep the SPKI, so pins and published TLSA
+// records stay valid across the switch to a CA-signed cert.
+func TestPKI_CSRWithExistingKey(t *testing.T) {
+	ca := testCA(t, "")
+	caKey, _ := ParsePrivateKeyPEM(ca.KeyPEM)
+
+	// The "existing self-signed cert" being upgraded.
+	oldTLS, oldLeaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	oldKey := oldTLS.PrivateKey.(crypto.Signer)
+
+	csrPEM, keyPEM, err := CreateCSR(CSROptions{
+		Name:     oldLeaf.Subject.CommonName,
+		DNSNames: oldLeaf.DNSNames,
+		IPs:      oldLeaf.IPAddresses,
+		Key:      oldKey,
+	})
+	if err != nil {
+		t.Fatalf("CreateCSR with existing key: %v", err)
+	}
+	if keyPEM != nil {
+		t.Fatal("no new key must be generated when one is supplied")
+	}
+	signed, err := SignCSR(ca.Cert, caKey, csrPEM, SignOptions{Server: true})
+	if err != nil {
+		t.Fatalf("SignCSR: %v", err)
+	}
+	// The whole point: SPKI (and so pin and TLSA rdata) unchanged.
+	if SPKISHA256(signed.Cert) != SPKISHA256(oldLeaf) {
+		t.Fatal("SPKI changed across re-certification — pins/TLSA would break")
+	}
+	oldTlsa, _ := NewTlsaRR("ns1.test.", 853, oldLeaf)
+	newTlsa, _ := NewTlsaRR("ns1.test.", 853, signed.Cert)
+	if oldTlsa.Certificate != newTlsa.Certificate {
+		t.Fatal("TLSA association data changed across re-certification")
+	}
+	// And the CA-signed cert verifies where the self-signed one could not.
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	if _, err := signed.Cert.Verify(x509.VerifyOptions{Roots: pool, DNSName: "ns1.test"}); err != nil {
+		t.Fatalf("upgraded cert does not verify against the CA: %v", err)
+	}
+}
+
+// TestPKI_ParseLegacyKeyPEM: keys from openssl/gen-cert.sh come in SEC1
+// ("EC PRIVATE KEY") and PKCS#1 ("RSA PRIVATE KEY") shapes too.
+func TestPKI_ParseLegacyKeyPEM(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa: %v", err)
+	}
+	sec1, err := x509.MarshalECPrivateKey(ecKey)
+	if err != nil {
+		t.Fatalf("marshal sec1: %v", err)
+	}
+	if _, err := ParsePrivateKeyPEM(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: sec1})); err != nil {
+		t.Fatalf("SEC1 EC key: %v", err)
+	}
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	pkcs1 := x509.MarshalPKCS1PrivateKey(rsaKey)
+	if _, err := ParsePrivateKeyPEM(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: pkcs1})); err != nil {
+		t.Fatalf("PKCS#1 RSA key: %v", err)
 	}
 }
 

--- a/v2/pki_test.go
+++ b/v2/pki_test.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package tdns
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"os"
+	"testing"
+
+	cache "github.com/johanix/tdns/v2/cache"
+)
+
+func testCA(t *testing.T, alg CertAlgorithm) *PKICert {
+	t.Helper()
+	ca, err := CreateCA(CAOptions{Name: "test-ca", Alg: alg})
+	if err != nil {
+		t.Fatalf("CreateCA: %v", err)
+	}
+	return ca
+}
+
+func TestPKI_CACreation(t *testing.T) {
+	ca := testCA(t, "")
+	if !ca.Cert.IsCA {
+		t.Fatal("CA cert must have IsCA")
+	}
+	if !ca.Cert.MaxPathLenZero || ca.Cert.MaxPathLen != 0 {
+		t.Fatal("CA must be pathlen 0 (signs leaves only)")
+	}
+	if ca.Cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Fatal("CA must have CertSign key usage")
+	}
+	// Self-verifies as a root.
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	if _, err := ca.Cert.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
+		t.Fatalf("CA does not verify as its own root: %v", err)
+	}
+	// Round-trips through the PEM parsers.
+	cert, err := ParseCertPEM(ca.CertPEM)
+	if err != nil || !cert.Equal(ca.Cert) {
+		t.Fatalf("ParseCertPEM round-trip failed: %v", err)
+	}
+	if _, err := ParsePrivateKeyPEM(ca.KeyPEM); err != nil {
+		t.Fatalf("ParsePrivateKeyPEM: %v", err)
+	}
+}
+
+func TestPKI_LeafVerifies(t *testing.T) {
+	ca := testCA(t, "")
+	caKey, err := ParsePrivateKeyPEM(ca.KeyPEM)
+	if err != nil {
+		t.Fatalf("parse CA key: %v", err)
+	}
+	leaf, err := IssueLeaf(ca.Cert, caKey, LeafOptions{
+		Name:     "ns1.test",
+		DNSNames: []string{"ns1.test"},
+		IPs:      []net.IP{net.ParseIP("127.0.0.1")},
+		Server:   true,
+		Client:   true,
+	})
+	if err != nil {
+		t.Fatalf("IssueLeaf: %v", err)
+	}
+	if leaf.Cert.IsCA {
+		t.Fatal("leaf must not be a CA")
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	for _, eku := range []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth} {
+		if _, err := leaf.Cert.Verify(x509.VerifyOptions{
+			Roots:     pool,
+			DNSName:   "ns1.test",
+			KeyUsages: []x509.ExtKeyUsage{eku},
+		}); err != nil {
+			t.Fatalf("leaf verify (eku %v): %v", eku, err)
+		}
+	}
+	// Wrong name must fail.
+	if _, err := leaf.Cert.Verify(x509.VerifyOptions{Roots: pool, DNSName: "ns2.test"}); err == nil {
+		t.Fatal("leaf must not verify for a name it does not carry")
+	}
+	// A leaf without any usage is refused at issuance.
+	if _, err := IssueLeaf(ca.Cert, caKey, LeafOptions{Name: "x"}); err == nil {
+		t.Fatal("leaf without server/client usage must be refused")
+	}
+}
+
+// TestPKI_LeafCannotSign: the pathlen-0 + IsCA=false constraints must prevent
+// a leaf from acting as an intermediate.
+func TestPKI_LeafCannotSign(t *testing.T) {
+	ca := testCA(t, "")
+	caKey, _ := ParsePrivateKeyPEM(ca.KeyPEM)
+	leaf, err := IssueLeaf(ca.Cert, caKey, LeafOptions{Name: "ns1.test", DNSNames: []string{"ns1.test"}, Server: true})
+	if err != nil {
+		t.Fatalf("IssueLeaf: %v", err)
+	}
+	leafKey, _ := ParsePrivateKeyPEM(leaf.KeyPEM)
+
+	// Attempt to use the leaf as a signing parent. Either CreateCertificate
+	// itself refuses (Go checks the parent's CertSign usage), or the result
+	// must fail chain verification against the root.
+	rogue, err := IssueLeaf(leaf.Cert, leafKey, LeafOptions{Name: "rogue.test", DNSNames: []string{"rogue.test"}, Server: true})
+	if err != nil {
+		return // refused at creation: good
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	inter := x509.NewCertPool()
+	inter.AddCert(leaf.Cert)
+	if _, err := rogue.Cert.Verify(x509.VerifyOptions{Roots: pool, Intermediates: inter, DNSName: "rogue.test"}); err == nil {
+		t.Fatal("a leaf-signed cert must never verify against the root")
+	}
+}
+
+func TestPKI_CSRRoundTrip(t *testing.T) {
+	ca := testCA(t, "")
+	caKey, _ := ParsePrivateKeyPEM(ca.KeyPEM)
+
+	csrPEM, keyPEM, err := CreateCSR(CSROptions{
+		Name:     "ns2.example.net",
+		DNSNames: []string{"ns2.example.net"},
+		IPs:      []net.IP{net.ParseIP("192.0.2.2")},
+	})
+	if err != nil {
+		t.Fatalf("CreateCSR: %v", err)
+	}
+	signed, err := SignCSR(ca.Cert, caKey, csrPEM, SignOptions{Client: true})
+	if err != nil {
+		t.Fatalf("SignCSR: %v", err)
+	}
+	if len(signed.KeyPEM) != 0 {
+		t.Fatal("SignCSR must not carry a private key (it stays with the requester)")
+	}
+	// SANs copied from the CSR.
+	if len(signed.Cert.DNSNames) != 1 || signed.Cert.DNSNames[0] != "ns2.example.net" {
+		t.Fatalf("DNS SANs not copied: %v", signed.Cert.DNSNames)
+	}
+	if len(signed.Cert.IPAddresses) != 1 || !signed.Cert.IPAddresses[0].Equal(net.ParseIP("192.0.2.2")) {
+		t.Fatalf("IP SANs not copied: %v", signed.Cert.IPAddresses)
+	}
+	// The signed cert must match the CSR's key: pair it with the CSR-side key.
+	if _, err := tls.X509KeyPair(signed.CertPEM, keyPEM); err != nil {
+		t.Fatalf("signed cert does not pair with the CSR key: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	if _, err := signed.Cert.Verify(x509.VerifyOptions{
+		Roots: pool, DNSName: "ns2.example.net",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Fatalf("signed CSR cert verify: %v", err)
+	}
+	// A tampered CSR must be refused.
+	broken := append([]byte(nil), csrPEM...)
+	if _, err := SignCSR(ca.Cert, caKey, broken[:len(broken)/2], SignOptions{Client: true}); err == nil {
+		t.Fatal("truncated CSR must be refused")
+	}
+}
+
+func TestPKI_Algorithms(t *testing.T) {
+	for _, alg := range []CertAlgorithm{CertAlgEd25519, CertAlgECDSAP256, CertAlgRSA2048} {
+		ca := testCA(t, alg)
+		caKey, err := ParsePrivateKeyPEM(ca.KeyPEM)
+		if err != nil {
+			t.Fatalf("%s: parse key: %v", alg, err)
+		}
+		leaf, err := IssueLeaf(ca.Cert, caKey, LeafOptions{Name: "n." + string(alg), DNSNames: []string{"n." + string(alg)}, Server: true, Alg: alg})
+		if err != nil {
+			t.Fatalf("%s: IssueLeaf: %v", alg, err)
+		}
+		pool := x509.NewCertPool()
+		pool.AddCert(ca.Cert)
+		if _, err := leaf.Cert.Verify(x509.VerifyOptions{Roots: pool, DNSName: "n." + string(alg)}); err != nil {
+			t.Fatalf("%s: verify: %v", alg, err)
+		}
+	}
+	if _, err := CreateCA(CAOptions{Name: "x", Alg: "dsa"}); err == nil {
+		t.Fatal("unknown algorithm must be refused")
+	}
+}
+
+// TestPKI_XoTIntegration is the §2.6 closing-the-loop test: a CA + server
+// leaf minted by the PKI primitives must satisfy all three XoT client auth
+// modes against the real transfer path.
+func TestPKI_XoTIntegration(t *testing.T) {
+	ca := testCA(t, "")
+	caKey, _ := ParsePrivateKeyPEM(ca.KeyPEM)
+	leaf, err := IssueLeaf(ca.Cert, caKey, LeafOptions{
+		Name:     "ns1.test",
+		DNSNames: []string{"ns1.test"},
+		IPs:      []net.IP{net.ParseIP("127.0.0.1")},
+		Server:   true,
+	})
+	if err != nil {
+		t.Fatalf("IssueLeaf: %v", err)
+	}
+	serverCert, err := tls.X509KeyPair(leaf.CertPEM, leaf.KeyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+
+	zd := loadTestTransferZone(t, basicZone)
+	srv := startTestAXFRServerTLS(t, zd, nil, serverCert)
+	defer srv.shutdown()
+
+	// pkix: ca-file = the minted CA cert.
+	caPath := t.TempDir() + "/ca.pem"
+	if err := os.WriteFile(caPath, ca.CertPEM, 0o644); err != nil {
+		t.Fatalf("write ca-file: %v", err)
+	}
+	conf := &Config{}
+	pkixPeer := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT,
+		TLSAuth: TLSAuthPKIX, TLSName: "ns1.test", CAFile: caPath}
+	if _, err := xotTransfer(t, conf, pkixPeer, srv, zd.ZoneName); err != nil {
+		t.Fatalf("pkix transfer with minted CA failed: %v", err)
+	}
+
+	// pin: the same digest cert pin/--emit-pin would print.
+	pinPeer := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT,
+		TLSAuth: TLSAuthPin, Pins: []string{SPKISHA256(leaf.Cert)}}
+	if _, err := xotTransfer(t, conf, pinPeer, srv, zd.ZoneName); err != nil {
+		t.Fatalf("pin transfer with minted leaf failed: %v", err)
+	}
+
+	// dane: the TLSA record --emit-tlsa would print, injected as validated.
+	danePeer := PeerConf{Addr: srv.addr, Key: NOKEY, Transport: TransportDoT,
+		TLSAuth: TLSAuthDANE, TLSName: "ns1.test"}
+	daneConf := daneTestConf(t, leaf.Cert, serverPort(t, srv), cache.ValidationStateSecure, true)
+	if _, err := xotTransfer(t, daneConf, danePeer, srv, zd.ZoneName); err != nil {
+		t.Fatalf("dane transfer with minted leaf failed: %v", err)
+	}
+}

--- a/v2/xot.go
+++ b/v2/xot.go
@@ -307,6 +307,27 @@ func ServerTLSConfigForDoT(conf *Config, cert *tls.Certificate, applyDownstreamA
 		}
 		tlsCfg.ClientCAs = pool
 		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+		// Optional identity binding for a shared CA (LE-4): the client
+		// leaf must additionally carry an allowlisted DNS SAN. The chain
+		// is already verified by RequireAndVerifyClientCert when
+		// VerifyConnection runs; this only narrows which subjects count.
+		if len(de.DownstreamNames) > 0 {
+			allowed := make(map[string]bool, len(de.DownstreamNames))
+			for _, n := range de.DownstreamNames {
+				allowed[strings.ToLower(strings.TrimSuffix(n, "."))] = true
+			}
+			tlsCfg.VerifyConnection = func(cs tls.ConnectionState) error {
+				if len(cs.PeerCertificates) == 0 {
+					return fmt.Errorf("xot: downstream presented no certificate")
+				}
+				for _, san := range cs.PeerCertificates[0].DNSNames {
+					if allowed[strings.ToLower(strings.TrimSuffix(san, "."))] {
+						return nil
+					}
+				}
+				return fmt.Errorf("xot: downstream cert SANs %v match none of the %d allowed downstream-names", cs.PeerCertificates[0].DNSNames, len(allowed))
+			}
+		}
 	default:
 		return nil, fmt.Errorf("dnsengine: unknown downstream-auth %q (supported: pin, ca)", de.DownstreamAuth)
 	}

--- a/v2/xot_pkix_test.go
+++ b/v2/xot_pkix_test.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * PKIX loose-end tests (docs/2026-07-21-pkix-cert-tooling-design.md LE-3/LE-7):
+ * intermediate-chain presentation and the agent-parity fetch path.
+ */
+package tdns
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"log"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+// buildThreeTierChain hand-builds root -> intermediate -> leaf. The tdns-cli
+// CA is deliberately pathlen-0 and cannot produce this shape, but operators
+// with an external CA can — the verifier must handle it.
+func buildThreeTierChain(t *testing.T) (rootCert *x509.Certificate, interDER []byte, leafDER []byte, leafKey *ecdsa.PrivateKey) {
+	t.Helper()
+	mkKey := func() *ecdsa.PrivateKey {
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("key: %v", err)
+		}
+		return k
+	}
+	serial := func() *big.Int {
+		s, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+		if err != nil {
+			t.Fatalf("serial: %v", err)
+		}
+		return s
+	}
+	rootKey, interKey, lKey := mkKey(), mkKey(), mkKey()
+
+	rootTmpl := &x509.Certificate{
+		SerialNumber: serial(), Subject: pkix.Name{CommonName: "test-root"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true,
+		KeyUsage: x509.KeyUsageCertSign,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("root: %v", err)
+	}
+	root, _ := x509.ParseCertificate(rootDER)
+
+	interTmpl := &x509.Certificate{
+		SerialNumber: serial(), Subject: pkix.Name{CommonName: "test-intermediate"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		IsCA: true, BasicConstraintsValid: true, MaxPathLen: 0, MaxPathLenZero: true,
+		KeyUsage: x509.KeyUsageCertSign,
+	}
+	interDER, err = x509.CreateCertificate(rand.Reader, interTmpl, root, &interKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("intermediate: %v", err)
+	}
+	inter, _ := x509.ParseCertificate(interDER)
+
+	leafTmpl := &x509.Certificate{
+		SerialNumber: serial(), Subject: pkix.Name{CommonName: "ns1.test"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{"ns1.test"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	leafDER, err = x509.CreateCertificate(rand.Reader, leafTmpl, inter, &lKey.PublicKey, interKey)
+	if err != nil {
+		t.Fatalf("leaf: %v", err)
+	}
+	return root, interDER, leafDER, lKey
+}
+
+// TestXoT_PKIXIntermediateChain (LE-7/LE-2): a secondary trusting only the
+// root must build the chain when the primary presents leaf+intermediate,
+// and must fail when the intermediate is omitted.
+func TestXoT_PKIXIntermediateChain(t *testing.T) {
+	root, interDER, leafDER, leafKey := buildThreeTierChain(t)
+
+	rootPath := t.TempDir() + "/root.pem"
+	if err := writeCertPEM(rootPath, root.Raw); err != nil {
+		t.Fatalf("write root: %v", err)
+	}
+	conf := &Config{}
+	peer := PeerConf{Addr: "", Key: NOKEY, Transport: TransportDoT,
+		TLSAuth: TLSAuthPKIX, TLSName: "ns1.test", CAFile: rootPath}
+
+	// Server presents leaf + intermediate: chain builds, transfer succeeds.
+	zd := loadTestTransferZone(t, basicZone)
+	withInter := tls.Certificate{Certificate: [][]byte{leafDER, interDER}, PrivateKey: leafKey}
+	srv := startTestAXFRServerTLS(t, zd, nil, withInter)
+	defer srv.shutdown()
+	peer.Addr = srv.addr
+	if _, err := xotTransfer(t, conf, peer, srv, zd.ZoneName); err != nil {
+		t.Fatalf("transfer with leaf+intermediate failed: %v", err)
+	}
+
+	// Server presents only the leaf: no path to the root, must fail.
+	zd2 := loadTestTransferZone(t, basicZone)
+	leafOnly := tls.Certificate{Certificate: [][]byte{leafDER}, PrivateKey: leafKey}
+	srv2 := startTestAXFRServerTLS(t, zd2, nil, leafOnly)
+	defer srv2.shutdown()
+	peer.Addr = srv2.addr
+	if _, err := xotTransfer(t, conf, peer, srv2, zd2.ZoneName); err == nil {
+		t.Fatal("transfer without the intermediate must fail chain building")
+	}
+}
+
+// TestXoT_FetchFromUpstreamPKIX (LE-3 agent parity): the full production
+// fetch path — FetchFromUpstream including the hard flip and snapshot
+// publish — over dot+pkix. Both tdns-auth and tdns-agent drive exactly this
+// function from the shared RefreshEngine, so this guards against the two
+// daemons drifting apart.
+func TestXoT_FetchFromUpstreamPKIX(t *testing.T) {
+	conf := testXfrConf(t)
+	primary := loadTestTransferZone(t, basicZone)
+	primary.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+	cert, leaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	srv := startTestAXFRServerTLS(t, primary, conf.tsigProvider(), cert)
+	defer srv.shutdown()
+
+	caPath := t.TempDir() + "/ca.pem"
+	if err := writeCertPEM(caPath, leaf.Raw); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+	sec := &ZoneData{
+		ZoneName:      "example.test.",
+		ZoneStore:     MapZone,
+		ZoneType:      Secondary,
+		Logger:        log.Default(),
+		FirstZoneLoad: false, // refresh path: applyRefreshReplacementLocked flips Ready itself
+		Upstreams: []PeerConf{{
+			Addr: srv.addr, Key: "tkey", Transport: TransportDoT,
+			TLSAuth: TLSAuthPKIX, TLSName: "ns1.test", CAFile: caPath,
+		}},
+	}
+	t.Cleanup(sec.stopPublisher)
+	// The snapshot publish path only publishes for zones registered in the
+	// global Zones map (zoneStillLive); register like the daemons do.
+	Zones.Set(sec.ZoneName, sec)
+	t.Cleanup(func() { Zones.Remove(sec.ZoneName) })
+
+	updated, err := sec.FetchFromUpstream(false, false, nil, conf)
+	if err != nil {
+		t.Fatalf("FetchFromUpstream over dot+pkix: %v", err)
+	}
+	if !updated {
+		t.Fatal("expected the zone to be fetched and flipped")
+	}
+	if sec.GetStatus() != ZoneStatusReady || !sec.Ready {
+		t.Fatalf("secondary not Ready after fetch: status=%v", sec.GetStatus())
+	}
+	// The published snapshot must serve the transferred data (the query path
+	// reads the snapshot, not zd.Data — GetSOA is the servable-data check).
+	soa, err := sec.GetSOA()
+	if err != nil || soa == nil {
+		t.Fatalf("no servable SOA after fetch: %v", err)
+	}
+	if soa.Serial != 1 {
+		t.Fatalf("expected transferred serial 1, got %d", soa.Serial)
+	}
+}

--- a/v2/xot_pkix_test.go
+++ b/v2/xot_pkix_test.go
@@ -13,9 +13,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"log"
 	"math/big"
 	"net"
+	"os"
 	"testing"
 	"time"
 )
@@ -112,6 +114,59 @@ func TestXoT_PKIXIntermediateChain(t *testing.T) {
 	peer.Addr = srv2.addr
 	if _, err := xotTransfer(t, conf, peer, srv2, zd2.ZoneName); err == nil {
 		t.Fatal("transfer without the intermediate must fail chain building")
+	}
+}
+
+// TestXoT_ServerMTLSDownstreamNames (LE-4): with a shared CA, the optional
+// downstream-names allowlist narrows which chain-valid client certs are
+// accepted; an empty allowlist keeps chain-only behavior (covered by
+// TestXoT_ServerMTLSCA on feature/xot).
+func TestXoT_ServerMTLSDownstreamNames(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	serverCert, serverLeaf := newTestTLSCert(t, []string{"ns1.test"}, []net.IP{net.ParseIP("127.0.0.1")})
+	// Both clients chain to the same "CA" (their own self-signed certs are
+	// pooled together, mimicking one shared trust bundle).
+	allowedCert, allowedLeaf := newTestTLSCert(t, []string{"sec1.test"}, nil)
+	otherCert, otherLeaf := newTestTLSCert(t, []string{"rogue.test"}, nil)
+
+	caPath := t.TempDir() + "/shared-ca.pem"
+	f, err := os.Create(caPath)
+	if err != nil {
+		t.Fatalf("create ca bundle: %v", err)
+	}
+	for _, der := range [][]byte{allowedLeaf.Raw, otherLeaf.Raw} {
+		if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+			t.Fatalf("write ca bundle: %v", err)
+		}
+	}
+	f.Close()
+
+	conf := &Config{}
+	conf.DnsEngine.DownstreamAuth = "ca"
+	conf.DnsEngine.DownstreamCA = caPath
+	conf.DnsEngine.DownstreamNames = []string{"sec1.test"}
+	srvTLS, err := ServerTLSConfigForDoT(conf, &serverCert, true)
+	if err != nil {
+		t.Fatalf("ServerTLSConfigForDoT: %v", err)
+	}
+	srv := startTestAXFRServerTLSConfig(t, zd, nil, srvTLS)
+	defer srv.shutdown()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(serverLeaf)
+	base := &tls.Config{RootCAs: pool, ServerName: "ns1.test", MinVersion: tls.VersionTLS13}
+
+	good := base.Clone()
+	good.Certificates = []tls.Certificate{allowedCert}
+	if _, err := axfrClientTLS(t, srv.addr, zd.ZoneName, good, nil); err != nil {
+		t.Fatalf("allowlisted client transfer failed: %v", err)
+	}
+
+	// Chain-valid but not allowlisted: refused.
+	bad := base.Clone()
+	bad.Certificates = []tls.Certificate{otherCert}
+	if _, err := axfrClientTLS(t, srv.addr, zd.ZoneName, bad, nil); err == nil {
+		t.Fatal("chain-valid client outside downstream-names must be refused")
 	}
 }
 


### PR DESCRIPTION
Implements docs/2026-07-21-pkix-cert-tooling-design.md (merged to main via #315). **Stacked on feature/xot (#314)** — the PKI reuses `SPKISHA256`/`NewTlsaRR` and the XoT test harness from that branch, so this PR is based on it and should merge after it.

## What this adds

**`tdns-cli cert` — a deliberately minimal internal PKI** (Part 2 / LE-1, the one real blocker for PKIX-based XoT). Pure-stdlib crypto in `v2/pki.go`, thin cobra wrappers in `v2/cli/cert_cmds.go`:

- `cert ca` — self-signed root, hard-coded pathlen 0 (leaves only, never a sub-CA), random 128-bit serials (no serial-file/DB state), ed25519 default (ecdsa-p256/rsa2048 available)
- `cert leaf` — CA-signed end-entity cert; `--emit-pin` / `--emit-tlsa <owner> --tlsa-port` (default 853) print the pin and the TLSA 3-1-1 record, so one issuance feeds all three XoT auth modes
- `cert csr` / `cert sign` — split provisioning for cross-org mutual TLS; the private key never leaves the requesting host
- `cert pin` / `cert show` — read-only helpers
- **`cert init`** — the tier-1 one-shot for third-party users: reads the local tdns-auth config, creates the CA if absent (reuses otherwise), derives SANs from the config's listen addresses + hostname, writes cert/key to the exact `certfile`/`keyfile` paths the config names, and prints ready-to-paste secondary config for pkix/pin/dane. Idempotent; `--force` to replace.

State is **plain PEM files** (CA home `/etc/tdns/ca/`, dir 0700, keys 0600, no overwrite without `--force`) plus an append-only human-readable `issued.log` — an audit trail, deliberately not a cert database. No CRL/OCSP/renewal; scope stated in `--help`. The `cert` subtree is top-level in tdns-cli (per the design doc; could move under `util` if preferred) and skips config/API init — it works with no daemon present.

**PKIX loose ends (Part 1):**
- LE-2: startup note for a single CA-signed cert in certfile + "leaf first, bundle intermediates" docs. Info rather than the doc's suggested Warn: that shape is exactly what `cert init` produces (two-tier PKI, root trusted directly), so a warning would cry wolf on the blessed flow.
- LE-3: agent-parity test driving the full production `FetchFromUpstream` path (hard flip + snapshot publish) over dot+pkix.
- LE-4 (own commit, easy to drop): opt-in `dnsengine.downstream-names` SAN allowlist for shared-CA mTLS; empty = unchanged chain-only behavior.
- LE-5: not implemented (non-goal per the doc).
- LE-6: dog prints an IP-SAN hint when `+cafile` targets an IP-literal server.
- LE-7: intermediate-chain test (hand-built root→intermediate→leaf; transfer succeeds with the chain presented, fails without the intermediate). SAN-mismatch was already covered on feature/xot.
- Ops guide: new tiered "Provisioning certificates" section — casual testers need none of this (mwe self-signed + pin/dane still the first path), `cert init` for one host, primitives for fleets.

## Testing

- PKI unit tests: CA constraints + self-verify, leaf chain/EKU/name verification, leaf-cannot-sign, CSR round-trip incl. tamper refusal, all three algorithms.
- Closing-the-loop integration: a minted CA + leaf satisfies all three XoT client auth modes (pkix/pin/dane) against the real transfer path.
- `go test -race` green across v2, v2/cli, v2/cache, v2/core, v2/edns0; all six binaries build.
- Live smoke: full `ca`/`leaf`/`csr`/`sign`/`pin`/`show` walkthrough (0600 keys, overwrite refusal, issued.log); `cert init` against an MWE config → daemon restart → dog `+cafile` PKIX-verified AXFR with the minted CA; re-run reuses the CA and refuses to clobber the leaf.

## Update (9144d15): SPKI-preserving upgrade path + provisioning guide

- `cert csr --key` (re-certify an existing key; SPKI unchanged so pins/TLSA stay valid) and `--from-cert` (copy CN+SANs); `ParsePrivateKeyPEM` accepts legacy openssl EC/RSA PEM keys.
- New **guide/cert-provisioning.md** (indexed in guide/README.md): worked examples for upgrading local and remote self-signed certs to CA-signed, building the ca-file for each kind of cert, renewal/rotation, and the no-revocation scope.
- Live-checked end-to-end: MWE self-signed cert upgraded in place (issuer flipped, pin unchanged), then a two-daemon pkix XoT pull + dog `+cafile` query against the CA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline `cert` CLI tooling for CA/leaf workflows, CSR generation/signing, and producing pins/TLSA records.
  * Added `cert init` for one-step local provisioning with automatic SAN detection.
  * Added CA-mode downstream client certificate DNS-name allowlists for stricter mTLS identity checks.
* **Improvements**
  * More resilient encrypted transport TLS cert bootstrapping and clearer certificate-chain messaging.
  * Improved guidance when IP-SAN PKIX verification fails.
* **Tests**
  * Added end-to-end PKI/TLSA/pin and PKIX edge-case coverage, plus CLI flag-binding regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->