### PR TITLE
servererror: server-wide error registry + transport/config instrumentation

### DIFF
--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -281,8 +281,9 @@ type ConfigResponse struct {
 	Msg                  string
 	Error                bool
 	ErrorMsg             string
-	TsigConflicts        []string `json:"tsigconflicts,omitempty"`
-	TsigWithheldRemovals []string `json:"tsigwithheldremovals,omitempty"`
+	TsigConflicts        []string      `json:"tsigconflicts,omitempty"`
+	TsigWithheldRemovals []string      `json:"tsigwithheldremovals,omitempty"`
+	ServerErrors         []ServerError `json:"servererrors,omitempty"` // active server-wide error conditions
 }
 
 type DelegationPost struct {

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -370,8 +370,13 @@ func APIconfig(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 			resp.ApiServer = conf.ApiServer
 			resp.Identities = conf.Service.Identities
 			resp.DBFile = conf.Db.File
-			resp.Msg = fmt.Sprintf("%s: Configuration is ok, boot time: %s, last config reload: %s",
-				Globals.App.Name, Globals.App.ServerBootTime.Format(TimeLayout), Globals.App.ServerConfigTime.Format(TimeLayout))
+			resp.ServerErrors = conf.Internal.ServerErrors.List()
+			health := "Configuration is ok"
+			if len(resp.ServerErrors) > 0 {
+				health = fmt.Sprintf("DEGRADED: %d active error(s)", len(resp.ServerErrors))
+			}
+			resp.Msg = fmt.Sprintf("%s: %s, boot time: %s, last config reload: %s",
+				Globals.App.Name, health, Globals.App.ServerBootTime.Format(TimeLayout), Globals.App.ServerConfigTime.Format(TimeLayout))
 
 		default:
 			resp.ErrorMsg = fmt.Sprintf("Unknown config command: %s", cp.Command)

--- a/v2/cli/config_cmds.go
+++ b/v2/cli/config_cmds.go
@@ -170,9 +170,15 @@ func runConfigCmd(role, command string, showVerboseStatus bool) {
 		fmt.Printf("Status for %s:\n", resp.AppName)
 		if len(resp.DnsEngine.Addresses) > 0 {
 			fmt.Printf("DnsEngine: listening on %v\n", resp.DnsEngine.Addresses)
-			fmt.Printf("DnsEngine: active transports: %v\n", resp.DnsEngine.Transports)
+			fmt.Printf("DnsEngine: configured transports: %v\n", resp.DnsEngine.Transports)
 		} else {
 			fmt.Printf("DnsEngine: not listening on any addresses\n")
+		}
+		if len(resp.ServerErrors) > 0 {
+			fmt.Printf("Active errors:\n")
+			for _, e := range resp.ServerErrors {
+				fmt.Printf("  [%s/%s] %s\n", e.Category, e.Subtype, e.Message)
+			}
 		}
 		if len(resp.DnsEngine.Options) > 0 {
 			fmt.Printf("DnsEngine: auth options:\n")

--- a/v2/config.go
+++ b/v2/config.go
@@ -482,6 +482,12 @@ type InternalDnsConf struct {
 type InternalConf struct {
 	InternalDnsConf
 
+	// ServerErrors is the daemon-wide error registry (v2/servererror.go):
+	// transport/config error conditions surfaced by `config status`. Created
+	// once and preserved across config reloads (so boot-scoped Transport
+	// errors survive a reload).
+	ServerErrors *ServerErrorRegistry
+
 	// LargeAlgorithms is the derived lookup set from Dnssec.LargeAlgorithms.
 	LargeAlgorithms map[uint8]bool
 

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -82,6 +82,9 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 				if err := s.ListenAndServe(); err != nil {
 					// ListenAndServe only returns on error or shutdown.
 					lgDns.Error("DnsEngine: server failed to start or stopped unexpectedly", "addr", addr, "transport", transport, "err", err)
+					if ctx.Err() == nil { // a real bind/serve failure, not shutdown
+						conf.Internal.ServerErrors.SetTransportPortError(addr+"/"+transport, err)
+					}
 				} else {
 					// This case is basically never reached unless shutdown is very clean.
 					lgDns.Debug("DnsEngine: server exited normally", "addr", addr, "transport", transport)
@@ -113,20 +116,24 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 	certFile := viper.GetString("dnsengine.certfile")
 	keyFile := viper.GetString("dnsengine.keyfile")
 	certKey := true
+	certReason := ""
 
 	if certFile == "" || keyFile == "" {
 		lgDns.Info("DnsEngine: no certificate file or key file provided. Not starting DoT, DoH or DoQ service.")
 		certKey = false
+		certReason = "certfile/keyfile not configured"
 	}
 
 	if _, err := os.Stat(certFile); os.IsNotExist(err) {
 		lgDns.Info("DnsEngine: certificate file does not exist. Not starting DoT, DoH or DoQ service.", "file", certFile)
 		certKey = false
+		certReason = fmt.Sprintf("certfile %s does not exist", certFile)
 	}
 
 	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
 		lgDns.Info("DnsEngine: key file does not exist. Not starting DoT, DoH or DoQ service.", "file", keyFile)
 		certKey = false
+		certReason = fmt.Sprintf("keyfile %s does not exist", keyFile)
 	}
 
 	var certPEM []byte
@@ -151,6 +158,7 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 		if err != nil {
 			lgDns.Error("DnsEngine: failed to load certificate, not starting DoT/DoH/DoQ service", "err", err)
 			certKey = false
+			certReason = fmt.Sprintf("loading certfile/keyfile: %v", err)
 		}
 
 		// Check certificate expiry at startup
@@ -203,6 +211,12 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 				lgDns.Error("Failed to setup the DoQ server", "err", err)
 			}
 		}
+	}
+	// Transport/Cert: encrypted transports are configured but the cert/key
+	// could not be loaded, so those listeners did not start (owned here,
+	// boot-scoped — clears on a fresh start with a working cert).
+	if !certKey && anyEncryptedTransport(conf.DnsEngine.Transports) {
+		conf.Internal.ServerErrors.SetTransportCertError(certReason)
 	}
 	return nil
 }

--- a/v2/do53.go
+++ b/v2/do53.go
@@ -118,19 +118,20 @@ func DnsEngine(ctx context.Context, conf *Config) error {
 	certKey := true
 	certReason := ""
 
+	// Mutually exclusive: an empty certFile/keyFile makes os.Stat("") return
+	// ENOENT (satisfies os.IsNotExist), so without the else-if the later
+	// blocks would run too and overwrite the accurate "not configured"
+	// reason with a misleading "keyfile  does not exist" (empty filename),
+	// besides the redundant stats/logs.
 	if certFile == "" || keyFile == "" {
 		lgDns.Info("DnsEngine: no certificate file or key file provided. Not starting DoT, DoH or DoQ service.")
 		certKey = false
 		certReason = "certfile/keyfile not configured"
-	}
-
-	if _, err := os.Stat(certFile); os.IsNotExist(err) {
+	} else if _, err := os.Stat(certFile); os.IsNotExist(err) {
 		lgDns.Info("DnsEngine: certificate file does not exist. Not starting DoT, DoH or DoQ service.", "file", certFile)
 		certKey = false
 		certReason = fmt.Sprintf("certfile %s does not exist", certFile)
-	}
-
-	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
+	} else if _, err := os.Stat(keyFile); os.IsNotExist(err) {
 		lgDns.Info("DnsEngine: key file does not exist. Not starting DoT, DoH or DoQ service.", "file", keyFile)
 		certKey = false
 		certReason = fmt.Sprintf("keyfile %s does not exist", keyFile)

--- a/v2/doh.go
+++ b/v2/doh.go
@@ -96,6 +96,9 @@ func DnsDoHEngine(ctx context.Context, conf *Config, dohaddrs []string, certFile
 				lgDns.Info("DnsEngine: setting up DoH server", "hostport", hp)
 				if err := s.ListenAndServeTLS(certFile, keyFile); err != http.ErrServerClosed {
 					lgDns.Error("failed to setup DoH server", "hostport", hp, "err", err)
+					if ctx.Err() == nil {
+						conf.Internal.ServerErrors.SetTransportPortError("doh "+hp, err)
+					}
 				} else {
 					lgDns.Info("DnsEngine: listening on DoH", "hostport", hp)
 				}

--- a/v2/doq.go
+++ b/v2/doq.go
@@ -42,6 +42,7 @@ func DnsDoQEngine(ctx context.Context, conf *Config, doqaddrs []string, cert *tl
 			})
 			if err != nil {
 				lgDns.Error("failed to setup DoQ listener", "hostport", hostport, "err", err)
+				conf.Internal.ServerErrors.SetTransportPortError("doq "+hostport, err)
 				continue
 			}
 			listeners = append(listeners, listener)

--- a/v2/dot.go
+++ b/v2/dot.go
@@ -71,6 +71,9 @@ func DnsDoTEngine(ctx context.Context, conf *Config, dotaddrs []string, cert *tl
 				lgDns.Info("DnsEngine: serving on DoT", "hostport", hp)
 				if err := srv.ListenAndServe(); err != nil {
 					lgDns.Error("failed to setup DoT server", "hostport", hp, "err", err)
+					if ctx.Err() == nil {
+						conf.Internal.ServerErrors.SetTransportPortError("dot "+hp, err)
+					}
 				} else {
 					lgDns.Info("DnsEngine: listening on DoT", "hostport", hp)
 				}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -329,6 +329,14 @@ func (conf *Config) ParseConfig(reload bool) error {
 		return fmt.Errorf("error decoding config: %v", err)
 	}
 
+	// Server-wide error registry: create once, preserve across reloads (so
+	// boot-scoped Transport errors survive a reload). parseconfig owns the
+	// Config/CertMissing check (clear-then-reassert on every load).
+	if conf.Internal.ServerErrors == nil {
+		conf.Internal.ServerErrors = NewServerErrorRegistry()
+	}
+	conf.validateDnsEngineCerts()
+
 	if len(md.Unused) > 0 {
 		// Split the unused keys into two buckets: keys that match a known
 		// DEPRECATED/RENAMED config shape (the config lags the code — emit

--- a/v2/servererror.go
+++ b/v2/servererror.go
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Server-wide error registry with clear-ownership subtyping
+ * (docs/2026-07-21-server-error-registry-design.md). Standalone by design:
+ * low-frequency, multi-writer, plain-mutex server state that shares nothing
+ * with the zone snapshot model. Errors are keyed by (Category, Subtype);
+ * every mutation goes through a named owned helper so each set/clear point is
+ * greppable and located with the code that owns the condition. The generic
+ * set/clear are unexported.
+ */
+package tdns
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ErrorCategory uint8
+
+const (
+	ErrCatTransport ErrorCategory = iota + 1 // a listener/transport is not serving
+	ErrCatConfig                             // a configured input is missing/invalid
+	ErrCatOther                              // catch-all until a category is defined
+)
+
+var errCategoryName = map[ErrorCategory]string{
+	ErrCatTransport: "Transport",
+	ErrCatConfig:    "Config",
+	ErrCatOther:     "Other",
+}
+
+func (c ErrorCategory) String() string {
+	if s, ok := errCategoryName[c]; ok {
+		return s
+	}
+	return fmt.Sprintf("Category(%d)", c)
+}
+
+type ErrorSubtype uint8
+
+const (
+	ErrSubCert        ErrorSubtype = iota + 1 // Transport: cert/key could not be loaded
+	ErrSubPort                                // Transport: a listener socket failed to bind
+	ErrSubCertMissing                         // Config: a configured cert/key file is absent
+)
+
+var errSubtypeName = map[ErrorSubtype]string{
+	ErrSubCert:        "Cert",
+	ErrSubPort:        "Port",
+	ErrSubCertMissing: "CertMissing",
+}
+
+func (s ErrorSubtype) String() string {
+	if n, ok := errSubtypeName[s]; ok {
+		return n
+	}
+	return fmt.Sprintf("Subtype(%d)", s)
+}
+
+// ServerError is one active server-wide error condition, identified by its
+// (Category, Subtype). Serialized in the config-status API response.
+type ServerError struct {
+	Category  ErrorCategory `json:"category"`
+	Subtype   ErrorSubtype  `json:"subtype"`
+	Message   string        `json:"message"`
+	FirstSeen time.Time     `json:"first_seen"`
+	LastSeen  time.Time     `json:"last_seen"`
+}
+
+func (e ServerError) String() string {
+	return fmt.Sprintf("[%s/%s] %s", e.Category, e.Subtype, e.Message)
+}
+
+type errKey struct {
+	cat ErrorCategory
+	sub ErrorSubtype
+}
+
+// ServerErrorRegistry holds the daemon-wide set of active error conditions,
+// one live entry per (Category, Subtype).
+type ServerErrorRegistry struct {
+	mu   sync.Mutex
+	errs map[errKey]ServerError
+}
+
+func NewServerErrorRegistry() *ServerErrorRegistry {
+	return &ServerErrorRegistry{errs: map[errKey]ServerError{}}
+}
+
+func (r *ServerErrorRegistry) set(cat ErrorCategory, sub ErrorSubtype, msg string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	k := errKey{cat, sub}
+	now := time.Now()
+	e, ok := r.errs[k]
+	if !ok {
+		e = ServerError{Category: cat, Subtype: sub, FirstSeen: now}
+	}
+	e.Message = msg
+	e.LastSeen = now
+	r.errs[k] = e
+}
+
+func (r *ServerErrorRegistry) clear(cat ErrorCategory, sub ErrorSubtype) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.errs, errKey{cat, sub})
+}
+
+// List returns the active errors, sorted by (category, subtype) for stable
+// output. Safe on a nil registry.
+func (r *ServerErrorRegistry) List() []ServerError {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ServerError, 0, len(r.errs))
+	for _, e := range r.errs {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Category != out[j].Category {
+			return out[i].Category < out[j].Category
+		}
+		return out[i].Subtype < out[j].Subtype
+	})
+	return out
+}
+
+// HasAny reports whether any error is active. Safe on a nil registry.
+func (r *ServerErrorRegistry) HasAny() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.errs) > 0
+}
+
+// --- named owned helpers: the ONLY blessed mutators ------------------------
+
+// Owned by DnsEngine (v2/do53.go). Set when the DoT/DoH/DoQ cert+key could
+// not be loaded so the encrypted listeners were skipped. Boot-scoped: the
+// registry starts empty each boot, so a clean start needs no explicit clear.
+func (r *ServerErrorRegistry) SetTransportCertError(msg string) {
+	r.set(ErrCatTransport, ErrSubCert, msg)
+}
+func (r *ServerErrorRegistry) ClearTransportCertError() {
+	r.clear(ErrCatTransport, ErrSubCert)
+}
+
+// Owned by DnsEngine (the transport engines). Set when a listener's socket
+// failed to bind (privileged port, address-in-use). Multiple failing
+// listeners aggregate into the single Port entry.
+func (r *ServerErrorRegistry) SetTransportPortError(hostport string, cause error) {
+	if r == nil {
+		return
+	}
+	entry := fmt.Sprintf("%s: %v", hostport, cause)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	k := errKey{ErrCatTransport, ErrSubPort}
+	now := time.Now()
+	e, ok := r.errs[k]
+	if !ok {
+		e = ServerError{Category: ErrCatTransport, Subtype: ErrSubPort, FirstSeen: now, Message: entry}
+	} else if !strings.Contains(e.Message, hostport) {
+		e.Message += "; " + entry
+	}
+	e.LastSeen = now
+	r.errs[k] = e
+}
+
+// Owned by parseconfig. Set when a configured dnsengine cert/key file is
+// absent/unreadable at (re)load; cleared by the same revalidation when the
+// files are present (clear-then-reassert).
+func (r *ServerErrorRegistry) SetConfigCertMissing(msg string) {
+	r.set(ErrCatConfig, ErrSubCertMissing, msg)
+}
+func (r *ServerErrorRegistry) ClearConfigCertMissing() {
+	r.clear(ErrCatConfig, ErrSubCertMissing)
+}
+
+// --- config-time cert validation (parseconfig, Config/CertMissing owner) ---
+
+// anyEncryptedTransport reports whether dot, doh or doq appears in the list.
+func anyEncryptedTransport(transports []string) bool {
+	return CaseFoldContains(transports, "dot") ||
+		CaseFoldContains(transports, "doh") ||
+		CaseFoldContains(transports, "doq")
+}
+
+// validateDnsEngineCerts is parseconfig's owned check for Config/CertMissing:
+// if any encrypted transport is configured, certfile and keyfile must exist
+// and be readable. Clear-then-reassert, so it self-corrects on every reload.
+func (conf *Config) validateDnsEngineCerts() {
+	reg := conf.Internal.ServerErrors
+	reg.ClearConfigCertMissing()
+	de := conf.DnsEngine
+	if !anyEncryptedTransport(de.Transports) {
+		return
+	}
+	var problems []string
+	if de.CertFile == "" {
+		problems = append(problems, "certfile is unset")
+	} else if _, err := os.Stat(de.CertFile); err != nil {
+		problems = append(problems, fmt.Sprintf("certfile %s: %v", de.CertFile, err))
+	}
+	if de.KeyFile == "" {
+		problems = append(problems, "keyfile is unset")
+	} else if _, err := os.Stat(de.KeyFile); err != nil {
+		problems = append(problems, fmt.Sprintf("keyfile %s: %v", de.KeyFile, err))
+	}
+	if len(problems) > 0 {
+		reg.SetConfigCertMissing(fmt.Sprintf("encrypted transports %v configured but %s",
+			de.Transports, strings.Join(problems, "; ")))
+	}
+}

--- a/v2/servererror_test.go
+++ b/v2/servererror_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+package tdns
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestServerErrors_SetClearList(t *testing.T) {
+	r := NewServerErrorRegistry()
+	if r.HasAny() || len(r.List()) != 0 {
+		t.Fatal("fresh registry must be empty")
+	}
+
+	r.SetTransportCertError("cert gone")
+	if !r.HasAny() || len(r.List()) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(r.List()))
+	}
+	e := r.List()[0]
+	if e.Category != ErrCatTransport || e.Subtype != ErrSubCert || e.Message != "cert gone" {
+		t.Fatalf("wrong error recorded: %s", e)
+	}
+	if e.FirstSeen.IsZero() || e.LastSeen.IsZero() {
+		t.Fatal("timestamps not set")
+	}
+
+	// Re-setting the same class updates the message, does not stack.
+	r.SetTransportCertError("still gone")
+	if len(r.List()) != 1 || r.List()[0].Message != "still gone" {
+		t.Fatalf("re-set should update in place: %v", r.List())
+	}
+
+	// A distinct class only clears itself.
+	r.SetConfigCertMissing("file missing")
+	if len(r.List()) != 2 {
+		t.Fatalf("expected 2 classes, got %d", len(r.List()))
+	}
+	r.ClearTransportCertError()
+	got := r.List()
+	if len(got) != 1 || got[0].Subtype != ErrSubCertMissing {
+		t.Fatalf("clearing Cert must leave only CertMissing: %v", got)
+	}
+	r.ClearConfigCertMissing()
+	if r.HasAny() {
+		t.Fatal("registry should be empty after clearing all")
+	}
+}
+
+func TestServerErrors_PortAggregation(t *testing.T) {
+	r := NewServerErrorRegistry()
+	r.SetTransportPortError("dot 127.0.0.1:853", errors.New("permission denied"))
+	r.SetTransportPortError("doh 127.0.0.1:443", errors.New("permission denied"))
+	// Same class, aggregated into one entry naming both listeners.
+	list := r.List()
+	if len(list) != 1 || list[0].Subtype != ErrSubPort {
+		t.Fatalf("expected a single aggregated Port error, got %v", list)
+	}
+	if !strings.Contains(list[0].Message, "853") || !strings.Contains(list[0].Message, "443") {
+		t.Fatalf("aggregated message should name both listeners: %q", list[0].Message)
+	}
+	// A repeat of the same hostport does not duplicate.
+	before := list[0].Message
+	r.SetTransportPortError("dot 127.0.0.1:853", errors.New("permission denied"))
+	if r.List()[0].Message != before {
+		t.Fatalf("repeat of same listener should not change message: %q -> %q", before, r.List()[0].Message)
+	}
+}
+
+func TestServerErrors_ListSorted(t *testing.T) {
+	r := NewServerErrorRegistry()
+	r.SetConfigCertMissing("c") // Config category
+	r.SetTransportPortError("dot x", errors.New("p"))
+	r.SetTransportCertError("cert")
+	list := r.List()
+	// Transport (1) before Config (2); within Transport, Cert (1) before Port (2).
+	if len(list) != 3 {
+		t.Fatalf("expected 3, got %d", len(list))
+	}
+	want := []struct {
+		cat ErrorCategory
+		sub ErrorSubtype
+	}{
+		{ErrCatTransport, ErrSubCert},
+		{ErrCatTransport, ErrSubPort},
+		{ErrCatConfig, ErrSubCertMissing},
+	}
+	for i, w := range want {
+		if list[i].Category != w.cat || list[i].Subtype != w.sub {
+			t.Fatalf("sort order wrong at %d: got %s", i, list[i])
+		}
+	}
+}
+
+func TestServerErrors_NilSafe(t *testing.T) {
+	var r *ServerErrorRegistry // nil, e.g. before init
+	r.SetTransportCertError("x")
+	r.SetTransportPortError("h", errors.New("e"))
+	r.ClearConfigCertMissing()
+	if r.HasAny() || r.List() != nil {
+		t.Fatal("nil registry must be a safe no-op")
+	}
+}
+
+func TestServerErrors_ValidateDnsEngineCerts(t *testing.T) {
+	conf := &Config{}
+	conf.Internal.ServerErrors = NewServerErrorRegistry()
+
+	// No encrypted transports: no cert error even with empty cert paths.
+	conf.DnsEngine.Transports = []string{"do53"}
+	conf.validateDnsEngineCerts()
+	if conf.Internal.ServerErrors.HasAny() {
+		t.Fatal("do53-only must not produce a CertMissing error")
+	}
+
+	// Encrypted transport + missing files: Config/CertMissing set.
+	conf.DnsEngine.Transports = []string{"do53", "dot"}
+	conf.DnsEngine.CertFile = "/nonexistent/x.crt"
+	conf.DnsEngine.KeyFile = "/nonexistent/x.key"
+	conf.validateDnsEngineCerts()
+	list := conf.Internal.ServerErrors.List()
+	if len(list) != 1 || list[0].Category != ErrCatConfig || list[0].Subtype != ErrSubCertMissing {
+		t.Fatalf("expected Config/CertMissing, got %v", list)
+	}
+
+	// Files now present + clear-then-reassert on the next validate: cleared.
+	crt, _ := os.CreateTemp(t.TempDir(), "x*.crt")
+	key, _ := os.CreateTemp(t.TempDir(), "x*.key")
+	conf.DnsEngine.CertFile = crt.Name()
+	conf.DnsEngine.KeyFile = key.Name()
+	conf.validateDnsEngineCerts()
+	if conf.Internal.ServerErrors.HasAny() {
+		t.Fatalf("CertMissing must clear once files exist: %v", conf.Internal.ServerErrors.List())
+	}
+}


### PR DESCRIPTION
Implements the design merged via #319 (docs/2026-07-21-server-error-registry-design.md). Fixes the `config status` bug found while testing XoT on nox: encrypted transports reported as active when the cert/key files were missing and the listeners never started.

## What's here

- **`v2/servererror.go`** — standalone `ServerErrorRegistry`: plain `sync.Mutex`, no contact with the zone snapshot model. Errors keyed by **(Category, Subtype)** — `Transport/{Cert,Port}`, `Config/CertMissing`. Generic `set`/`clear` unexported; every mutation goes through a **named owned helper**. `List()`/`HasAny()` nil-safe.
- **Ownership/clearing** — parseconfig owns `Config/CertMissing` (`validateDnsEngineCerts`, clear-then-reassert every load); DnsEngine owns `Transport/*` (boot-scoped, clears on a fresh start). The registry is created once and preserved across reloads.
- **Instrumentation, all four transports** — `Transport/Cert` when the cert/key won't load so the encrypted listeners are skipped (do53); `Transport/Port` on a bind failure in do53/dot/doh/doq (ctx-guarded so a shutdown isn't misreported).
- **Reporting** — additive `ServerErrors` field on `ConfigResponse`; the status handler populates it and degrades the top line to `DEGRADED: N active error(s)`; `config status -v` prints an `Active errors` list and relabels the transports line **"configured transports"** (it's the config list, not proof of listening).

Your missing-cert case now yields two errors owned by two parts — `Config/CertMissing` (parseconfig) + `Transport/Cert` (DnsEngine) — both clearing on restart.

## Scope

Registry + the transport/config instrumentation only, per the design. No repo-wide sweep; zones untouched. Off `main` so it merges independently of the XoT stack.

## Testing

- `go test ./v2/...` green; v2 + v2/cli build; auth + cli binaries build.
- Registry tests: set/clear/re-set-in-place, port aggregation across listeners (+ no-dup on repeat), sorted `List`, nil-safety, and `validateDnsEngineCerts` (do53-only clean → missing files set `Config/CertMissing` → clear-then-reassert clears once files exist).

Not yet run: a live two-daemon smoke on a box with a deliberately-missing cert to see the DEGRADED status in `config status` — easy to do on nox; say the word.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server health reporting for active transport, certificate, and configuration errors, including timestamps.
  * Configuration status now shows degraded state when active errors exist, and verbose status lists active errors.
* **Bug Fixes**
  * Prevented shutdown/cancellation from being counted as active listener startup failures.
  * Improved certificate readiness reporting and more accurate recording of TLS/cert/key issues.
* **Tests**
  * Added coverage for error registry behavior, timestamp updates, aggregation, sorted output, nil-safety, and certificate validation/clearing across reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->