### PR TITLE
build: keep version.go current automatically on every make

### DIFF
--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -63,8 +63,13 @@ GENALGS ?= ../genalgs/tdns-genalgs
 #
 # ALGREPO comes from `-include ../algs-env.mk` in the app Makefile; per-app
 # C-library env comes from `-include algs-libs.mk` (see ALGS_ENV above).
+# version.go is kept current automatically: missing -> generated, and
+# regenerated whenever the version string changes (new commits, branch
+# switch, clean<->dirty transition — anything `git describe --dirty`
+# reflects). Left untouched otherwise so no-change rebuilds stay
+# no-ops. `make version` still forces a rewrite with a fresh appDate.
 build: generate
-	@test -f version.go || /bin/sh ../../utils/make-version.sh "unknown" "unknown" $(PROG)
+	@/bin/sh ../../utils/make-version.sh --if-changed $(VERSION)-$(BRANCH)-$(COMMIT) $(APPDATE) $(PROG)
 	$(ALGS_ENV) $(GO) build $(GOFLAGS) -o ${PROG}
 
 # Ensure the generator binary exists (cmdv2/Makefile also builds it first).

--- a/utils/make-version.sh
+++ b/utils/make-version.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
+# make-version.sh [--if-changed] <appversion> <appdate> <prog>
+#
+# Writes version.go (appVersion/appDate/appName constants) for the
+# versioned programs. With --if-changed, version.go is left untouched
+# when it already records exactly <appversion>; it is (re)written when
+# the file is missing or the version string differs (new commits, a
+# branch switch, or a clean<->dirty transition all change the string,
+# since it embeds `git describe --dirty`). This keeps `go build` a
+# no-op on unchanged trees — an unconditional rewrite would refresh
+# appDate and force a relink of every app on every make run.
+ifchanged=no
+if [ "$1" = "--if-changed" ]; then
+    ifchanged=yes
+    shift
+fi
+
 appversion=$1
 appdate=$2
 prog=$3
@@ -8,6 +24,10 @@ versioned_progs="tdns-agent tdns-auth tdns-combiner tdns-cli \
 
 case " $versioned_progs " in
     *" $prog "*)
+	if [ "$ifchanged" = yes ] && [ -f version.go ] &&
+	   grep -qxF "const appVersion = \"${appversion}\"" version.go; then
+	    exit 0
+	fi
 	echo generating version.go
 	{
 	echo "package main"
@@ -20,6 +40,9 @@ case " $versioned_progs " in
 	}
 	;;
     *)
-	echo not generating version.go, $prog is not a versioned program
+	# Quiet under --if-changed: this runs on every build.
+	if [ "$ifchanged" = no ]; then
+	    echo not generating version.go, $prog is not a versioned program
+	fi
 	;;
 esac


### PR DESCRIPTION
Removes the need to remember `make version` before `make`.

## Behavior
- **version.go missing** (fresh checkout): generated during `make` with the real `VERSION-branch-describe` string — no more "unknown" placeholder binaries.
- **New commits / branch switch / clean↔dirty transition**: regenerated automatically. No new git plumbing in make — the version string already embeds `git describe --dirty`, so comparing the recorded `appVersion` against the current string catches all three.
- **Nothing changed**: version.go untouched, so `go build` remains a complete no-op.
- **`make version`**: unchanged — still forces a rewrite with a fresh `appDate`.

## Why not always regenerate (the question you raised)
An unconditional rewrite refreshes `appDate` each run, which changes version.go's content hash and forces go to recompile + relink every app on every `make`, even with zero source changes. For the PQ-enabled apps the link against the static C archives dominates build time, so no-op builds would stop being cheap. The compare approach gives the same freshness guarantees without the churn. Trade-off: `appDate` reflects the last version-string change, not the last relink; the commit-hash part is always accurate.

## Mechanics
`make-version.sh` gains an `--if-changed` flag (default behavior untouched for `make version`); the shared `build:` target in `utils/Makefile.common` calls it on every build, replacing the old `test -f version.go || …unknown…` fallback. The "not a versioned program" message is suppressed under `--if-changed` since the script now runs on every build.

## Tested
- macOS/gmake, cmdv2/cli: missing → generated (correct branch + `+WiP` marker); rebuild → untouched (mtime verified, no relink); stale string → regenerated; `make version` → forced rewrite.
- Script standalone under NetBSD `/bin/sh` (ash): all four modes identical, non-versioned prog silent. The recipe line uses the same backtick-deferral idiom as the existing `version:` target, already proven under bmake.