### PR TITLE
config check: stop warning on zone names without a trailing dot

### DIFF
--- a/v2/cli/config_check_cmds.go
+++ b/v2/cli/config_check_cmds.go
@@ -698,12 +698,13 @@ func checkZones(cfg *tdns.Config, rep *ccReport, online bool, role string) {
 		}
 
 		if zname == "" {
-			rep.fail(g, zlabel, "zone has no name", "every zone needs a name (FQDN with trailing dot)")
+			rep.fail(g, zlabel, "zone has no name", "every zone needs a name")
 			continue
 		}
-		if !strings.HasSuffix(zname, ".") {
-			rep.warn(g, zname, "zone name is not a FQDN (missing trailing dot)", "write the name with a trailing dot, e.g. example.com.")
-		}
+		// A missing trailing dot is NOT flagged: tdns accepts zone names both
+		// with and without it, and the daemon canonicalizes to FQDN internally
+		// (correlateZones already compares dns.Fqdn-normalized names), so a
+		// non-FQDN name is not a defect.
 		if seen[lc(zname)] {
 			rep.fail(g, zname, "duplicate zone declaration", "remove the duplicate entry")
 			continue


### PR DESCRIPTION
## What

`tdns-cli auth config check` (and the agent/imr variants, which share
`checkZones`) emitted a `WARN` for every zone whose name lacked a trailing
dot:

```
WARN  qruov1.pq.axfr.net — zone name is not a FQDN (missing trailing dot)
      ↳ write the name with a trailing dot, e.g. example.com.
```

tdns accepts zone names **both** with and without the trailing dot, and the
daemon canonicalizes to FQDN internally, so a non-FQDN name is not a defect.
On a normal config the warning fired on eight zones — pure noise.

## Why it's safe

`correlateZones` already compares `dns.Fqdn`-normalized names on both the
config and running-daemon sides, so drift detection is unaffected by the
spelling. Dropping the warning changes nothing except that the shorter
spelling stops being flagged. Also removed the "(FQDN with trailing dot)"
tail from the no-name FAIL suggestion, which implied the dot is required.

## Verification

- `v2/cli`: build + `go vet` + `go test ./...` green.
- Functional: a config mixing `fqdn.example.` and `nodot.example` now shows
  `Zones PASS (2 checks)` with zero FQDN warnings; the FQDN zone still
  validates as before.

## Scope note

This is deliberately the **only** change. The separate `upstreams:` /
`primaries:` alias handling in `config check` (the "secondary zone has no
primaries" FAIL on `upstreams:`-style zones) is already implemented in the
open peers PR #318 via `NormalizeXfrAliases`, and depends on helpers not
present on main; it is intentionally left to land with #318 rather than
duplicated here.