### PR TITLE
Answer DS queries from the local parent zone, never via the resolver

### DIFF
--- a/v2/defaultqueryhandlers.go
+++ b/v2/defaultqueryhandlers.go
@@ -109,7 +109,7 @@ func DefaultQueryHandler(ctx context.Context, req *DnsQueryRequest) error {
 		}
 
 		lgHandler.Debug("query for known zone", "qname", qname)
-		err := zd.QueryResponder(ctx, w, r, qname, qtype, msgoptions, kdb, conf.Internal.ImrEngine)
+		err := zd.QueryResponder(ctx, w, r, qname, qtype, msgoptions, kdb)
 		if err != nil {
 			lgHandler.Error("QueryResponder failed", "error", err)
 			m := new(dns.Msg)
@@ -169,7 +169,7 @@ func DefaultQueryHandler(ctx context.Context, req *DnsQueryRequest) error {
 		return nil
 	}
 
-	err := zd.QueryResponder(ctx, w, r, qname, qtype, msgoptions, kdb, conf.Internal.ImrEngine)
+	err := zd.QueryResponder(ctx, w, r, qname, qtype, msgoptions, kdb)
 	if err != nil {
 		lgHandler.Error("QueryResponder failed", "error", err)
 	}

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -226,133 +226,137 @@ func (zd *ZoneData) signRRsetForZone(rrset core.RRset, name string, msgoptions *
 	return rrset, nil
 }
 
-// handleDSQuery handles DS queries.
+// handleDSQuery answers a DS query. DS is parent-side data (RFC 4035 §3.1.4.1):
+// it is authoritative in the zone that DELEGATES to qname, never in qname's own
+// zone. The answering zone is therefore the nearest zone we host that is a
+// STRICT ancestor of qname — and it is resolved entirely from the local Zones
+// map. We NEVER chase the parent via the recursive resolver.
 //
-// Two cases need to be distinguished by the relationship between qname and
-// the zone we matched on:
+// Four outcomes, decided by which ancestor we host and where its delegation
+// toward qname sits:
 //
-//  1. qname is a strict child of zd.ZoneName (e.g. zd is "dnslab.", qname is
-//     "bravo.dnslab."). We ARE the parent. Serve the DS RRset directly from
-//     our own zone tree at qname.
+//   - We host the immediate parent (it delegates directly to qname): serve the
+//     DS RRset if present; otherwise an authenticated NODATA proving the
+//     delegation is insecure (NS present, DS absent).
 //
-//  2. qname == zd.ZoneName (DS-at-our-apex query). We are the child. Walk
-//     up via imr.ParentZone() to find a parent zone we host, and serve DS
-//     from there. If we don't host the parent, return a SOA-only response
-//     authoritative for our own zone with EDE/CDE for guidance.
+//   - We host only a grandparent (it delegates to qname's real parent, which we
+//     do NOT host): return a referral to that parent — the DS is its to answer.
 //
-// Pre-fix behavior was always case (2), which broke DS queries against the
-// parent zone for any child name — the responder walked one zone too far up
-// and failed to find DS data that was correctly present in the parent zone.
-func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string, apex *OwnerData, snap *zoneSnapshot,
-	msgoptions *edns0.MsgOptions, kdb *KeyDB, dak *DnssecKeys, imr *Imr,
-	signFunc func(core.RRset, string) (core.RRset, error)) error {
+//   - We host qname (as its own zone) but no ancestor at all: REFUSED. The DS
+//     lives in a parent we don't host; answering NODATA would be us
+//     authoritatively denying parent-side data we don't own. (A correct
+//     validator asks the parent's servers for DS, never the child's, so this
+//     should not occur in practice.)
+//
+//   - qname is ordinary in-zone data of a hosted ancestor (e.g. `www DS`), or
+//     does not exist: NODATA / NXDOMAIN from that ancestor.
+func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string,
+	msgoptions *edns0.MsgOptions, kdb *KeyDB) error {
 
-	// Case 1: qname is a strict child of zd.ZoneName — we are the parent.
-	if qname != zd.ZoneName && dns.IsSubDomain(zd.ZoneName, qname) {
-		lgHandler.Debug("QueryResponder: DS query, serving from parent zone (this zone)",
-			"qname", qname, "zone", zd.ZoneName)
-		// Make sure apex RRsets are signed (SOA in authority for negative
-		// answers; DNSKEY/etc as needed by signApexRRsets).
-		soaRRset, _, err := zd.signedApexRRsets(apex, msgoptions, kdb, nil)
-		if err != nil {
-			lgHandler.Error("failed to sign parent apex RRsets for DS query", "err", err)
+	pzd := nearestHostedStrictAncestor(qname)
+	if pzd == nil {
+		// No hosted ancestor: we can only host qname itself (the child) or
+		// nothing relevant. Nothing to serve or refer to → REFUSED.
+		lgHandler.Debug("QueryResponder: DS query, no hosted parent zone — REFUSED",
+			"qname", qname)
+		m.MsgHdr.Authoritative = false
+		m.MsgHdr.Rcode = dns.RcodeRefused
+		w.WriteMsg(m)
+		return nil
+	}
+
+	// Switch to the parent-side zone: pin ITS snapshot, apex, and signer.
+	psnap := pzd.publishedSnapshot()
+	if psnap == nil {
+		lgHandler.Error("DS query: parent-side zone has no published snapshot",
+			"zone", pzd.ZoneName, "qname", qname)
+		m.MsgHdr.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return nil
+	}
+	papex := getOwnerFrom(psnap, pzd.ZoneName)
+	if papex == nil {
+		lgHandler.Error("DS query: parent-side zone snapshot missing apex",
+			"zone", pzd.ZoneName, "qname", qname)
+		m.MsgHdr.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return nil
+	}
+	// All signing below uses the parent-side zone's own keys. Only synthesized
+	// denial NSECs are signed here; stored data (DS, apex SOA) already carries
+	// its RRSIGs in the snapshot (or the zone is broken and SERVFAILs).
+	pSign := func(rrset core.RRset, name string) (core.RRset, error) {
+		return pzd.signRRsetForZone(rrset, name, msgoptions, kdb, nil)
+	}
+
+	cdd := pzd.findDelegationFrom(psnap, qname, msgoptions.DO)
+	switch {
+	case cdd != nil && cdd.ChildName == qname:
+		// Immediate parent: we delegate directly to qname, the DS is ours.
+		m.MsgHdr.Authoritative = true
+		if cdd.DS_rrset != nil && len(cdd.DS_rrset.RRs) > 0 {
+			lgHandler.Debug("QueryResponder: DS query, serving DS from parent zone",
+				"qname", qname, "parent", pzd.ZoneName)
+			m.MsgHdr.Rcode = dns.RcodeSuccess
+			ds := *cdd.DS_rrset
 			if msgoptions.DO {
-				m.MsgHdr.Rcode = dns.RcodeServerFailure
-				w.WriteMsg(m)
-				return fmt.Errorf("failed to sign parent apex RRsets for DS query: %v", err)
-			}
-		}
-		m.MsgHdr.Rcode = dns.RcodeSuccess
-		dsRRset := getRRsetFrom(snap, qname, dns.TypeDS)
-		if dsRRset != nil && len(dsRRset.RRs) > 0 {
-			signed, err := signFunc(*dsRRset, qname)
-			if err != nil {
-				lgHandler.Error("failed to sign DS RRset", "qname", qname, "err", err)
-				if msgoptions.DO {
+				signed, err := pSign(ds, qname)
+				if err != nil {
+					lgHandler.Error("DS query: failed to sign DS RRset", "qname", qname, "err", err)
 					m.MsgHdr.Rcode = dns.RcodeServerFailure
 					w.WriteMsg(m)
-					return fmt.Errorf("failed to sign DS RRset for %s: %v", qname, err)
+					return nil
 				}
-			} else {
-				dsRRset = &signed
+				ds = signed
 			}
-			m.Answer = append(m.Answer, dsRRset.RRs...)
+			m.Answer = append(m.Answer, ds.RRs...)
 			if msgoptions.DO {
-				m.Answer = append(m.Answer, dsRRset.RRSIGs...)
+				m.Answer = append(m.Answer, ds.RRSIGs...)
 			}
-		}
-		m.Ns = append(m.Ns, soaRRset.RRs...)
-		w.WriteMsg(m)
-		return nil
-	}
-
-	// Case 2: qname == zd.ZoneName — DS-at-apex query. Walk up to find a
-	// parent zone we host.
-	lgHandler.Debug("QueryResponder: DS-at-apex query, looking up parent zone",
-		"qname", qname, "zone", zd.ZoneName)
-	parent, err := imr.ParentZone(zd.ZoneName)
-	if err != nil {
-		lgHandler.Error("failed to find parent zone for DS query", "qname", qname)
-		m.MsgHdr.Rcode = dns.RcodeServerFailure
-		w.WriteMsg(m)
-		return nil
-	}
-	pzd, ok := FindZone(parent)
-	if !ok {
-		// we don't have the parent zone
-		m.MsgHdr.Rcode = dns.RcodeSuccess
-		m.Ns = append(m.Ns, apex.RRtypes.GetOnlyRRSet(dns.TypeSOA).RRs...)
-		if msgoptions.DO {
-			zd.addCDEResponse(m, qname, apex, nil, msgoptions, signFunc)
-		}
-		w.WriteMsg(m)
-		return nil
-	}
-	// We have the parent zone; pin ITS snapshot and read the DS from that.
-	zd = pzd
-	snap = zd.publishedSnapshot()
-	apex = getOwnerFrom(snap, zd.ZoneName)
-	if apex == nil {
-		lgHandler.Error("failed to get apex data for parent zone", "zone", zd.ZoneName)
-		m.MsgHdr.Rcode = dns.RcodeServerFailure
-		w.WriteMsg(m)
-		return nil
-	}
-	// Use parent zone's own keys; let signRRsetForZone fetch them via kdb.
-	soaRRset, _, err := zd.signedApexRRsets(apex, msgoptions, kdb, nil)
-	if err != nil {
-		lgHandler.Error("failed to sign parent apex RRsets for DS query", "err", err)
-		if msgoptions.DO {
-			m.MsgHdr.Rcode = dns.RcodeServerFailure
 			w.WriteMsg(m)
-			return fmt.Errorf("failed to sign parent apex RRsets for DS query: %v", err)
+			return nil
 		}
-	}
-	m.MsgHdr.Rcode = dns.RcodeSuccess
-	dsRRset := getRRsetFrom(snap, qname, dns.TypeDS)
-	if dsRRset != nil && len(dsRRset.RRs) > 0 {
-		// Use parent zone's signing context (signFunc closes over the
-		// original zd; route through signRRsetForZone on the parent we
-		// just switched to).
-		signed, err := zd.signRRsetForZone(*dsRRset, qname, msgoptions, kdb, nil)
-		if err != nil {
-			lgHandler.Error("failed to sign DS RRset", "qname", qname, "err", err)
-			if msgoptions.DO {
-				m.MsgHdr.Rcode = dns.RcodeServerFailure
-				w.WriteMsg(m)
-				return fmt.Errorf("failed to sign DS RRset for %s: %v", qname, err)
-			}
-		} else {
-			dsRRset = &signed
-		}
-		m.Answer = append(m.Answer, dsRRset.RRs...)
+		// Insecure delegation: delegation exists, no DS. Authenticated NODATA
+		// (compact NSEC at qname: NS present, DS absent).
+		lgHandler.Debug("QueryResponder: DS query, insecure delegation (no DS) — authenticated NODATA",
+			"qname", qname, "parent", pzd.ZoneName)
+		m.MsgHdr.Rcode = dns.RcodeSuccess
+		m.Ns = append(m.Ns, pzd.soaForResponseFrom(psnap, papex).RRs...)
 		if msgoptions.DO {
-			m.Answer = append(m.Answer, dsRRset.RRSIGs...)
+			pzd.addCDEResponse(m, qname, papex, []uint16{dns.TypeNS}, msgoptions, pSign)
 		}
+		w.WriteMsg(m)
+		return nil
+
+	case cdd != nil:
+		// Grandparent: we delegate to cdd.ChildName (qname's real parent, not
+		// hosted here). Refer the client to it; the DS is the parent's to serve.
+		lgHandler.Debug("QueryResponder: DS query, referring to unhosted parent",
+			"qname", qname, "parent", cdd.ChildName, "grandparent", pzd.ZoneName)
+		m.MsgHdr.Rcode = dns.RcodeSuccess
+		pzd.sendReferral(m, w, cdd, papex, msgoptions, pSign)
+		return nil
+
+	default:
+		// No delegation covering qname inside pzd: qname is ordinary in-zone
+		// data (e.g. `www.example.com DS`) or does not exist. DS is not a
+		// parent-side concern here — plain NODATA / NXDOMAIN from pzd.
+		if owner := getOwnerFrom(psnap, qname); owner != nil {
+			m.MsgHdr.Authoritative = true
+			m.MsgHdr.Rcode = dns.RcodeSuccess
+			m.Ns = append(m.Ns, pzd.soaForResponseFrom(psnap, papex).RRs...)
+			if msgoptions.DO {
+				// Existing types at qname (DS is not among them) → NODATA proof.
+				pzd.addCDEResponse(m, qname, papex, owner.RRtypes.Keys(), msgoptions, pSign)
+			}
+			w.WriteMsg(m)
+			return nil
+		}
+		lgHandler.Debug("QueryResponder: DS query for a name that does not exist — NXDOMAIN",
+			"qname", qname, "zone", pzd.ZoneName)
+		pzd.sendNXDOMAIN(m, w, qname, papex, psnap, msgoptions, pSign)
+		return nil
 	}
-	m.Ns = append(m.Ns, soaRRset.RRs...)
-	w.WriteMsg(m)
-	return nil
 }
 
 // sendReferral sends a referral response for a child delegation.
@@ -705,7 +709,7 @@ func (zd *ZoneData) handleCNAMEChain(m *dns.Msg, w dns.ResponseWriter, qname str
 }
 
 func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r *dns.Msg,
-	qname string, qtype uint16, msgoptions *edns0.MsgOptions, kdb *KeyDB, imr *Imr) error {
+	qname string, qtype uint16, msgoptions *edns0.MsgOptions, kdb *KeyDB) error {
 
 	select {
 	case <-ctx.Done():
@@ -795,9 +799,11 @@ func (zd *ZoneData) QueryResponder(ctx context.Context, w dns.ResponseWriter, r 
 	var wildqname string
 	origqname := qname
 
-	// 0. Is this a DS query? If so, trap it ASAP and try to find the parent zone
+	// 0. Is this a DS query? If so, trap it ASAP: DS is parent-side data, so it
+	// is answered from the nearest hosted ancestor of qname, resolved from the
+	// local Zones map (never the resolver). See handleDSQuery.
 	if qtype == dns.TypeDS {
-		return zd.handleDSQuery(m, w, qname, apex, snap, msgoptions, kdb, dak, imr, MaybeSignRRset)
+		return zd.handleDSQuery(m, w, qname, msgoptions, kdb)
 	}
 
 	// log.Printf("---> Checking for existence of qname %s", qname)

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -229,34 +229,39 @@ func (zd *ZoneData) signRRsetForZone(rrset core.RRset, name string, msgoptions *
 // handleDSQuery answers a DS query. DS is parent-side data (RFC 4035 §3.1.4.1):
 // it is authoritative in the zone that DELEGATES to qname, never in qname's own
 // zone. The answering zone is therefore the nearest zone we host that is a
-// STRICT ancestor of qname — and it is resolved entirely from the local Zones
-// map. We NEVER chase the parent via the recursive resolver.
+// STRICT ancestor of qname — found by stripping qname's leftmost label and
+// letting FindZone walk up from there, entirely within the local Zones map. We
+// NEVER chase the parent via the recursive resolver.
 //
-// Four outcomes, decided by which ancestor we host and where its delegation
-// toward qname sits:
+// Outcomes, ordered from most to least common (a grandparent referral is by far
+// the rarest, so it is the last arm):
+//
+//   - No hosted ancestor at all: REFUSED. The DS lives in a parent we don't
+//     host; answering NODATA would be us authoritatively denying parent-side
+//     data we don't own. (A correct validator asks the parent's servers for DS,
+//     never the child's, so this should not occur in practice.)
 //
 //   - We host the immediate parent (it delegates directly to qname): serve the
 //     DS RRset if present; otherwise an authenticated NODATA proving the
 //     delegation is insecure (NS present, DS absent).
 //
-//   - We host only a grandparent (it delegates to qname's real parent, which we
-//     do NOT host): return a referral to that parent — the DS is its to answer.
-//
-//   - We host qname (as its own zone) but no ancestor at all: REFUSED. The DS
-//     lives in a parent we don't host; answering NODATA would be us
-//     authoritatively denying parent-side data we don't own. (A correct
-//     validator asks the parent's servers for DS, never the child's, so this
-//     should not occur in practice.)
-//
 //   - qname is ordinary in-zone data of a hosted ancestor (e.g. `www DS`), or
 //     does not exist: NODATA / NXDOMAIN from that ancestor.
+//
+//   - We host only a grandparent (it delegates to qname's real parent, which we
+//     do NOT host): referral to that parent — the DS is its to answer. Rarest.
 func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string,
 	msgoptions *edns0.MsgOptions, kdb *KeyDB) error {
 
-	pzd := nearestHostedStrictAncestor(qname)
+	// DS can never live in qname's own zone, so strip qname's leftmost label
+	// and look up the parent side. FindZone walks up from there and returns the
+	// nearest hosted strict ancestor of qname (with the same case-folding as the
+	// main lookup); it can never return qname's own zone. qname is a FQDN here,
+	// so it always has at least the root dot.
+	pzd, _ := FindZone(qname[strings.Index(qname, ".")+1:])
 	if pzd == nil {
-		// No hosted ancestor: we can only host qname itself (the child) or
-		// nothing relevant. Nothing to serve or refer to → REFUSED.
+		// We host nothing above qname (at most qname itself). Nothing to serve
+		// or refer to → REFUSED.
 		lgHandler.Debug("QueryResponder: DS query, no hosted parent zone — REFUSED",
 			"qname", qname)
 		m.MsgHdr.Authoritative = false
@@ -289,6 +294,8 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 		return pzd.signRRsetForZone(rrset, name, msgoptions, kdb, nil)
 	}
 
+	// One local delegation lookup classifies the query; arms are ordered by
+	// frequency, with the (rare) grandparent referral last.
 	cdd := pzd.findDelegationFrom(psnap, qname, msgoptions.DO)
 	switch {
 	case cdd != nil && cdd.ChildName == qname:
@@ -328,16 +335,7 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 		w.WriteMsg(m)
 		return nil
 
-	case cdd != nil:
-		// Grandparent: we delegate to cdd.ChildName (qname's real parent, not
-		// hosted here). Refer the client to it; the DS is the parent's to serve.
-		lgHandler.Debug("QueryResponder: DS query, referring to unhosted parent",
-			"qname", qname, "parent", cdd.ChildName, "grandparent", pzd.ZoneName)
-		m.MsgHdr.Rcode = dns.RcodeSuccess
-		pzd.sendReferral(m, w, cdd, papex, msgoptions, pSign)
-		return nil
-
-	default:
+	case cdd == nil:
 		// No delegation covering qname inside pzd: qname is ordinary in-zone
 		// data (e.g. `www.example.com DS`) or does not exist. DS is not a
 		// parent-side concern here — plain NODATA / NXDOMAIN from pzd.
@@ -355,6 +353,16 @@ func (zd *ZoneData) handleDSQuery(m *dns.Msg, w dns.ResponseWriter, qname string
 		lgHandler.Debug("QueryResponder: DS query for a name that does not exist — NXDOMAIN",
 			"qname", qname, "zone", pzd.ZoneName)
 		pzd.sendNXDOMAIN(m, w, qname, papex, psnap, msgoptions, pSign)
+		return nil
+
+	default:
+		// cdd != nil && cdd.ChildName != qname — we host only a grandparent that
+		// delegates to qname's real parent (which we do NOT host). Refer the
+		// client to that parent; the DS is the parent's to serve. Rarest case.
+		lgHandler.Debug("QueryResponder: DS query, referring to unhosted parent",
+			"qname", qname, "parent", cdd.ChildName, "grandparent", pzd.ZoneName)
+		m.MsgHdr.Rcode = dns.RcodeSuccess
+		pzd.sendReferral(m, w, cdd, papex, msgoptions, pSign)
 		return nil
 	}
 }

--- a/v2/queryresponder_ds_test.go
+++ b/v2/queryresponder_ds_test.go
@@ -1,0 +1,124 @@
+package tdns
+
+import (
+	"testing"
+
+	edns0 "github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// TestHandleDSQueryParentSelection verifies that a DS query is answered from the
+// nearest hosted ancestor of qname, resolved from the local Zones map — never
+// via the resolver. It exercises the three delegation relationships plus the
+// no-ancestor case. All cases are non-DNSSEC (DO=0): the regression was in zone
+// SELECTION, which is independent of signing.
+func TestHandleDSQueryParentSelection(t *testing.T) {
+	dsRR := "c.pq.example. 3600 IN DS 12345 8 2 " +
+		"E2D3C916F6DEEAC73294E8268FB5885044A833FC5459588F4A9184CFC41A5766"
+
+	t.Run("immediate_parent_serves_DS", func(t *testing.T) {
+		// We host BOTH the parent (which delegates to, and holds the DS for, the
+		// child) and the child itself. This is the foffe regression: the query
+		// exact-matches the child zone, and DS must still be served from the
+		// parent — from local data, without any resolver walk-up.
+		parent := `pq.example.	3600	IN	SOA	ns.pq.example. hostmaster.pq.example. 1 7200 1800 604800 7200
+pq.example.	3600	IN	NS	ns.pq.example.
+ns.pq.example.	3600	IN	A	192.0.2.1
+c.pq.example.	3600	IN	NS	ns.c.pq.example.
+` + dsRR + `
+ns.c.pq.example.	3600	IN	A	192.0.2.2
+`
+		child := `c.pq.example.	3600	IN	SOA	ns.c.pq.example. hostmaster.c.pq.example. 1 7200 1800 604800 7200
+c.pq.example.	3600	IN	NS	ns.c.pq.example.
+ns.c.pq.example.	3600	IN	A	192.0.2.2
+`
+		testSnapshotZone(t, "pq.example.", parent)
+		childZd := testSnapshotZone(t, "c.pq.example.", child)
+
+		rw := &fakeRW{}
+		if err := childZd.handleDSQuery(new(dns.Msg), rw, "c.pq.example.", &edns0.MsgOptions{}, nil); err != nil {
+			t.Fatalf("handleDSQuery: %v", err)
+		}
+		resp := rw.written
+		if resp == nil || resp.MsgHdr.Rcode != dns.RcodeSuccess {
+			t.Fatalf("want NOERROR, got %+v", resp)
+		}
+		var gotDS bool
+		for _, rr := range resp.Answer {
+			if ds, ok := rr.(*dns.DS); ok && ds.Header().Name == "c.pq.example." {
+				gotDS = true
+			}
+		}
+		if !gotDS {
+			t.Fatalf("DS-at-child-apex should be served from the parent zone; answer=%v", resp.Answer)
+		}
+		if !resp.MsgHdr.Authoritative {
+			t.Fatal("DS answer from the parent should be authoritative")
+		}
+	})
+
+	t.Run("grandparent_refers_to_parent", func(t *testing.T) {
+		// We host a grandparent (which delegates to the child's real parent) and
+		// the child, but NOT the immediate parent. All we can do is refer down to
+		// the parent.
+		grandparent := `example.	3600	IN	SOA	ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example.	3600	IN	NS	ns.example.
+ns.example.	3600	IN	A	192.0.2.1
+p.example.	3600	IN	NS	ns.p.example.
+ns.p.example.	3600	IN	A	192.0.2.3
+`
+		child := `x.p.example.	3600	IN	SOA	ns.x.p.example. hostmaster.x.p.example. 1 7200 1800 604800 7200
+x.p.example.	3600	IN	NS	ns.x.p.example.
+ns.x.p.example.	3600	IN	A	192.0.2.4
+`
+		testSnapshotZone(t, "example.", grandparent)
+		childZd := testSnapshotZone(t, "x.p.example.", child)
+
+		rw := &fakeRW{}
+		if err := childZd.handleDSQuery(new(dns.Msg), rw, "x.p.example.", &edns0.MsgOptions{}, nil); err != nil {
+			t.Fatalf("handleDSQuery: %v", err)
+		}
+		resp := rw.written
+		if resp == nil {
+			t.Fatal("no response written")
+		}
+		if resp.MsgHdr.Authoritative {
+			t.Fatal("a referral must NOT set the AA bit")
+		}
+		var refersToParent bool
+		for _, rr := range resp.Ns {
+			if ns, ok := rr.(*dns.NS); ok && ns.Header().Name == "p.example." {
+				refersToParent = true
+			}
+		}
+		if !refersToParent {
+			t.Fatalf("expected a referral to p.example.; authority=%v", resp.Ns)
+		}
+		if len(resp.Answer) != 0 {
+			t.Fatalf("a referral has no answer records; got %v", resp.Answer)
+		}
+	})
+
+	t.Run("child_only_refused", func(t *testing.T) {
+		// We host the child but no ancestor at all. The DS lives in a parent we
+		// don't host and there is nothing to refer to → REFUSED (never a NODATA
+		// that would deny parent-side data we don't own).
+		child := `lonely.example.	3600	IN	SOA	ns.lonely.example. hostmaster.lonely.example. 1 7200 1800 604800 7200
+lonely.example.	3600	IN	NS	ns.lonely.example.
+ns.lonely.example.	3600	IN	A	192.0.2.5
+`
+		childZd := testSnapshotZone(t, "lonely.example.", child)
+
+		rw := &fakeRW{}
+		if err := childZd.handleDSQuery(new(dns.Msg), rw, "lonely.example.", &edns0.MsgOptions{}, nil); err != nil {
+			t.Fatalf("handleDSQuery: %v", err)
+		}
+		resp := rw.written
+		if resp == nil || resp.MsgHdr.Rcode != dns.RcodeRefused {
+			t.Fatalf("want REFUSED, got %+v", resp)
+		}
+		if resp.MsgHdr.Authoritative {
+			t.Fatal("REFUSED must not set the AA bit")
+		}
+	})
+}

--- a/v2/queryresponder_edns_test.go
+++ b/v2/queryresponder_edns_test.go
@@ -49,7 +49,7 @@ www.example. 3600 IN A 10.0.0.2
 			t.Fatalf("ExtractFlagsAndEDNS0Options: %v", err)
 		}
 		rw := &fakeRW{}
-		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeA, msgo, kdb, nil); err != nil {
+		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeA, msgo, kdb); err != nil {
 			t.Fatalf("QueryResponder: %v", err)
 		}
 		if rw.written == nil {
@@ -115,7 +115,7 @@ www.example. 3600 IN A 10.0.0.2
 			t.Fatalf("ExtractFlagsAndEDNS0Options: %v", err)
 		}
 		rw := &fakeRW{}
-		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeNXNAME, msgo, kdb, nil); err != nil {
+		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeNXNAME, msgo, kdb); err != nil {
 			t.Fatalf("QueryResponder: %v", err)
 		}
 		resp := rw.written

--- a/v2/zone_snapshot_test.go
+++ b/v2/zone_snapshot_test.go
@@ -408,7 +408,7 @@ www.example. 3600 IN A 10.0.0.1
 		req := new(dns.Msg)
 		req.SetQuestion("www.example.", dns.TypeA)
 		rw := &fakeRW{}
-		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeA, msgo, nil, nil); err != nil {
+		if err := zd.QueryResponder(ctx, rw, req, "www.example.", dns.TypeA, msgo, nil); err != nil {
 			continue
 		}
 		resp := rw.written
@@ -484,7 +484,7 @@ www.broken.example. 3600 IN A 10.0.0.2
 	req := new(dns.Msg)
 	req.SetQuestion("www.broken.example.", dns.TypeA)
 	rw := &fakeRW{}
-	if err := zd.QueryResponder(ctx, rw, req, "www.broken.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+	if err := zd.QueryResponder(ctx, rw, req, "www.broken.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb); err != nil {
 		t.Fatalf("QueryResponder (DO): %v", err)
 	}
 	resp := rw.written
@@ -506,7 +506,7 @@ www.broken.example. 3600 IN A 10.0.0.2
 	req2 := new(dns.Msg)
 	req2.SetQuestion("www.broken.example.", dns.TypeA)
 	rw2 := &fakeRW{}
-	if err := zd.QueryResponder(ctx, rw2, req2, "www.broken.example.", dns.TypeA, &edns0.MsgOptions{}, kdb, nil); err != nil {
+	if err := zd.QueryResponder(ctx, rw2, req2, "www.broken.example.", dns.TypeA, &edns0.MsgOptions{}, kdb); err != nil {
 		t.Fatalf("QueryResponder (non-DO): %v", err)
 	}
 	if rw2.written == nil || rw2.written.MsgHdr.Rcode != dns.RcodeSuccess {
@@ -616,7 +616,7 @@ ns.broken-wild.example. 3600 IN A 10.0.0.1
 		req := new(dns.Msg)
 		req.SetQuestion("nothere.broken-wild.example.", dns.TypeA)
 		rw := &fakeRW{}
-		if err := zd.QueryResponder(ctx, rw, req, "nothere.broken-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+		if err := zd.QueryResponder(ctx, rw, req, "nothere.broken-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb); err != nil {
 			t.Fatalf("QueryResponder (DO wildcard): %v", err)
 		}
 		resp := rw.written
@@ -653,7 +653,7 @@ ns.signed-wild.example. 3600 IN A 10.0.0.1
 		req := new(dns.Msg)
 		req.SetQuestion("host.signed-wild.example.", dns.TypeA)
 		rw := &fakeRW{}
-		if err := zd.QueryResponder(ctx, rw, req, "host.signed-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+		if err := zd.QueryResponder(ctx, rw, req, "host.signed-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb); err != nil {
 			t.Fatalf("QueryResponder (DO signed wildcard): %v", err)
 		}
 		resp := rw.written
@@ -693,7 +693,7 @@ ns.plain-wild.example. 3600 IN A 10.0.0.1
 		req := new(dns.Msg)
 		req.SetQuestion("host.plain-wild.example.", dns.TypeA)
 		rw := &fakeRW{}
-		if err := zd.QueryResponder(ctx, rw, req, "host.plain-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb, nil); err != nil {
+		if err := zd.QueryResponder(ctx, rw, req, "host.plain-wild.example.", dns.TypeA, &edns0.MsgOptions{DO: true}, kdb); err != nil {
 			t.Fatalf("QueryResponder (DO unsigned wildcard): %v", err)
 		}
 		resp := rw.written

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -666,6 +666,24 @@ func FindZoneNG(qname string) *ZoneData {
 	return nil
 }
 
+// nearestHostedStrictAncestor returns the closest zone we host locally that is a
+// STRICT ancestor of qname (qname lies strictly below it), or nil if we host no
+// such zone. Unlike FindZone it never returns a zone whose apex equals qname.
+//
+// This is the parent-side lookup for DS queries: DS is authoritative in the zone
+// that DELEGATES to qname (RFC 4035 §3.1.4.1), never in qname's own zone, and it
+// must be resolved from the local Zones map — never via the recursive resolver.
+func nearestHostedStrictAncestor(qname string) *ZoneData {
+	labels := strings.Split(qname, ".")
+	// Start at i=1 so qname itself is excluded (strict ancestor only).
+	for i := 1; i < len(labels)-1; i++ {
+		if zd, ok := Zones.Get(strings.Join(labels[i:], ".")); ok {
+			return zd
+		}
+	}
+	return nil
+}
+
 // nextOutboundSerial returns the next SOA serial that should be advertised
 // to downstreams given zd.CurrentSerial and the configured outbound_soa_serial
 // mode:

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -666,24 +666,6 @@ func FindZoneNG(qname string) *ZoneData {
 	return nil
 }
 
-// nearestHostedStrictAncestor returns the closest zone we host locally that is a
-// STRICT ancestor of qname (qname lies strictly below it), or nil if we host no
-// such zone. Unlike FindZone it never returns a zone whose apex equals qname.
-//
-// This is the parent-side lookup for DS queries: DS is authoritative in the zone
-// that DELEGATES to qname (RFC 4035 §3.1.4.1), never in qname's own zone, and it
-// must be resolved from the local Zones map — never via the recursive resolver.
-func nearestHostedStrictAncestor(qname string) *ZoneData {
-	labels := strings.Split(qname, ".")
-	// Start at i=1 so qname itself is excluded (strict ancestor only).
-	for i := 1; i < len(labels)-1; i++ {
-		if zd, ok := Zones.Get(strings.Join(labels[i:], ".")); ok {
-			return zd
-		}
-	}
-	return nil
-}
-
 // nextOutboundSerial returns the next SOA serial that should be advertised
 // to downstreams given zd.CurrentSerial and the configured outbound_soa_serial
 // mode:


### PR DESCRIPTION
## The regression

On a server authoritative for **both** a parent (`pq.axfr.net`) and its children (`{alg}-{alg}.pq.axfr.net`), a DS query at a child apex was answered from the wrong place, and external validation SERVFAILed.

## Root cause

`handleDSQuery` had two branches:
- **Case 1** (host the parent, child is a plain delegation) — served the DS correctly.
- **Case 2** (`qname` == the apex of a zone we host) — walked up to the parent via `imr.ParentZone()`, i.e. a full **iterative SOA resolution from the root through the recursive resolver**.

When the server hosts the child as its *own* zone, the query exact-matches the child and **always** takes Case 2, which never consults the local `Zones` map that already holds the parent. In an isolated/self-referential testbed that recursion fails, and the fallback returned the **child's** SOA as NODATA — "looked in the child, found no DS."

Second, latent defect: on an auth server with `imrengine.active: false`, `conf.Internal.ImrEngine` is nil and that same path **panicked**.

## The fix

DS is parent-side data (RFC 4035 §3.1.4.1), so it is answered by the **nearest zone we host that is a strict ancestor of qname, resolved entirely from the local `Zones` map** — the resolver is never consulted. The two cases unify into one entry-zone-independent function driven by a single local delegation lookup:

| relationship | response |
|---|---|
| immediate parent (delegates directly to qname) | serve DS if present; else authenticated NODATA (compact NSEC: NS present, DS absent = insecure delegation) |
| grandparent only (delegates to qname's real parent, not hosted) | referral to that parent |
| we host qname but no ancestor | **REFUSED** — never a NODATA denying parent-side data we don't own |
| qname is ordinary in-zone data / nonexistent | plain NODATA / NXDOMAIN |

This also fixes the pre-existing Case 1, which returned NODATA instead of a referral when the only hosted ancestor was a grandparent.

`imr.ParentZone()` is **retained** — it is still correct for the outbound operations (childsync/DS-push, delegation-sync, scanner) that legitimately resolve a possibly-external parent. Only the query-answering path stops using it; the now-unused `imr` parameter is dropped from `QueryResponder`/`handleDSQuery`.

## Validation

- `v2/cli` … `v2`: `go vet` + `go test ./...` green.
- New `queryresponder_ds_test.go` covers the three delegation relationships + the no-ancestor REFUSED.
- **Live, end-to-end** against a signed parent+child on one `tdns-auth`:
  - `c.pq.example. DS +dnssec` → **DS + parent-key RRSIG, `aa` set** (was broken).
  - insecure delegation → parent-signed NSEC NODATA (`NS RRSIG NSEC`).
  - `pq.example. DS` (top hosted zone, parent not hosted) → **REFUSED**.
  - normal SOA/A serving and in-zone `DS` NODATA all correct.

## Open question (tracked separately)

The 2.3 no-ancestor case returns **REFUSED**; deployed BIND/NSD tend to return NODATA there. Johan is confirming the RFC-correct choice — it's a one-line change if we switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DS query handling by selecting the nearest hosted delegation ancestor.
  * DS queries now return appropriate authoritative answers, referrals, NODATA/NXDOMAIN responses, or refusal when no suitable hosted ancestor exists.
  * Preserved correct DNSSEC signing behavior for DS responses.
  * Updated EDNS and zone-query handling to maintain correct response metadata and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->