### PR TITLE
acl: reject bare-IP ip-specs; require an explicit prefix length

### DIFF
--- a/cmdv2/auth/auth-templates.sample.yaml
+++ b/cmdv2/auth/auth-templates.sample.yaml
@@ -230,9 +230,9 @@ templates:
         - addr: "192.0.2.2:53"
           key:  NOKEY
      downstreams:                        # ...and let them transfer
-        - prefix: "192.0.2.1"
+        - prefix: "192.0.2.1/32"         # single host — explicit mask required
           key:    NOKEY
-        - prefix: "192.0.2.2"
+        - prefix: "192.0.2.2/32"
           key:    NOKEY
      options:
         - delegation-sync-parent

--- a/cmdv2/auth/auth-zones.sample.yaml
+++ b/cmdv2/auth/auth-zones.sample.yaml
@@ -45,8 +45,10 @@
 # they guard: allow-notify: guards inbound NOTIFY on a secondary, downstreams:
 # guards outbound zone transfer on a primary.
 #
-# prefix — an ip-spec matched against the SOURCE address of the request:
-#     bare IP     192.0.2.1              ::1
+# prefix — an ip-spec matched against the SOURCE address of the request. It must
+# carry an explicit boundary; a bare IP (e.g. 192.0.2.1) is rejected — write a
+# single host as an explicit /32 or /128:
+#     single host 192.0.2.1/32           ::1/128
 #     CIDR        192.0.2.0/24           2001:db8::/32
 #     netmask     192.0.2.0&255.255.255.0
 #     range       192.0.2.10-192.0.2.20  2001:db8::10-2001:db8::20
@@ -95,9 +97,9 @@ zones:
         - addr: "192.0.2.2:53"     # And this one
           key:  NOKEY
      downstreams:                  # ...and let those same secondaries transfer
-        - prefix: "192.0.2.1"
+        - prefix: "192.0.2.1/32"    # single host — explicit mask required
           key:    NOKEY
-        - prefix: "192.0.2.2"
+        - prefix: "192.0.2.2/32"
           key:    NOKEY
      options:
         - delegation-sync-parent   # Provide delegation sync for children
@@ -117,9 +119,9 @@ zones:
         - addr: "203.0.113.2:53"
           key:  NOKEY
      allow-notify:                                           # Only these may NOTIFY us
-        - prefix: "203.0.113.1"
+        - prefix: "203.0.113.1/32"                            # single host — explicit mask required
           key:    NOKEY
-        - prefix: "203.0.113.2"
+        - prefix: "203.0.113.2/32"
           key:    NOKEY
      options:
         - delegation-sync-child    # Push DS/NS updates to parent
@@ -200,7 +202,8 @@ zones:
    # EXAMPLE 6: AXFR restricted by prefix, unsigned (IPv4 + IPv6)
    # ===========================================================================
    # Still NOKEY (no TSIG), but only from our own secondary networks. Note the
-   # mixed ip-spec forms: CIDR, a bare host address, and a range.
+   # mixed ip-spec forms: CIDR, an explicit single-host /32, and a range. A bare
+   # host address (203.0.113.7 with no /len) is rejected — write it as /32.
    - name:            prefix-acl.example.
      type:            primary
      zonefile:        /etc/tdns/zones/prefix-acl.example.zone
@@ -209,11 +212,11 @@ zones:
           key:    NOKEY
         - prefix: "2001:db8:1::/48"                  # IPv6 CIDR
           key:    NOKEY
-        - prefix: "203.0.113.7"                      # a single IPv4 host
+        - prefix: "203.0.113.7/32"                   # a single IPv4 host (explicit /32)
           key:    NOKEY
         - prefix: "2001:db8:2::10-2001:db8:2::1f"    # an IPv6 range
           key:    NOKEY
-        - prefix: "192.0.2.66"                       # ...but never this one:
+        - prefix: "192.0.2.66/32"                    # ...but never this one:
           key:    BLOCKED                            # BLOCKED beats every allow
 
    # ===========================================================================
@@ -244,7 +247,7 @@ zones:
           key:    xfr-key-2026
         - prefix: "2001:db8:1::/48"
           key:    xfr-key-2025
-        - prefix: "192.0.2.66"      # compromised host: denied even with a key
+        - prefix: "192.0.2.66/32"   # compromised host: denied even with a key
           key:    BLOCKED
      options:
         - online-signing
@@ -261,7 +264,7 @@ zones:
         - addr: "192.0.2.20:53"    # Notify secondaries about catalog changes
           key:  NOKEY
      downstreams:
-        - prefix: "192.0.2.20"
+        - prefix: "192.0.2.20/32"
           key:    NOKEY
      options:
         - catalog-zone                    # RFC 9432 catalog zone

--- a/guide/config-tdns-auth.md
+++ b/guide/config-tdns-auth.md
@@ -53,7 +53,7 @@ zones:
      downstreams:                                  # who may AXFR from us
         - prefix:  "127.0.0.0/8"
           key:     NOKEY
-        - prefix:  "::1"
+        - prefix:  "::1/128"                        # single host — explicit mask required
           key:     NOKEY
 ```
 
@@ -143,11 +143,14 @@ an empty prefix and quarantines the zone with `bad ip-spec ""`.
 
 ### The prefix field
 
-`prefix` is an ip-spec matched against the **source address** of the request:
+`prefix` is an ip-spec matched against the **source address** of the request. It
+must carry an explicit boundary — a bare address such as `192.0.2.1` is rejected
+with `add an explicit prefix length`; write a single host as an explicit `/32`
+(or `/128`):
 
 | Form | IPv4 | IPv6 |
 |------|------|------|
-| bare address | `192.0.2.1` | `::1` |
+| single host | `192.0.2.1/32` | `::1/128` |
 | CIDR | `192.0.2.0/24` | `2001:db8::/32` |
 | netmask | `192.0.2.0&255.255.255.0` | — |
 | range | `192.0.2.10-192.0.2.20` | `2001:db8::10-2001:db8::20` |
@@ -198,7 +201,7 @@ downstreams:
      key:    xfr-key-2026     # new key
    - prefix: "2001:db8:1::/48"
      key:    xfr-key-2025     # old key, still accepted during the overlap
-   - prefix: "192.0.2.66"
+   - prefix: "192.0.2.66/32"
      key:    BLOCKED          # denied even with a valid key
 ```
 

--- a/v2/acl.go
+++ b/v2/acl.go
@@ -17,9 +17,10 @@ import (
 const BLOCKED = "BLOCKED"
 
 // AclEntry is one entry in an allow-notify: / downstreams: address ACL (NSD
-// allow-notify / provide-xfr). Prefix is an ip-spec — a bare IP, CIDR
-// (1.2.3.4/24), mask (1.2.3.4&255.255.255.0), range (1.2.3.4-1.2.3.25), or
-// 0.0.0.0/0 / ::/0 for "any". Key is a keys.tsig name (TSIG required), NOKEY
+// allow-notify / provide-xfr). Prefix is an ip-spec — a CIDR (1.2.3.4/24, or
+// 1.2.3.4/32 for a single host), mask (1.2.3.4&255.255.255.0), range
+// (1.2.3.4-1.2.3.25), or 0.0.0.0/0 / ::/0 for "any". A bare IP is rejected;
+// write an explicit /32 (or /128). Key is a keys.tsig name (TSIG required), NOKEY
 // (unsigned accepted), or BLOCKED (deny). The struct shape matches PeerConf
 // ({addr, key}) so the config keeps one entry style.
 type AclEntry struct {
@@ -104,10 +105,11 @@ func ValidateACL(acl []AclEntry, keyDefined func(string) bool) error {
 	return nil
 }
 
-// parseIPSpec parses an ip-spec into either a netip.Prefix (CIDR / mask / bare-IP
-// host route) or a [lo, hi] netip.Addr range (isRange). lo/hi are Unmap'd and of
-// the same family. The string spellings a&m and a-b have no netip parser, so the
-// splitting is by hand; the addresses and matching are netip.
+// parseIPSpec parses an ip-spec into either a netip.Prefix (CIDR / mask) or a
+// [lo, hi] netip.Addr range (isRange). lo/hi are Unmap'd and of the same family.
+// A bare IP with no explicit boundary is rejected: a single host must be written
+// as an explicit /32 or /128 CIDR. The string spellings a&m and a-b have no netip
+// parser, so the splitting is by hand; the addresses and matching are netip.
 func parseIPSpec(spec string) (pfx netip.Prefix, lo, hi netip.Addr, isRange bool, err error) {
 	spec = strings.TrimSpace(spec)
 	switch {
@@ -158,12 +160,17 @@ func parseIPSpec(spec string) (pfx netip.Prefix, lo, hi netip.Addr, isRange bool
 		}
 		return pfx, loA, hiA, true, nil
 
-	default: // bare IP -> host route
+	default: // no explicit boundary — reject a bare IP
 		a, e := netip.ParseAddr(spec)
 		if e != nil {
 			return pfx, lo, hi, false, fmt.Errorf("bad ip-spec %q", spec)
 		}
+		// A single host must carry an explicit mask (/32 or /128); a bare address
+		// under a field called "prefix" is ambiguous, so require the boundary.
+		// BitLen is 32 for an (Unmap'd) IPv4 address and 128 for IPv6.
 		a = a.Unmap()
-		return netip.PrefixFrom(a, a.BitLen()), lo, hi, false, nil
+		return pfx, lo, hi, false, fmt.Errorf(
+			"bare address %q is not accepted; add an explicit prefix length, e.g. %q",
+			spec, fmt.Sprintf("%s/%d", spec, a.BitLen()))
 	}
 }

--- a/v2/acl_test.go
+++ b/v2/acl_test.go
@@ -153,9 +153,11 @@ func TestParseIPSpec_RejectsBareAddress(t *testing.T) {
 			t.Errorf("ValidateIPSpec(%q) = %v, want accepted", spec, err)
 		}
 	}
-	// A truly malformed spec keeps the "bad ip-spec" error, not the bare-address one.
-	if err := ValidateIPSpec("not-an-ip"); err == nil {
-		t.Error(`ValidateIPSpec("not-an-ip") = nil, want error`)
+	// A no-boundary token that isn't an address at all keeps the "bad ip-spec"
+	// parse error — distinct from the bare-address rejection above. ("not-an-ip"
+	// would route to the range branch via its hyphen, so use a separator-free token.)
+	if err := ValidateIPSpec("garbage"); err == nil || !strings.Contains(err.Error(), "bad ip-spec") {
+		t.Errorf(`ValidateIPSpec("garbage") = %v, want "bad ip-spec" error`, err)
 	}
 }
 

--- a/v2/acl_test.go
+++ b/v2/acl_test.go
@@ -2,6 +2,7 @@ package tdns
 
 import (
 	"net/netip"
+	"strings"
 	"testing"
 )
 
@@ -13,8 +14,9 @@ func TestIpSpecMatch(t *testing.T) {
 		ip   string
 		want bool
 	}{
-		{"192.0.2.1", "192.0.2.1", true},
-		{"192.0.2.1", "192.0.2.2", false},
+		{"192.0.2.1/32", "192.0.2.1", true},  // single host, explicit mask
+		{"192.0.2.1/32", "192.0.2.2", false}, // ...only that host
+		{"192.0.2.1", "192.0.2.1", false},    // bare IP is no longer a valid spec -> never matches
 		{"192.0.2.0/24", "192.0.2.55", true},
 		{"192.0.2.0/24", "192.0.3.1", false},
 		{"192.0.2.0&255.255.255.0", "192.0.2.99", true},
@@ -42,7 +44,7 @@ func TestMatchACL(t *testing.T) {
 		t.Error("empty ACL should deny")
 	}
 	acl := []AclEntry{
-		{Prefix: "192.0.2.5", Key: BLOCKED},           // deny this host
+		{Prefix: "192.0.2.5/32", Key: BLOCKED},        // deny this host
 		{Prefix: "192.0.2.0/24", Key: "transfer-key"}, // allow the /24 with key
 		{Prefix: "0.0.0.0/0", Key: NOKEY},             // catch-all, unsigned
 	}
@@ -84,7 +86,7 @@ func TestMatchACL_DualKey(t *testing.T) {
 func TestMatchACL_BlockedSupersedesLaterOrder(t *testing.T) {
 	acl := []AclEntry{
 		{Prefix: "192.0.2.0/24", Key: "k"},
-		{Prefix: "192.0.2.5", Key: BLOCKED}, // listed after the allow, still supersedes
+		{Prefix: "192.0.2.5/32", Key: BLOCKED}, // listed after the allow, still supersedes
 	}
 	if ok, _ := matchACL(acl, aclIP("192.0.2.5")); ok {
 		t.Error("BLOCKED should supersede a preceding allow")
@@ -119,8 +121,41 @@ func TestValidateACL(t *testing.T) {
 	if err := ValidateACL([]AclEntry{{Prefix: "garbage", Key: NOKEY}}, defined); err == nil {
 		t.Error("bad prefix accepted")
 	}
-	if err := ValidateACL([]AclEntry{{Prefix: "192.0.2.1", Key: "undefined"}}, defined); err == nil {
+	if err := ValidateACL([]AclEntry{{Prefix: "192.0.2.1/32", Key: "undefined"}}, defined); err == nil {
 		t.Error("unknown key accepted")
+	}
+}
+
+// TestParseIPSpec_RejectsBareAddress is the enforcement side of the deliberate
+// breaking change: a bare IP (no explicit boundary) is rejected, but an explicit
+// /32 or /128 — and the other spec forms — are still accepted.
+func TestParseIPSpec_RejectsBareAddress(t *testing.T) {
+	for _, spec := range []string{"192.0.2.7", "2001:db8::1"} {
+		err := ValidateIPSpec(spec)
+		if err == nil {
+			t.Errorf("ValidateIPSpec(%q) = nil, want a bare-address rejection", spec)
+			continue
+		}
+		if !strings.Contains(err.Error(), "explicit prefix length") {
+			t.Errorf("ValidateIPSpec(%q) error = %q, want it to mention an explicit prefix length", spec, err)
+		}
+	}
+	// The error suggests the family-correct mask (/32 for v4, /128 for v6).
+	if err := ValidateIPSpec("192.0.2.7"); err == nil || !strings.Contains(err.Error(), "192.0.2.7/32") {
+		t.Errorf("v4 bare address should suggest /32, got %v", err)
+	}
+	if err := ValidateIPSpec("2001:db8::1"); err == nil || !strings.Contains(err.Error(), "2001:db8::1/128") {
+		t.Errorf("v6 bare address should suggest /128, got %v", err)
+	}
+	// Explicit single-host masks and the other boundary forms still parse.
+	for _, spec := range []string{"192.0.2.7/32", "2001:db8::1/128", "192.0.2.0/24", "192.0.2.0&255.255.255.0", "192.0.2.10-192.0.2.20"} {
+		if err := ValidateIPSpec(spec); err != nil {
+			t.Errorf("ValidateIPSpec(%q) = %v, want accepted", spec, err)
+		}
+	}
+	// A truly malformed spec keeps the "bad ip-spec" error, not the bare-address one.
+	if err := ValidateIPSpec("not-an-ip"); err == nil {
+		t.Error(`ValidateIPSpec("not-an-ip") = nil, want error`)
 	}
 }
 


### PR DESCRIPTION
## What

`parseIPSpec` (the shared parser behind every ACL ip-spec — `downstreams:`,
`allow-notify:`, and any other ip-spec) now **rejects a bare IP address** and
requires an explicit boundary. A single host must be written with an explicit
mask (`/32` for IPv4, `/128` for IPv6).

Previously the `default` (no-separator) case accepted a bare address and
silently treated it as a `/32`/`/128` host route. The case now returns an
actionable error instead:

```
bare address "198.51.100.7" is not accepted; add an explicit prefix length, e.g. "198.51.100.7/32"
```

The suggested mask is computed from the address family (`/32` for v4, `/128`
for v6), so it is copy-pasteable for both. A truly unparseable spec still
returns the existing `bad ip-spec` error.

The other three forms already carry an explicit boundary and are **unchanged**:
CIDR (`/`), `ip&netmask` (`&`), and `lo-hi` ranges (`-`).

## Why

A bare IP under a field literally named `prefix` is ambiguous and easy to
misread. Explicit is better than a silently inferred mask.

## ⚠️ Deliberate breaking change

A bare-IP `downstreams:` / `allow-notify:` entry **no longer loads**. Operators
must add an explicit `/len` to any bare-IP ACL entry before reload; otherwise
the affected zone is quarantined at config time with the error above.

**Server addresses are not affected** — `primaries:` / `notify:` `addr:` values,
dial targets, and IP-validation paths do not go through `parseIPSpec`. Only
ACL/ip-spec prefixes change.

## Changes

- `v2/acl.go` — `parseIPSpec` `default` case rejects bare IPs; doc comments updated.
- `v2/acl_test.go` — existing bare-IP ACL cases moved to explicit masks; new
  `TestParseIPSpec_RejectsBareAddress` asserts the rejection, the family-correct
  suggestion, and that CIDR/`&netmask`/range still parse.
- `cmdv2/auth/auth-zones.sample.yaml`, `cmdv2/auth/auth-templates.sample.yaml`,
  `guide/config-tdns-auth.md` — bare-IP ACL examples converted to explicit
  `/32`/`/128` (CIDR shown alongside single hosts where useful); the ip-spec
  reference tables updated.

## Verification

- `gofmt -l` clean on changed Go files.
- `go build ./...` green in every module (`v2`, `v2/cli`, `v2/core`, `v2/cache`,
  `v2/edns0`, and the `cmdv2/{dog,cli,auth,agent,imr}` mains).
- `go test -race ./...` green for `v2`, including the new rejection test and the
  `sample_config_test.go` guard that re-validates every shipped sample ACL prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ACL entries now require an explicit prefix length for IP addresses.
  * Bare IPv4 and IPv6 addresses are rejected with guidance to use `/32` or `/128`.
  * Explicit single-host CIDRs, such as `192.0.2.1/32`, continue to work.
  * ACL validation now correctly rejects unknown keys for explicitly defined IP ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->