### PR TITLE
Dynamic primary zones: API-provisioned, template-constrained primaries

### DIFF
--- a/cmdv2/auth/auth-templates.sample.yaml
+++ b/cmdv2/auth/auth-templates.sample.yaml
@@ -49,6 +49,16 @@
 # set `template:` to inherit from another template; cycles are detected and
 # rejected.
 #
+# DYNAMIC-ZONE BLESSING: a template carrying `dynamiczones: true` may be
+# instantiated at runtime via the management API (tdns-cli auth zone add
+# --type primary --template <name>), provided dynamiczones.dynamic.allowed
+# includes "primary" in the main config. The flag marks the TEMPLATE as
+# API-instantiable and is never copied to zones. This is the security
+# envelope: an API client cannot express an update policy, it can only pick
+# among templates you bless here. A blessed template for a dynamic primary
+# must yield a zonefile (set a %s pattern) and must not use
+# allow-child-updates, catalog-*, or multi-provider options (refused in v1).
+#
 # ==============================================================================
 # COMPLETE LIST OF ZONE OPTIONS
 # ==============================================================================
@@ -249,3 +259,20 @@ templates:
      downstreams:
         - prefix: "2001:db8::/32"
           key:    NOKEY
+
+   # API-instantiable dynamic-primary template (see DYNAMIC-ZONE BLESSING
+   # above): `tdns-cli auth zone add -z <zone> --type primary --template
+   # api-primary` mints a primary with this exact configuration — a
+   # bootstrapped apex (SOA/NS/glue from dnsengine.addresses), updatable via
+   # DNS UPDATE per the update policy below, persisted across restarts.
+   - name:            api-primary
+     dynamiczones:    true                    # operator blessing (gate 2)
+     type:            primary
+     store:           map
+     zonefile:        /var/lib/tdns/zones/%szone
+     options:
+        - allow-updates
+     updatepolicy:
+        zone:
+           type:     selfsub
+           rrtypes:  [ TXT, A, AAAA ]

--- a/cmdv2/auth/tdns-auth.sample.yaml
+++ b/cmdv2/auth/tdns-auth.sample.yaml
@@ -9,7 +9,11 @@
 include:
    - auth-templates.sample.yaml          # Zone templates (rename to .yaml when deploying)
    - auth-zones.sample.yaml              # Zone declarations (rename to .yaml when deploying)
-   - /var/lib/tdns/dynamic-zones.yaml    # Dynamic zones (auto-managed, don't edit manually)
+   # NOTE: do NOT include the dynamiczones configfile here. Dynamic zones are
+   # loaded at startup on their own (with their API-managed/catalog markers);
+   # including the file would route them through the static zone parser (which
+   # drops the markers) and its zones: list would OVERRIDE the zones: of the
+   # other included files (include merges replace list-valued keys).
 
 service:
    name:              TDNS-AUTH
@@ -489,7 +493,8 @@ catalog:
 # catalog member zones, and API-created zones).
 dynamiczones:
    # Absolute path to YAML file where dynamic zone configs are stored.
-   # This file should be included in the 'include:' section above.
+   # Loaded automatically at startup — do NOT add it to include: (see the
+   # note in the include: section above).
    # Server must have write access to this file.
    configfile:     /var/lib/tdns/dynamic-zones.yaml
 
@@ -507,9 +512,14 @@ dynamiczones:
       allowed:  true             # Whether catalog member zones are allowed
       storage:  persistent       # "memory" or "persistent" - default: "memory"
 
-   # Configuration for direct API-created zones (future feature)
+   # Configuration for direct API-created zones (zone add/delete/modify).
+   # allowed: is a LIST of zone types the API may create — secondary
+   # (transfer-provisioned) and/or primary (template-provisioned; the
+   # template must carry dynamiczones: true, see auth-templates.sample.yaml).
+   # Absent/empty means deny all. NOTE: the pre-2026-07 bool form
+   # (allowed: true/false) is a hard config error naming this syntax.
    dynamic:
-      allowed:  false            # Whether direct API-created zones are allowed (default: false)
+      allowed:  [ ]              # e.g. [ secondary ] or [ secondary, primary ]
       storage:  memory           # "memory" or "persistent" - default: "memory"
 
 db:

--- a/docs/2026-07-13-dynamic-primary-zones.md
+++ b/docs/2026-07-13-dynamic-primary-zones.md
@@ -434,7 +434,40 @@ is shared with the secondary path; only the rewiring target differs
 (static zones keep their existing direct-assignment path in `ParseZones` —
 untouched).
 
-### 11.10 Delivery shape
+### 11.10 Found live: query-handler registration on a zone-less server
+
+The live smoke run (add → serve on a config with `zones:` empty) exposed a
+pre-existing latent bug affecting ALL dynamic zones, not just primaries:
+`RegisterDefaultQueryHandlers` only registered the zone-based query handler
+when the config had static zones at boot, so a zone-less server — exactly the
+self-service deployment this feature targets — REFUSEd every query for
+dynamically added zones. Fixed: the handler also registers when dynamic zones
+are possible (`dynamiczones.configfile` set, or a non-empty
+`dynamic.allowed`). Testbeds never saw this because they always carry static
+zones.
+
+Relatedly, `CheckDynamicConfigFileIncluded` warned in the WRONG direction
+("not included via include: — dynamic zones will not be loaded on startup"),
+a leftover from before `LoadDynamicZoneFiles` owned the boot path. It now
+warns when the dynamic config file IS in `include:` (which would drop the
+API-managed/catalog markers via ParseZones and clobber other files' `zones:`
+lists through the include merge's list-override). The sample config no longer
+lists the dynamic file under `include:`.
+
+### 11.11 Live validation (2026-07-24)
+
+Smoke-validated end-to-end on a freshly built tdns-auth with an empty
+`zones:` list: `zone add --type primary --template api-primary` → bootstrap
+apex synthesized → SOA/NS/glue served; unsigned DNS UPDATE refused; restart →
+`LoadDynamicZoneFiles` re-expanded the template (policy re-derived, zone
+Ready and still update-gated); `zone delete` → RCODE back to REFUSED, zone
+file removed, dynamic config entry gone. Gate matrix, bootstrap edge cases,
+TSIG rewiring, and the activation helper are covered by unit tests
+(`dynamic_primary_test.go`, `dynamic_zones_gates_test.go`,
+`update_policy_activation_test.go`); full `-race` suites green in all five
+modules.
+
+### 11.12 Delivery shape
 
 Implemented as ONE branch/PR (`feature/dynamic-primary-zones`) with commits
 sequenced per §10.4's PR1→PR4 stages, because the owner asked for a single

--- a/docs/2026-07-13-dynamic-primary-zones.md
+++ b/docs/2026-07-13-dynamic-primary-zones.md
@@ -1,9 +1,11 @@
 # Dynamic primary zones — API-provisioned, template-constrained
 
 **Date:** 2026-07-13
-**Status:** DESIGN — agreed in discussion. **Sequenced after
-`feature/zone-snapshot-correctness` merges** (see §8); implementation must build
-on the post-snapshot world.
+**Status:** IMPLEMENTED on `feature/dynamic-primary-zones` (2026-07-24, PR
+pending). §2 was re-verified against main @ `7885f23` before implementation;
+claims that had drifted are corrected in place and every design fork resolved
+during the (owner-AFK) implementation is recorded in §11. The §8 sequencing
+precondition (snapshot-correctness merge) was satisfied 2026-07-15 (`965df6f`).
 **Companion:** `2026-07-13-tdns-debug-test-tool.md` — whose provisioning stage
 (§6.3 there) is the immediate consumer; this feature turns its
 "operator installs zone + config" step into a fully automated
@@ -38,16 +40,29 @@ The striking finding is how little is missing:
   options unioned, and `Zonefile` as a `%s`-pattern substituted with the zone
   name (traversal-guarded) — built for stamping out many zones from one
   declaration.
-- **Restart already works.** The dynamic config file is pulled in via
-  `include:` and parsed by the normal `ParseZones` at boot — the same path
-  that performs template expansion and update-policy activation (including
-  `OptAllowUpdates`) for static zones. Persist `type: primary` +
-  `template: <name>` in the dynamic entry and a restarted server rebuilds the
-  zone with full policy through existing code. (Today `zoneDataToZoneConf`
-  does not serialize `Template` — a one-field addition, §5.)
-- **Dirty-primary machinery exists.** `OptDirty` blocks reload of a modified
-  primary; the refresh engine's zone-file write-back covers persistable
-  (API-managed, B5a) zones with the B5b `zoneStillLive` guards.
+- **Restart mostly works — but through `LoadDynamicZoneFiles`, not
+  `include:`+`ParseZones`.** *(Corrected 2026-07-24; the original claim had
+  drifted.)* Since B5a, the canonical boot path for dynamic zones is
+  `LoadDynamicZoneFiles` (called from StartAuth/StartAgent after the
+  RefreshEngine is up): it re-derives the `ApiManaged`/`SourceCatalog`
+  markers, validates persisted ACLs, and enqueues file-load refreshers. The
+  `include:` route still exists but is NOT the mechanism to build on: the
+  include merge *overrides* list-valued keys, so an included dynamic file
+  carrying `zones:` clobbers the `zones:` of any other config file, and the
+  `ParseZones` path would drop the `ApiManaged` marker (it is re-derived only
+  in `LoadDynamicZoneFiles`). Consequence: boot-time template re-expansion +
+  update-policy activation for dynamic primaries must be added to
+  `LoadDynamicZoneFiles` (§11.1) — small, and it reuses the same shared
+  helper as the add path, so the two cannot drift. (`zoneDataToZoneConf` not
+  serializing `Template` remains a one-field addition, §5.)
+- **Dirty-primary machinery exists, with one persistence gap.** `OptDirty`
+  blocks reload of a modified primary, and the refresh engine's zone-file
+  write-back covers persistable (API-managed, B5a) zones with the B5b
+  `zoneStillLive` guards — but that write-back only runs on a *refresh*, and
+  a dirty primary refuses refresh, so RFC 2136 ZONE-UPDATE content was never
+  auto-persisted (only `freeze`, the `zone write` API, and the CHILD-UPDATE
+  `direct` backend wrote the file). An update-time write-back for
+  API-managed primaries closes this (§11.4).
 
 What is genuinely new is only the **add path** (§4) and the **gates** (§3).
 
@@ -71,16 +86,21 @@ What is genuinely new is only the **add path** (§4) and the **gates** (§3).
 
    ```yaml
    templates:
-     churn-test:
+     - name: churn-test
        dynamiczones: true
-       zonefile: /var/tdns/dynamic/%s.zone
-       update-policy:
+       type: primary
+       zonefile: /var/tdns/dynamic/%szone   # %s includes the trailing dot
+       updatepolicy:
          zone:
            type: selfsub   # signer key _churn.<id>.<zone> owns names under itself
            rrtypes: [ TXT ]
        downstreams:
          - { prefix: 127.0.0.1/32, key: NOKEY }
    ```
+
+   *(Example corrected 2026-07-24: `templates:` is a LIST with per-entry
+   `name:`, the key is `updatepolicy:` not `update-policy:`, and the
+   `zonefile:` `%s` substitution includes the zone's trailing dot.)*
 
    (Named `dynamiczones:`, not `dynamic:` — it is the *zones using* the
    template that are dynamic, not the template.) A template without the flag
@@ -304,3 +324,119 @@ remains reads mechanical, and most of §10.2 genuinely is. But three items
 carry real regression risk (E, the snapshot-integration of C, the gate
 cutover), and the acceptance surface (§9) is broad. Net: **a medium feature,
 ~3–5 focused sessions — not an afternoon, and not a large project either.**
+
+---
+
+## 11. Implementation decisions (2026-07-24, `feature/dynamic-primary-zones`)
+
+The owner was AFK during implementation; each open fork was resolved with the
+minimal option consistent with this document's direction and the existing
+dynamic-secondary / peers / keystore patterns. Recorded here with rationale.
+
+### 11.1 Boot path: re-expansion in `LoadDynamicZoneFiles`, not `include:`
+
+Per the corrected §2: the persisted dynamic entry carries `type: primary` +
+`template:` (+ the materialized `zonefile:`/ACLs/options), and
+`LoadDynamicZoneFiles` re-expands the template and re-activates the update
+policy at boot through the SAME shared helper the add path uses
+(`prepareDynamicPrimary`), then enqueues a file-load refresher. The
+gap-fill semantics the original design counted on still hold: the persisted
+(materialized) fields win over the template's. A dynamic-primary entry whose
+template has been *removed* from config registers an error-state zone
+(visible in `zone list`, not silently skipped) — the §5 "missing template ⇒
+ERROR state" behavior, now explicit in the load path. `include:`-ing the
+dynamic config file remains possible but is not required and not the
+supported restart mechanism for primaries.
+
+### 11.2 v1 restrictions on what a blessed template may express
+
+- **`allow-child-updates` is refused** for dynamic primaries. Child updates
+  require a wired delegation backend; backend wiring lives in `ParseZones`
+  only, so an API-added zone (and a `LoadDynamicZoneFiles`-restored one)
+  would carry the option with a nil backend — the exact "silently misbehaving
+  scanner" state the static path refuses to start. Zone-scope
+  `allow-updates` (the driving use case) is fully supported. Revisit if a
+  real need appears.
+- **`catalog-zone`, `catalog-member-auto-*`, and `multi-provider` options
+  are refused** — different machinery with its own provisioning paths.
+- **Store must be `map`** (template `store:` of anything else is refused) —
+  the existing dynamic-zones map-only chokepoint, kept loud.
+- **The template's own `type:` must be `primary` or unset** when used for a
+  primary add; the expanded config's type always comes from the request.
+- **The expanded config must yield a `zonefile:`** (the template carries the
+  `%s` pattern); a primary with no file has nothing to load or persist.
+- **An unusable `dnssecpolicy:`** (unknown/broken policy reference) refuses
+  the add rather than minting an unsigned zone (ParseZones quarantines
+  instead; for an API request the refusal IS the quarantine-equivalent, and
+  fail-loud beats silently serving unsigned).
+
+### 11.3 Modify: refused for primaries (as designed in §5)
+
+`ModifyDynamicZone` rejects `ZoneType == Primary` with a pointer at the
+supported channels (DNS UPDATE for content, keystore API for keys,
+delete + re-add for config).
+
+### 11.4 Content persistence: update-time write-back
+
+RFC 2136 ZONE-UPDATEs on an API-managed primary now persist the zone file
+immediately after a successful apply (`WriteZone(tosource)` — the exact
+mirror of the CHILD-UPDATE `direct`-backend persist, and scoped to
+`OptApiManagedZone` primaries so no existing zone class changes behavior).
+This closes the §2 gap: without it, updated content lived only in RAM until
+a freeze/manual write, and "restart → content survives" (§9) failed.
+
+### 11.5 Zone-file path handling for template-pattern files
+
+- `zoneDataToZoneConf` now serializes `zd.Zonefile` when set (falling back
+  to the `<zonedirectory>/<zone>zone` derivation) plus `zd.Template` and the
+  real zone type. Previously it unconditionally derived the path from
+  `zonedirectory:`, which would silently re-point a template-pattern primary
+  (e.g. `/etc/tdns/zones/%szone`) at the wrong file on the next persist.
+  For every existing dynamic-zone class the two paths coincide, so this is
+  behavior-neutral outside the new feature.
+- `RemoveDynamicZone` additionally best-effort removes `zd.Zonefile` (the
+  template-expanded path) — an API-managed primary is disposable by
+  construction (§5); previously only the `zonedirectory:`-derived path was
+  removed.
+
+### 11.6 Concurrency: template access under `confMu`
+
+The add path copies the template out of the global `Templates` map under
+`confMu.RLock()` (the map is wholesale-replaced by template reload under
+`confMu.Lock()`; entries are never mutated in place, so a copied entry is
+safe to use after release). Matches the list-zones handler's locking
+convention.
+
+### 11.7 Gate 1 mechanics (bool → list cutover)
+
+`dynamiczones.dynamic:` gets its own config type (`DynamicApiZoneConf`) so
+the cutover does not touch the catalog structs that share the old
+`DynamicZoneTypeConf`. The `allowed:` field decodes via a dedicated
+mapstructure hook that turns a legacy bool into a hard config error naming
+the new syntax (`allowed: [secondary]`), wired into BOTH decode chains (the
+daemon loader and `config check`/`ValidateConfig`) so the checker and the
+daemon cannot disagree. Unknown list values are a hard config error.
+Absent/empty list ⇒ deny all (unchanged default posture).
+
+### 11.8 Inline TSIG on a primary add
+
+As §4: the staged key is applied to every keyless (`""`/`NOKEY`)
+`downstreams:` entry of the *expanded* config — `BLOCKED` entries are never
+rewired — and the rewired ACL is persisted with the zone, so boot
+re-expansion preserves it by gap-fill. The staging/commit/rollback machinery
+is shared with the secondary path; only the rewiring target differs
+(`AclEntry` downstreams vs `PeerConf` primaries).
+
+### 11.9 Publish cadence
+
+`ZoneRefresher` gains a parsed `PublishCadence` field so a template's
+`publish-cadence:` reaches dynamic zones on both the add and boot paths
+(static zones keep their existing direct-assignment path in `ParseZones` —
+untouched).
+
+### 11.10 Delivery shape
+
+Implemented as ONE branch/PR (`feature/dynamic-primary-zones`) with commits
+sequenced per §10.4's PR1→PR4 stages, because the owner asked for a single
+reviewable PR end-to-end. The §10.4 split remains the right review order —
+the commits follow it.

--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -222,6 +222,12 @@ type ZonePost struct {
 	// strings.
 	Primaries []PeerConf
 	Options   []string
+	// ZoneType selects what `zone add` creates: "secondary" (the default) or
+	// "primary" (template-provisioned). Template names the operator-blessed
+	// (dynamiczones: true) template a primary is expanded from — REQUIRED for
+	// primaries, unused for secondaries.
+	ZoneType string
+	Template string
 	// Inline TSIG key for the add/modify: when TsigName is set the server upserts
 	// {name, algo, secret} into its keys: store, points keyless primaries at it,
 	// and persists it with the zone (survives restart). TsigAlgo defaults to

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -214,9 +214,21 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			resp.Zones = zones
 
 		case "add":
+			zoneType := Secondary
+			switch strings.ToLower(zp.ZoneType) {
+			case "", "secondary":
+				// default
+			case "primary":
+				zoneType = Primary
+			default:
+				resp.Error = true
+				resp.ErrorMsg = fmt.Sprintf("unknown zone type %q (valid: primary, secondary)", zp.ZoneType)
+				return
+			}
 			msg, err := Conf.ProvisionDynamicZone(r.Context(), DynamicZoneInput{
 				Name:       zp.Zone,
-				Type:       Secondary,
+				Type:       zoneType,
+				Template:   zp.Template,
 				Primaries:  zp.Primaries,
 				Options:    zoneOptionsFromStrings(zp.Options),
 				TsigName:   zp.TsigName,

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -206,25 +206,42 @@ States: update-unsupported / ready / foreign-key / waiting-for-key.`,
 	// flag: dynamic zones are map-only. The --tsig-* flags are accepted now but
 	// inert in Improvement 1 (a non-NOKEY key is rejected server-side).
 	var dzPrimaryKey, dzTsigName, dzTsigSecret, dzTsigSecretFile, dzTsigAlgo string
+	var dzZoneType, dzTemplate string
 	var dzPrimaries, dzOptions []string
 
 	add := &cobra.Command{
 		Use:   "add",
-		Short: "Add a dynamic secondary zone at runtime (persists across restart)",
+		Short: "Add a dynamic zone at runtime: secondary, or template-constrained primary (persists across restart)",
 		Run: func(cmd *cobra.Command, args []string) {
-			RunZoneAdd(role, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigSecretFile, dzTsigAlgo)
+			// --primaries is required for secondaries (the pre-primary
+			// MarkFlagRequired behavior) and refused server-side for
+			// primaries; --template is required for primaries.
+			switch strings.ToLower(dzZoneType) {
+			case "", "secondary":
+				if len(dzPrimaries) == 0 {
+					fmt.Println("Error: a secondary zone requires --primaries")
+					os.Exit(1)
+				}
+			case "primary":
+				if dzTemplate == "" {
+					fmt.Println("Error: a primary zone requires --template (an operator-blessed template with dynamiczones: true)")
+					os.Exit(1)
+				}
+			}
+			RunZoneAdd(role, dzZoneType, dzTemplate, dzPrimaries, dzPrimaryKey, dzOptions, dzTsigName, dzTsigSecret, dzTsigSecretFile, dzTsigAlgo)
 		},
 	}
 	add.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to add")
-	add.Flags().StringSliceVar(&dzPrimaries, "primaries", nil, "Primary (upstream) addresses [host:port], comma-separated")
+	add.Flags().StringVar(&dzZoneType, "type", "secondary", "Zone type: secondary (default) or primary (requires --template)")
+	add.Flags().StringVar(&dzTemplate, "template", "", "Config template for a primary zone (must carry dynamiczones: true)")
+	add.Flags().StringSliceVar(&dzPrimaries, "primaries", nil, "Primary (upstream) addresses [host:port], comma-separated (secondary zones)")
 	add.Flags().StringVar(&dzPrimaryKey, "primary-key", tdns.NOKEY, "Primary TSIG key name applied to all primaries (NOKEY for none)")
-	add.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated)")
-	add.Flags().StringVar(&dzTsigName, "tsig-name", "", "Inline TSIG key name; created in keystore if absent and applied to keyless primaries")
+	add.Flags().StringSliceVar(&dzOptions, "options", nil, "Zone options (comma-separated; secondary zones — primaries take options from the template)")
+	add.Flags().StringVar(&dzTsigName, "tsig-name", "", "Inline TSIG key name; created in keystore if absent and applied to keyless primaries (secondary) or keyless downstreams (primary)")
 	add.Flags().StringVar(&dzTsigSecretFile, "tsig-secret-file", "", "File containing the inline TSIG secret (base64); preferred over --tsig-secret")
 	add.Flags().StringVar(&dzTsigSecret, "tsig-secret", "", "Inline TSIG secret (base64). WARNING: visible in shell history / process list; prefer --tsig-secret-file")
 	add.Flags().StringVar(&dzTsigAlgo, "tsig-algo", "", "Inline TSIG algorithm (default hmac-sha256)")
 	add.MarkFlagRequired("zone")
-	add.MarkFlagRequired("primaries")
 
 	del := &cobra.Command{
 		Use:   "delete",
@@ -584,7 +601,7 @@ func resolveTsigSecret(literal, file string) (string, error) {
 	return strings.TrimSpace(string(b)), nil
 }
 
-func RunZoneAdd(role string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigSecretFile, tsigAlgo string) {
+func RunZoneAdd(role, zoneType, template string, primaries []string, primaryKey string, options []string, tsigName, tsigSecret, tsigSecretFile, tsigAlgo string) {
 	if tdns.Globals.Zonename == "" {
 		fmt.Println("Error: zone name not specified")
 		os.Exit(1)
@@ -601,6 +618,8 @@ func RunZoneAdd(role string, primaries []string, primaryKey string, options []st
 	cr, err := SendZoneCommand(api, tdns.ZonePost{
 		Command:    "add",
 		Zone:       dns.Fqdn(tdns.Globals.Zonename),
+		ZoneType:   zoneType,
+		Template:   template,
 		Primaries:  peerConfsFromAddrs(primaries, primaryKey),
 		Options:    options,
 		TsigName:   tsigName,

--- a/v2/config.go
+++ b/v2/config.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -444,13 +445,54 @@ type DynamicZonesConf struct {
 	ZoneDirectory  string                   `yaml:"zonedirectory" mapstructure:"zonedirectory"`     // Absolute path to zone file directory
 	CatalogZones   DynamicZoneTypeConf      `yaml:"catalog_zones" mapstructure:"catalog_zones"`     // Configuration for catalog zones
 	CatalogMembers DynamicCatalogMemberConf `yaml:"catalog_members" mapstructure:"catalog_members"` // Configuration for catalog member zones
-	Dynamic        DynamicZoneTypeConf      `yaml:"dynamic" mapstructure:"dynamic"`                 // Configuration for direct API-created zones (future)
+	Dynamic        DynamicApiZoneConf       `yaml:"dynamic" mapstructure:"dynamic"`                 // Configuration for direct API-created zones
 }
 
 // DynamicZoneTypeConf defines configuration for a type of dynamic zone
 type DynamicZoneTypeConf struct {
 	Allowed bool   `yaml:"allowed" mapstructure:"allowed"`                                              // Whether this type of zone is allowed
 	Storage string `yaml:"storage" mapstructure:"storage" validate:"omitempty,oneof=memory persistent"` // "memory" or "persistent"
+}
+
+// ZoneTypeList is the value of dynamiczones.dynamic.allowed: the zone types
+// ("primary", "secondary") that may be created via the zone-add API. A named
+// type so legacyDynamicAllowedHook can target exactly this field and turn a
+// legacy bool value into a config error naming the new syntax.
+type ZoneTypeList []string
+
+// DynamicApiZoneConf defines configuration for direct API-created zones
+// (zone add/delete/modify). Unlike the catalog blocks (DynamicZoneTypeConf,
+// still bool-gated), the API gate is a LIST of allowed zone types — the
+// dynamic-primary extension made "allowed" two independent capabilities.
+// Absent/empty list means deny all.
+type DynamicApiZoneConf struct {
+	Allowed ZoneTypeList `yaml:"allowed" mapstructure:"allowed"`                                              // Zone types the API may create: primary, secondary
+	Storage string       `yaml:"storage" mapstructure:"storage" validate:"omitempty,oneof=memory persistent"` // "memory" or "persistent"
+}
+
+// Allows reports whether the API may create zones of type zt.
+func (c DynamicApiZoneConf) Allows(zt ZoneType) bool {
+	want := ZoneTypeToString[zt]
+	for _, t := range c.Allowed {
+		if strings.EqualFold(strings.TrimSpace(t), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate checks the dynamiczones: block for values the decoder accepts but
+// the code does not. Called from both the daemon loader (ParseConfig) and
+// `config check` (ValidateConfig) so the two cannot disagree.
+func (d *DynamicZonesConf) Validate() error {
+	for _, t := range d.Dynamic.Allowed {
+		switch strings.ToLower(strings.TrimSpace(t)) {
+		case "primary", "secondary":
+		default:
+			return fmt.Errorf("dynamiczones.dynamic.allowed: unknown zone type %q (valid values: primary, secondary)", t)
+		}
+	}
+	return nil
 }
 
 // DynamicCatalogMemberConf defines configuration for catalog member zones (includes add/remove policy)

--- a/v2/config_validate.go
+++ b/v2/config_validate.go
@@ -39,6 +39,7 @@ func ValidateConfig(v *viper.Viper, cfgfile string) error {
 		mapstructure.StringToSliceHookFunc(","),
 		stringToPeerConfHook(),
 		stringToAclEntryHook(),
+		legacyDynamicAllowedHook(),
 	))
 	if v == nil {
 		if err := viper.Unmarshal(&config, decodeHook); err != nil {
@@ -48,6 +49,12 @@ func ValidateConfig(v *viper.Viper, cfgfile string) error {
 		if err := v.Unmarshal(&config, decodeHook); err != nil {
 			return fmt.Errorf("ValidateConfig: Unmarshal error: %v", err)
 		}
+	}
+
+	// Same dynamiczones: value validation the daemon loader applies
+	// (ParseConfig), so `config check` and the daemon cannot disagree.
+	if err := config.DynamicZones.Validate(); err != nil {
+		return fmt.Errorf("ValidateConfig: %v", err)
 	}
 
 	var configsections = make(map[string]interface{}, 5)

--- a/v2/defaultqueryhandlers.go
+++ b/v2/defaultqueryhandlers.go
@@ -178,14 +178,20 @@ func DefaultQueryHandler(ctx context.Context, req *DnsQueryRequest) error {
 
 // RegisterDefaultQueryHandlers registers the default zone-based query handler.
 // This is called automatically during TDNS initialization.
-// The default handler is registered if (a) zones are configured in the config, or
-// (b) app type is Agent (agent gets an autozone from SetupAgent, needed for SOA/AXFR).
+// The default handler is registered if (a) zones are configured in the config,
+// (b) app type is Agent (agent gets an autozone from SetupAgent, needed for
+// SOA/AXFR), or (c) dynamic zones can appear at runtime (persisted dynamic
+// config, or API zone-adds allowed) — a zone-less server that mints its first
+// zone via `zone add` must not REFUSE its queries.
 // Apps that need .server. query support should register ServerQueryHandler themselves.
 func RegisterDefaultQueryHandlers(conf *Config) error {
 	// Register default query handler if we will have zones to serve:
 	// - zones in config (auth, combiner, etc.), or
 	// - agent (autozone is created later in SetupAgent; handler will serve SOA/AXFR at query time)
-	needDefault := conf != nil && (len(conf.Zones) > 0 || Globals.App.Type == AppTypeAgent)
+	// - dynamic zones possible: persisted dynamic zones load at startup
+	//   (LoadDynamicZoneFiles) and API adds create zones at runtime
+	needDefault := conf != nil && (len(conf.Zones) > 0 || Globals.App.Type == AppTypeAgent ||
+		conf.DynamicZones.ConfigFile != "" || len(conf.DynamicZones.Dynamic.Allowed) > 0)
 	if needDefault {
 		if err := RegisterQueryHandler(0, DefaultQueryHandler); err != nil {
 			return err

--- a/v2/dynamic_primary.go
+++ b/v2/dynamic_primary.go
@@ -285,6 +285,21 @@ func (conf *Config) synthesizeBootstrapZonefile(zone, path string) error {
 		os.Remove(tempFilePath)
 		return fmt.Errorf("failed to write temp file: %v", err)
 	}
+	// Fsync before rename: without it a crash can leave a correctly-named but
+	// empty zonefile, which the boot path would load as an empty primary.
+	if err := tempFile.Sync(); err != nil {
+		tempFile.Close()
+		os.Remove(tempFilePath)
+		return fmt.Errorf("failed to sync temp file: %v", err)
+	}
+	// os.CreateTemp yields 0600; the UPDATE write-back (WriteZone → WriteFile
+	// → os.Create) produces 0644, so set 0644 up front rather than having the
+	// mode flip on the first update.
+	if err := tempFile.Chmod(0644); err != nil {
+		tempFile.Close()
+		os.Remove(tempFilePath)
+		return fmt.Errorf("failed to chmod temp file: %v", err)
+	}
 	if err := tempFile.Close(); err != nil {
 		os.Remove(tempFilePath)
 		return fmt.Errorf("failed to close temp file: %v", err)
@@ -397,6 +412,9 @@ func (conf *Config) provisionDynamicPrimary(ctx context.Context, in DynamicZoneI
 			}
 		})
 	}
+	// SetupZoneSync's delegation-sync-child path does an unbounded send to
+	// DelegationSyncQ, and OnFirstLoad callbacks run inside the RefreshEngine
+	// loop — dispatch async so a full/stopped consumer cannot stall it.
 	if options[OptDelSyncParent] || options[OptDelSyncChild] {
 		delegationSyncQ := conf.Internal.DelegationSyncQ
 		zd.OnFirstLoad = append(zd.OnFirstLoad, func(z *ZoneData) {
@@ -404,9 +422,11 @@ func (conf *Config) provisionDynamicPrimary(ctx context.Context, in DynamicZoneI
 				lg.Error("DelegationSyncQ not available", "zone", z.ZoneName)
 				return
 			}
-			if err := z.SetupZoneSync(delegationSyncQ); err != nil {
-				lg.Error("SetupZoneSync failed", "zone", z.ZoneName, "error", err)
-			}
+			go func() {
+				if err := z.SetupZoneSync(delegationSyncQ); err != nil {
+					lg.Error("SetupZoneSync failed", "zone", z.ZoneName, "error", err)
+				}
+			}()
 		})
 	}
 
@@ -445,6 +465,11 @@ func (conf *Config) provisionDynamicPrimary(ctx context.Context, in DynamicZoneI
 		Force:          true, // load from file regardless of serial
 	}
 	if err := conf.enqueueRefresh(ctx, zr); err != nil {
+		// Mark the registered-but-unscheduled zone so list-dynamic shows a
+		// visible error instead of an indefinite "provisioning" (the boot
+		// path registers an error state for its analogous failure).
+		// RefreshError is deliberately not service-impacting.
+		zd.SetError(RefreshError, "initial load not scheduled: %v", err)
 		return "", fmt.Errorf("zone %s registered but failed to schedule initial load: %w", name, err)
 	}
 

--- a/v2/dynamic_primary.go
+++ b/v2/dynamic_primary.go
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Dynamic PRIMARY zones: API-provisioned, template-constrained primaries
+ * (docs/2026-07-13-dynamic-primary-zones.md). The template is the security
+ * envelope: an API client cannot express an update policy at all, it can only
+ * pick among operator-blessed configurations.
+ */
+
+package tdns
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+
+	core "github.com/johanix/tdns/v2/core"
+)
+
+// dynamicPrimarySpec is the validated result of expanding a dynamic-primary
+// zone config against its template: everything the add path (and the boot
+// re-expansion in LoadDynamicZoneFiles) needs to build the zone.
+type dynamicPrimarySpec struct {
+	Zconf          ZoneConf            // fully expanded + validated config
+	Options        map[ZoneOption]bool // parsed zone options (policy-adjusted)
+	Policy         UpdatePolicy        // activated update policy
+	PublishCadence time.Duration       // parsed publish-cadence (0 = default)
+}
+
+// dynamicPrimaryDisallowedOptions are template options that name machinery a
+// dynamic primary must not participate in (v1): catalogs have their own
+// provisioning paths and multi-provider zones their own signing model.
+var dynamicPrimaryDisallowedOptions = map[ZoneOption]bool{
+	OptCatalogZone:             true,
+	OptCatalogMemberAutoCreate: true,
+	OptCatalogMemberAutoDelete: true,
+	OptMultiProvider:           true,
+}
+
+// lookupZoneTemplate copies a template out of the global Templates map under
+// confMu (the map is wholesale-replaced by template reload while holding the
+// write lock; entries are never mutated in place, so the copy is safe to use
+// after release).
+func lookupZoneTemplate(name string) (ZoneConf, bool) {
+	confMu.RLock()
+	defer confMu.RUnlock()
+	tmpl, ok := Templates[name]
+	return tmpl, ok
+}
+
+// prepareDynamicPrimary expands zconf (Name + Template, plus any persisted
+// fields, which win over the template by gap-fill) against its template and
+// runs the same validation/activation sequence ParseZones applies to static
+// zones. staged, when non-nil, is an inline TSIG key being added with the
+// zone: keyless (""/NOKEY) downstreams entries are rewired to it (BLOCKED and
+// explicitly-keyed entries are never touched) BEFORE ACL validation, and the
+// ACL check accepts the staged name. fromAPI enforces the per-template
+// dynamiczones: blessing (gate 2) — the boot path only warns, mirroring how
+// dynamiczones.dynamic.allowed gates new adds but not already-persisted zones.
+//
+// A non-nil error means the config is invalid: the add path refuses the
+// request, the boot path registers an error-state zone.
+func (conf *Config) prepareDynamicPrimary(zconf ZoneConf, staged *TsigDetails, fromAPI bool) (*dynamicPrimarySpec, error) {
+	zconf.Name = dns.Fqdn(zconf.Name)
+	zconf.Type = "primary"
+
+	if zconf.Template == "" {
+		return nil, fmt.Errorf("dynamic primary zone requires a template")
+	}
+	tmpl, ok := lookupZoneTemplate(zconf.Template)
+	if !ok {
+		return nil, fmt.Errorf("template %q does not exist", zconf.Template)
+	}
+	if fromAPI && !tmpl.DynamicZones {
+		return nil, fmt.Errorf("template %q is not blessed for dynamic zones (set dynamiczones: true on the template)", zconf.Template)
+	}
+	if !fromAPI && !tmpl.DynamicZones {
+		lg.Warn("dynamic primary: template no longer blessed for dynamic zones; loading persisted zone anyway (blessing gates new adds)", "zone", zconf.Name, "template", zconf.Template)
+	}
+	if tmpl.Type != "" && strings.ToLower(tmpl.Type) != "primary" {
+		return nil, fmt.Errorf("template %q is type %s, not primary", zconf.Template, tmpl.Type)
+	}
+
+	// A conflicted template (primaries:+upstreams: etc.) would silently hand
+	// the zone its broader canonical ACL — same quarantine rule as ParseZones.
+	if conflict := zoneOrTemplateAliasConflict(conf.Internal.XfrAliasConflicts, zconf.Name, zconf.Template); conflict != "" {
+		return nil, fmt.Errorf("conflicting transfer-list spellings: %s", conflict)
+	}
+
+	expanded, err := ExpandTemplate(zconf, &tmpl, Globals.App.Type)
+	if err != nil {
+		return nil, fmt.Errorf("template expansion error: %q: %v", zconf.Template, err)
+	}
+
+	// Expand `- peers: [ id, ... ]` references into concrete entries.
+	if err := conf.expandPeerRefs(&expanded, conf.Internal.BrokenPeers); err != nil {
+		return nil, fmt.Errorf("peers: %v", err)
+	}
+
+	// A primary is file-backed: the template must yield a zonefile (its %s
+	// pattern) unless the persisted entry already carries one.
+	if expanded.Zonefile == "" {
+		return nil, fmt.Errorf("template %q yields no zonefile for the zone (a dynamic primary requires a zonefile pattern)", zconf.Template)
+	}
+
+	// Dynamic zones are map-only (the same chokepoint the secondary add
+	// enforces); a template asking for another store is refused loudly.
+	if store := parseZoneStore(expanded.Store); store != MapZone {
+		return nil, fmt.Errorf("dynamic zones are map-only (template %q sets store: %s)", zconf.Template, expanded.Store)
+	}
+
+	// Inline TSIG: rewire keyless (""/NOKEY) downstreams entries to the staged
+	// key — gating outbound transfers by it, the mirror image of the secondary
+	// case. BLOCKED and explicitly-keyed entries are never rewired (rewiring
+	// only ever tightens access). Done before ACL validation so the validation
+	// sees the final ACL.
+	if staged != nil {
+		for i := range expanded.Downstreams {
+			if expanded.Downstreams[i].Key == "" || expanded.Downstreams[i].Key == NOKEY {
+				expanded.Downstreams[i].Key = staged.Name
+			}
+		}
+	}
+
+	// The same per-list validation ParseZones applies. The ACL key check
+	// accepts the staged inline key (it is committed with the zone).
+	keyOK := func(name string) bool { return conf.tsigKeyAcceptable(name, staged) }
+	if err := validateDownstreamAuth(expanded.DownstreamAuth); err != nil {
+		return nil, fmt.Errorf("downstream-auth: %v", err)
+	}
+	crossCheckDownstreamAuth(expanded.Name, expanded.DownstreamAuth, expanded.Downstreams, conf.Internal.ImrEngine != nil)
+	for _, n := range expanded.Notify {
+		if n.Legacy != "" {
+			return nil, fmt.Errorf("notify now requires {addr, key} (got bare string %q)", n.Legacy)
+		}
+		if n.Transport != "" || n.TLSAuth != "" || n.TLSName != "" || len(n.Pins) > 0 || n.CAFile != "" {
+			return nil, fmt.Errorf("notify %s: transport/tls-* not supported for notify targets", n.Addr)
+		}
+		if n.Key != "" && n.Key != NOKEY && !keyOK(n.Key) {
+			return nil, fmt.Errorf("notify %s references unknown key %q", n.Addr, n.Key)
+		}
+	}
+	if err := ValidateACL(expanded.AllowNotify, keyOK); err != nil {
+		return nil, fmt.Errorf("allow-notify: %v", err)
+	}
+	if err := ValidateACL(expanded.Downstreams, keyOK); err != nil {
+		return nil, fmt.Errorf("downstreams: %v", err)
+	}
+
+	publishCadence, err := parsePublishCadence(expanded.PublishCadence)
+	if err != nil {
+		return nil, fmt.Errorf("publish-cadence: %v", err)
+	}
+
+	// DNSSEC policy: "none" means unsigned; an unusable policy reference is a
+	// refusal here (ParseZones quarantines instead — for an API request the
+	// refusal IS the quarantine-equivalent, and fail-loud beats silently
+	// minting an unsigned zone).
+	if expanded.DnssecPolicy == "none" {
+		expanded.DnssecPolicy = ""
+	}
+	if expanded.DnssecPolicy != "" {
+		if _, errMsg := resolveZonePolicyRef(expanded.DnssecPolicy, conf.Internal.DnssecPolicies); errMsg != "" {
+			return nil, fmt.Errorf("dnssecpolicy %q: %s", expanded.DnssecPolicy, errMsg)
+		}
+	}
+
+	// Option pre-scan: parseZoneOptions (shared below) logs-and-drops what it
+	// dislikes; for a template-driven zone every such case must refuse loudly
+	// instead — a blessed template that silently loses an option is exactly
+	// the drift the envelope is supposed to prevent.
+	for _, o := range expanded.OptionsStrs {
+		o = strings.ToLower(strings.TrimSpace(o))
+		if o == "" {
+			continue
+		}
+		opt, known := StringToZoneOption[o]
+		if !known {
+			return nil, fmt.Errorf("unknown config option: %q", o)
+		}
+		if dynamicPrimaryDisallowedOptions[opt] {
+			return nil, fmt.Errorf("option %q is not supported for dynamic primary zones", o)
+		}
+		if (opt == OptOnlineSigning || opt == OptInlineSigning) && expanded.DnssecPolicy == "" {
+			return nil, fmt.Errorf("%s requires the template to set a dnssecpolicy", o)
+		}
+	}
+	options := parseZoneOptions(conf, expanded.Name, &expanded, nil)
+
+	policy, err := activateUpdatePolicy(&expanded, options)
+	if err != nil {
+		return nil, err
+	}
+	// v1: no child-update policies on dynamic primaries. The delegation
+	// backend is wired in ParseZones only, so an API-added (or dynamically
+	// re-loaded) zone would carry the option with a nil backend — the exact
+	// silently-misbehaving-scanner state the static path refuses to start.
+	if options[OptAllowChildUpdates] {
+		return nil, fmt.Errorf("allow-child-updates is not supported for dynamic primary zones (use a static zone)")
+	}
+
+	return &dynamicPrimarySpec{
+		Zconf:          expanded,
+		Options:        options,
+		Policy:         policy,
+		PublishCadence: publishCadence,
+	}, nil
+}
+
+// bootstrapApexRecords synthesizes the minimal apex content for a freshly
+// provisioned dynamic primary: SOA, apex NS (ns.<zone>) and A/AAAA glue built
+// from the server's own listen addresses (ports stripped, deduplicated,
+// wildcard listeners skipped with a WARN — predictable beats clever). Returns
+// zone-file lines. With zero usable addresses the zone is still created (NS
+// without address records) with a WARN; once live it is reshaped via DNS
+// UPDATE as the template's policy allows.
+func bootstrapApexRecords(zone string, listenAddrs []string) []string {
+	zone = dns.Fqdn(zone)
+	nsName := "ns." + zone
+
+	lines := []string{
+		fmt.Sprintf("%s\t3600\tIN\tSOA\t%s hostmaster.%s 1 3600 600 604800 300", zone, nsName, zone),
+		fmt.Sprintf("%s\t3600\tIN\tNS\t%s", zone, nsName),
+	}
+
+	seen := map[string]bool{}
+	glue := 0
+	for _, la := range listenAddrs {
+		host, _, err := net.SplitHostPort(la)
+		if err != nil {
+			host = la // address without port
+		}
+		addr, err := netip.ParseAddr(host)
+		if err != nil {
+			lg.Warn("bootstrap apex: unparsable listen address, skipping", "zone", zone, "address", la)
+			continue
+		}
+		if addr.IsUnspecified() {
+			lg.Warn("bootstrap apex: skipping wildcard listener (list concrete addresses in dnsengine.addresses to have them in synthesized apexes)", "zone", zone, "address", la)
+			continue
+		}
+		key := addr.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		if addr.Is4() {
+			lines = append(lines, fmt.Sprintf("%s\t3600\tIN\tA\t%s", nsName, key))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s\t3600\tIN\tAAAA\t%s", nsName, key))
+		}
+		glue++
+	}
+	if glue == 0 {
+		lg.Warn("bootstrap apex: no usable listen address; zone created with NS but no address records", "zone", zone)
+	}
+	return lines
+}
+
+// synthesizeBootstrapZonefile writes the bootstrap apex for zone to path
+// (atomically: temp + rename, directory created as needed). The caller has
+// already established that no file exists at path.
+func (conf *Config) synthesizeBootstrapZonefile(zone, path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create zone file directory %s: %v", dir, err)
+	}
+	content := strings.Join(bootstrapApexRecords(zone, conf.DnsEngine.Addresses), "\n") + "\n"
+
+	tempFile, err := os.CreateTemp(dir, fmt.Sprintf(".%s.bootstrap.tmp", filepath.Base(path)))
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %v", err)
+	}
+	tempFilePath := tempFile.Name()
+	if _, err := tempFile.WriteString(content); err != nil {
+		tempFile.Close()
+		os.Remove(tempFilePath)
+		return fmt.Errorf("failed to write temp file: %v", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		os.Remove(tempFilePath)
+		return fmt.Errorf("failed to close temp file: %v", err)
+	}
+	if err := os.Rename(tempFilePath, path); err != nil {
+		os.Remove(tempFilePath)
+		return fmt.Errorf("failed to rename temp file to zone file: %v", err)
+	}
+	lg.Info("synthesized bootstrap apex for dynamic primary", "zone", zone, "path", path)
+	return nil
+}
+
+// provisionDynamicPrimary is the primary branch of ProvisionDynamicZone: the
+// common gates (allowed-list, template-required, name validity, duplicate)
+// have already passed. It expands + validates against the template, bootstraps
+// the zone file if absent, registers a pre-configured first-load stub in the
+// Zones map (the same shape ParseZones leaves for static zones, so the
+// RefreshEngine runs the full first-bind sequence: FetchFromFile → initial
+// snapshot install → policy sync → OnFirstLoad signing), persists with
+// rollback, and enqueues the file-load refresh.
+func (conf *Config) provisionDynamicPrimary(ctx context.Context, in DynamicZoneInput, fromAPI bool) (string, error) {
+	name := dns.Fqdn(in.Name)
+
+	// The template is the whole configuration envelope: caller-supplied
+	// options would extend it outside operator control, so they are refused
+	// rather than silently ignored.
+	if len(in.Options) > 0 {
+		return "", fmt.Errorf("zone %s: a primary zone takes its options from the template; per-zone options are not accepted", name)
+	}
+	if len(in.Primaries) > 0 {
+		return "", fmt.Errorf("zone %s: a primary zone has no upstream primaries; the primaries list is not accepted", name)
+	}
+
+	// Stage the inline TSIG key (validate + collision-check only; in.Primaries
+	// is empty so no rewiring happens here — prepareDynamicPrimary rewires the
+	// expanded downstreams instead). Committed only after persistence.
+	staged, serr := conf.stageInlineTsigKey(&in)
+	if serr != nil {
+		return "", fmt.Errorf("zone %s: %w", name, serr)
+	}
+
+	spec, perr := conf.prepareDynamicPrimary(ZoneConf{Name: name, Template: in.Template}, staged, fromAPI)
+	if perr != nil {
+		return "", fmt.Errorf("zone %s: %w", name, perr)
+	}
+
+	options := spec.Options
+	if fromAPI {
+		options[OptApiManagedZone] = true
+	}
+
+	// Bootstrap the zone file if absent; an existing file (e.g. re-add after
+	// a delete that failed to remove it, or operator-provided content) is
+	// used as-is.
+	createdFile := false
+	if _, err := os.Stat(spec.Zconf.Zonefile); err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("zone %s: cannot stat zonefile %s: %v", name, spec.Zconf.Zonefile, err)
+		}
+		if err := conf.synthesizeBootstrapZonefile(name, spec.Zconf.Zonefile); err != nil {
+			return "", fmt.Errorf("zone %s: %w", name, err)
+		}
+		createdFile = true
+	} else {
+		lg.Info("dynamic primary: zone file already exists, using as-is", "zone", name, "path", spec.Zconf.Zonefile)
+	}
+	cleanupFile := func() {
+		if createdFile {
+			if err := os.Remove(spec.Zconf.Zonefile); err != nil && !os.IsNotExist(err) {
+				lg.Warn("dynamic primary: failed to remove bootstrap zone file on rollback", "zone", name, "path", spec.Zconf.Zonefile, "error", err)
+			}
+		}
+	}
+
+	// Build the fully-configured first-load stub. FirstZoneLoad routes the
+	// enqueued refresher down the RefreshEngine's pre-registered-stub branch
+	// (the static-primary first-bind path); ZoneType being set skips the
+	// engine's config merge, so everything must be carried here.
+	msc := ConfLive().MultiSigner[spec.Zconf.MultiSigner]
+	zd := &ZoneData{
+		ZoneName:         name,
+		ZoneType:         Primary,
+		ZoneStore:        MapZone,
+		Zonefile:         spec.Zconf.Zonefile,
+		Template:         in.Template,
+		Notify:           normalizePeerAddrs(spec.Zconf.Notify),
+		AllowNotify:      spec.Zconf.AllowNotify,
+		Downstreams:      spec.Zconf.Downstreams,
+		DownstreamAuth:   spec.Zconf.DownstreamAuth,
+		Logger:           log.Default(),
+		Options:          options,
+		UpdatePolicy:     spec.Policy,
+		DnssecPolicyName: spec.Zconf.DnssecPolicy, // config-base name; struct bound post-Ready
+		MultiSigner:      &msc,
+		DelegationSyncQ:  conf.Internal.DelegationSyncQ,
+		Status:           ZoneStatusPending,
+		Data:             core.NewCmap[OwnerData](),
+		KeyDB:            conf.Internal.KeyDB,
+		FirstZoneLoad:    true,
+		publishCadence:   spec.PublishCadence,
+	}
+
+	// First-load callbacks, mirroring what ParseZones registers for static
+	// zones (the engine's stub branch drains OnFirstLoad post-Ready).
+	if options[OptOnlineSigning] || options[OptInlineSigning] {
+		resignQ := conf.Internal.ResignQ
+		zd.OnFirstLoad = append(zd.OnFirstLoad, func(z *ZoneData) {
+			if err := z.SetupZoneSigning(resignQ); err != nil {
+				lg.Error("SetupZoneSigning failed in OnFirstLoad", "zone", z.ZoneName, "error", err)
+			}
+		})
+	}
+	if options[OptDelSyncParent] || options[OptDelSyncChild] {
+		delegationSyncQ := conf.Internal.DelegationSyncQ
+		zd.OnFirstLoad = append(zd.OnFirstLoad, func(z *ZoneData) {
+			if delegationSyncQ == nil {
+				lg.Error("DelegationSyncQ not available", "zone", z.ZoneName)
+				return
+			}
+			if err := z.SetupZoneSync(delegationSyncQ); err != nil {
+				lg.Error("SetupZoneSync failed", "zone", z.ZoneName, "error", err)
+			}
+		})
+	}
+
+	// Commit the staged inline key just before registration/persistence (so
+	// the keystore holds it when the zone goes live), then register and
+	// persist. On persist failure roll back registration, key, and a
+	// freshly-synthesized bootstrap file — a failed add leaves nothing behind.
+	rollbackKey, cerr := conf.commitStagedTsigKey(staged)
+	if cerr != nil {
+		cleanupFile()
+		return "", fmt.Errorf("zone %s: %w", name, cerr)
+	}
+	Zones.Set(name, zd)
+	if err := conf.AddDynamicZoneToConfig(zd); err != nil {
+		zd.stopPublisher()
+		Zones.Remove(name)
+		rollbackKey()
+		cleanupFile()
+		return "", fmt.Errorf("failed to persist dynamic zone %s: %w", name, err)
+	}
+
+	zr := ZoneRefresher{
+		Name:           name,
+		ZoneType:       Primary,
+		ZoneStore:      MapZone,
+		Zonefile:       spec.Zconf.Zonefile,
+		Template:       in.Template,
+		PublishCadence: spec.PublishCadence,
+		Notify:         zd.Notify,
+		AllowNotify:    spec.Zconf.AllowNotify,
+		Downstreams:    spec.Zconf.Downstreams,
+		DownstreamAuth: spec.Zconf.DownstreamAuth,
+		Options:        options,
+		UpdatePolicy:   spec.Policy,
+		DnssecPolicy:   spec.Zconf.DnssecPolicy,
+		Force:          true, // load from file regardless of serial
+	}
+	if err := conf.enqueueRefresh(ctx, zr); err != nil {
+		return "", fmt.Errorf("zone %s registered but failed to schedule initial load: %w", name, err)
+	}
+
+	return fmt.Sprintf("zone %s provisioning (primary from template %s); poll list-dynamic for state", name, in.Template), nil
+}

--- a/v2/dynamic_primary_test.go
+++ b/v2/dynamic_primary_test.go
@@ -186,6 +186,63 @@ func TestPrepareDynamicPrimary_HappyPathAndTsigRewire(t *testing.T) {
 	if spec.Zconf.Downstreams[1].Key != "BLOCKED" {
 		t.Errorf("BLOCKED downstream must never be rewired: %+v", spec.Zconf.Downstreams[1])
 	}
+	// Rewiring must not leak the staged key back into the template: the next
+	// zone stamped from it would inherit this zone's key. (ExpandTemplate's
+	// gap-fill clones slices; this pins that invariant.)
+	if got := Templates["dyn-test"].Downstreams[0].Key; got != NOKEY {
+		t.Errorf("template mutated by rewiring: downstream key %q", got)
+	}
+}
+
+func TestProvisionDynamicZone_RejectsPathSeparatorNames(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+	dir := t.TempDir()
+	withTestTemplates(t, map[string]ZoneConf{"dyn-test": dynPrimaryTestTemplate(dir)})
+
+	// dns.IsDomainName accepts "/" — the add path must not, for either type,
+	// since the name feeds file paths (template %s-pattern, zonedirectory).
+	for _, name := range []string{"evil/zone.example", `evil\zone.example`} {
+		if _, err := conf.ProvisionDynamicZone(context.Background(), DynamicZoneInput{
+			Name: name, Type: Primary, Template: "dyn-test",
+		}, true); err == nil || !strings.Contains(err.Error(), "path separators") {
+			t.Errorf("primary add with name %q must be rejected: %v", name, err)
+		}
+		if _, err := conf.ProvisionDynamicZone(context.Background(), DynamicZoneInput{
+			Name: name, Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}},
+		}, true); err == nil || !strings.Contains(err.Error(), "path separators") {
+			t.Errorf("secondary add with name %q must be rejected: %v", name, err)
+		}
+	}
+}
+
+func TestProvisionDynamicPrimary_EnqueueFailureMarksError(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+	dir := t.TempDir()
+	withTestTemplates(t, map[string]ZoneConf{"dyn-test": dynPrimaryTestTemplate(dir)})
+
+	// A cancelled context makes enqueueRefresh fail immediately: the zone
+	// must be left registered with a visible error, not stuck "provisioning".
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Fill the channel so the select cannot take the send arm first.
+	ch := conf.Internal.RefreshZoneCh
+	for len(ch) < cap(ch) {
+		ch <- ZoneRefresher{}
+	}
+	if _, err := conf.ProvisionDynamicZone(ctx, DynamicZoneInput{
+		Name: "stuck.example", Type: Primary, Template: "dyn-test",
+	}, true); err == nil {
+		t.Fatal("expected enqueue failure with a cancelled context and full channel")
+	}
+	zd, ok := Zones.Get("stuck.example.")
+	if !ok {
+		t.Fatal("zone should remain registered after enqueue failure")
+	}
+	if !zd.HasError(RefreshError) {
+		t.Error("zone must carry a visible RefreshError after enqueue failure")
+	}
 }
 
 func TestProvisionDynamicPrimary_EndToEnd(t *testing.T) {

--- a/v2/dynamic_primary_test.go
+++ b/v2/dynamic_primary_test.go
@@ -1,0 +1,392 @@
+package tdns
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTestTemplates installs templates into the global Templates map for the
+// duration of the test.
+func withTestTemplates(t *testing.T, tmpls map[string]ZoneConf) {
+	t.Helper()
+	saved := Templates
+	Templates = tmpls
+	t.Cleanup(func() { Templates = saved })
+}
+
+// dynPrimaryTestTemplate returns a minimal blessed primary template whose
+// zonefile pattern lands in dir.
+func dynPrimaryTestTemplate(dir string) ZoneConf {
+	tmpl := ZoneConf{
+		Name:         "dyn-test",
+		Type:         "primary",
+		Store:        "map",
+		DynamicZones: true,
+		Zonefile:     filepath.Join(dir, "%szone"),
+		OptionsStrs:  []string{"allow-updates"},
+		Downstreams:  []AclEntry{{Prefix: "127.0.0.1/32", Key: NOKEY}},
+	}
+	tmpl.UpdatePolicy.Zone.Type = "selfsub"
+	tmpl.UpdatePolicy.Zone.RRtypes = []string{"TXT"}
+	return tmpl
+}
+
+func TestBootstrapApexRecords(t *testing.T) {
+	lines := bootstrapApexRecords("boot.example.", []string{
+		"127.0.0.1:5354",   // v4 with port
+		"127.0.0.1:5355",   // same address, different port -> deduplicated
+		"[2001:db8::1]:53", // v6 with port
+		"0.0.0.0:53",       // wildcard -> skipped with WARN
+		"::",               // wildcard, no port -> skipped
+		"not-an-address",   // unparsable -> skipped
+	})
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "SOA\tns.boot.example. hostmaster.boot.example. 1 3600 600 604800 300") {
+		t.Errorf("SOA missing or malformed:\n%s", joined)
+	}
+	if !strings.Contains(joined, "NS\tns.boot.example.") {
+		t.Errorf("apex NS missing:\n%s", joined)
+	}
+	if c := strings.Count(joined, "\tA\t127.0.0.1"); c != 1 {
+		t.Errorf("want exactly 1 deduplicated A record, got %d:\n%s", c, joined)
+	}
+	if !strings.Contains(joined, "\tAAAA\t2001:db8::1") {
+		t.Errorf("AAAA glue missing:\n%s", joined)
+	}
+	if strings.Contains(joined, "0.0.0.0") || strings.Contains(joined, "\tAAAA\t::") {
+		t.Errorf("wildcard listener leaked into apex:\n%s", joined)
+	}
+
+	// Zero usable addresses: zone still gets SOA + NS, no glue.
+	lines = bootstrapApexRecords("empty.example.", []string{"0.0.0.0:53"})
+	if len(lines) != 2 {
+		t.Errorf("zero-address bootstrap should yield SOA+NS only, got %d lines", len(lines))
+	}
+}
+
+func TestPrepareDynamicPrimary_Gates(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+	dir := t.TempDir()
+	tmpl := dynPrimaryTestTemplate(dir)
+	withTestTemplates(t, map[string]ZoneConf{"dyn-test": tmpl})
+
+	// Missing template.
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "nope"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("missing template: %v", err)
+	}
+
+	// Unblessed template refused on the API path, tolerated on the boot path.
+	unblessed := tmpl
+	unblessed.DynamicZones = false
+	Templates["unblessed"] = unblessed
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "unblessed"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "not blessed") {
+		t.Errorf("unblessed template on API path: %v", err)
+	}
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "unblessed"}, nil, false); err != nil {
+		t.Errorf("unblessed template must load on the boot path (blessing gates new adds): %v", err)
+	}
+
+	// Wrong template type.
+	sec := tmpl
+	sec.Type = "secondary"
+	Templates["sec"] = sec
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "sec"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "not primary") {
+		t.Errorf("secondary template: %v", err)
+	}
+
+	// No zonefile pattern.
+	nofile := tmpl
+	nofile.Zonefile = ""
+	Templates["nofile"] = nofile
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "nofile"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "zonefile") {
+		t.Errorf("missing zonefile: %v", err)
+	}
+
+	// Non-map store.
+	xfr := tmpl
+	xfr.Store = "xfr"
+	Templates["xfr"] = xfr
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "xfr"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "map-only") {
+		t.Errorf("xfr store: %v", err)
+	}
+
+	// Disallowed option.
+	cat := tmpl
+	cat.OptionsStrs = []string{"catalog-zone"}
+	Templates["cat"] = cat
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "cat"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "not supported") {
+		t.Errorf("catalog-zone option: %v", err)
+	}
+
+	// Signing option without a policy.
+	signing := tmpl
+	signing.OptionsStrs = []string{"online-signing"}
+	Templates["signing"] = signing
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "signing"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "dnssecpolicy") {
+		t.Errorf("signing without policy: %v", err)
+	}
+
+	// allow-child-updates refused (v1).
+	child := tmpl
+	child.OptionsStrs = []string{"allow-child-updates"}
+	child.DelegationBackend = "direct"
+	child.UpdatePolicy.Child.Type = "selfsub"
+	Templates["child"] = child
+	if _, err := conf.prepareDynamicPrimary(ZoneConf{Name: "a.example", Template: "child"}, nil, true); err == nil ||
+		!strings.Contains(err.Error(), "allow-child-updates") {
+		t.Errorf("allow-child-updates: %v", err)
+	}
+}
+
+func TestPrepareDynamicPrimary_HappyPathAndTsigRewire(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+	dir := t.TempDir()
+	tmpl := dynPrimaryTestTemplate(dir)
+	tmpl.Downstreams = []AclEntry{
+		{Prefix: "127.0.0.1/32", Key: NOKEY},     // rewired
+		{Prefix: "192.0.2.0/24", Key: "BLOCKED"}, // never rewired
+	}
+	withTestTemplates(t, map[string]ZoneConf{"dyn-test": tmpl})
+
+	spec, err := conf.prepareDynamicPrimary(ZoneConf{Name: "happy.example", Template: "dyn-test"}, nil, true)
+	if err != nil {
+		t.Fatalf("prepareDynamicPrimary: %v", err)
+	}
+	if spec.Zconf.Zonefile != filepath.Join(dir, "happy.example.zone") {
+		t.Errorf("zonefile not %%s-expanded: %q", spec.Zconf.Zonefile)
+	}
+	if !spec.Options[OptAllowUpdates] {
+		t.Error("allow-updates option lost")
+	}
+	if spec.Policy.Zone.Type != "selfsub" {
+		t.Errorf("update policy not activated: %+v", spec.Policy)
+	}
+
+	// Inline TSIG rewiring: keyless entries get the staged key, BLOCKED stays.
+	staged := &TsigDetails{Name: "test-key.", Algorithm: "hmac-sha256", Secret: "c2VjcmV0"}
+	spec, err = conf.prepareDynamicPrimary(ZoneConf{Name: "tsig.example", Template: "dyn-test"}, staged, true)
+	if err != nil {
+		t.Fatalf("prepareDynamicPrimary with staged key: %v", err)
+	}
+	if spec.Zconf.Downstreams[0].Key != "test-key." {
+		t.Errorf("keyless downstream not rewired: %+v", spec.Zconf.Downstreams[0])
+	}
+	if spec.Zconf.Downstreams[1].Key != "BLOCKED" {
+		t.Errorf("BLOCKED downstream must never be rewired: %+v", spec.Zconf.Downstreams[1])
+	}
+}
+
+func TestProvisionDynamicPrimary_EndToEnd(t *testing.T) {
+	resetZonesForTest()
+	conf, ch := newTestConfigForCores(t)
+	conf.DnsEngine.Addresses = []string{"127.0.0.1:5354", "[2001:db8::1]:5354"}
+	dir := t.TempDir()
+	withTestTemplates(t, map[string]ZoneConf{"dyn-test": dynPrimaryTestTemplate(dir)})
+
+	// Caller-supplied options/primaries are refused for primaries.
+	if _, err := conf.ProvisionDynamicZone(context.Background(), DynamicZoneInput{
+		Name: "p1.example", Type: Primary, Template: "dyn-test",
+		Options: map[ZoneOption]bool{OptFoldCase: true},
+	}, true); err == nil || !strings.Contains(err.Error(), "options") {
+		t.Errorf("caller options must be refused: %v", err)
+	}
+	if _, err := conf.ProvisionDynamicZone(context.Background(), DynamicZoneInput{
+		Name: "p1.example", Type: Primary, Template: "dyn-test",
+		Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}},
+	}, true); err == nil || !strings.Contains(err.Error(), "primaries") {
+		t.Errorf("caller primaries must be refused: %v", err)
+	}
+
+	// Happy path.
+	msg, err := conf.ProvisionDynamicZone(context.Background(), DynamicZoneInput{
+		Name: "p1.example", Type: Primary, Template: "dyn-test",
+	}, true)
+	if err != nil {
+		t.Fatalf("primary add failed: %v", err)
+	}
+	if !strings.Contains(msg, "dyn-test") {
+		t.Errorf("response should name the template: %q", msg)
+	}
+	zd, ok := Zones.Get("p1.example.")
+	if !ok {
+		t.Fatal("zone not registered")
+	}
+	if zd.ZoneType != Primary || zd.ZoneStore != MapZone || !zd.FirstZoneLoad {
+		t.Errorf("zone shape wrong: type=%v store=%v firstLoad=%v", zd.ZoneType, zd.ZoneStore, zd.FirstZoneLoad)
+	}
+	if zd.Template != "dyn-test" {
+		t.Errorf("template not recorded on ZoneData: %q", zd.Template)
+	}
+	if !zd.Options[OptApiManagedZone] || !zd.Options[OptAllowUpdates] {
+		t.Errorf("options wrong: %v", zd.Options)
+	}
+	if zd.UpdatePolicy.Zone.Type != "selfsub" {
+		t.Errorf("update policy not activated on ZoneData: %+v", zd.UpdatePolicy)
+	}
+
+	// Bootstrap file synthesized with SOA/NS/glue.
+	content, err := os.ReadFile(filepath.Join(dir, "p1.example.zone"))
+	if err != nil {
+		t.Fatalf("bootstrap zone file not written: %v", err)
+	}
+	for _, want := range []string{"SOA", "NS\tns.p1.example.", "A\t127.0.0.1", "AAAA\t2001:db8::1"} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("bootstrap file missing %q:\n%s", want, content)
+		}
+	}
+
+	// A file-load refresher was enqueued with the activated policy.
+	select {
+	case zr := <-ch:
+		if zr.ZoneType != Primary || !zr.Force || zr.Zonefile == "" {
+			t.Errorf("refresher shape wrong: %+v", zr)
+		}
+		if zr.UpdatePolicy.Zone.Type != "selfsub" {
+			t.Errorf("refresher lacks the activated policy: %+v", zr.UpdatePolicy)
+		}
+		if zr.Template != "dyn-test" {
+			t.Errorf("refresher lacks the template name: %q", zr.Template)
+		}
+	default:
+		t.Error("expected a ZoneRefresher to be enqueued")
+	}
+
+	// Duplicate add refused.
+	if _, err := conf.ProvisionDynamicZone(context.Background(), DynamicZoneInput{
+		Name: "p1.example", Type: Primary, Template: "dyn-test",
+	}, true); err == nil {
+		t.Error("duplicate primary add must be refused")
+	}
+
+	// An existing zone file is used as-is (not overwritten).
+	pre := filepath.Join(dir, "p2.example.zone")
+	if err := os.WriteFile(pre, []byte("p2.example.\t3600\tIN\tSOA\tns.p2.example. h.p2.example. 42 3600 600 604800 300\np2.example.\t3600\tIN\tNS\tns.p2.example.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conf.ProvisionDynamicZone(context.Background(), DynamicZoneInput{
+		Name: "p2.example", Type: Primary, Template: "dyn-test",
+	}, true); err != nil {
+		t.Fatalf("add with pre-existing file failed: %v", err)
+	}
+	content, _ = os.ReadFile(pre)
+	if !strings.Contains(string(content), " 42 ") {
+		t.Errorf("pre-existing zone file was overwritten:\n%s", content)
+	}
+}
+
+func TestModifyDynamicZone_RefusesPrimary(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+
+	zd := &ZoneData{ZoneName: "prim.example.", ZoneType: Primary, Options: map[ZoneOption]bool{OptApiManagedZone: true}}
+	Zones.Set("prim.example.", zd)
+	if _, err := conf.ModifyDynamicZone(context.Background(), DynamicZoneInput{Name: "prim.example"}); err == nil ||
+		!strings.Contains(err.Error(), "not supported for primary") {
+		t.Errorf("modify on a primary must be refused: %v", err)
+	}
+}
+
+func TestRemoveDynamicZone_RemovesTemplatePathZonefile(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+	dir := t.TempDir()
+
+	zonefile := filepath.Join(dir, "del.example.zone")
+	if err := os.WriteFile(zonefile, []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	zd := &ZoneData{ZoneName: "del.example.", ZoneType: Primary, Zonefile: zonefile,
+		Options: map[ZoneOption]bool{OptApiManagedZone: true}}
+	Zones.Set("del.example.", zd)
+
+	if _, err := conf.RemoveDynamicZone("del.example"); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	if _, err := os.Stat(zonefile); !os.IsNotExist(err) {
+		t.Error("template-path zone file not removed on delete")
+	}
+}
+
+// TestLoadDynamicZoneFiles_PrimaryReExpansion drives the boot path: a
+// persisted template primary re-expands and enqueues with a re-derived update
+// policy; a missing template registers a visible error-state zone.
+func TestLoadDynamicZoneFiles_PrimaryReExpansion(t *testing.T) {
+	resetZonesForTest()
+	conf, ch := newTestConfigForCores(t)
+	dir := t.TempDir()
+	withTestTemplates(t, map[string]ZoneConf{"dyn-test": dynPrimaryTestTemplate(dir)})
+
+	zonefile := filepath.Join(dir, "boot.example.zone")
+	if err := os.WriteFile(zonefile, []byte("boot.example.\t3600\tIN\tSOA\tns.boot.example. h.boot.example. 1 3600 600 604800 300\nboot.example.\t3600\tIN\tNS\tns.boot.example.\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dynCfg := filepath.Join(dir, "dynamic-zones.yaml")
+	cfgYaml := `zones:
+  - name: boot.example.
+    type: primary
+    store: map
+    template: dyn-test
+    zonefile: ` + zonefile + `
+    apimanaged: true
+  - name: lost.example.
+    type: primary
+    store: map
+    template: gone-template
+    zonefile: /nonexistent/lost.example.zone
+    apimanaged: true
+`
+	if err := os.WriteFile(dynCfg, []byte(cfgYaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	conf.DynamicZones.ConfigFile = dynCfg
+	conf.DynamicZones.ZoneDirectory = dir
+
+	if err := conf.LoadDynamicZoneFiles(context.Background()); err != nil {
+		t.Fatalf("LoadDynamicZoneFiles: %v", err)
+	}
+
+	// boot.example: enqueued with the template's re-derived policy.
+	select {
+	case zr := <-ch:
+		if zr.Name != "boot.example." || zr.ZoneType != Primary {
+			t.Errorf("unexpected refresher: %+v", zr)
+		}
+		if zr.UpdatePolicy.Zone.Type != "selfsub" {
+			t.Errorf("boot re-expansion lost the update policy: %+v", zr.UpdatePolicy)
+		}
+		if !zr.Options[OptApiManagedZone] {
+			t.Error("ApiManaged marker not re-derived on boot")
+		}
+		if zr.Zonefile != zonefile {
+			t.Errorf("persisted zonefile must win over the template pattern: %q", zr.Zonefile)
+		}
+	default:
+		t.Error("expected boot.example. to be enqueued")
+	}
+
+	// lost.example: registered in ERROR state, not silently skipped, not enqueued.
+	zd, ok := Zones.Get("lost.example.")
+	if !ok {
+		t.Fatal("zone with missing template must be registered (visible), not skipped")
+	}
+	if !zd.Error || !strings.Contains(zd.ErrorMsg, "does not exist") {
+		t.Errorf("zone with missing template must be in ERROR state: err=%v msg=%q", zd.Error, zd.ErrorMsg)
+	}
+	select {
+	case zr := <-ch:
+		t.Errorf("zone with missing template must not be enqueued: %+v", zr)
+	default:
+	}
+}

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -254,6 +254,69 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 			options[OptApiManagedZone] = true
 		}
 
+		// Dynamic PRIMARY with a template: re-expand the template and
+		// re-activate the update policy through the same shared helper the
+		// add path uses (prepareDynamicPrimary) — persisted fields win over
+		// the template by gap-fill, and the update policy is deliberately NOT
+		// persisted (it re-derives from the template; one source of truth).
+		// A hand-authored template-less primary entry keeps the generic path
+		// below, unchanged. On error the zone is registered in ERROR state
+		// (visible in zone list) rather than silently skipped — §5: missing/
+		// broken template ⇒ ERROR state.
+		if zoneType == Primary && zconf.Template != "" {
+			spec, perr := conf.prepareDynamicPrimary(zconf, nil, false)
+			if perr != nil {
+				lg.Error("dynamic primary: config invalid, zone in error state", "zone", zoneName, "template", zconf.Template, "err", perr)
+				zd := &ZoneData{
+					ZoneName:  zoneName,
+					ZoneType:  Primary,
+					ZoneStore: MapZone,
+					Zonefile:  zconf.Zonefile,
+					Template:  zconf.Template,
+					Logger:    log.Default(),
+					Options:   options,
+					Status:    ZoneStatusPending,
+					Data:      core.NewCmap[OwnerData](),
+					KeyDB:     conf.Internal.KeyDB,
+				}
+				Zones.Set(zoneName, zd)
+				zd.SetError(ConfigError, "dynamic primary: %v", perr)
+				skippedCount++
+				continue
+			}
+			specOptions := spec.Options
+			// Re-derive the internal marker (B5a) onto the freshly parsed set.
+			if zconf.ApiManaged {
+				specOptions[OptApiManagedZone] = true
+			}
+			zr := ZoneRefresher{
+				Name:           zoneName,
+				Force:          true, // load from file on startup
+				ZoneType:       Primary,
+				ZoneStore:      MapZone,
+				Zonefile:       spec.Zconf.Zonefile,
+				Template:       zconf.Template,
+				PublishCadence: spec.PublishCadence,
+				Notify:         spec.Zconf.Notify,
+				AllowNotify:    spec.Zconf.AllowNotify,
+				Downstreams:    spec.Zconf.Downstreams,
+				DownstreamAuth: spec.Zconf.DownstreamAuth,
+				ConfigUpdate:   true, // config-bearing (persisted dynamic zone)
+				Options:        specOptions,
+				UpdatePolicy:   spec.Policy,
+				DnssecPolicy:   spec.Zconf.DnssecPolicy,
+			}
+			select {
+			case conf.Internal.RefreshZoneCh <- zr:
+				loadedCount++
+				lg.Info("LoadDynamicZoneFiles: enqueued dynamic primary for refresh", "zone", zoneName, "template", zconf.Template, "zonefile", spec.Zconf.Zonefile)
+			case <-ctx.Done():
+				lg.Warn("LoadDynamicZoneFiles: context cancelled while enqueueing dynamic zone", "zone", zoneName)
+				return ctx.Err()
+			}
+			continue
+		}
+
 		// Log what we're loading
 		if options[OptCatalogZone] {
 			lg.Debug("enqueuing catalog zone for refresh", "zone", zoneName, "type", zconf.Type)
@@ -765,6 +828,11 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 		return "", fmt.Errorf("zone %s already exists", name)
 	}
 
+	// Primary zones take the template-constrained path (dynamic_primary.go).
+	if in.Type == Primary {
+		return conf.provisionDynamicPrimary(ctx, in, fromAPI)
+	}
+
 	// Stage an inline TSIG key (tsig_name/secret/algo) and apply it to keyless
 	// primaries. Staging only validates + rewrites; the key is committed to the
 	// live store later (after persistence), so a rejected add installs nothing.
@@ -926,6 +994,14 @@ func (conf *Config) RemoveDynamicZone(name string) (string, error) {
 			lg.Warn("RemoveDynamicZone: failed to remove zone file", "zone", name, "path", zoneFilePath, "error", err)
 		}
 	}
+	// Also the zone's actual file when it differs (a template-expanded
+	// primary's file lives at the template's pattern path, not under
+	// zonedirectory:). An API-managed zone is disposable by construction.
+	if zd.Zonefile != "" {
+		if err := os.Remove(zd.Zonefile); err != nil && !os.IsNotExist(err) {
+			lg.Warn("RemoveDynamicZone: failed to remove zone file", "zone", name, "path", zd.Zonefile, "error", err)
+		}
+	}
 
 	return fmt.Sprintf("zone %s deleted", name), nil
 }
@@ -944,6 +1020,12 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	}
 	if !oldZd.Options[OptApiManagedZone] {
 		return "", fmt.Errorf("zone %s is not API-managed and cannot be modified here", name)
+	}
+	// v1: modify is secondary-only. Modify-for-primary has murky semantics
+	// (re-expansion clobbers policy-legitimate drift; partial application is a
+	// new merge concept) and every concrete use has a cleaner home.
+	if oldZd.ZoneType == Primary {
+		return "", fmt.Errorf("zone %s is a primary; modify is not supported for primary zones (content via DNS UPDATE, keys via the keystore API, config via delete + re-add)", name)
 	}
 	// Stage an inline TSIG key (validate + rewrite keyless primaries) without
 	// mutating the live store. The key is committed only after the modify succeeds.

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -669,11 +669,19 @@ func (conf *Config) RemoveDynamicZoneFromConfig(zoneName string) error {
 	return conf.WriteDynamicConfigFile()
 }
 
-// CheckDynamicConfigFileIncluded checks if the dynamic config file is included in the main config
-// Returns true if included, false otherwise (logs warning if not included)
+// CheckDynamicConfigFileIncluded checks whether the dynamic config file is
+// pulled in via include: in the main config — and warns if it IS. Dynamic
+// zones are loaded at startup by LoadDynamicZoneFiles (which re-derives the
+// ApiManaged/SourceCatalog markers and, for template primaries, re-expands the
+// template); including the file additionally routes them through ParseZones,
+// which loses the markers (the zones degrade to looking static) — and the
+// include merge OVERRIDES list-valued keys, so a dynamic file carrying zones:
+// clobbers the zones: of any other config file. Returns true if included.
+// (Historical note: this check used to warn in the opposite direction, from
+// before LoadDynamicZoneFiles owned the boot path.)
 func (conf *Config) CheckDynamicConfigFileIncluded(includedFiles []string) bool {
 	if conf.DynamicZones.ConfigFile == "" {
-		return true // No config file configured, nothing to check
+		return false // No config file configured, nothing to check
 	}
 
 	configFileAbs := filepath.Clean(conf.DynamicZones.ConfigFile)
@@ -682,12 +690,10 @@ func (conf *Config) CheckDynamicConfigFileIncluded(includedFiles []string) bool 
 	for _, includedFile := range includedFiles {
 		includedFileAbs := filepath.Clean(includedFile)
 		if configFileAbs == includedFileAbs {
+			lg.Warn("dynamiczones.configfile is listed in include:; remove it — dynamic zones load at startup on their own, and the include path both drops their API-managed/catalog markers and overrides any zones: list from other config files", "path", conf.DynamicZones.ConfigFile)
 			return true
 		}
 	}
-
-	// Not included - log warning
-	lg.Warn("dynamic config file not included via 'include:' in main config, dynamic zones will not be loaded on startup", "path", conf.DynamicZones.ConfigFile)
 	return false
 }
 

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -830,6 +830,14 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 	if _, err := dns.IsDomainName(name); !err {
 		return "", fmt.Errorf("invalid zone name %q", in.Name)
 	}
+	// dns.IsDomainName is deliberately liberal (DNS is 8-bit) and accepts
+	// path separators. Zone names feed file paths — the template's %s-pattern
+	// zonefile and the <zonedirectory>/<zone>.zone derivation — so a name
+	// like "evil/zone" would create and later delete files in a caller-chosen
+	// subdirectory. Reject explicitly, for both zone types.
+	if strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("invalid zone name %q (path separators are not allowed)", in.Name)
+	}
 	if _, exists := Zones.Get(name); exists {
 		return "", fmt.Errorf("zone %s already exists", name)
 	}

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -140,8 +140,9 @@ func (conf *Config) ShouldPersistZone(zd *ZoneData) bool {
 	}
 
 	if zd.Options[OptApiManagedZone] {
-		// API-managed zone (zone add/delete/modify)
-		return conf.DynamicZones.Dynamic.Storage == "persistent" && conf.DynamicZones.Dynamic.Allowed
+		// API-managed zone (zone add/delete/modify); the allowed: gate is
+		// per zone type since the dynamic-primary extension
+		return conf.DynamicZones.Dynamic.Storage == "persistent" && conf.DynamicZones.Dynamic.Allows(zd.ZoneType)
 	}
 
 	return false
@@ -375,9 +376,15 @@ var (
 
 // zoneDataToZoneConf converts a ZoneData to ZoneConf for serialization
 func zoneDataToZoneConf(zd *ZoneData, zoneDirectory string) ZoneConf {
-	// Generate zone file path
-	zoneFileName := fmt.Sprintf("%s.zone", strings.TrimSuffix(zd.ZoneName, "."))
-	zoneFilePath := filepath.Join(zoneDirectory, zoneFileName)
+	// Zone file path: the zone's actual file when it has one (a template-
+	// expanded primary's file may live outside zonedirectory:), else the
+	// canonical <zonedirectory>/<zone>.zone derivation. For pre-existing
+	// dynamic-zone classes the two coincide, so this is behavior-neutral.
+	zoneFilePath := zd.Zonefile
+	if zoneFilePath == "" {
+		zoneFileName := fmt.Sprintf("%s.zone", strings.TrimSuffix(zd.ZoneName, "."))
+		zoneFilePath = filepath.Join(zoneDirectory, zoneFileName)
+	}
 
 	// Convert options to strings
 	optionsStrs := make([]string, 0)
@@ -417,6 +424,7 @@ func zoneDataToZoneConf(zd *ZoneData, zoneDirectory string) ZoneConf {
 		Downstreams:    zd.Downstreams,
 		DownstreamAuth: zd.DownstreamAuth,
 		OptionsStrs:    optionsStrs,
+		Template:       zd.Template,
 		SourceCatalog:  zd.SourceCatalog,
 		ApiManaged:     zd.Options[OptApiManagedZone],
 		// Note: We don't serialize Frozen, Dirty, Error, ErrorType, ErrorMsg, RefreshCount
@@ -626,7 +634,11 @@ type DynamicZoneInput struct {
 	Name      string
 	Type      ZoneType
 	Primaries []PeerConf
-	Options   map[ZoneOption]bool
+	// Template names the operator-blessed config template a primary zone is
+	// expanded from. REQUIRED for Type == Primary (API path); unused for
+	// secondaries. The template must carry dynamiczones: true (gate 2).
+	Template string
+	Options  map[ZoneOption]bool
 	// Inline TSIG key (API/CLI add/modify). When TsigName is set it is validated
 	// and upserted into the keys: store, then applied to every keyless primary
 	// (NOKEY/empty). The secret is persisted with the zone (the dynamic config
@@ -724,16 +736,26 @@ func (conf *Config) commitStagedTsigKey(staged *TsigDetails) (rollback func(), e
 func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInput, fromAPI bool) (string, error) {
 	name := dns.Fqdn(in.Name)
 
-	// API/CLI callers are gated by dynamiczones.dynamic.allowed (defaults false).
+	// API/CLI callers are gated by dynamiczones.dynamic.allowed — a list of
+	// zone types since the dynamic-primary extension (defaults to deny-all).
 	// The catalog path is gated by its own members config, not this.
-	if fromAPI && !conf.DynamicZones.Dynamic.Allowed {
-		return "", fmt.Errorf("dynamic zone provisioning via API is not allowed (set dynamiczones.dynamic.allowed: true)")
+	if fromAPI && !conf.DynamicZones.Dynamic.Allows(in.Type) {
+		return "", fmt.Errorf("dynamic %s zone provisioning via API is not allowed (add %q to dynamiczones.dynamic.allowed)",
+			ZoneTypeToString[in.Type], ZoneTypeToString[in.Type])
 	}
 
-	// API/CLI v1 is secondary-only (primary + notify peers are static/catalog
-	// config until a later extension).
-	if fromAPI && in.Type != Secondary {
-		return "", fmt.Errorf("zone add supports secondary zones only (got %s)", ZoneTypeToString[in.Type])
+	// The API creates secondary zones (transfer-provisioned) and primary
+	// zones (template-provisioned; a template is REQUIRED for primaries —
+	// the operator curates the policy space, the API caller picks a point
+	// in it). Anything else is rejected.
+	switch in.Type {
+	case Secondary:
+	case Primary:
+		if fromAPI && in.Template == "" {
+			return "", fmt.Errorf("zone add for a primary zone requires a template (operator-blessed with dynamiczones: true)")
+		}
+	default:
+		return "", fmt.Errorf("zone add supports primary and secondary zones only (got %s)", ZoneTypeToString[in.Type])
 	}
 
 	if _, err := dns.IsDomainName(name); !err {

--- a/v2/dynamic_zones_b5_test.go
+++ b/v2/dynamic_zones_b5_test.go
@@ -83,10 +83,10 @@ func TestZoneDataToZoneConf_PersistsAsWrittenPrimaries(t *testing.T) {
 func TestShouldPersistZone_DynamicBranch(t *testing.T) {
 	conf := &Config{}
 	conf.DynamicZones.ZoneDirectory = "/tmp/zones"
-	conf.DynamicZones.Dynamic.Allowed = true
+	conf.DynamicZones.Dynamic.Allowed = ZoneTypeList{"secondary"}
 	conf.DynamicZones.Dynamic.Storage = "persistent"
 
-	api := &ZoneData{ZoneName: "api.example.", Options: map[ZoneOption]bool{OptApiManagedZone: true}}
+	api := &ZoneData{ZoneName: "api.example.", ZoneType: Secondary, Options: map[ZoneOption]bool{OptApiManagedZone: true}}
 	if !conf.ShouldPersistZone(api) {
 		t.Error("API-managed zone should persist when dynamic allowed+persistent")
 	}

--- a/v2/dynamic_zones_cores_test.go
+++ b/v2/dynamic_zones_cores_test.go
@@ -14,7 +14,7 @@ func newTestConfigForCores(t *testing.T) (*Config, chan ZoneRefresher) {
 	ch := make(chan ZoneRefresher, 16)
 	conf := &Config{}
 	conf.Internal.RefreshZoneCh = ch
-	conf.DynamicZones.Dynamic.Allowed = true
+	conf.DynamicZones.Dynamic.Allowed = ZoneTypeList{"secondary", "primary"}
 	// A real (empty-cache) IMR so hostname primaries route through the resolver;
 	// literal-IP primaries short-circuit before any lookup.
 	conf.Internal.ImrEngine = newTestImr(t)
@@ -31,7 +31,7 @@ func resetZonesForTest() {
 func TestProvisionDynamicZone_Gate(t *testing.T) {
 	resetZonesForTest()
 	conf, _ := newTestConfigForCores(t)
-	conf.DynamicZones.Dynamic.Allowed = false
+	conf.DynamicZones.Dynamic.Allowed = nil
 
 	in := DynamicZoneInput{Name: "gated.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err == nil {

--- a/v2/dynamic_zones_cores_test.go
+++ b/v2/dynamic_zones_cores_test.go
@@ -43,14 +43,16 @@ func TestProvisionDynamicZone_Gate(t *testing.T) {
 	}
 }
 
-func TestProvisionDynamicZone_RejectsPrimaryAndBadKey(t *testing.T) {
+func TestProvisionDynamicZone_RejectsTemplatelessPrimaryAndBadKey(t *testing.T) {
 	resetZonesForTest()
 	conf, _ := newTestConfigForCores(t)
 
-	// type: primary is rejected on the API path (v1 secondary-only).
-	prim := DynamicZoneInput{Name: "prim.example", Type: Primary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
+	// type: primary without a template is rejected on the API path (a
+	// template is REQUIRED for primaries — the operator-blessed envelope).
+	// Template-provisioned primaries are exercised in dynamic_primary_test.go.
+	prim := DynamicZoneInput{Name: "prim.example", Type: Primary}
 	if _, err := conf.ProvisionDynamicZone(context.Background(), prim, true); err == nil {
-		t.Error("expected type: primary to be rejected on API path")
+		t.Error("expected template-less primary to be rejected on API path")
 	}
 
 	// non-NOKEY key is rejected until TSIG keys exist.

--- a/v2/dynamic_zones_gates_test.go
+++ b/v2/dynamic_zones_gates_test.go
@@ -1,0 +1,118 @@
+package tdns
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// TestLegacyDynamicAllowedHook_BoolIsConfigError verifies the hard cutover:
+// a legacy bool value for dynamiczones.dynamic.allowed fails the decode with
+// an error naming the new list syntax, while the list form decodes cleanly.
+func TestLegacyDynamicAllowedHook_BoolIsConfigError(t *testing.T) {
+	decode := func(raw map[string]interface{}) (DynamicZonesConf, error) {
+		var dzc DynamicZonesConf
+		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			TagName:    "yaml",
+			Result:     &dzc,
+			DecodeHook: legacyDynamicAllowedHook(),
+		})
+		if err != nil {
+			t.Fatalf("NewDecoder: %v", err)
+		}
+		return dzc, dec.Decode(raw)
+	}
+
+	// Legacy bool -> hard error naming the new syntax.
+	_, err := decode(map[string]interface{}{
+		"dynamic": map[string]interface{}{"allowed": true},
+	})
+	if err == nil {
+		t.Fatal("expected legacy bool allowed: to be a config error")
+	}
+	if !strings.Contains(err.Error(), "allowed: [secondary]") {
+		t.Errorf("error should name the new syntax, got: %v", err)
+	}
+
+	// List form decodes.
+	dzc, err := decode(map[string]interface{}{
+		"dynamic": map[string]interface{}{"allowed": []interface{}{"secondary", "primary"}},
+	})
+	if err != nil {
+		t.Fatalf("list form failed to decode: %v", err)
+	}
+	if len(dzc.Dynamic.Allowed) != 2 {
+		t.Errorf("allowed list = %v, want [secondary primary]", dzc.Dynamic.Allowed)
+	}
+
+	// The hook must not touch the catalog blocks' bool allowed:.
+	dzc, err = decode(map[string]interface{}{
+		"catalog_zones": map[string]interface{}{"allowed": true},
+	})
+	if err != nil {
+		t.Fatalf("catalog_zones bool allowed: must still decode: %v", err)
+	}
+	if !dzc.CatalogZones.Allowed {
+		t.Error("catalog_zones.allowed lost its value")
+	}
+}
+
+func TestDynamicZonesConfValidate(t *testing.T) {
+	var d DynamicZonesConf
+	if err := d.Validate(); err != nil {
+		t.Errorf("empty allowed list must validate: %v", err)
+	}
+	d.Dynamic.Allowed = ZoneTypeList{"secondary", "Primary"}
+	if err := d.Validate(); err != nil {
+		t.Errorf("valid (case-insensitive) values must validate: %v", err)
+	}
+	d.Dynamic.Allowed = ZoneTypeList{"secondary", "tertiary"}
+	if err := d.Validate(); err == nil {
+		t.Error("unknown zone type in allowed: must be a config error")
+	}
+}
+
+func TestDynamicApiZoneConfAllows(t *testing.T) {
+	var c DynamicApiZoneConf
+	if c.Allows(Primary) || c.Allows(Secondary) {
+		t.Error("empty allowed list must deny all")
+	}
+	c.Allowed = ZoneTypeList{"SECONDARY"}
+	if !c.Allows(Secondary) {
+		t.Error("allowed match must be case-insensitive")
+	}
+	if c.Allows(Primary) {
+		t.Error("primary must not be allowed by [secondary]")
+	}
+}
+
+// TestProvisionDynamicZone_TypeGateMatrix drives the per-type allowed: gate
+// through the add core: each type is admitted iff listed.
+func TestProvisionDynamicZone_TypeGateMatrix(t *testing.T) {
+	resetZonesForTest()
+	conf, _ := newTestConfigForCores(t)
+
+	// allowed: [secondary] -> primary add refused at the gate.
+	conf.DynamicZones.Dynamic.Allowed = ZoneTypeList{"secondary"}
+	prim := DynamicZoneInput{Name: "gate1.example", Type: Primary, Template: "whatever"}
+	if _, err := conf.ProvisionDynamicZone(context.Background(), prim, true); err == nil {
+		t.Error("primary add must be refused when allowed: [secondary]")
+	}
+
+	// allowed: [primary] -> secondary add refused at the gate.
+	conf.DynamicZones.Dynamic.Allowed = ZoneTypeList{"primary"}
+	sec := DynamicZoneInput{Name: "gate2.example", Type: Secondary, Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
+	if _, err := conf.ProvisionDynamicZone(context.Background(), sec, true); err == nil {
+		t.Error("secondary add must be refused when allowed: [primary]")
+	}
+
+	// primary allowed but no template -> refused (template REQUIRED in v1).
+	noTmpl := DynamicZoneInput{Name: "gate3.example", Type: Primary}
+	if _, err := conf.ProvisionDynamicZone(context.Background(), noTmpl, true); err == nil {
+		t.Error("primary add without a template must be refused")
+	} else if !strings.Contains(err.Error(), "template") {
+		t.Errorf("refusal should mention the template requirement, got: %v", err)
+	}
+}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -914,87 +914,12 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 		lgConfig.Debug("zone incoming update policy", "zone", zname, "policy", fmt.Sprintf("%+v", zconf.UpdatePolicy))
 
-		switch zconf.UpdatePolicy.Child.Type {
-		case "selfsub", "self":
-			// all ok, we know these
-		case "none", "":
-			// these are also ok, but imply that no updates are allowed
-			options[OptAllowChildUpdates] = false
-		default:
-			lgConfig.Error("zone has unknown child update policy type, zone in error state", "zone", zname, "type", zconf.UpdatePolicy.Child.Type)
-			zd.SetError(ConfigError, "unknown child update policy type: %s", zconf.UpdatePolicy.Child.Type)
+		policy, perr := activateUpdatePolicy(zconf, options)
+		if perr != nil {
+			lgConfig.Error("zone update policy invalid, zone in error state", "zone", zname, "err", perr)
+			zd.SetError(ConfigError, "%s", perr)
 			broken_zones = append(broken_zones, zname)
 			continue
-		}
-
-		// A zone that accepts child updates MUST have a delegation backend.
-		// Without one, the write path mutates in-memory zone data while the
-		// scanner read path queries the (nil) backend, so diff computation
-		// always sees "empty current state" and child updates accumulate
-		// without ever being removed. Refuse to start such a zone rather
-		// than letting it silently misbehave.
-		if options[OptAllowChildUpdates] && zconf.DelegationBackend == "" {
-			lgConfig.Error("zone has 'allow-child-updates' but no 'delegationbackend' configured, zone in error state", "zone", zname)
-			zd.SetError(ConfigError, "allow-child-updates requires delegationbackend to be configured (e.g. 'delegationbackend: direct')")
-			broken_zones = append(broken_zones, zname)
-			continue
-		}
-
-		switch zconf.UpdatePolicy.Zone.Type {
-		case "selfsub", "self":
-			// all ok, we know these
-		case "none", "":
-			// these are also ok, but imply that no updates are allowed
-			options[OptAllowUpdates] = false
-		default:
-			lgConfig.Error("zone has unknown update policy type, zone in error state", "zone", zname, "type", zconf.UpdatePolicy.Zone.Type)
-			zd.SetError(ConfigError, "unknown update policy type: %s", zconf.UpdatePolicy.Zone.Type)
-			broken_zones = append(broken_zones, zname)
-			continue
-		}
-
-		// log.Printf("*** ParseZones: 2")
-		var rrt uint16
-		var exist bool
-		childrrtypes := map[uint16]bool{}
-		for _, rrtype := range zconf.UpdatePolicy.Child.RRtypes {
-			rrtype = strings.ToUpper(rrtype)
-			if rrt, exist = dns.StringToType[rrtype]; exist {
-				childrrtypes[rrt] = true
-			}
-		}
-
-		// log.Printf("*** ParseZones: 3")
-		zonerrtypes := map[uint16]bool{}
-		for _, rrtype := range zconf.UpdatePolicy.Zone.RRtypes {
-			rrtype = strings.ToUpper(rrtype)
-			if rrt, exist = dns.StringToType[rrtype]; exist {
-				zonerrtypes[rrt] = true
-			}
-		}
-
-		// log.Printf("*** ParseZones: 4")
-		childTTL := zconf.UpdatePolicy.Child.TTL
-		if childTTL == 0 {
-			childTTL = 120
-		}
-		zoneTTL := zconf.UpdatePolicy.Zone.TTL
-		if zoneTTL == 0 {
-			zoneTTL = 120
-		}
-		policy := UpdatePolicy{
-			Child: UpdatePolicyDetail{
-				Type:         zconf.UpdatePolicy.Child.Type,
-				RRtypes:      childrrtypes,
-				KeyBootstrap: zconf.UpdatePolicy.Child.KeyBootstrap,
-				KeyUpload:    zconf.UpdatePolicy.Child.KeyUpload,
-				TTL:          childTTL,
-			},
-			Zone: UpdatePolicyDetail{
-				Type:    zconf.UpdatePolicy.Zone.Type,
-				RRtypes: zonerrtypes,
-				TTL:     zoneTTL,
-			},
 		}
 
 		if Globals.App.Type == AppTypeAgent && zconf.Type == "primary" {
@@ -1248,6 +1173,88 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 	lgConfig.Debug("ParseZones complete")
 	return all_zones, broken_zones, nil
+}
+
+// activateUpdatePolicy validates a zone's update-policy config and builds the
+// runtime UpdatePolicy, mutating options to reflect it: a "none"/unset policy
+// type forces the corresponding OptAllowChildUpdates/OptAllowUpdates option
+// off, and allow-child-updates without a delegation backend is refused (the
+// write path would mutate in-memory zone data while the scanner queries the
+// nil backend — silent misbehavior). Extracted verbatim from ParseZones so the
+// dynamic-primary add/load paths activate policy through the SAME code and
+// cannot drift; error strings are the exact former ConfigError texts. Unknown
+// RRtype names are silently dropped (pre-extraction behavior, preserved).
+func activateUpdatePolicy(zconf *ZoneConf, options map[ZoneOption]bool) (UpdatePolicy, error) {
+	switch zconf.UpdatePolicy.Child.Type {
+	case "selfsub", "self":
+		// all ok, we know these
+	case "none", "":
+		// these are also ok, but imply that no updates are allowed
+		options[OptAllowChildUpdates] = false
+	default:
+		return UpdatePolicy{}, fmt.Errorf("unknown child update policy type: %s", zconf.UpdatePolicy.Child.Type)
+	}
+
+	// A zone that accepts child updates MUST have a delegation backend.
+	// Without one, the write path mutates in-memory zone data while the
+	// scanner read path queries the (nil) backend, so diff computation
+	// always sees "empty current state" and child updates accumulate
+	// without ever being removed. Refuse to start such a zone rather
+	// than letting it silently misbehave.
+	if options[OptAllowChildUpdates] && zconf.DelegationBackend == "" {
+		return UpdatePolicy{}, fmt.Errorf("allow-child-updates requires delegationbackend to be configured (e.g. 'delegationbackend: direct')")
+	}
+
+	switch zconf.UpdatePolicy.Zone.Type {
+	case "selfsub", "self":
+		// all ok, we know these
+	case "none", "":
+		// these are also ok, but imply that no updates are allowed
+		options[OptAllowUpdates] = false
+	default:
+		return UpdatePolicy{}, fmt.Errorf("unknown update policy type: %s", zconf.UpdatePolicy.Zone.Type)
+	}
+
+	var rrt uint16
+	var exist bool
+	childrrtypes := map[uint16]bool{}
+	for _, rrtype := range zconf.UpdatePolicy.Child.RRtypes {
+		rrtype = strings.ToUpper(rrtype)
+		if rrt, exist = dns.StringToType[rrtype]; exist {
+			childrrtypes[rrt] = true
+		}
+	}
+
+	zonerrtypes := map[uint16]bool{}
+	for _, rrtype := range zconf.UpdatePolicy.Zone.RRtypes {
+		rrtype = strings.ToUpper(rrtype)
+		if rrt, exist = dns.StringToType[rrtype]; exist {
+			zonerrtypes[rrt] = true
+		}
+	}
+
+	childTTL := zconf.UpdatePolicy.Child.TTL
+	if childTTL == 0 {
+		childTTL = 120
+	}
+	zoneTTL := zconf.UpdatePolicy.Zone.TTL
+	if zoneTTL == 0 {
+		zoneTTL = 120
+	}
+	return UpdatePolicy{
+		Child: UpdatePolicyDetail{
+			Type:         zconf.UpdatePolicy.Child.Type,
+			RRtypes:      childrrtypes,
+			KeyBootstrap: zconf.UpdatePolicy.Child.KeyBootstrap,
+			KeyUpload:    zconf.UpdatePolicy.Child.KeyUpload,
+			TTL:          childTTL,
+		},
+		Zone: UpdatePolicyDetail{
+			Type:    zconf.UpdatePolicy.Zone.Type,
+			RRtypes: zonerrtypes,
+			TTL:     zoneTTL,
+		},
+	}, nil
 }
 
 // ExpandTemplate applies template tmpl's settings to zone zconf. Every config

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -325,6 +325,7 @@ func (conf *Config) ParseConfig(reload bool) error {
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			stringToPeerConfHook(),
 			stringToAclEntryHook(),
+			legacyDynamicAllowedHook(),
 		),
 	}
 	decoder, err := mapstructure.NewDecoder(decoderConfig)
@@ -366,6 +367,14 @@ func (conf *Config) ParseConfig(reload bool) error {
 		conf.Internal.ServerErrors = NewServerErrorRegistry()
 	}
 	conf.validateDnsEngineCerts()
+
+	// dynamiczones: value validation (e.g. an unknown zone type in
+	// dynamic.allowed) is a hard config error — the decoder accepts any
+	// string, so the check lives here. A legacy bool for dynamic.allowed is
+	// caught earlier, by legacyDynamicAllowedHook failing the decode.
+	if err := conf.DynamicZones.Validate(); err != nil {
+		return err
+	}
 
 	if len(md.Unused) > 0 {
 		// Split the unused keys into two buckets: keys that match a known
@@ -1285,6 +1294,9 @@ func ExpandTemplate(zconf ZoneConf, tmpl *ZoneConf, appMode AppType) (ZoneConf, 
 	bespoke := map[string]bool{
 		"Name": true, "Template": true, // never copied from a template
 		"Zonefile": true, "OptionsStrs": true, "DnssecPolicy": true, // handled above
+		// DynamicZones is a property of the TEMPLATE (API-instantiable), not
+		// of the zones stamped out from it — never copied.
+		"DynamicZones": true,
 	}
 	gapFillStruct(reflect.ValueOf(&zconf).Elem(), reflect.ValueOf(tmpl).Elem(), bespoke, false)
 	return zconf, nil
@@ -1835,6 +1847,22 @@ func stringToAclEntryHook() mapstructure.DecodeHookFunc {
 			return data, nil
 		}
 		return AclEntry{Legacy: data.(string)}, nil
+	}
+}
+
+// legacyDynamicAllowedHook turns a legacy bool value for
+// dynamiczones.dynamic.allowed into a hard config error naming the new list
+// syntax. The field decodes into ZoneTypeList — a named type used by exactly
+// that key — so the hook cannot misfire on any other config field. There is
+// deliberately NO legacy decode (true -> [secondary]): the dynamic-primary
+// extension made "allowed" mean two independent capabilities, and a silent
+// mapping would hide that the operator has a decision to make.
+func legacyDynamicAllowedHook() mapstructure.DecodeHookFunc {
+	return func(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+		if to != reflect.TypeOf(ZoneTypeList(nil)) || from.Kind() != reflect.Bool {
+			return data, nil
+		}
+		return nil, fmt.Errorf("dynamiczones.dynamic.allowed is now a list of zone types, not a bool: use `allowed: [secondary]` (add `primary` to also allow API-created primary zones)")
 	}
 }
 

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -274,6 +274,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							zd.Downstreams = zr.Downstreams
 							zd.DownstreamAuth = zr.DownstreamAuth
 							zd.Zonefile = zr.Zonefile
+							zd.Template = zr.Template
+							if zr.PublishCadence != 0 {
+								zd.publishCadence = zr.PublishCadence
+							}
 							zd.ZoneType = zr.ZoneType
 							zd.Options = zr.Options
 							zd.UpdatePolicy = zr.UpdatePolicy
@@ -599,6 +603,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						Downstreams:      zr.Downstreams,
 						DownstreamAuth:   zr.DownstreamAuth,
 						Zonefile:         zr.Zonefile,
+						Template:         zr.Template,
 						ZoneType:         zr.ZoneType,
 						Options:          zr.Options,
 						UpdatePolicy:     zr.UpdatePolicy,
@@ -609,6 +614,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						KeyDB:            conf.Internal.KeyDB,
 						FirstZoneLoad:    true,
 						Status:           ZoneStatusPending, // registered + enqueued, no data yet (B6)
+						publishCadence:   zr.PublishCadence,
 					}
 
 					Zones.Set(zone, zd)
@@ -638,6 +644,22 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						})
 					} else if len(zd.OnFirstLoad) == 0 {
 						zd.OnFirstLoad = append(zd.OnFirstLoad, func(*ZoneData) {})
+					}
+					// Template-driven dynamic zones (dynamic primaries): wire
+					// delegation sync on first load, as ParseZones does for
+					// static zones. Scoped to zr.Template != "" so no
+					// pre-existing dynamic-zone class changes behavior.
+					if zr.Template != "" && (zd.Options[OptDelSyncParent] || zd.Options[OptDelSyncChild]) {
+						delegationSyncQ := conf.Internal.DelegationSyncQ
+						zd.OnFirstLoad = append(zd.OnFirstLoad, func(z *ZoneData) {
+							if delegationSyncQ == nil {
+								lgEngine.Error("DelegationSyncQ not available", "zone", z.ZoneName)
+								return
+							}
+							if err := z.SetupZoneSync(delegationSyncQ); err != nil {
+								lgEngine.Error("SetupZoneSync failed", "zone", z.ZoneName, "error", err)
+							}
+						})
 					}
 					zd.mu.Unlock()
 					if err := finishFirstLoadPolicy(ctx, zd, conf, zr.DnssecPolicy); err != nil {

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -617,17 +617,16 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						publishCadence:   zr.PublishCadence,
 					}
 
-					Zones.Set(zone, zd)
-
-					if _, err := initialLoadZone(ctx, zd, zone, zr, conf, refreshCounters,
-						tryPostpass); err != nil {
-						lgEngine.Error("zone refresh failed", "zone", zone, "error", err)
-						zd.SetError(RefreshError, "refresh error: %v", err)
-						zd.LatestError = time.Now()
-						continue
-					}
-
-					zd.InstallInitialSnapshot()
+					// Register the OnFirstLoad callbacks BEFORE the initial load:
+					// on a first-load failure the ticker retry path re-runs
+					// initialLoadZone + completeFirstZonePolicyAndLoad against
+					// the SAME ZoneData, and only drains callbacks that are
+					// already registered — registering after a successful load
+					// (the historical order) meant a failed-then-retried dynamic
+					// zone never got signing/sync set up. Registration is inert
+					// until drainAndRunOnFirstLoad, so the success path is
+					// unchanged.
+					//
 					// Dynamic zones historically called SetupZoneSigning inline
 					// (not via OnFirstLoad). Register it on OnFirstLoad so a
 					// sync failure is retryable by the ticker completion path
@@ -649,6 +648,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 					// delegation sync on first load, as ParseZones does for
 					// static zones. Scoped to zr.Template != "" so no
 					// pre-existing dynamic-zone class changes behavior.
+					// SetupZoneSync's delegation-sync-child path does an
+					// unbounded send to DelegationSyncQ, and OnFirstLoad
+					// callbacks run inside this engine loop — dispatch async so
+					// a full/stopped consumer cannot stall refresh processing.
 					if zr.Template != "" && (zd.Options[OptDelSyncParent] || zd.Options[OptDelSyncChild]) {
 						delegationSyncQ := conf.Internal.DelegationSyncQ
 						zd.OnFirstLoad = append(zd.OnFirstLoad, func(z *ZoneData) {
@@ -656,12 +659,26 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 								lgEngine.Error("DelegationSyncQ not available", "zone", z.ZoneName)
 								return
 							}
-							if err := z.SetupZoneSync(delegationSyncQ); err != nil {
-								lgEngine.Error("SetupZoneSync failed", "zone", z.ZoneName, "error", err)
-							}
+							go func() {
+								if err := z.SetupZoneSync(delegationSyncQ); err != nil {
+									lgEngine.Error("SetupZoneSync failed", "zone", z.ZoneName, "error", err)
+								}
+							}()
 						})
 					}
 					zd.mu.Unlock()
+
+					Zones.Set(zone, zd)
+
+					if _, err := initialLoadZone(ctx, zd, zone, zr, conf, refreshCounters,
+						tryPostpass); err != nil {
+						lgEngine.Error("zone refresh failed", "zone", zone, "error", err)
+						zd.SetError(RefreshError, "refresh error: %v", err)
+						zd.LatestError = time.Now()
+						continue
+					}
+
+					zd.InstallInitialSnapshot()
 					if err := finishFirstLoadPolicy(ctx, zd, conf, zr.DnssecPolicy); err != nil {
 						lgEngine.Warn("DNSSEC policy sync for dynamic zone failed", "zone", zone, "err", err)
 						zd.SetError(DnssecPolicyWarning, "DNSSEC policy sync failed: %v", err)

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -136,19 +136,24 @@ type ZoneData struct {
 	XfrType string // axfr | ixfr
 	Logger  *log.Logger
 	// ZoneFile           string // TODO: Remove this
-	IncomingSerial    uint32 // SOA serial that we got from upstream
-	CurrentSerial     uint32 // SOA serial after local bumping
-	FirstZoneLoad     bool   // true until first zone data has been loaded
-	Verbose           bool
-	Debug             bool
-	IxfrChain         []Ixfr
-	PrimariesConf     []PeerConf // as-written primaries; persisted; re-resolved each load (P3)
-	Upstreams         []PeerConf // resolved addr:port tuples; runtime-only; used for transfer
-	Notify            []PeerConf // downstream secondaries that we notify (addr + key)
-	AllowNotify       []AclEntry // secondary: who may NOTIFY us; empty => accept from resolved primaries
-	Downstreams       []AclEntry // primary: who may AXFR from us (provide-xfr ACL); empty => deny
-	DownstreamAuth    []string   // acceptable transfer-auth mechanism classes (empty => unrestricted); see authorizeTransfer
-	Zonefile          string
+	IncomingSerial uint32 // SOA serial that we got from upstream
+	CurrentSerial  uint32 // SOA serial after local bumping
+	FirstZoneLoad  bool   // true until first zone data has been loaded
+	Verbose        bool
+	Debug          bool
+	IxfrChain      []Ixfr
+	PrimariesConf  []PeerConf // as-written primaries; persisted; re-resolved each load (P3)
+	Upstreams      []PeerConf // resolved addr:port tuples; runtime-only; used for transfer
+	Notify         []PeerConf // downstream secondaries that we notify (addr + key)
+	AllowNotify    []AclEntry // secondary: who may NOTIFY us; empty => accept from resolved primaries
+	Downstreams    []AclEntry // primary: who may AXFR from us (provide-xfr ACL); empty => deny
+	DownstreamAuth []string   // acceptable transfer-auth mechanism classes (empty => unrestricted); see authorizeTransfer
+	Zonefile       string
+	// Template names the config template an API-provisioned zone was expanded
+	// from (zone add --template). Persisted in the dynamic config entry so a
+	// restart re-expands it; the update policy is deliberately NOT persisted —
+	// it re-derives from the template at boot (one source of truth).
+	Template          string
 	DelegationSyncQ   chan DelegationSyncRequest
 	Parent            string   // name of parentzone (if filled in)
 	ParentNS          []string // names of parent nameservers
@@ -282,8 +287,8 @@ type ZoneConf struct {
 	Store             string     // xfr | map | slice | reg (defaults to "map" if not specified)
 	Primaries         []PeerConf `yaml:"primaries" mapstructure:"primaries"` // upstream set, for secondary zones
 	Notify            []PeerConf
-	AllowNotify       []AclEntry   `yaml:"allow-notify" mapstructure:"allow-notify"` // secondary: who may NOTIFY us (ip-spec + key｜NOKEY｜BLOCKED)
-	Downstreams       []AclEntry   `yaml:"downstreams" mapstructure:"downstreams"`   // primary: who may AXFR from us (provide-xfr ACL)
+	AllowNotify       []AclEntry   `yaml:"allow-notify" mapstructure:"allow-notify"`       // secondary: who may NOTIFY us (ip-spec + key｜NOKEY｜BLOCKED)
+	Downstreams       []AclEntry   `yaml:"downstreams" mapstructure:"downstreams"`         // primary: who may AXFR from us (provide-xfr ACL)
 	DownstreamAuth    []string     `yaml:"downstream-auth" mapstructure:"downstream-auth"` // acceptable transfer-auth mechanisms: prefix|tsig|tls-pin|tls-pkix|tls-dane|any
 	OptionsStrs       []string     `yaml:"options" mapstructure:"options"`
 	Options           []ZoneOption `yaml:"-" mapstructure:"-"` // Ignore during both yaml and mapstructure decoding
@@ -315,15 +320,21 @@ type ZoneConf struct {
 	// applied-policy record failed, so `zone desc` can distinguish a backend
 	// failure from a genuinely absent record rather than showing both as
 	// "(not recorded)".
-	AppliedError  string            `yaml:"-"`
-	PolicyDetail  *DnssecPolicyView `yaml:"-"`
-	Template      string            `yaml:"template" mapstructure:"template"`
-	MultiSigner   string            `yaml:"multisigner" mapstructure:"multisigner"`
-	Error         bool              // zone is broken and cannot be used
-	ErrorType     ErrorType         // "config" | "refresh" | "agent" | "DNSSEC"
-	ErrorMsg      string            // reason for the error (if known)
-	RefreshCount  int               // number of times the zone has been sucessfully refreshed (used to determine if we have zonedata)
-	SourceCatalog string            // if auto-configured, which catalog zone created this zone
+	AppliedError string            `yaml:"-"`
+	PolicyDetail *DnssecPolicyView `yaml:"-"`
+	Template     string            `yaml:"template" mapstructure:"template"`
+	// DynamicZones marks a TEMPLATE as instantiable via the dynamic-zones API
+	// (zone add --type primary --template <name>). It is the per-template
+	// opt-in gate: an API client can only pick among operator-blessed
+	// configurations, never author one. Meaningful on templates only; never
+	// copied to zones by ExpandTemplate.
+	DynamicZones  bool      `yaml:"dynamiczones" mapstructure:"dynamiczones"`
+	MultiSigner   string    `yaml:"multisigner" mapstructure:"multisigner"`
+	Error         bool      // zone is broken and cannot be used
+	ErrorType     ErrorType // "config" | "refresh" | "agent" | "DNSSEC"
+	ErrorMsg      string    // reason for the error (if known)
+	RefreshCount  int       // number of times the zone has been sucessfully refreshed (used to determine if we have zonedata)
+	SourceCatalog string    // if auto-configured, which catalog zone created this zone
 	// ApiManaged marks a zone created/managed via the dynamic-zones API (zone
 	// add/delete/modify). Persisted so OptApiManagedZone can be re-derived on
 	// reload — a dedicated bool, not a SourceCatalog="api" sentinel.
@@ -683,14 +694,14 @@ func rrsToStrings(rrs []dns.RR) []string {
 }
 
 type ZoneRefresher struct {
-	Name          string
-	ZoneType      ZoneType   // primary | secondary
-	PrimariesConf []PeerConf // as-written; copied to zd.PrimariesConf on merge
-	Primaries     []PeerConf // resolved; copied to zd.Upstreams on merge
-	Notify        []PeerConf
-	AllowNotify   []AclEntry // copied to zd.AllowNotify on merge
-	Downstreams   []AclEntry // copied to zd.Downstreams on merge
-	DownstreamAuth []string  // copied to zd.DownstreamAuth on merge (config-bearing only)
+	Name           string
+	ZoneType       ZoneType   // primary | secondary
+	PrimariesConf  []PeerConf // as-written; copied to zd.PrimariesConf on merge
+	Primaries      []PeerConf // resolved; copied to zd.Upstreams on merge
+	Notify         []PeerConf
+	AllowNotify    []AclEntry // copied to zd.AllowNotify on merge
+	Downstreams    []AclEntry // copied to zd.Downstreams on merge
+	DownstreamAuth []string   // copied to zd.DownstreamAuth on merge (config-bearing only)
 	// ConfigUpdate marks a config-bearing refresher (from ParseZones /
 	// LoadDynamicZoneFiles) as opposed to a NOTIFY/refresh-only trigger. On reload
 	// it lets the merge assign Notify/AllowNotify/Downstreams even when they are
@@ -700,14 +711,22 @@ type ZoneRefresher struct {
 	ConfigUpdate bool
 	ZoneStore    ZoneStore // 1=xfr, 2=map
 	Zonefile     string
-	Options      map[ZoneOption]bool
-	Edns0Options *edns0.MsgOptions
-	UpdatePolicy UpdatePolicy
-	DnssecPolicy string
-	MultiSigner  string
-	Force        bool // force refresh, ignoring SOA serial
-	Wait         bool // wait for refresh to complete before responding
-	Response     chan RefresherResponse
+	// Template propagates the config-template name of a dynamic zone to the
+	// ZoneData built by the RefreshEngine (copied to zd.Template), so a later
+	// persist re-serializes it. Empty for template-less zones.
+	Template string
+	// PublishCadence, when non-zero, sets the zone's minimum snapshot publish
+	// interval (zd.publishCadence). Carried parsed so the RefreshEngine does
+	// not re-parse; zero means "leave the zone's default".
+	PublishCadence time.Duration
+	Options        map[ZoneOption]bool
+	Edns0Options   *edns0.MsgOptions
+	UpdatePolicy   UpdatePolicy
+	DnssecPolicy   string
+	MultiSigner    string
+	Force          bool // force refresh, ignoring SOA serial
+	Wait           bool // wait for refresh to complete before responding
+	Response       chan RefresherResponse
 }
 
 type RefresherResponse struct {
@@ -1017,7 +1036,7 @@ type ImrMgmtPost struct {
 	Zone     ZoneName               `json:"zone,omitempty"`
 	Id       string                 `json:"id,omitempty"`   // e.g. imr-show: cache identity to show
 	Data     map[string]interface{} `json:"data,omitempty"` // command-specific parameters
-	Response chan *ImrMgmtResponse   `json:"-"`
+	Response chan *ImrMgmtResponse  `json:"-"`
 }
 
 // ImrMgmtResponse is the response from a daemon's /imr endpoint.

--- a/v2/update_policy_activation_test.go
+++ b/v2/update_policy_activation_test.go
@@ -1,0 +1,79 @@
+package tdns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Tests for activateUpdatePolicy, the helper extracted from ParseZones and
+// shared with the dynamic-primary add/load paths. The error strings are part
+// of the contract (they were ConfigError texts surfaced by zone list) — the
+// assertions pin them.
+
+func TestActivateUpdatePolicy_HappyPath(t *testing.T) {
+	zconf := &ZoneConf{Name: "p.example."}
+	zconf.UpdatePolicy.Zone.Type = "selfsub"
+	zconf.UpdatePolicy.Zone.RRtypes = []string{"txt", "A"}
+	zconf.UpdatePolicy.Child.Type = ""
+	options := map[ZoneOption]bool{OptAllowUpdates: true, OptAllowChildUpdates: true}
+
+	policy, err := activateUpdatePolicy(zconf, options)
+	if err != nil {
+		t.Fatalf("activateUpdatePolicy: %v", err)
+	}
+	if !options[OptAllowUpdates] {
+		t.Error("OptAllowUpdates must survive a selfsub zone policy")
+	}
+	if options[OptAllowChildUpdates] {
+		t.Error("OptAllowChildUpdates must be forced off by an unset child policy")
+	}
+	if !policy.Zone.RRtypes[dns.TypeTXT] || !policy.Zone.RRtypes[dns.TypeA] {
+		t.Errorf("RRtypes not mapped (case-insensitively): %v", policy.Zone.RRtypes)
+	}
+	if policy.Zone.TTL != 120 || policy.Child.TTL != 120 {
+		t.Errorf("TTL defaults = %d/%d, want 120/120", policy.Zone.TTL, policy.Child.TTL)
+	}
+}
+
+func TestActivateUpdatePolicy_UnknownTypes(t *testing.T) {
+	zconf := &ZoneConf{Name: "p.example."}
+	zconf.UpdatePolicy.Child.Type = "bogus"
+	if _, err := activateUpdatePolicy(zconf, map[ZoneOption]bool{}); err == nil ||
+		!strings.Contains(err.Error(), "unknown child update policy type: bogus") {
+		t.Errorf("child policy error drifted: %v", err)
+	}
+
+	zconf = &ZoneConf{Name: "p.example."}
+	zconf.UpdatePolicy.Zone.Type = "bogus"
+	if _, err := activateUpdatePolicy(zconf, map[ZoneOption]bool{}); err == nil ||
+		!strings.Contains(err.Error(), "unknown update policy type: bogus") {
+		t.Errorf("zone policy error drifted: %v", err)
+	}
+}
+
+func TestActivateUpdatePolicy_ChildUpdatesRequireBackend(t *testing.T) {
+	zconf := &ZoneConf{Name: "p.example."}
+	zconf.UpdatePolicy.Child.Type = "selfsub"
+	options := map[ZoneOption]bool{OptAllowChildUpdates: true}
+	if _, err := activateUpdatePolicy(zconf, options); err == nil ||
+		!strings.Contains(err.Error(), "allow-child-updates requires delegationbackend") {
+		t.Errorf("backend requirement error drifted: %v", err)
+	}
+
+	zconf.DelegationBackend = "direct"
+	if _, err := activateUpdatePolicy(zconf, options); err != nil {
+		t.Errorf("with a backend the same config must activate: %v", err)
+	}
+
+	// Unknown RRtype names are silently dropped (preserved behavior).
+	zconf.UpdatePolicy.Child.RRtypes = []string{"NS", "NOTATYPE"}
+	policy, err := activateUpdatePolicy(zconf, options)
+	if err != nil {
+		t.Fatalf("activateUpdatePolicy: %v", err)
+	}
+	if !policy.Child.RRtypes[dns.TypeNS] || len(policy.Child.RRtypes) != 1 {
+		t.Errorf("unknown RRtype handling drifted: %v", policy.Child.RRtypes)
+	}
+}

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -179,6 +179,21 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 						lg.Debug("ZoneUpdater: zone updated, setting dirty flag", "zone", zd.ZoneName)
 						zd.Options[OptDirty] = true
 						logUpdateActions("ZONE-UPDATE", ur.Actions)
+
+						// API-managed primaries persist updated content
+						// immediately (the mirror of the CHILD-UPDATE 'direct'
+						// backend persist): without this, updated content
+						// lives only in RAM until a freeze/manual write and is
+						// lost on restart. WriteZone clears OptDirty on
+						// success, which also un-blocks the dirty-primary
+						// reload refusal.
+						if zd.ZoneType == Primary && zd.Options[OptApiManagedZone] && zd.Zonefile != "" {
+							if _, werr := zd.WriteZone(true, false); werr != nil {
+								lg.Warn("ZoneUpdater: failed to persist API-managed primary after ZONE-UPDATE (updated content is in memory only until the next successful write)", "zone", zd.ZoneName, "file", zd.Zonefile, "error", werr)
+							} else {
+								lg.Debug("ZoneUpdater: persisted API-managed primary after ZONE-UPDATE", "zone", zd.ZoneName, "file", zd.Zonefile)
+							}
+						}
 					}
 
 					// Enqueue delegation sync after successful apply

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -177,21 +177,43 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 					}
 					if updated && !ur.InternalUpdate {
 						lg.Debug("ZoneUpdater: zone updated, setting dirty flag", "zone", zd.ZoneName)
-						zd.Options[OptDirty] = true
+						zd.SetOption(OptDirty, true)
 						logUpdateActions("ZONE-UPDATE", ur.Actions)
+					}
 
-						// API-managed primaries persist updated content
-						// immediately (the mirror of the CHILD-UPDATE 'direct'
-						// backend persist): without this, updated content
-						// lives only in RAM until a freeze/manual write and is
-						// lost on restart. WriteZone clears OptDirty on
-						// success, which also un-blocks the dirty-primary
-						// reload refusal.
-						if zd.ZoneType == Primary && zd.Options[OptApiManagedZone] && zd.Zonefile != "" {
-							if _, werr := zd.WriteZone(true, false); werr != nil {
-								lg.Warn("ZoneUpdater: failed to persist API-managed primary after ZONE-UPDATE (updated content is in memory only until the next successful write)", "zone", zd.ZoneName, "file", zd.Zonefile, "error", werr)
+					// API-managed primaries persist updated content
+					// immediately (the mirror of the CHILD-UPDATE 'direct'
+					// backend persist): without this, updated content lives
+					// only in RAM until a freeze/manual write and is lost on
+					// restart. Internal updates (CSYNC/KEY publication etc.)
+					// are included — they change zone data too but never set
+					// OptDirty, so they need force. WriteZone clears OptDirty
+					// on success, which also un-blocks the dirty-primary
+					// reload refusal. The persistence decision reads a
+					// zd.mu-protected snapshot (RefreshEngine mutates these
+					// fields under that lock on reload); the lock is NOT held
+					// across WriteZone, which reacquires it.
+					if updated {
+						zd.mu.Lock()
+						apiPrimary := zd.ZoneType == Primary && zd.Options[OptApiManagedZone]
+						zonefile := zd.Zonefile
+						zd.mu.Unlock()
+						if apiPrimary && zonefile != "" {
+							if _, werr := zd.WriteZone(true, ur.InternalUpdate); werr != nil {
+								// The client response is long gone (async queue),
+								// so surface the persistence failure durably:
+								// visible in zone list, deliberately NOT
+								// service-impacting (memory state is good).
+								lg.Warn("ZoneUpdater: failed to persist API-managed primary after ZONE-UPDATE (updated content is in memory only until the next successful write)", "zone", zd.ZoneName, "file", zonefile, "error", werr)
+								zd.SetError(RefreshError, "failed to persist zone after update: %v", werr)
+								zd.LatestError = time.Now()
 							} else {
-								lg.Debug("ZoneUpdater: persisted API-managed primary after ZONE-UPDATE", "zone", zd.ZoneName, "file", zd.Zonefile)
+								// A successful persist is the primary-zone
+								// analogue of a successful refresh (both are
+								// file I/O): clear RefreshError, same as the
+								// refresh paths do.
+								zd.ClearError(RefreshError)
+								lg.Debug("ZoneUpdater: persisted API-managed primary after ZONE-UPDATE", "zone", zd.ZoneName, "file", zonefile, "internal", ur.InternalUpdate)
 							}
 						}
 					}


### PR DESCRIPTION
Implements the agreed design in `docs/2026-07-13-dynamic-primary-zones.md`: API-provisioned, **template-constrained primary zones** — create/serve new primaries at runtime via `zone add --type primary --template <name>`, constrained to operator-blessed templates, persisted so a restart rebuilds them. One branch end-to-end, commits sequenced per the doc's §10.4 PR1→PR4 stages.

## What's in here

**Gates (§3)**
- `dynamiczones.dynamic.allowed` changes **bool → list of zone types** (`allowed: [secondary, primary]`), in its own `DynamicApiZoneConf` (catalog blocks keep the bool). A legacy bool is a **hard config error naming the new syntax** (decode hook wired into both the daemon loader and `config check`); unknown values are config errors; absent/empty = deny all. **This is the one breaking config change** — deployed configs using `dynamic: allowed: true/false` need the list syntax.
- Templates gain a `dynamiczones: true` blessing flag (never copied to zones). API adds require it; already-persisted zones load without it (blessing gates new adds, mirroring how `allowed:` treats persisted zones).

**Shared activation (§10.2-E)** — the update-policy validation/activation block was factored out of `ParseZones` into `activateUpdatePolicy`, behavior-preserving (error strings pinned by tests), and is used by ParseZones + the add path + the boot path, so they cannot drift.

**Primary add path (§4)** — `prepareDynamicPrimary` runs the same validation sequence ParseZones applies (alias-conflict, peer-refs, downstream-auth + ACLs, publish-cadence, DNSSEC-policy resolution, options, policy activation), bootstraps the apex (SOA serial 1, timers `3600 600 604800 300`, NS + glue from `dnsengine.addresses`; wildcard listeners skipped with WARN; existing files used as-is), registers a fully-configured first-load stub so the RefreshEngine runs the standard first-bind sequence — the bootstrapped apex lands through the post-snapshot publish path (§10.3 risk 2). Inline TSIG is reinterpreted for the primary role: keyless `downstreams` entries are rewired to the staged key (BLOCKED never touched).

**Restart (§5)** — the persisted entry carries `template:` + `type: primary`; `LoadDynamicZoneFiles` re-expands via the same shared helper (persisted fields win by gap-fill; update policy deliberately NOT persisted — re-derives from the template). Missing/broken template ⇒ visible ERROR-state zone, not a silent skip.

**Lifecycle** — `modify` refused for primaries (v1, per §5); `delete` also removes the template-path zone file; RFC 2136 ZONE-UPDATEs on an API-managed primary persist the zone file immediately (mirror of the CHILD-UPDATE `direct`-backend persist) so updated content survives a restart.

## Design-doc corrections + resolved forks

The doc's §2 "already exists" claims were re-verified against main @ 7885f23; two had drifted and are corrected in place:
- **Restart works via `LoadDynamicZoneFiles`, not `include:`+ParseZones** — the include merge *overrides* list-valued keys (an included dynamic file's `zones:` clobbers other files' zones) and the ParseZones route drops the ApiManaged marker.
- **Dirty-primary content was never auto-persisted** (write-back only ran on refresh, which dirty primaries refuse) — closed by the update-time write-back.

Every fork resolved during the (owner-AFK) implementation is recorded with rationale in the doc's new **§11** — highlights: v1 refuses `allow-child-updates` / catalog / multi-provider options in blessed templates; unusable dnssecpolicy refuses the add; caller-supplied options/primaries refused for primaries (the template IS the envelope); `zoneDataToZoneConf` honors `zd.Zonefile`; template reads under `confMu.RLock`.

## Found & fixed in live testing

A pre-existing latent bug affecting **all** dynamic zones: on a server with zero static zones, the default query handler was never registered, so every dynamically-added zone's queries got REFUSED (masked on testbeds that always carry static zones). The handler now also registers when dynamic zones are possible. Relatedly, `CheckDynamicConfigFileIncluded` warned in the wrong direction (pre-`LoadDynamicZoneFiles` leftover) — it now warns when the dynamic file IS included, and the sample config no longer lists it under `include:`.

## Test evidence

- Unit: gate matrix (allowed-list × blessing × type), legacy-bool config error, activation-helper behavior pinning, bootstrap edge cases (wildcard/dedupe/zero-address), TSIG downstreams rewiring (BLOCKED untouched), boot re-expansion incl. ERROR-state registration, modify-refusal, delete file removal, existing-file preservation.
- `go test -race ./...` green in all five modules (v2, v2/cli, v2/core, v2/cache, v2/edns0); gofmt clean on touched files; all six cmdv2 binaries build via make.
- **Live smoke** (fresh tdns-auth, empty `zones:`): add → SOA/NS/glue served from the synthesized apex → unsigned UPDATE refused → restart → template re-expanded, zone Ready and still update-gated → delete → zone, zone file, and dynamic-config entry all gone.

Not live-exercised: signed-UPDATE round-trip (needs SIG(0) truststore setup) and the inline-TSIG transfer gating — both unit-covered; suggest exercising via tdns-debug per §6 as follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API/CLI support for creating dynamic primary and secondary zones, with template selection for primary zones.
  * Introduced per-zone-type configuration controls for which dynamic zone types can be created via the API.
  * Dynamic primary provisioning now includes template-aware bootstrapping and refresh handling, including delegation sync when enabled.
* **Bug Fixes**
  * Improved validation and clearer errors for invalid dynamic-zone configuration (including legacy syntax handling).
  * Ensured API-managed primary zones persist successful primary updates promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->