### PR TITLE
Outbound IXFR (RFC 1995): delta retention + incremental serving

### DIFF
--- a/docs/2026-07-02-ixfr-support.md
+++ b/docs/2026-07-02-ixfr-support.md
@@ -1,92 +1,240 @@
 # Project C — IXFR Support (RFC 1995)
 
-**Status:** design sketch — **scheduled after Project B**; details firm up once B
-lands (the snapshot/publish/chain foundation determines the specifics).
-**Date:** 2026-07-02
-**Depends on:** Project B (`…-zone-mutation-snapshot-correctness.md`) — the
-immutable snapshot, `publish()` (which already *computes* per-publish deltas), and
-the per-zone publish path. **Uses:** Project A's TCP-AXFR-over-TSIG test harness
-(`…-outbound-transfer-hardening.md`).
-**Reference:** the sibling POP already does outbound IXFR the same way —
-`tapir/docs/2026-06-02-pop-149-snapshot-concurrency-design.md` (POP §4 for the
-chain + downstream tracker). Anchors as of 2026-07-02.
-
-> This doc is intentionally not polished to implementation-ready detail: the exact
-> shapes depend on how B's `publish()`/`ZoneSnapshot` land. Revisit and detail it
-> when B is done.
+**Status:** FIRMED UP 2026-07-24 (was: design sketch deferred until Project B landed).
+Project B (#279) and Project A are both DONE on main; this doc now reflects the
+**verified** state of main @ 7885f23 and the concrete plan being implemented on
+`feature/ixfr-support`.
+**Scope implemented:** outbound delta-IXFR = C1-lite (per-publish delta retention
+into the byte-bounded `IxfrChain`) + C3 (outbound IXFR serving). See §6 for what
+is deliberately deferred (inbound IXFR / C2, the POP-style downstream tracker,
+condensation).
+**Date:** 2026-07-02 (sketch), 2026-07-24 (firm-up)
 
 ---
 
-## 1. Current state (dead scaffolding to reuse)
-IXFR is ~5% present: `Ixfr{FromSerial,ToSerial uint32; Removed,Added []core.RRset}`
-(structs.go:509), `IxfrChain` (structs.go:140), `XfrType` (structs.go:132) —
-declared, never used. `ZoneTransferIn` (dnsutils.go:54) can emit an IXFR request
-(`SetIxfr`, :63) but `FetchFromUpstream` hardcodes AXFR (zone_utils.go:312).
-`IsIxfr()` (zone_utils.go:668) exists, unused. Dispatch sends both AXFR and IXFR
-to `ZoneTransferOut` (queryresponder.go:813-816), ignoring the client serial.
-**Reuse all of it.**
+## 1. Verified state of main (2026-07-24)
 
-## 2. Guiding principle — blast radius
-- An **inbound** IXFR bug corrupts only this server's copy → self-heals by
-  re-pulling AXFR.
-- An **outbound** IXFR bug ships a bad delta to downstreams → silent divergence.
+What the 2026-07-02 sketch guessed at is now checked against code:
 
-So: build inbound first, outbound last, and hold one hard invariant —
-**AXFR fallback is always available; IXFR is never a correctness dependency.** Any
-doubt (unknown/too-old serial, non-contiguous chain, audit mismatch) ⇒ full AXFR.
-Worst case of any bug is a slower transfer, never a wrong delta.
+* `Ixfr{FromSerial,ToSerial uint32; Removed,Added []core.RRset}` (structs.go)
+  and `ZoneData.IxfrChain []Ixfr` exist; `zoneSnapshot.IxfrChain` is copied on
+  every publish via `copyIxfrChain` (zone_mutation.go `buildSnapshotLocked`).
+  **Nothing ever appends to the chain — it is always empty on main.** There is
+  no delta history to serve from; retention must be built (this project).
+* `publish()` does NOT compute an RR-level delta. The only diffing on main is
+  `pendingChanges()` (B2 observability): owner/type-level, on-demand, not
+  retained.
+* **The delta IS cheaply computable at publish time.** Post-B3, the working set
+  is seeded from the published snapshot **sharing `*OwnerData` pointers**
+  (`ensureWorkingSet`), and every mutator goes through `cloneOwner` /
+  `stageOwnerReplaceLocked`, which swap in a fresh pointer. Therefore
+  changed owners == owners whose pointer differs between the old snapshot's
+  `Data` and the new working set. The diff is O(#owners) pointer compares plus
+  RR-level comparison only on changed owners. This is the load-bearing fact
+  that makes delta retention affordable on the publish hot path.
+* `ZoneTransferOut` (dnsutils.go) already: runs the complete transfer-out
+  authorization gate (`authorizeTransfer`: downstreams ACL + downstream-auth
+  mechanism ladder, XoT-aware), pins ONE snapshot for the whole transfer (M1),
+  fail-closes on unsigned must-be-signed zones, and streams through the
+  Project-A envelope batcher (`batchState`, `appendRRset`, 64000-byte safe
+  cap, oversize-RRset abort). IXFR queries are dispatched to it
+  (queryresponder.go) but the client serial is ignored and a full AXFR-shaped
+  response is served — which is already the RFC 1995 §4 fallback, so the
+  baseline on main is compliant-but-never-incremental.
+* The johanix/dns fork (v1.1.72-johanix.2) `Transfer.Out` writes envelopes
+  verbatim (Answer := envelope RRs) with TSIG continuation; `Transfer.In`'s
+  `inIxfr` gives the exact client-side framing contract (see §4.2).
+* Publishes that change content WITHOUT bumping the serial exist on main:
+  catalog version-TXT injection (apihandler_catalog.go), transport-signal
+  commits (tsignal.go), `RepopulateDynamicRRs` (zone_utils.go). Publishes that
+  bump the serial without changing content also exist
+  (outbound_soa_serial=unixtime/persist restore, refreshengine.go). Both must
+  be handled by retention (§4.1).
+* Wholesale zone replacement on the SAME `ZoneData` happens only in
+  `applyRefreshReplacementLocked` (refresh/AXFR-in/reload). `ModifyDynamicZone`
+  replaces the whole `ZoneData` object, so its chain resets for free.
+  `InstallInitialSnapshot` re-baselines from `zd.Data`.
 
-## 3. Phases (rough)
+## 2. Scope decision (owner AFK — decided and documented)
 
-### C1 — Chain retention + serial-space spec + downstream tracker  [needs B]
-- **Retain** the delta `publish()` already computes into the snapshot's
-  **byte-bounded** `IxfrChain` (append + front-trim; config knob; **one canonical
-  order — newest-last —** with prune and serve agreeing). Reload / full-AXFR flip
-  and API zone-replace (`ModifyDynamicZone`, dynamic_zones.go:960-981) = **epoch
-  reset** (clear chain, new baseline — no `zoneDiff`).
-- **`downstreamTracker`** (POP §4): downstream last-seen serials, written by DNS
-  goroutines, get a **dedicated small mutex**; chain prune is a **pure function the
-  writer runs while building the next snapshot** (reads `tracker.lowest()`), never
-  mutating shared state from a request goroutine.
-- **Serial-space spec:** chain serials are `CurrentSerial`; inbound apply sets
-  `IncomingSerial` to the upstream `ToSerial`; response/transfer SOA always
-  `CurrentSerial`; publish advances `CurrentSerial` once (no double-advance).
-- **Audit oracle spec:** canonical RRset key + cheap full-zone snapshot for tests
-  + NSEC/RRSIG-churn collapsing; `served == baseline + Σ retained deltas`.
+**Implement real outbound delta-IXFR now**, not just the fallback baseline:
 
-### C2 — Inbound IXFR (low blast radius)  [needs B, C1]
-- `FetchFromUpstream` requests IXFR with `IncomingSerial` when a baseline exists;
-  `ZoneTransferIn` parses RFC 1995 difference sequences (reuse miekg's
-  envelope-stream semantics, not just `IsIxfr` on RR slices) into deltas, applies
-  each via `publish()`, advancing `IncomingSerial` stepwise.
-- **AXFR fallback** on upstream-AXFR / gap / malformed; audit-oracle reconcile ⇒
-  drop + re-pull AXFR + log loudly. Verify `SetIxfr("",..)` produces a valid
-  Authority SOA for upstreams that want MNAME/RNAME.
+* The mission fork was "(i) real deltas if the snapshot chain gives enough
+  history, (ii) otherwise fallback baseline first". Literally, main retains no
+  history — but the pointer-sharing property above means correct, exact deltas
+  are computable at publish time with near-zero incremental cost, and the
+  snapshot/pinning discipline gives torn-free serving for free. Building only
+  the fallback would leave the interesting 90% (retention) unbuilt while all
+  its foundations are in place; and the fallback shape ALREADY exists on main.
+* Blast-radius control (§2 of the sketch) is preserved: **IXFR is never a
+  correctness dependency.** Any doubt — unknown serial, non-contiguous chain,
+  same-serial content mutation, serial regression, over-budget chain, UDP —
+  degrades to the existing full-transfer path or a single-SOA answer.
+  The worst case of any retention bug is a wasteful transfer, never a wrong
+  delta... provided retention itself is exact, which the tests must pin down.
 
-### C3 — Outbound IXFR  [needs B complete, C1, A]
-- Detect IXFR (`Qtype==IXFR` + client SOA in `r.Ns`); walk `snap.IxfrChain` in
-  `CurrentSerial` space (RFC 1982 arithmetic — reuse `year68` dnsutils.go:25 /
-  cache/rrset_validate.go:1028-1040, don't reinvent). Contiguous ⇒ **concatenate**
-  per-step difference sequences with RFC 1995 bracketing
-  `SOA(begin)→dels→adds→SOA(end)` — a **distinct emission driver that reuses
-  Project A's batcher size machinery** (not AXFR's leading-apex/trailing-SOA
-  shape). Else ⇒ **AXFR fallback**. Signed IXFR reuses the per-envelope TSIG path.
-- Enable only once B guarantees the chain is complete (every mutator publishes).
+## 3. Guiding invariants (unchanged from the sketch)
 
-## 4. Design decisions (carried from the combined plan)
-- **Concatenate, don't condense** (v1) — concatenation is RFC 1995 canonical;
-  condensation is the optional optimization and a *merge* step (an outbound-bug
-  risk) we skip. The byte-bounded chain caps the worst-case concatenated response;
-  RRSIG-churn replay is the amplifier, bounded by the chain budget.
-- **Chain bounded by bytes** (primary knob; count secondary).
-- Deferred: condensation; `XfrType`-driven policy (wire or delete the field).
+1. AXFR fallback is always available; serve a full zone whenever the chain
+   cannot prove a contiguous path `clientSerial → snap.Serial`.
+2. Serve ONLY from one pinned snapshot (`snap.IxfrChain`, `snap.SOA`,
+   `snap.Data`) — never from live `zd` state — so a concurrent publish cannot
+   tear a response.
+3. One canonical chain order: newest-last. Append at publish; trim from the
+   front on budget; contiguity `chain[i].ToSerial == chain[i+1].FromSerial`
+   holds by construction and is re-verified at serve time (belt and braces).
+4. Serial space: chain serials live in the OUTBOUND (`CurrentSerial`) space —
+   the same space the SOA in every response and transfer uses. Inbound
+   (`IncomingSerial`) never enters the chain.
+5. Concatenate, don't condense (RFC 1995-canonical; condensation is the
+   optional merge step we skip — an outbound-bug risk with no v1 payoff).
 
-## 5. Rough risk / effort / LOC (refine after B)
-| Phase | Risk | Effort (agent) | LOC (impl+test) |
-|---|---|---|---|
-| C1 chain + serial/audit + tracker | medium | ~1–1.5 h | ~360 |
-| C2 inbound IXFR | medium (self-heals) | ~1.5–2.5 h | ~470 |
-| C3 outbound IXFR | medium | ~1.5–2.5 h | ~500 |
+## 4. Design
 
-Total ~1330 LOC, ~4–6 h — but re-estimate once B's `publish()`/snapshot shapes are
-known.
+### 4.1 Retention (the publish path)
+
+Single choke point: `publishWorkingSetLocked` (all cadence/urgent/staged
+publishes funnel through it), immediately before `buildSnapshotLocked`, so the
+new snapshot's copied chain always ends exactly at the new snapshot's serial.
+
+`zd.updateIxfrChainLocked(old *zoneSnapshot, newSerial, newData, newSOA)`:
+
+* `old == nil || old.SOA == nil` → chain = nil (first publish / no baseline).
+* staged epoch reset (`zd.wsIxfrEpochReset`, set by
+  `applyRefreshReplacementLocked`) → chain = nil, skip diffing entirely (a
+  wholesale replace has no meaningful "delta"; diffing it would be O(zone)
+  work to produce a delta nobody should serve).
+* `newSerial == old.Serial`: diff; empty → chain unchanged (e.g. a
+  signalSynth-only publish); non-empty → **chain = nil + loud log** (a
+  same-serial content change makes "serial N" ambiguous — any retained history
+  through that point could ship a wrong delta; see also the §7 wart).
+* `newSerial` not RFC-1982-newer than `old.Serial` → chain = nil + log
+  (serial regression/wrap anomaly).
+* else: compute the delta, append
+  `Ixfr{FromSerial: old.Serial, ToSerial: newSerial, FromSOA, ToSOA, Removed,
+  Added, EstBytes}`; an EMPTY delta still appends a link (serial-only advance,
+  e.g. outbound_soa_serial=unixtime — the empty step keeps the chain
+  contiguous and is legal RFC 1995 wire: `SOA(from) SOA(to)`).
+* trim: while total `EstBytes` exceeds the budget (or link count > hard cap),
+  drop the OLDEST link; if the newest link alone exceeds the budget →
+  chain = nil (history cannot be retained at this budget).
+
+Delta computation (`computeZoneDelta(oldData, newData)`):
+
+* Pointer-diff owners first (the COW property); RRset-level comparison
+  (`rrsetEqual`, exists on main) only for owners whose pointer changed;
+  RR-level string-keyed set difference only for RRsets that differ. TTL or
+  RDATA change ⇒ delete-old + add-new, per RFC 1995.
+* **Apex SOA special case:** the SOA RRs themselves are EXCLUDED from
+  Removed/Added — in the wire format the bracketing SOAs ARE the SOA change.
+  SOA RRSIGs are ordinary diff content (they must travel in Removed/Added, and
+  they churn on every re-sign). Bracket SOAs are stored as full RRs
+  (`FromSOA`/`ToSOA`) because SOA RDATA (timers/MNAME) can change between
+  serials — reconstructing brackets by rewriting the current SOA's serial
+  would be wrong.
+* Removed/Added hold REFERENCES to snapshot-owned RRs (no dns.Copy): snapshot
+  data is immutable by the B invariant, and the chain budget bounds retained
+  bytes. Emission only reads them.
+
+`Ixfr` struct: gains `FromSOA, ToSOA *dns.SOA` and `EstBytes int` — additive;
+the struct is declared-but-unused on main so this breaks nobody.
+
+Epoch resets: `applyRefreshReplacementLocked` (flag as above) and
+`InstallInitialSnapshot` (unconditional chain = nil: it re-baselines from
+`zd.Data` outside the publish path).
+
+Config: `ixfr-chain-max-bytes` (per-zone in ZoneConf, template-gap-filled like
+every other field; parsed next to publish-cadence). 0/unset → default
+1 MiB; negative → retention disabled (zone serves only fallback AXFR). Link
+count is secondarily capped (512) as a defensive bound. Default-ON: retention
+is cheap, additive, and AXFR remains available regardless.
+
+### 4.2 Serving (ZoneTransferOut)
+
+All existing gates run UNCHANGED first (authorizeTransfer, Ready, MapZone,
+snapshot pinned, apex/SOA present, signed-zone fail-closed). Then, for
+`Qtype == IXFR` only:
+
+1. Parse the client's SOA from the query Authority section. No SOA → log +
+   serve the full zone (always-correct; SetIxfr always includes it, so this is
+   a malformed-client corner, not a protocol branch).
+2. `clientSerial` same-or-newer than `snap.Serial` (RFC 1982; incomparable
+   counts as not-older, conservative) → **single-SOA reply** (RFC 1995 §2), a
+   normal TSIG-signed response via `signResponseLikeRequest`, not an envelope
+   stream.
+3. Transport is UDP → **single-SOA reply** (RFC 1995 §4 "does not fit"
+   signal; the client retries over TCP). v1 never attempts delta-over-UDP —
+   optional per RFC, and it sidesteps the truncation minefield. (UDP AXFR
+   behavior is untouched.)
+4. Chain walk on the PINNED snapshot: find `chain[i].FromSerial ==
+   clientSerial`, verify contiguity through the tail AND tail `ToSerial ==
+   snap.Serial`. Found → emit the delta stream. Not found / any
+   inconsistency → log + fall through to the existing full-transfer code
+   (RFC 1995 §4 fallback).
+
+Delta emission reuses the Project-A machinery exactly (same tr.Out goroutine,
+`batchState`, size caps, oversize abort, TSIG-per-envelope, done-channel
+client-disconnect handling):
+
+```
+SOA(cur)                                        ← bare RR, serial = snap.Serial
+per step: FromSOA, Removed…, ToSOA, Added…      ← bare bracket SOAs; RRSIGs inside Removed/Added
+SOA(cur)                                        ← trailing, with the AXFR path's
+                                                  flush-before-trailing treatment
+```
+
+No bare SOA RR may ever appear inside Removed/Added (the §4.1 exclusion): the
+client-side framing (fork `inIxfr`) counts SOA records to find step boundaries
+and the end of the stream; a stray SOA would break framing. The emission
+contract against fork `inIxfr`, verified: first RR must be SOA (cur);
+`qser >= serial` short-circuits up-to-date; stream ends at the third
+occurrence of a cur-serial SOA (or the second for AXFR-shaped responses).
+
+### 4.3 Serial arithmetic
+
+`serialNewer(a, b uint32) bool` — RFC 1982 "a is newer than b":
+`d := a - b (mod 2^32); d != 0 && d < 2^31`. Distance exactly 2^31 is
+undefined by the RFC → reports not-newer both ways → we serve a single SOA
+(client not provably behind) — conservative, self-healing (client's own SOA
+refresh logic recovers). Table-tested including wrap.
+
+## 5. Tests (all in v2, table/harness style; reuse the Project-A harness)
+
+Retention: publish appends exact delta (adds/removes/brackets/serials); apex
+SOA excluded, SOA RRSIG churn included; epoch reset on refresh-replacement and
+InstallInitialSnapshot; same-serial content change resets; serial-only publish
+appends empty link; byte budget trims oldest / nukes on oversize link;
+disabled (negative) keeps chain empty.
+
+Serving (loopback DNS server + fork Transfer.In, per Project A):
+up-to-date and client-ahead → single SOA; unknown/too-old serial → full zone
+(AXFR-shaped: second RR non-SOA); one-step delta → exact RFC 1995 sequence;
+multi-step → concatenated sequences, envelope caps respected; UDP IXFR →
+single SOA via fakeRW; TSIG round-trip on the delta path; contiguity-violation
+snapshot (hand-built) → fallback.
+
+`serialNewer` table incl. wrap and the 2^31 boundary.
+
+Gate: full `v2` -race suite green; gofmt clean; cmdv2 binaries build via
+gmake (GOROOT=/opt/local/lib/go).
+
+## 6. Deferred (documented, not blocking)
+
+* **C2 inbound IXFR** (`FetchFromUpstream` still hardcodes AXFR): separate
+  project; needs the RFC 1995 difference-sequence parser on the client side
+  and stepwise apply via publish. Nothing in this PR blocks it; retention
+  gives it the serial bookkeeping it will need.
+* **Downstream tracker** (POP §4): prune-by-lowest-downstream-serial is an
+  optimization on top of the byte budget; the budget alone bounds memory and
+  the fallback covers pruned-too-far clients. Add when a real deployment
+  shows chain churn.
+* **Condensation**; **XfrType field wiring** (still dead — wire or delete in a
+  cleanup PR); serving IXFR-delta over UDP when it fits.
+
+## 7. Known wart surfaced (NOT fixed here)
+
+Same-serial content changes (catalog TXT, transport signals, dynamic RRs) are
+a pre-existing zone-consistency wart: downstreams that already hold serial N
+never see those changes until the next serial bump. Retention handles it
+safely (reset + loud log) but does not fix it; candidate follow-up is bumping
+the serial in those paths. Kept out of scope to stay additive.

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -496,6 +496,7 @@ func (zd *ZoneData) refuseTransfer(w dns.ResponseWriter, r *dns.Msg) (int, error
 	signResponseLikeRequest(w, r, m)
 	if err := w.WriteMsg(m); err != nil {
 		zd.Logger.Printf("ZoneTransferOut: %s: WriteMsg on REFUSED failed: %v", dns.Fqdn(zd.ZoneName), err)
+		return 0, err
 	}
 	return 0, nil
 }

--- a/v2/dnsutils.go
+++ b/v2/dnsutils.go
@@ -62,8 +62,10 @@ func (zd *ZoneData) ZoneTransferIn(up PeerConf, serial uint32, ttype string, con
 
 	msg := new(dns.Msg)
 	if ttype == "ixfr" {
-		// msg.SetIxfr(zone, serial, soa.Ns, soa.Mbox)
-		msg.SetIxfr(zd.ZoneName, serial, "", "")
+		// NB: SetIxfr("", "") packs ZERO bytes for the empty MNAME/RNAME
+		// (malformed SOA rdata → the primary FORMERRs the request). Root
+		// names pack correctly; the primary only reads the serial anyway.
+		msg.SetIxfr(zd.ZoneName, serial, ".", ".")
 	} else {
 		msg.SetAxfr(zd.ZoneName)
 	}
@@ -317,6 +319,36 @@ func (zd *ZoneData) ZoneTransferOut(ctx context.Context, w dns.ResponseWriter, r
 		zd.Logger.Printf("ZoneTransferOut: Will try to serve zone %s", zone)
 	}
 
+	// Outbound IXFR (RFC 1995, Project C). Decided before the envelope stream
+	// is set up: single-SOA answers short-circuit entirely; a provable delta
+	// (contiguous chain from the client's serial to the pinned snapshot's
+	// serial) is streamed below; anything else falls through to the full
+	// transfer, which IS the RFC 1995 §4 fallback shape. All decisions key on
+	// the pinned snapshot only.
+	var ixfrSteps []Ixfr
+	if len(r.Question) > 0 && r.Question[0].Qtype == dns.TypeIXFR && snap.SOA != nil {
+		clientSOA := ixfrQuerySOA(r)
+		switch {
+		case clientSOA == nil:
+			zd.Logger.Printf("ZoneTransferOut: %s: IXFR query from %s carries no SOA in the authority section; serving full zone",
+				zone, w.RemoteAddr())
+		case !serialNewer(snap.Serial, clientSOA.Serial):
+			// Client is same-or-newer than us: single SOA (RFC 1995 §2).
+			return zd.ixfrSingleSOAReply(w, r, dns.Copy(snap.SOA).(*dns.SOA))
+		case isUDPTransport(w):
+			// v1 never streams deltas over UDP: a single SOA at the current
+			// serial tells the client to retry over TCP (RFC 1995 §4).
+			return zd.ixfrSingleSOAReply(w, r, dns.Copy(snap.SOA).(*dns.SOA))
+		default:
+			if steps, ok := ixfrDeltaSteps(snap, clientSOA.Serial); ok {
+				ixfrSteps = steps
+			} else {
+				zd.Logger.Printf("ZoneTransferOut: %s: no contiguous IXFR history from serial %d to %d; falling back to full transfer",
+					zone, clientSOA.Serial, snap.Serial)
+			}
+		}
+	}
+
 	outbound_xfr := make(chan *dns.Envelope)
 	done := make(chan struct{})
 	var closeOnce sync.Once
@@ -356,6 +388,10 @@ func (zd *ZoneData) ZoneTransferOut(ctx context.Context, w dns.ResponseWriter, r
 		zd:            zd,
 	}
 
+	if ixfrSteps != nil {
+		return zd.emitIxfrDelta(bs, dns.Copy(snap.SOA).(*dns.SOA), ixfrSteps)
+	}
+
 	if !appendRRset(bs, transferSOA) {
 		return 0, nil
 	}
@@ -389,7 +425,14 @@ func (zd *ZoneData) ZoneTransferOut(ctx context.Context, w dns.ResponseWriter, r
 		}
 	}
 
-	trailingSOA := dns.Copy(soaCopy).(*dns.SOA)
+	return zd.finishTransferWithTrailingSOA(bs, dns.Copy(soaCopy).(*dns.SOA))
+}
+
+// finishTransferWithTrailingSOA appends the trailing SOA (flushing first when
+// it would not fit), runs the final oversize check, and sends the last
+// envelope. Shared by the AXFR and IXFR emission paths.
+func (zd *ZoneData) finishTransferWithTrailingSOA(bs *batchState, trailingSOA *dns.SOA) (int, error) {
+	zone := dns.Fqdn(zd.ZoneName)
 	trailingSize := estimateRRSize(trailingSOA)
 	if !maybeFlushBatch(bs, trailingSize, false) {
 		return 0, nil
@@ -421,20 +464,20 @@ func (zd *ZoneData) ZoneTransferOut(ctx context.Context, w dns.ResponseWriter, r
 		return 0, fmt.Errorf("ZoneTransferOut: %s: oversize transfer envelope (%d bytes)", zone, finalSize)
 	}
 
-	totalSent += *bs.count
+	*bs.totalSent += *bs.count
 	if zd.Verbose || Globals.Debug {
 		zd.Logger.Printf("XfrOut: Zone %s: Sending final batch #%d: %d RRs, %d bytes (total sent: %d RRs)",
-			zd.ZoneName, batchNum, len(*bs.rrs), finalSize, totalSent)
+			zd.ZoneName, *bs.batchNum, len(*bs.rrs), finalSize, *bs.totalSent)
 	} else {
 		zd.Logger.Printf("XfrOut: Zone %s: Sending final %d RRs (including trailing SOA, total sent %d)",
-			zd.ZoneName, len(*bs.rrs), totalSent)
+			zd.ZoneName, len(*bs.rrs), *bs.totalSent)
 	}
 	if !bs.sendEnvelope(*bs.rrs) {
 		return 0, nil
 	}
 
-	zd.Logger.Printf("ZoneTransferOut: %s: Sent %d RRs.", zone, totalSent)
-	return totalSent, nil
+	zd.Logger.Printf("ZoneTransferOut: %s: Sent %d RRs.", zone, *bs.totalSent)
+	return *bs.totalSent, nil
 }
 
 func oversizeRRsetOwner(rrs []dns.RR) (owner, rrtype string) {

--- a/v2/ixfr.go
+++ b/v2/ixfr.go
@@ -348,7 +348,7 @@ func (zd *ZoneData) ixfrSingleSOAReply(w dns.ResponseWriter, r *dns.Msg, soa *dn
 	if err := w.WriteMsg(m); err != nil {
 		zd.Logger.Printf("ZoneTransferOut: %s: WriteMsg on IXFR single-SOA reply failed: %v",
 			dns.Fqdn(zd.ZoneName), err)
-		return 0, nil
+		return 0, err
 	}
 	return 1, nil
 }

--- a/v2/ixfr.go
+++ b/v2/ixfr.go
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ */
+package tdns
+
+// Outbound IXFR (RFC 1995), Project C: delta retention at the publish choke
+// point plus incremental serving from the pinned snapshot.
+//
+// Invariants (docs/2026-07-02-ixfr-support.md):
+//   - IXFR is never a correctness dependency: any doubt (unknown serial,
+//     non-contiguous chain, same-serial content change, serial regression,
+//     over-budget history, UDP) degrades to the full-transfer path or a
+//     single-SOA answer. The worst case is a wasteful transfer, never a
+//     wrong delta.
+//   - Serving reads ONLY the pinned snapshot (snap.IxfrChain / snap.SOA /
+//     snap.Data), so a concurrent publish cannot tear a response.
+//   - Chain order is newest-last; contiguity holds by construction at append
+//     time and is re-verified at serve time.
+//   - No bare SOA RR ever appears inside a link's Removed/Added: the
+//     bracketing FromSOA/ToSOA carry the SOA change, and client-side framing
+//     counts SOA records to delimit difference sequences. Apex SOA RRSIGs are
+//     ordinary diff content.
+
+import (
+	"net"
+	"sort"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+const (
+	// DefaultIxfrChainMaxBytes bounds the per-zone retained delta history
+	// (estimated wire bytes) when ixfr-chain-max-bytes is unset.
+	DefaultIxfrChainMaxBytes = 1 << 20 // 1 MiB
+	// ixfrChainMaxLinks is a defensive secondary cap on chain length.
+	ixfrChainMaxLinks = 512
+)
+
+// serialNewer reports whether serial a is newer than b in RFC 1982 serial
+// arithmetic. Equal serials are not newer; the undefined half-way distance
+// (2^31) reports not-newer in both directions, so callers degrade
+// conservatively (single-SOA answer rather than a transfer).
+func serialNewer(a, b uint32) bool {
+	d := a - b
+	return d != 0 && d < year68
+}
+
+// ixfrBudget returns the effective retention budget for the zone:
+// 0/unset => default; negative => retention disabled.
+func (zd *ZoneData) ixfrBudget() int {
+	if zd.ixfrChainMaxBytes == 0 {
+		return DefaultIxfrChainMaxBytes
+	}
+	return zd.ixfrChainMaxBytes
+}
+
+// updateIxfrChainLocked maintains zd.IxfrChain across one publish: called
+// under zd.mu from publishWorkingSetLocked immediately before the snapshot is
+// built, so the chain copied into the new snapshot always ends exactly at the
+// new snapshot's serial. old is the currently-published snapshot; newSerial /
+// newData describe the snapshot about to be built.
+func (zd *ZoneData) updateIxfrChainLocked(old *zoneSnapshot, newSerial uint32, newData map[string]*OwnerData) {
+	epochReset := zd.wsIxfrEpochReset
+	zd.wsIxfrEpochReset = false
+
+	budget := zd.ixfrBudget()
+	if budget < 0 {
+		zd.IxfrChain = nil // retention disabled for this zone
+		return
+	}
+	if epochReset || old == nil || old.SOA == nil {
+		// Wholesale replace (refresh/reload/AXFR-in) or no baseline: new
+		// epoch. A replace has no meaningful delta; do not diff it.
+		zd.IxfrChain = nil
+		return
+	}
+	newSOA := soaFromApex(newSerial, apexFromSnapshotData(zd, newData))
+	if newSOA == nil {
+		// Callers refuse apex-less swaps before this point; belt and braces.
+		zd.IxfrChain = nil
+		return
+	}
+
+	removed, added, est := computeZoneDelta(zd.ZoneName, old.Data, newData)
+
+	if newSerial == old.Serial {
+		if len(removed) == 0 && len(added) == 0 {
+			return // nothing changed (e.g. signalSynth-only publish): keep history
+		}
+		// Content changed under an unchanged serial: "serial N" is now
+		// ambiguous, so any delta through this point could be wrong for some
+		// downstream. Drop history; serve full transfers until it rebuilds.
+		lg.Error("ixfr: zone content changed without a serial bump; resetting IXFR history",
+			"zone", zd.ZoneName, "serial", newSerial)
+		zd.IxfrChain = nil
+		return
+	}
+	if !serialNewer(newSerial, old.Serial) {
+		lg.Error("ixfr: outbound serial did not advance (RFC 1982); resetting IXFR history",
+			"zone", zd.ZoneName, "old", old.Serial, "new", newSerial)
+		zd.IxfrChain = nil
+		return
+	}
+
+	// An empty delta still appends a link: a serial-only advance (e.g.
+	// outbound_soa_serial=unixtime) is a legal empty difference sequence and
+	// keeps the chain contiguous.
+	link := Ixfr{
+		FromSerial: old.Serial,
+		ToSerial:   newSerial,
+		FromSOA:    old.SOA, // snapshot-owned; immutable by the B invariant
+		ToSOA:      newSOA,  // fresh copy from soaFromApex
+		Removed:    removed,
+		Added:      added,
+		EstBytes:   est + estimateRRSize(old.SOA) + estimateRRSize(newSOA),
+	}
+	if link.EstBytes > budget {
+		lg.Warn("ixfr: single delta exceeds ixfr-chain-max-bytes; resetting IXFR history",
+			"zone", zd.ZoneName, "delta_bytes", link.EstBytes, "budget", budget)
+		zd.IxfrChain = nil
+		return
+	}
+
+	chain := append(zd.IxfrChain, link)
+	total := 0
+	for i := range chain {
+		total += chain[i].EstBytes
+	}
+	start := 0
+	for total > budget || len(chain)-start > ixfrChainMaxLinks {
+		total -= chain[start].EstBytes
+		start++
+	}
+	if start > 0 {
+		// Fresh backing array so trimmed links do not linger via slice aliasing.
+		chain = append([]Ixfr(nil), chain[start:]...)
+	}
+	zd.IxfrChain = chain
+}
+
+// computeZoneDelta returns the RR-level difference between two snapshot owner
+// maps plus an estimated wire size. It leans on the copy-on-write publish
+// discipline: an owner whose *OwnerData pointer is unchanged was not touched
+// by any stager, so only changed owners are content-compared. The apex SOA
+// RRs are excluded (the IXFR brackets carry the SOA change); apex SOA RRSIGs
+// are included. Output is sorted by owner name then type for determinism.
+func computeZoneDelta(zoneName string, oldData, newData map[string]*OwnerData) (removed, added []core.RRset, est int) {
+	type ownerPair struct {
+		name     string
+		old, new *OwnerData
+	}
+	var pairs []ownerPair
+	for name, nod := range newData {
+		ood := oldData[name]
+		if ood == nod {
+			continue // COW: identical pointer == untouched owner
+		}
+		pairs = append(pairs, ownerPair{name, ood, nod})
+	}
+	for name, ood := range oldData {
+		if _, ok := newData[name]; !ok {
+			pairs = append(pairs, ownerPair{name, ood, nil})
+		}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].name < pairs[j].name })
+
+	for _, p := range pairs {
+		rem, add, sz := diffOwner(zoneName, p.name, p.old, p.new)
+		removed = append(removed, rem...)
+		added = append(added, add...)
+		est += sz
+	}
+	return removed, added, est
+}
+
+func ownerTypes(od *OwnerData) []uint16 {
+	if od == nil || od.RRtypes == nil {
+		return nil
+	}
+	return od.RRtypes.Keys()
+}
+
+func ownerRRset(od *OwnerData, t uint16) core.RRset {
+	if od == nil || od.RRtypes == nil {
+		return core.RRset{}
+	}
+	return od.RRtypes.GetOnlyRRSet(t)
+}
+
+// diffOwner computes per-RRset removed/added RRs for one owner name. Either
+// side may be nil (owner added or deleted).
+func diffOwner(zoneName, name string, old, new *OwnerData) (removed, added []core.RRset, est int) {
+	types := map[uint16]bool{}
+	for _, t := range ownerTypes(old) {
+		types[t] = true
+	}
+	for _, t := range ownerTypes(new) {
+		types[t] = true
+	}
+	sorted := make([]uint16, 0, len(types))
+	for t := range types {
+		sorted = append(sorted, t)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	apexSOA := name == zoneName
+	for _, t := range sorted {
+		ors := ownerRRset(old, t)
+		nrs := ownerRRset(new, t)
+		if rrsetEqual(ors, nrs) {
+			continue
+		}
+		remRRs, addRRs := rrDiff(ors.RRs, nrs.RRs)
+		remSigs, addSigs := rrDiff(ors.RRSIGs, nrs.RRSIGs)
+		if apexSOA && t == dns.TypeSOA {
+			// The bracketing FromSOA/ToSOA carry the SOA change on the wire;
+			// a bare SOA inside a diff section would break client framing.
+			remRRs, addRRs = nil, nil
+		}
+		if len(remRRs) > 0 || len(remSigs) > 0 {
+			rs := core.RRset{Name: name, Class: dns.ClassINET, RRtype: t, RRs: remRRs, RRSIGs: remSigs}
+			removed = append(removed, rs)
+			est += rrsetWireEstimate(rs)
+		}
+		if len(addRRs) > 0 || len(addSigs) > 0 {
+			rs := core.RRset{Name: name, Class: dns.ClassINET, RRtype: t, RRs: addRRs, RRSIGs: addSigs}
+			added = append(added, rs)
+			est += rrsetWireEstimate(rs)
+		}
+	}
+	return removed, added, est
+}
+
+// rrDiff returns the string-keyed set difference between two RR slices:
+// RRs only in a (removed) and RRs only in b (added). A TTL or RDATA change
+// therefore becomes delete-old + add-new, per RFC 1995.
+func rrDiff(a, b []dns.RR) (onlyA, onlyB []dns.RR) {
+	inA := make(map[string]bool, len(a))
+	for _, rr := range a {
+		inA[rr.String()] = true
+	}
+	inB := make(map[string]bool, len(b))
+	for _, rr := range b {
+		inB[rr.String()] = true
+	}
+	for _, rr := range a {
+		if !inB[rr.String()] {
+			onlyA = append(onlyA, rr)
+		}
+	}
+	for _, rr := range b {
+		if !inA[rr.String()] {
+			onlyB = append(onlyB, rr)
+		}
+	}
+	return onlyA, onlyB
+}
+
+func rrsetWireEstimate(rs core.RRset) int {
+	sz := 0
+	for _, rr := range rs.RRs {
+		sz += estimateRRSize(rr)
+	}
+	for _, rr := range rs.RRSIGs {
+		sz += estimateRRSize(rr)
+	}
+	return sz
+}
+
+// --- serving ---
+
+// ixfrQuerySOA returns the SOA the client presented in the IXFR query's
+// authority section (the serial it currently holds), or nil.
+func ixfrQuerySOA(r *dns.Msg) *dns.SOA {
+	if r == nil {
+		return nil
+	}
+	for _, rr := range r.Ns {
+		if soa, ok := rr.(*dns.SOA); ok {
+			return soa
+		}
+	}
+	return nil
+}
+
+// ixfrDeltaSteps returns the contiguous run of chain links leading from
+// clientSerial to the pinned snapshot's serial, or ok=false when no provable
+// path exists (caller then serves a full transfer, RFC 1995 §4).
+func ixfrDeltaSteps(snap *zoneSnapshot, clientSerial uint32) (steps []Ixfr, ok bool) {
+	if snap == nil || len(snap.IxfrChain) == 0 {
+		return nil, false
+	}
+	chain := snap.IxfrChain
+	start := -1
+	for i := range chain {
+		if chain[i].FromSerial == clientSerial {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return nil, false
+	}
+	for i := start; i < len(chain); i++ {
+		if chain[i].FromSOA == nil || chain[i].ToSOA == nil {
+			return nil, false
+		}
+		if i > start && chain[i].FromSerial != chain[i-1].ToSerial {
+			return nil, false
+		}
+	}
+	if chain[len(chain)-1].ToSerial != snap.Serial {
+		return nil, false
+	}
+	return chain[start:], true
+}
+
+func soaOnlyRRset(soa *dns.SOA) core.RRset {
+	return core.RRset{
+		Name:   soa.Hdr.Name,
+		Class:  soa.Hdr.Class,
+		RRtype: dns.TypeSOA,
+		RRs:    []dns.RR{soa},
+	}
+}
+
+func isUDPTransport(w dns.ResponseWriter) bool {
+	if w == nil || w.RemoteAddr() == nil {
+		return false
+	}
+	switch w.RemoteAddr().(type) {
+	case *net.UDPAddr:
+		return true
+	}
+	return false
+}
+
+// ixfrSingleSOAReply answers an IXFR query with a single SOA at the current
+// serial: the up-to-date/client-ahead answer (RFC 1995 §2) and the
+// retry-over-TCP signal for UDP (RFC 1995 §4). Signed like the request.
+func (zd *ZoneData) ixfrSingleSOAReply(w dns.ResponseWriter, r *dns.Msg, soa *dns.SOA) (int, error) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Authoritative = true
+	m.Answer = []dns.RR{soa}
+	signResponseLikeRequest(w, r, m)
+	if err := w.WriteMsg(m); err != nil {
+		zd.Logger.Printf("ZoneTransferOut: %s: WriteMsg on IXFR single-SOA reply failed: %v",
+			dns.Fqdn(zd.ZoneName), err)
+		return 0, nil
+	}
+	return 1, nil
+}
+
+// emitIxfrDelta streams the RFC 1995 difference sequences through the shared
+// transfer batcher: SOA(cur), then per step FromSOA / removed / ToSOA / added,
+// then the trailing SOA(cur) via the same flush-before-trailing treatment as
+// the full-transfer path.
+func (zd *ZoneData) emitIxfrDelta(bs *batchState, currentSOA *dns.SOA, steps []Ixfr) (int, error) {
+	if !appendRRset(bs, soaOnlyRRset(currentSOA)) {
+		return 0, nil
+	}
+	for i := range steps {
+		st := &steps[i]
+		if !appendRRset(bs, soaOnlyRRset(st.FromSOA)) {
+			return 0, nil
+		}
+		for _, rs := range st.Removed {
+			if !appendRRset(bs, rs) {
+				return 0, nil
+			}
+		}
+		if !appendRRset(bs, soaOnlyRRset(st.ToSOA)) {
+			return 0, nil
+		}
+		for _, rs := range st.Added {
+			if !appendRRset(bs, rs) {
+				return 0, nil
+			}
+		}
+	}
+	return zd.finishTransferWithTrailingSOA(bs, currentSOA)
+}

--- a/v2/ixfr_test.go
+++ b/v2/ixfr_test.go
@@ -1,0 +1,667 @@
+package tdns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	core "github.com/johanix/tdns/v2/core"
+	"github.com/miekg/dns"
+)
+
+// --- helpers (mustRR comes from childsync_replace_test.go) ---
+
+// loadIxfrTestZone loads the shared transfer-test zone AND registers it in the
+// global Zones map so publishWorkingSetLocked's zoneStillLive gate passes for
+// re-publishes (the retention path under test).
+func loadIxfrTestZone(t *testing.T, zoneData string) *ZoneData {
+	t.Helper()
+	zd := loadTestTransferZone(t, zoneData)
+	Zones.Set(zd.ZoneName, zd)
+	t.Cleanup(func() { Zones.Remove(zd.ZoneName) })
+	return zd
+}
+
+// stageAndPublish stages changes through the production staging API and
+// publishes with a serial bump, exactly like the UPDATE/publisher path.
+func stageAndPublish(t *testing.T, zd *ZoneData, stage func(*ZoneData)) {
+	t.Helper()
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	if stage != nil {
+		stage(zd)
+	}
+	zd.publishLocked(zd.generation.Load())
+	zd.mu.Unlock()
+}
+
+func stageAddA(t *testing.T, zd *ZoneData, owner, addr string) func(*ZoneData) {
+	t.Helper()
+	rr := mustRR(t, fmt.Sprintf("%s 60 IN A %s", owner, addr))
+	return func(zd *ZoneData) {
+		zd.stageRRsetLocked(owner, core.RRset{
+			Name: owner, Class: dns.ClassINET, RRtype: dns.TypeA, RRs: []dns.RR{rr},
+		})
+	}
+}
+
+func chainOf(zd *ZoneData) []Ixfr {
+	snap := zd.publishedSnapshot()
+	if snap == nil {
+		return nil
+	}
+	return snap.IxfrChain
+}
+
+func soaSerials(rrs []dns.RR) []uint32 {
+	var out []uint32
+	for _, rr := range rrs {
+		if soa, ok := rr.(*dns.SOA); ok {
+			out = append(out, soa.Serial)
+		}
+	}
+	return out
+}
+
+func serialsEqual(a, b []uint32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func ixfrClientCore(t *testing.T, provider dns.TsigProvider, addr, zone string, serial uint32) ([]dns.RR, error) {
+	t.Helper()
+	msg := new(dns.Msg)
+	msg.SetIxfr(zone, serial, ".", ".")
+	tr := new(dns.Transfer)
+	if provider != nil {
+		tr.TsigProvider = provider
+	}
+	ch, err := tr.In(msg, addr)
+	if err != nil {
+		return nil, err
+	}
+	var rrs []dns.RR
+	for env := range ch {
+		if env.Error != nil {
+			return rrs, env.Error
+		}
+		rrs = append(rrs, env.RR...)
+	}
+	return rrs, nil
+}
+
+func ixfrClient(t *testing.T, addr, zone string, serial uint32) ([]dns.RR, error) {
+	t.Helper()
+	return ixfrClientCore(t, nil, addr, zone, serial)
+}
+
+func ixfrClientTSIG(t *testing.T, conf *Config, addr, zone, keyName string, serial uint32) ([]dns.RR, error) {
+	t.Helper()
+	msg := new(dns.Msg)
+	msg.SetIxfr(zone, serial, ".", ".")
+	provider, err := SignForPeer(msg, keyName, conf)
+	if err != nil {
+		t.Fatalf("SignForPeer: %v", err)
+	}
+	tr := &dns.Transfer{TsigProvider: provider}
+	ch, err := tr.In(msg, addr)
+	if err != nil {
+		return nil, err
+	}
+	var rrs []dns.RR
+	for env := range ch {
+		if env.Error != nil {
+			return rrs, env.Error
+		}
+		rrs = append(rrs, env.RR...)
+	}
+	return rrs, nil
+}
+
+// --- serial arithmetic ---
+
+func TestSerialNewer(t *testing.T) {
+	cases := []struct {
+		a, b uint32
+		want bool
+	}{
+		{2, 1, true},
+		{1, 2, false},
+		{1, 1, false},
+		{0, 0xFFFFFFFF, true},  // wrap: 0 is newer than 2^32-1
+		{0xFFFFFFFF, 0, false}, // and not vice versa
+		{5, 0x80000006, true},  // distance 2^31-1: still comparable
+		{0x80000000, 0, false}, // distance exactly 2^31: undefined => not newer
+		{0, 0x80000000, false}, // ... in both directions
+		{0x80000001, 1, false}, // distance exactly 2^31 again, off-origin
+		{1, 0x80000001, false}, // symmetric check
+	}
+	for _, c := range cases {
+		if got := serialNewer(c.a, c.b); got != c.want {
+			t.Errorf("serialNewer(%#x, %#x) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// --- retention ---
+
+func TestIxfrChain_PublishAppendsDelta(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone) // serial 1
+	if got := chainOf(zd); len(got) != 0 {
+		t.Fatalf("fresh zone should have empty chain, got %d links", len(got))
+	}
+
+	add := stageAddA(t, zd, "added.example.test.", "192.0.2.9")
+	stageAndPublish(t, zd, func(zd *ZoneData) {
+		add(zd)
+		zd.stageDeleteLocked("www.example.test.", dns.TypeA)
+	})
+
+	chain := chainOf(zd)
+	if len(chain) != 1 {
+		t.Fatalf("expected 1 chain link, got %d", len(chain))
+	}
+	link := chain[0]
+	if link.FromSerial != 1 || link.ToSerial != 2 {
+		t.Fatalf("link serials = %d->%d, want 1->2", link.FromSerial, link.ToSerial)
+	}
+	if link.FromSOA == nil || link.FromSOA.Serial != 1 {
+		t.Fatalf("FromSOA = %v, want serial 1", link.FromSOA)
+	}
+	if link.ToSOA == nil || link.ToSOA.Serial != 2 {
+		t.Fatalf("ToSOA = %v, want serial 2", link.ToSOA)
+	}
+	if len(link.Removed) != 1 || link.Removed[0].Name != "www.example.test." || len(link.Removed[0].RRs) != 1 {
+		t.Fatalf("Removed = %+v, want exactly the www A RRset", link.Removed)
+	}
+	if len(link.Added) != 1 || link.Added[0].Name != "added.example.test." || len(link.Added[0].RRs) != 1 {
+		t.Fatalf("Added = %+v, want exactly the added A RRset", link.Added)
+	}
+	// The apex SOA change must NOT appear as diff content (brackets carry it).
+	for _, rs := range append(append([]core.RRset{}, link.Removed...), link.Added...) {
+		for _, rr := range rs.RRs {
+			if rr.Header().Rrtype == dns.TypeSOA {
+				t.Fatalf("bare SOA leaked into diff content: %v", rr)
+			}
+		}
+	}
+	if link.EstBytes <= 0 {
+		t.Fatalf("EstBytes = %d, want > 0", link.EstBytes)
+	}
+}
+
+func TestIxfrChain_EmptyDeltaAppendsEmptyLink(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, nil) // serial-only publish: 1 -> 2
+
+	chain := chainOf(zd)
+	if len(chain) != 1 {
+		t.Fatalf("expected 1 link after serial-only publish, got %d", len(chain))
+	}
+	if chain[0].FromSerial != 1 || chain[0].ToSerial != 2 {
+		t.Fatalf("link serials = %d->%d, want 1->2", chain[0].FromSerial, chain[0].ToSerial)
+	}
+	if len(chain[0].Removed) != 0 || len(chain[0].Added) != 0 {
+		t.Fatalf("expected empty delta, got removed=%v added=%v", chain[0].Removed, chain[0].Added)
+	}
+}
+
+func TestIxfrChain_MultiplePublishesStayContiguous(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	stageAndPublish(t, zd, stageAddA(t, zd, "two.example.test.", "192.0.2.12"))
+
+	chain := chainOf(zd)
+	if len(chain) != 2 {
+		t.Fatalf("expected 2 links, got %d", len(chain))
+	}
+	if chain[0].ToSerial != chain[1].FromSerial {
+		t.Fatalf("chain not contiguous: %d->%d then %d->%d",
+			chain[0].FromSerial, chain[0].ToSerial, chain[1].FromSerial, chain[1].ToSerial)
+	}
+	if chain[1].ToSerial != zd.publishedSnapshot().Serial {
+		t.Fatalf("chain tail %d != snapshot serial %d", chain[1].ToSerial, zd.publishedSnapshot().Serial)
+	}
+}
+
+func TestIxfrChain_SameSerialContentChangeResets(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	if len(chainOf(zd)) != 1 {
+		t.Fatal("setup: expected 1 link")
+	}
+
+	// Content change WITHOUT a serial bump (the tsignal/catalog-shaped publish).
+	add := stageAddA(t, zd, "sneaky.example.test.", "192.0.2.66")
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	add(zd)
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
+	zd.mu.Unlock()
+
+	if got := chainOf(zd); len(got) != 0 {
+		t.Fatalf("same-serial content change must reset the chain, got %d links", len(got))
+	}
+}
+
+func TestIxfrChain_SameSerialNoChangeKeepsChain(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+
+	// A no-op publish at the same serial (signalSynth-style) keeps history.
+	zd.mu.Lock()
+	zd.ensureWorkingSet()
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
+	zd.mu.Unlock()
+
+	if got := chainOf(zd); len(got) != 1 {
+		t.Fatalf("no-op same-serial publish must keep the chain, got %d links", len(got))
+	}
+}
+
+func TestIxfrChain_EpochResetOnRefreshReplacement(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	if len(chainOf(zd)) != 1 {
+		t.Fatal("setup: expected 1 link")
+	}
+
+	newZone := strings.Replace(basicZone, "1 ; serial", "10 ; serial", 1)
+	newZd := &ZoneData{
+		ZoneName:  zd.ZoneName,
+		ZoneStore: MapZone,
+		ZoneType:  Primary,
+		Logger:    zd.Logger,
+	}
+	if _, _, err := newZd.ReadZoneData(newZone, true); err != nil {
+		t.Fatalf("ReadZoneData: %v", err)
+	}
+
+	zd.mu.Lock()
+	err := zd.applyRefreshReplacementLocked(newZd, nil, false)
+	zd.mu.Unlock()
+	if err != nil {
+		t.Fatalf("applyRefreshReplacementLocked: %v", err)
+	}
+
+	if got := chainOf(zd); len(got) != 0 {
+		t.Fatalf("wholesale replacement must reset the chain, got %d links", len(got))
+	}
+}
+
+func TestIxfrChain_InstallInitialSnapshotResets(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	zd.mu.Lock()
+	zd.IxfrChain = append([]Ixfr(nil), zd.IxfrChain...) // ensure non-nil
+	zd.mu.Unlock()
+
+	// Re-baseline from zd.Data (the restart / test-utility path).
+	zd.InstallInitialSnapshot()
+
+	if got := chainOf(zd); len(got) != 0 {
+		t.Fatalf("InstallInitialSnapshot must reset the chain, got %d links", len(got))
+	}
+}
+
+func TestIxfrChain_ByteBudgetTrimsOldest(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	// Budget fits roughly one small link (two bracket SOAs ~ 2x86B + one A
+	// ~ 205B estimated) but not two.
+	zd.ixfrChainMaxBytes = 300
+
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	first := chainOf(zd)
+	if len(first) != 1 {
+		t.Fatalf("expected 1 link within budget, got %d", len(first))
+	}
+	stageAndPublish(t, zd, stageAddA(t, zd, "two.example.test.", "192.0.2.12"))
+
+	chain := chainOf(zd)
+	if len(chain) != 1 {
+		t.Fatalf("expected budget to trim to 1 link, got %d", len(chain))
+	}
+	if chain[0].FromSerial != 2 || chain[0].ToSerial != 3 {
+		t.Fatalf("surviving link = %d->%d, want the newest (2->3)", chain[0].FromSerial, chain[0].ToSerial)
+	}
+}
+
+func TestIxfrChain_OversizeSingleDeltaResets(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ixfrChainMaxBytes = 50 // smaller than even the two bracket SOAs
+
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	if got := chainOf(zd); len(got) != 0 {
+		t.Fatalf("oversize single delta must reset the chain, got %d links", len(got))
+	}
+}
+
+func TestIxfrChain_NegativeBudgetDisablesRetention(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ixfrChainMaxBytes = -1
+
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	if got := chainOf(zd); len(got) != 0 {
+		t.Fatalf("negative budget must disable retention, got %d links", len(got))
+	}
+}
+
+// --- delta planning ---
+
+func TestIxfrDeltaSteps(t *testing.T) {
+	soa := func(serial uint32) *dns.SOA {
+		return &dns.SOA{Hdr: dns.RR_Header{Name: "z.", Rrtype: dns.TypeSOA, Class: dns.ClassINET}, Serial: serial}
+	}
+	link := func(from, to uint32) Ixfr {
+		return Ixfr{FromSerial: from, ToSerial: to, FromSOA: soa(from), ToSOA: soa(to)}
+	}
+	snap := &zoneSnapshot{Serial: 4, IxfrChain: []Ixfr{link(1, 2), link(2, 3), link(3, 4)}}
+
+	if steps, ok := ixfrDeltaSteps(snap, 1); !ok || len(steps) != 3 {
+		t.Fatalf("from 1: ok=%v len=%d, want ok/3", ok, len(steps))
+	}
+	if steps, ok := ixfrDeltaSteps(snap, 3); !ok || len(steps) != 1 {
+		t.Fatalf("from 3: ok=%v len=%d, want ok/1", ok, len(steps))
+	}
+	if _, ok := ixfrDeltaSteps(snap, 0); ok {
+		t.Fatal("unknown serial must not plan a delta")
+	}
+
+	gap := &zoneSnapshot{Serial: 4, IxfrChain: []Ixfr{link(1, 2), link(3, 4)}}
+	if _, ok := ixfrDeltaSteps(gap, 1); ok {
+		t.Fatal("non-contiguous chain must not plan a delta")
+	}
+	// A gapped chain can still serve from AFTER the gap.
+	if steps, ok := ixfrDeltaSteps(gap, 3); !ok || len(steps) != 1 {
+		t.Fatalf("from 3 across gap start: ok=%v len=%d, want ok/1", ok, len(steps))
+	}
+
+	stale := &zoneSnapshot{Serial: 9, IxfrChain: []Ixfr{link(1, 2)}}
+	if _, ok := ixfrDeltaSteps(stale, 1); ok {
+		t.Fatal("chain tail != snapshot serial must not plan a delta")
+	}
+
+	nilSOA := &zoneSnapshot{Serial: 2, IxfrChain: []Ixfr{{FromSerial: 1, ToSerial: 2}}}
+	if _, ok := ixfrDeltaSteps(nilSOA, 1); ok {
+		t.Fatal("nil bracket SOAs must not plan a delta")
+	}
+}
+
+// --- serving ---
+
+func TestZoneTransferOut_IXFRUpToDate(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone) // serial 1
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClient(t, srv.addr, zd.ZoneName, 1)
+	if err != nil {
+		t.Fatalf("IXFR: %v", err)
+	}
+	if len(rrs) != 1 {
+		t.Fatalf("up-to-date IXFR must answer a single SOA, got %d RRs: %v", len(rrs), rrs)
+	}
+	soa, ok := rrs[0].(*dns.SOA)
+	if !ok || soa.Serial != 1 {
+		t.Fatalf("expected SOA serial 1, got %v", rrs[0])
+	}
+}
+
+func TestZoneTransferOut_IXFRClientAhead(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClient(t, srv.addr, zd.ZoneName, 7)
+	if err != nil {
+		t.Fatalf("IXFR: %v", err)
+	}
+	if len(rrs) != 1 {
+		t.Fatalf("client-ahead IXFR must answer a single SOA, got %d RRs", len(rrs))
+	}
+}
+
+func TestZoneTransferOut_IXFRFallbackNoHistory(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone) // fresh zone: chain empty
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClient(t, srv.addr, zd.ZoneName, 0)
+	if err != nil {
+		t.Fatalf("IXFR: %v", err)
+	}
+	if len(rrs) < 5 {
+		t.Fatalf("fallback must serve the full zone, got %d RRs", len(rrs))
+	}
+	if _, ok := rrs[0].(*dns.SOA); !ok {
+		t.Fatalf("first RR must be SOA, got %T", rrs[0])
+	}
+	if _, ok := rrs[1].(*dns.SOA); ok {
+		t.Fatal("second RR is SOA: response is not AXFR-shaped")
+	}
+	if _, ok := rrs[len(rrs)-1].(*dns.SOA); !ok {
+		t.Fatalf("last RR must be SOA, got %T", rrs[len(rrs)-1])
+	}
+}
+
+func TestZoneTransferOut_IXFRFallbackUnknownSerialWithHistory(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11")) // chain: 1->2
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	// Serial 0 is older than current but not in the chain: full transfer.
+	rrs, err := ixfrClient(t, srv.addr, zd.ZoneName, 0)
+	if err != nil {
+		t.Fatalf("IXFR: %v", err)
+	}
+	if len(rrs) < 5 {
+		t.Fatalf("fallback must serve the full zone, got %d RRs", len(rrs))
+	}
+	if _, ok := rrs[1].(*dns.SOA); ok {
+		t.Fatal("second RR is SOA: response is not AXFR-shaped")
+	}
+}
+
+func TestZoneTransferOut_IXFRDeltaSingleStep(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone) // serial 1
+	stageAndPublish(t, zd, func(z *ZoneData) {
+		stageAddA(t, zd, "added.example.test.", "192.0.2.9")(z)
+		z.stageDeleteLocked("www.example.test.", dns.TypeA)
+	}) // serial 2
+
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClient(t, srv.addr, zd.ZoneName, 1)
+	if err != nil {
+		t.Fatalf("IXFR: %v", err)
+	}
+	// SOA(2) | SOA(1) www-A SOA(2) added-A | SOA(2)
+	if len(rrs) != 6 {
+		t.Fatalf("expected 6 RRs in the delta stream, got %d: %v", len(rrs), rrs)
+	}
+	if got, want := soaSerials(rrs), []uint32{2, 1, 2, 2}; !serialsEqual(got, want) {
+		t.Fatalf("SOA serial sequence = %v, want %v", got, want)
+	}
+	if rrs[2].Header().Name != "www.example.test." || rrs[2].Header().Rrtype != dns.TypeA {
+		t.Fatalf("removed section: got %v, want www.example.test. A", rrs[2])
+	}
+	if rrs[4].Header().Name != "added.example.test." || rrs[4].Header().Rrtype != dns.TypeA {
+		t.Fatalf("added section: got %v, want added.example.test. A", rrs[4])
+	}
+}
+
+func TestZoneTransferOut_IXFRDeltaMultiStep(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone) // serial 1
+	stageAndPublish(t, zd, func(z *ZoneData) {
+		stageAddA(t, zd, "added.example.test.", "192.0.2.9")(z)
+		z.stageDeleteLocked("www.example.test.", dns.TypeA)
+	}) // serial 2
+	stageAndPublish(t, zd, stageAddA(t, zd, "second.example.test.", "192.0.2.10")) // serial 3
+
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClient(t, srv.addr, zd.ZoneName, 1)
+	if err != nil {
+		t.Fatalf("IXFR from 1: %v", err)
+	}
+	// SOA(3) | SOA(1) www-A SOA(2) added-A | SOA(2) SOA(3) second-A | SOA(3)
+	if got, want := soaSerials(rrs), []uint32{3, 1, 2, 2, 3, 3}; !serialsEqual(got, want) {
+		t.Fatalf("SOA serial sequence = %v, want %v", got, want)
+	}
+	if len(rrs) != 9 {
+		t.Fatalf("expected 9 RRs, got %d: %v", len(rrs), rrs)
+	}
+
+	rrs, err = ixfrClient(t, srv.addr, zd.ZoneName, 2)
+	if err != nil {
+		t.Fatalf("IXFR from 2: %v", err)
+	}
+	// SOA(3) | SOA(2) SOA(3) second-A | SOA(3)
+	if got, want := soaSerials(rrs), []uint32{3, 2, 3, 3}; !serialsEqual(got, want) {
+		t.Fatalf("SOA serial sequence = %v, want %v", got, want)
+	}
+	if len(rrs) != 5 {
+		t.Fatalf("expected 5 RRs, got %d: %v", len(rrs), rrs)
+	}
+}
+
+func TestZoneTransferOut_IXFRDeltaSpansEnvelopes(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, func(z *ZoneData) {
+		for i := 0; i < 80; i++ {
+			owner := fmt.Sprintf("pad%d.example.test.", i)
+			rr := mustRR(t, fmt.Sprintf("%s 60 IN TXT \"%s\"", owner, strings.Repeat("x", 900)))
+			z.stageRRsetLocked(owner, core.RRset{
+				Name: owner, Class: dns.ClassINET, RRtype: dns.TypeTXT, RRs: []dns.RR{rr},
+			})
+		}
+	})
+
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClient(t, srv.addr, zd.ZoneName, 1)
+	if err != nil {
+		t.Fatalf("IXFR: %v", err)
+	}
+	if len(rrs) != 80+4 {
+		t.Fatalf("expected 84 RRs (4 SOAs + 80 TXT), got %d", len(rrs))
+	}
+	if len(srv.sizes) < 2 {
+		t.Fatalf("expected the delta to span multiple envelopes, got %d", len(srv.sizes))
+	}
+	assertTransferEnvelopeSizes(t, srv.sizes)
+}
+
+func TestZoneTransferOut_IXFRUDPSingleSOA(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11")) // serial 2, history exists
+
+	w := &fakeRW{remote: udpAddr("127.0.0.1")}
+	r := new(dns.Msg)
+	r.SetIxfr(zd.ZoneName, 1, ".", ".")
+	sent, err := zd.ZoneTransferOut(context.Background(), w, r, nil)
+	if err != nil {
+		t.Fatalf("ZoneTransferOut: %v", err)
+	}
+	if sent != 1 {
+		t.Fatalf("expected 1 RR sent over UDP, got %d", sent)
+	}
+	if w.written == nil || len(w.written.Answer) != 1 {
+		t.Fatalf("expected a single-SOA answer, got %v", w.written)
+	}
+	soa, ok := w.written.Answer[0].(*dns.SOA)
+	if !ok || soa.Serial != 2 {
+		t.Fatalf("expected SOA serial 2, got %v", w.written.Answer[0])
+	}
+}
+
+func TestZoneTransferOut_IXFRNoSOAInQueryServesFullZone(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	// Hand-rolled malformed IXFR query: no SOA in the authority section.
+	q := new(dns.Msg)
+	q.SetQuestion(zd.ZoneName, dns.TypeIXFR)
+	c := &dns.Client{Net: "tcp"}
+	in, _, err := c.Exchange(q, srv.addr)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if len(in.Answer) < 5 {
+		t.Fatalf("expected the full zone in one message, got %d RRs", len(in.Answer))
+	}
+	if _, ok := in.Answer[0].(*dns.SOA); !ok {
+		t.Fatalf("first RR must be SOA, got %T", in.Answer[0])
+	}
+}
+
+func TestZoneTransferOut_IXFRDeltaTSIG(t *testing.T) {
+	conf := testXfrConf(t)
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11")) // serial 2
+
+	srv := startTestAXFRServerTSIG(t, zd, conf)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClientTSIG(t, conf, srv.addr, zd.ZoneName, "tkey", 1)
+	if err != nil {
+		t.Fatalf("IXFR/TSIG: %v", err)
+	}
+	// SOA(2) | SOA(1) SOA(2) one-A | SOA(2)
+	if got, want := soaSerials(rrs), []uint32{2, 1, 2, 2}; !serialsEqual(got, want) {
+		t.Fatalf("SOA serial sequence = %v, want %v", got, want)
+	}
+}
+
+func TestZoneTransferOut_IXFRUpToDateTSIG(t *testing.T) {
+	conf := testXfrConf(t)
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.Downstreams = []AclEntry{{Prefix: "127.0.0.0/8", Key: "tkey"}}
+
+	srv := startTestAXFRServerTSIG(t, zd, conf)
+	defer srv.shutdown()
+
+	rrs, err := ixfrClientTSIG(t, conf, srv.addr, zd.ZoneName, "tkey", 1)
+	if err != nil {
+		t.Fatalf("IXFR/TSIG: %v", err)
+	}
+	if len(rrs) != 1 {
+		t.Fatalf("up-to-date IXFR must answer a single SOA, got %d RRs", len(rrs))
+	}
+}
+
+// AXFR must be wholly unaffected by the presence of IXFR history.
+func TestZoneTransferOut_AXFRIgnoresChain(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+
+	srv := startTestAXFRServer(t, zd)
+	defer srv.shutdown()
+
+	rrs, err := axfrClient(t, srv.addr, zd.ZoneName)
+	if err != nil {
+		t.Fatalf("AXFR: %v", err)
+	}
+	if got := soaSerials(rrs); len(got) != 2 || got[0] != 2 || got[1] != 2 {
+		t.Fatalf("AXFR SOA serials = %v, want [2 2]", got)
+	}
+	for _, rr := range rrs[1 : len(rrs)-1] {
+		if rr.Header().Rrtype == dns.TypeSOA {
+			t.Fatalf("AXFR body contains an SOA: %v", rr)
+		}
+	}
+}

--- a/v2/ixfr_test.go
+++ b/v2/ixfr_test.go
@@ -621,6 +621,30 @@ func TestZoneTransferOut_IXFRUDPSingleSOA(t *testing.T) {
 	}
 }
 
+// failingRW is a fakeRW whose WriteMsg always errors, for asserting that
+// single-message reply paths propagate transport write failures.
+type failingRW struct {
+	fakeRW
+	writeErr error
+}
+
+func (f *failingRW) WriteMsg(m *dns.Msg) error { return f.writeErr }
+
+func TestZoneTransferOut_IXFRSingleSOAWriteErrorPropagates(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+
+	w := &failingRW{fakeRW: fakeRW{remote: udpAddr("127.0.0.1")}, writeErr: fmt.Errorf("boom")}
+	r := new(dns.Msg)
+	r.SetIxfr(zd.ZoneName, 1, ".", ".") // up-to-date: single-SOA reply path
+	sent, err := zd.ZoneTransferOut(context.Background(), w, r, nil)
+	if err == nil {
+		t.Fatal("expected the WriteMsg failure to propagate, got nil error")
+	}
+	if sent != 0 {
+		t.Fatalf("expected 0 RRs reported on write failure, got %d", sent)
+	}
+}
+
 func TestZoneTransferOut_IXFRNoSOAInQueryServesFullZone(t *testing.T) {
 	zd := loadIxfrTestZone(t, basicZone)
 	srv := startTestAXFRServer(t, zd)

--- a/v2/ixfr_test.go
+++ b/v2/ixfr_test.go
@@ -297,6 +297,40 @@ func TestIxfrChain_EpochResetOnRefreshReplacement(t *testing.T) {
 	}
 }
 
+// TestIxfrChain_DroppedEpochResetDoesNotLeak is the regression test for the
+// CodeRabbit round-1 finding: a staged wsIxfrEpochReset whose publish is
+// dropped (here: the apex-less refusal path) must NOT survive and wipe the
+// chain on the next, unrelated successful publish.
+func TestIxfrChain_DroppedEpochResetDoesNotLeak(t *testing.T) {
+	zd := loadIxfrTestZone(t, basicZone)
+	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))
+	if len(chainOf(zd)) != 1 {
+		t.Fatal("setup: expected 1 link")
+	}
+
+	// A wholesale-replace publish that gets REFUSED (apex-less working set),
+	// with the epoch-reset flag staged the way applyRefreshReplacementLocked
+	// stages it.
+	zd.mu.Lock()
+	zd.wsIxfrEpochReset = true
+	zd.workingSet = map[string]*OwnerData{}
+	zd.publishWorkingSetLocked(zd.generation.Load(), false)
+	leaked := zd.wsIxfrEpochReset
+	zd.mu.Unlock()
+	if leaked {
+		t.Fatal("refused publish left wsIxfrEpochReset set")
+	}
+	if len(chainOf(zd)) != 1 {
+		t.Fatalf("refused publish must not touch the served chain, got %d links", len(chainOf(zd)))
+	}
+
+	// The next ordinary incremental publish must EXTEND the chain, not wipe it.
+	stageAndPublish(t, zd, stageAddA(t, zd, "two.example.test.", "192.0.2.12"))
+	if got := chainOf(zd); len(got) != 2 {
+		t.Fatalf("stale epoch reset leaked into an unrelated publish: got %d links, want 2", len(got))
+	}
+}
+
 func TestIxfrChain_InstallInitialSnapshotResets(t *testing.T) {
 	zd := loadIxfrTestZone(t, basicZone)
 	stageAndPublish(t, zd, stageAddA(t, zd, "one.example.test.", "192.0.2.11"))

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -1029,6 +1029,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		zdp.mu.Lock()
 		zdp.Options = newOpts
 		zdp.publishCadence = publishCadence
+		zdp.ixfrChainMaxBytes = zconf.IxfrChainMaxBytes
 		zdp.mu.Unlock()
 
 		invokeOptionHandlers(zname, options)

--- a/v2/rr_print.go
+++ b/v2/rr_print.go
@@ -317,8 +317,9 @@ func xfrErrorRcode(errstr string) (string, bool) {
 func ZoneTransferPrint(zname, upstream string, serial uint32, ttype uint16, options map[string]string, tsigName, tsigAlgo, tsigSecret string, tlsConfig *tls.Config) error {
 	msg := new(dns.Msg)
 	if ttype == dns.TypeIXFR {
-		// msg.SetIxfr(zone, serial, soa.Ns, soa.Mbox)
-		msg.SetIxfr(zname, serial, "", "")
+		// NB: empty MNAME/RNAME pack to zero bytes (malformed SOA rdata →
+		// FORMERR from the server); root names pack correctly.
+		msg.SetIxfr(zname, serial, ".", ".")
 	} else {
 		msg.SetAxfr(zname)
 	}

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -196,15 +196,24 @@ type ZoneData struct {
 	// wsSignalSynth stages the synthesized-transport-signal fallback map for the
 	// next publish (see zoneSnapshot.signalSynth). Seeded from the published
 	// snapshot in ensureWorkingSet so unrelated publishes preserve it.
-	wsSignalSynth   map[string]*core.RRset
-	publishCadence  time.Duration
-	publishQueued   bool
-	publishUrgent   bool
-	lastPublish     time.Time
-	publishWake     chan struct{}
-	publisherOnce   sync.Once
-	publishStop     chan struct{}
-	publishStopOnce sync.Once
+	wsSignalSynth  map[string]*core.RRset
+	publishCadence time.Duration
+	publishQueued  bool
+	publishUrgent  bool
+	// wsIxfrEpochReset marks the next publish as a new IXFR epoch (wholesale
+	// zone replacement): updateIxfrChainLocked clears the delta history
+	// instead of diffing. Set under zd.mu by applyRefreshReplacementLocked.
+	wsIxfrEpochReset bool
+	// ixfrChainMaxBytes bounds the retained IXFR delta history (estimated
+	// wire bytes). 0 => DefaultIxfrChainMaxBytes; negative => retention
+	// disabled (IXFR queries are answered with full transfers). From zone
+	// config ixfr-chain-max-bytes; written at parse time under zd.mu.
+	ixfrChainMaxBytes int
+	lastPublish       time.Time
+	publishWake       chan struct{}
+	publisherOnce     sync.Once
+	publishStop       chan struct{}
+	publishStopOnce   sync.Once
 	// RemoteDNSKEYs holds DNSKEY RRs from other signers (multi-signer mode 4).
 	// These are DNSKEYs found in the incoming zone that do not match keys in our
 	// local keystore. They are preserved across resignings and merged into the
@@ -282,8 +291,8 @@ type ZoneConf struct {
 	Store             string     // xfr | map | slice | reg (defaults to "map" if not specified)
 	Primaries         []PeerConf `yaml:"primaries" mapstructure:"primaries"` // upstream set, for secondary zones
 	Notify            []PeerConf
-	AllowNotify       []AclEntry   `yaml:"allow-notify" mapstructure:"allow-notify"` // secondary: who may NOTIFY us (ip-spec + key｜NOKEY｜BLOCKED)
-	Downstreams       []AclEntry   `yaml:"downstreams" mapstructure:"downstreams"`   // primary: who may AXFR from us (provide-xfr ACL)
+	AllowNotify       []AclEntry   `yaml:"allow-notify" mapstructure:"allow-notify"`       // secondary: who may NOTIFY us (ip-spec + key｜NOKEY｜BLOCKED)
+	Downstreams       []AclEntry   `yaml:"downstreams" mapstructure:"downstreams"`         // primary: who may AXFR from us (provide-xfr ACL)
 	DownstreamAuth    []string     `yaml:"downstream-auth" mapstructure:"downstream-auth"` // acceptable transfer-auth mechanisms: prefix|tsig|tls-pin|tls-pkix|tls-dane|any
 	OptionsStrs       []string     `yaml:"options" mapstructure:"options"`
 	Options           []ZoneOption `yaml:"-" mapstructure:"-"` // Ignore during both yaml and mapstructure decoding
@@ -331,6 +340,10 @@ type ZoneConf struct {
 	// PublishCadence is the minimum interval between coalesced snapshot publishes
 	// for this zone (default 5s when unset). RFC 2136 urgent publishes bypass.
 	PublishCadence string `yaml:"publish-cadence" mapstructure:"publish-cadence"`
+	// IxfrChainMaxBytes bounds the retained outbound-IXFR delta history for
+	// this zone (estimated wire bytes). 0/unset => 1 MiB default; negative =>
+	// disable retention (IXFR clients always get a full transfer).
+	IxfrChainMaxBytes int `yaml:"ixfr-chain-max-bytes" mapstructure:"ixfr-chain-max-bytes"`
 	// Provisioning is a display-only derived lifecycle string
 	// ("pending"|"loading"|"ready"|"error") populated by the list handlers from
 	// ZoneStatus + the error registry. Not config; not serialized to YAML.
@@ -595,8 +608,16 @@ type DnssecPolicyTTLS struct {
 type Ixfr struct {
 	FromSerial uint32
 	ToSerial   uint32
-	Removed    []core.RRset
-	Added      []core.RRset
+	// FromSOA/ToSOA are the bracketing SOA RRs for this difference sequence,
+	// stored as full RRs because SOA RDATA (timers/MNAME) may change between
+	// serials — rewriting the current SOA's serial would not reproduce them.
+	FromSOA *dns.SOA
+	ToSOA   *dns.SOA
+	Removed []core.RRset
+	Added   []core.RRset
+	// EstBytes is the estimated wire size of this link (RRs + bracket SOAs),
+	// used for the byte-bounded chain trim.
+	EstBytes int
 }
 
 type OwnerData struct {
@@ -683,14 +704,14 @@ func rrsToStrings(rrs []dns.RR) []string {
 }
 
 type ZoneRefresher struct {
-	Name          string
-	ZoneType      ZoneType   // primary | secondary
-	PrimariesConf []PeerConf // as-written; copied to zd.PrimariesConf on merge
-	Primaries     []PeerConf // resolved; copied to zd.Upstreams on merge
-	Notify        []PeerConf
-	AllowNotify   []AclEntry // copied to zd.AllowNotify on merge
-	Downstreams   []AclEntry // copied to zd.Downstreams on merge
-	DownstreamAuth []string  // copied to zd.DownstreamAuth on merge (config-bearing only)
+	Name           string
+	ZoneType       ZoneType   // primary | secondary
+	PrimariesConf  []PeerConf // as-written; copied to zd.PrimariesConf on merge
+	Primaries      []PeerConf // resolved; copied to zd.Upstreams on merge
+	Notify         []PeerConf
+	AllowNotify    []AclEntry // copied to zd.AllowNotify on merge
+	Downstreams    []AclEntry // copied to zd.Downstreams on merge
+	DownstreamAuth []string   // copied to zd.DownstreamAuth on merge (config-bearing only)
 	// ConfigUpdate marks a config-bearing refresher (from ParseZones /
 	// LoadDynamicZoneFiles) as opposed to a NOTIFY/refresh-only trigger. On reload
 	// it lets the merge assign Notify/AllowNotify/Downstreams even when they are
@@ -1017,7 +1038,7 @@ type ImrMgmtPost struct {
 	Zone     ZoneName               `json:"zone,omitempty"`
 	Id       string                 `json:"id,omitempty"`   // e.g. imr-show: cache identity to show
 	Data     map[string]interface{} `json:"data,omitempty"` // command-specific parameters
-	Response chan *ImrMgmtResponse   `json:"-"`
+	Response chan *ImrMgmtResponse  `json:"-"`
 }
 
 // ImrMgmtResponse is the response from a daemon's /imr endpoint.

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -314,6 +314,9 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 	zd.resignWorkingSetSOAIfSigned()
 
 	data := zd.workingSet
+	// Maintain the IXFR delta history BEFORE building the snapshot so the
+	// chain copied into it ends exactly at this publish's serial (Project C).
+	zd.updateIxfrChainLocked(zd.snapshot.Load(), serial, data)
 	snap := zd.buildSnapshotLocked(serial, data, zd.wsSignalSynth)
 	zd.snapshot.Store(snap)
 
@@ -365,6 +368,8 @@ func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs [
 		zd.wsSignalSynth = nil
 	}
 	zd.repopulateWorkingSetLocked(dynamicRRs)
+	// A refresh replaces zone data wholesale: new IXFR epoch, no delta.
+	zd.wsIxfrEpochReset = true
 	zd.publishWorkingSetLocked(zd.generation.Load(), false)
 
 	// Only advertise the zone as Ready once a snapshot actually exists. If the
@@ -445,6 +450,9 @@ func (zd *ZoneData) InstallInitialSnapshot() {
 		lg.Error("InstallInitialSnapshot: no apex in data and no valid snapshot; zone left not Ready", "zone", zd.ZoneName)
 		return
 	}
+	// This is a re-baseline from zd.Data outside the publish path: a new
+	// IXFR epoch by definition (no delta links the previous snapshot to it).
+	zd.IxfrChain = nil
 	snap := zd.buildSnapshotLocked(zd.CurrentSerial, data, nil)
 	zd.snapshot.Store(snap)
 	zd.Ready = true

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -277,6 +277,11 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 	if zd.workingSet == nil {
 		zd.publishQueued = false
 		zd.publishUrgent = false
+		// The epoch-reset flag is staged together with a working set; with no
+		// working set it is orphaned. Clear it so a dropped publish cannot
+		// carry it into a later unrelated publish (which would needlessly
+		// wipe the IXFR history).
+		zd.wsIxfrEpochReset = false
 		return
 	}
 	if !zoneStillLive(zd, gen) {
@@ -284,6 +289,7 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 		zd.wsSignalSynth = nil
 		zd.publishQueued = false
 		zd.publishUrgent = false
+		zd.wsIxfrEpochReset = false
 		return
 	}
 
@@ -301,6 +307,7 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 		zd.wsSignalSynth = nil
 		zd.publishQueued = false
 		zd.publishUrgent = false
+		zd.wsIxfrEpochReset = false
 		return
 	}
 

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -473,6 +473,25 @@ func TestZoneTransferOut_RefusesWhenNotReady(t *testing.T) {
 	}
 }
 
+// TestZoneTransferOut_RefuseWriteErrorPropagates mirrors the IXFR single-SOA
+// error-path test: a WriteMsg failure on the REFUSED reply must surface to the
+// caller rather than being swallowed as (0, nil). AXFR and IXFR are treated the
+// same way on the refuse path (failingRW is defined in ixfr_test.go).
+func TestZoneTransferOut_RefuseWriteErrorPropagates(t *testing.T) {
+	zd := loadTestTransferZone(t, basicZone)
+	zd.Status = ZoneStatusLoading // force the refuse path
+	w := &failingRW{fakeRW: fakeRW{remote: udpAddr("127.0.0.1")}, writeErr: fmt.Errorf("boom")}
+	r := new(dns.Msg)
+	r.SetAxfr(zd.ZoneName)
+	sent, err := zd.ZoneTransferOut(context.Background(), w, r, nil)
+	if err == nil {
+		t.Fatal("expected the WriteMsg failure to propagate, got nil error")
+	}
+	if sent != 0 {
+		t.Fatalf("expected 0 RRs reported on write failure, got %d", sent)
+	}
+}
+
 // TestZoneTransferOut_RefusesUnsignedMustBeSignedZone: a zone configured for
 // online/inline signing whose SOA carries no RRSIG (unsigned/broken) must be
 // refused, never transferred unsigned to a secondary (fail-closed).

--- a/v2/zone_transfer_out_test.go
+++ b/v2/zone_transfer_out_test.go
@@ -61,6 +61,7 @@ func startTestAXFRServerCore(t *testing.T, zd *ZoneData, tsigProvider dns.TsigPr
 		Listener:          ln,
 		Handler:           mux,
 		TsigProvider:      tsigProvider,
+		MsgAcceptFunc:     MsgAcceptFunc, // production accept func: permits the IXFR authority-SOA
 		NotifyStartedFunc: func() { close(started) },
 	}
 	go func() { _ = dnsSrv.ActivateAndServe() }()


### PR DESCRIPTION
## What

Implements **outbound IXFR** (Project C of the XFR series, RFC 1995): per-publish delta retention into the byte-bounded `IxfrChain`, plus incremental serving from the pinned snapshot in `ZoneTransferOut`. The plan doc (`docs/2026-07-02-ixfr-support.md`) was first firmed up against the landed snapshot machinery (commit 1) and documents every decision below in detail; the implementation is commit 2.

## Scope decision (made autonomously, owner AFK)

The mission fork was: real delta-IXFR if the #279 snapshot chain gives enough history, else an AXFR-fallback baseline. Verified reality: **main retains no delta history** (`IxfrChain` exists but nothing ever appends), *but* the B3 copy-on-write publish discipline makes exact RR-level deltas cheap to compute at the publish choke point — an owner whose `*OwnerData` pointer is unchanged was untouched, so the diff is pointer-compares plus content comparison on changed owners only. So this PR implements **real delta-IXFR** (retention + serving), holding the sketch's blast-radius invariant: **IXFR is never a correctness dependency** — unknown serial, non-contiguous chain, same-serial content change, serial regression, over-budget history, UDP, malformed query all degrade to a single-SOA answer or the existing full-transfer path (which is itself the RFC 1995 §4 fallback shape).

## Retention (publish path)

- `updateIxfrChainLocked` runs under `zd.mu` in `publishWorkingSetLocked`, immediately before the snapshot build, so each snapshot's chain copy ends exactly at that snapshot's serial.
- Bracketing `FromSOA`/`ToSOA` stored as full RRs (SOA RDATA may change between serials); apex SOA RRs are excluded from diff content (client-side framing counts SOA records); SOA RRSIGs travel as ordinary diff content.
- Byte-bounded via new per-zone `ixfr-chain-max-bytes` (default 1 MiB, negative disables retention, template-gap-filled like other zone fields) + a defensive 512-link cap; trims oldest-first.
- Epoch resets: wholesale refresh replacement (`applyRefreshReplacementLocked`), `InstallInitialSnapshot` re-baseline, same-serial content change (loud log — pre-existing consistency wart, documented in the plan doc §7), RFC 1982 serial regression, over-budget single delta. `ModifyDynamicZone` replaces the whole `ZoneData`, so it resets for free.
- Serial-only publishes (e.g. `outbound_soa_serial=unixtime`) append an *empty* link, keeping the chain contiguous.

## Serving (`ZoneTransferOut`)

All existing gates run unchanged first (authorizeTransfer ladder, Ready, MapZone, snapshot pinning, signed-zone fail-closed). Then for IXFR only:
- client same-or-newer (RFC 1982; the undefined 2^31 distance counts as not-older) → single-SOA reply, TSIG-signed like the request;
- UDP → single-SOA reply (§4 retry-over-TCP signal; v1 never streams deltas over UDP);
- contiguous chain path from client serial to `snap.Serial` (re-verified at serve time) → concatenated difference sequences (concatenate-don't-condense) through the shared Project-A envelope batcher (size caps, oversize abort, per-envelope TSIG, disconnect handling);
- anything else → existing full-transfer path (log line says why).

AXFR behavior is byte-identical; its trailing-SOA finish was extracted into a shared helper used by both paths.

## Drive-by fixes (needed to exercise the feature)

- `SetIxfr(zone, serial, "", "")` packs **zero bytes** for the empty MNAME/RNAME → malformed SOA rdata → any compliant server FORMERRs the request. `ZoneTransferIn` and dog's `ZoneTransferPrint` now send root names. (Dormant until now: nothing served IXFR.)
- The transfer-out test server now installs the production `MsgAcceptFunc` so IXFR queries (one authority SOA) reach the handler, matching production wiring.

## Deferred (documented in the plan doc §6)

Inbound IXFR (C2 — `FetchFromUpstream` still requests AXFR), the POP-style downstream tracker, condensation, delta-over-UDP-when-it-fits, `XfrType` field wiring.

## Test evidence

- **Unit/e2e (new, in `v2/ixfr_test.go`)**: RFC 1982 table incl. wrap + 2^31 boundary; retention (exact delta content, empty link, contiguity, all five reset paths, budget trim, oversize reset, disabled); delta planning (gap / stale tail / nil-SOA refusal); serving end-to-end over loopback TCP (up-to-date, client-ahead, no-history fallback, unknown-serial-with-history fallback, single-step delta with exact RR sequence, multi-step concatenation, multi-envelope delta with cap assertions, TSIG on both delta and single-SOA paths, UDP single-SOA, malformed no-SOA query, AXFR-unchanged-with-history).
- **Full `v2` suite `-race` green** (all packages); gofmt clean on every touched file; all cmdv2 apps (auth, cli, agent, imr, dog, debug) build via make with the alg registry.
- **Live smoke** against a real `tdns-auth` on 127.0.0.1:5391: SOA query; `dog IXFR=0` → full-zone fallback (+ expected "no contiguous IXFR history" log); `tdns-cli auth zone bump` (serial 1→2, a real publish through the retention choke point); `dog IXFR=1` → **exact live delta** `SOA(2) | SOA(1) SOA(2) | SOA(2)`; `dog IXFR=2` → single SOA.

Both commits GPG-signed. Not merging — merge decision is yours.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound/in-server IXFR support to serve incremental updates when contiguous history is available.
  * Added configurable IXFR history retention via `ixfr-chain-max-bytes`.
  * Improved IXFR response shaping for UDP/TSIG, including correct up-to-date vs delta vs full-transfer behavior.
* **Bug Fixes**
  * Fixed malformed/authority-missing IXFR queries to avoid format issues and safely fall back to full transfers.
  * Corrected IXFR history reset/rebasing across refresh/replacement, initial snapshot installs, and reloads.
* **Tests**
  * Added comprehensive IXFR/AXFR regression tests covering chaining, budgeting, planning, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->