### PR TITLE
config: server-side reload guardrail for same-name DNSSEC policy algorithm changes

### DIFF
--- a/docs/2026-07-17-config-reload-policy-guardrail-plan.md
+++ b/docs/2026-07-17-config-reload-policy-guardrail-plan.md
@@ -1,13 +1,15 @@
 # Config-reload policy-change guardrail — design & sequencing plan
 
-- **Status:** DRAFT, for discussion. Records the design thread of 2026-07-16/17.
-  Sections are tagged **[DECIDED]**, **[LEANING]**, or **[OPEN]** — do not treat
-  LEANING/OPEN items as ratified.
+- **Status:** **PR-B IMPLEMENTED 2026-07-24** (branch
+  `feature/config-reload-policy-guardrail`). §1–§7 below are the original design
+  thread of 2026-07-16/17 (tags **[DECIDED]** / **[LEANING]** / **[OPEN]**); the
+  code has since drifted (PR-2 merged, other parts already landed). **§9 is the
+  authoritative "what was verified and built" layer — read it first.** Inline
+  `[UPD 2026-07-24]` notes mark where the historical design no longer matches main.
 - **Relationship to other work:** builds on PR-2 (transactional policy reload,
-  `docs/2026-07-15-transactional-policy-reload-plan.md`, PR #292). Sequenced to
-  land *after* PR-2 merges. See §7.
-- **Intended home:** `tdns-project/tdns/docs/2026-07-17-config-reload-policy-guardrail-plan.md`
-  (staged in scratchpad because the Write safety-classifier was transiently down).
+  `docs/2026-07-15-transactional-policy-reload-plan.md`, PR #292 — **now MERGED to
+  main**, so this guardrail's precondition is met).
+- **Intended home:** `tdns-project/tdns/docs/2026-07-17-config-reload-policy-guardrail-plan.md`.
 
 ---
 
@@ -103,6 +105,17 @@ This is where "restart = policy-reset" lives, but note it generalizes:
 
 ## 4. The template-fallback bug **[DECIDED: it's a bug]** — independent
 
+> **[UPD 2026-07-24] ALREADY FIXED on main — no work needed (PR-A dropped).**
+> Verified against current `parseconfig.go`: `ExpandTemplate` (parseconfig.go:1253)
+> runs BEFORE the policy resolution and gap-fills `DnssecPolicy` only when the
+> zone left it empty (zone-wins, line 1277). The zone loop then calls
+> `resolveZonePolicyRef` (parseconfig.go:1718) at line 885, which **fails closed**:
+> an explicit-but-unresolvable policy sets `zconf.DnssecPolicy = ""` **and**
+> `zd.SetError(DnssecError, …)` (parseconfig.go:886-889) → the zone is quarantined,
+> never silently signed under the template's `default`. The §8 live evidence
+> (2026-07-19) already relied on this fail-closed behavior. So PR-A is a no-op and
+> is not part of the implemented PR-B.
+
 A zone with an **explicit** `dnssecpolicy` whose name does **not** resolve
 currently falls back to the template's policy (observed: `test.foo` bound to
 `no-such-policy-xyz` silently signed under the template's `default`). This is
@@ -113,6 +126,21 @@ policy resolution (`resolveZonePolicyRef`, `parseconfig.go:1570`, called from
 `parseconfig.go:790`), independent of §3/§3.2.
 
 ## 5. Feasibility of the server-side dry-run (investigated 2026-07-17)
+
+> **[UPD 2026-07-24] Confirmed and built (this is the core of PR-B).** Two notes on
+> drift: (a) the anchors moved — `ParseConfig` decode is now parseconfig.go:283-330,
+> `parseDnssecConfig` is parseconfig.go:1624, `reloadDnssecFromFile` is
+> parseconfig.go:1431; (b) the §5.3 "refactor `processConfigFile`+decode into a
+> shared `decodeConfigFile`" was **NOT** done — the implemented `dryParseDnssecPolicies`
+> re-reads the file the SAME way `reloadDnssecFromFile` does (a scratch `&Config{}`
+> receiver + `parseDnssecConfig`), which is the §5 "decode into a scratch `*Config`"
+> path and needs no refactor. `decodeConfigFile` extraction stays a future de-dup.
+> Also: the "build once, three consumers" payoff did NOT materialize as a single
+> shared primitive — `config check` (PR-D, PR #303) had already shipped its OWN
+> CLIENT-side predictor (`checkPolicyAlgVsActiveKeys` / `missingRoleAlgs`,
+> config_check_cmds.go). PR-B adds a parallel SERVER-side predictor
+> (`policyAlgStrandsActiveKeys`, config_reload_guardrail.go); both are small, pure,
+> and unit-tested. Consolidating them is deferred (see §9).
 
 **Verdict: low-complexity for the part that matters; most enabling code exists.**
 
@@ -229,3 +257,99 @@ never touches it. **Strengthens §3.2 → build it.**
   the D episode is the case for it (PR-B in §7).
 - **New dependency surfaced:** a **DNSSEC error-classification restructure** gates
   the `ClearError` fix and would sharpen §3.2's diagnostics.
+
+---
+
+## 9. Implementation — PR-B landed (2026-07-24) **[AUTHORITATIVE]**
+
+Branch `feature/config-reload-policy-guardrail`, cut off current `main` (post-#292).
+This section supersedes the §1–§7 sequencing where they disagree.
+
+### 9.1 Verification of the plan against current main
+
+| Plan item | Status on main (2026-07-24) | Action |
+|-----------|-----------------------------|--------|
+| PR-2 (transactional reload, #292) | **MERGED** — precondition met | — |
+| §1 blind spot (same-name alg edit invisible to the classifier) | **Still real.** `classifyPolicyChange` (zone_policy_apply.go:85) resolves applied+intent from the same `ConfLive()` by name; a same-name edit → both resolve to the *new* policy → `PolicyChangeNone` → Branch 1 rebinds with no re-sign; `reconcileActiveKeyAlgorithms` (sign.go:302) then REFUSES at sign. | **Guardrail built (PR-B).** |
+| §4 template fail-closed (PR-A) | **ALREADY FIXED** (see §4 note). | Dropped. |
+| §5 server-side dry-run+correlate | Feasible as described; anchors moved. | **Built.** |
+| PR-D `tdns-checkconf` | **ALREADY SHIPPED** as `config check` (#303), CLIENT-side. | Reused as prior art; not rebuilt. |
+| PR-C converge (`refuse → drop+regen` + auto-CDS) | Not built; MUST follow PR-B. | **Deferred (out of scope).** |
+
+### 9.2 What PR-B implements
+
+The server-side reload guardrail (§3.2 / §5), all in `v2/`:
+
+- **`config_reload_guardrail.go`** (new):
+  - `policyAlgStrandsActiveKeys(want, active, relaxed)` — the **pure** dry-run of
+    `reconcileActiveKeyAlgorithms`, lenient in the same sense as the CLI's
+    `missingRoleAlgs` (zero-keys → not a miss; mid-rollover with the wanted alg
+    present → not a miss). Compares **codepoints** (in-process, no name dance).
+  - `dryParseDnssecPolicies()` — re-reads the `dnssec:` block into a throwaway
+    `&Config{}` and runs `parseDnssecConfig` (no side effects); returns the
+    would-be-new policies + the new `completeness` mode.
+  - `detectStrandingPolicyChanges(newPolicies, relaxed)` — the §5.2 correlation: a
+    read-only loop over live `Zones` comparing `newPolicies[zd.DnssecPolicyName]`
+    (the zone's CURRENT bound name — same-name scope, §6) against the zone's active
+    keys. Never mutates.
+  - `ReloadGuardrailError` + `reloadGuardrailDecision(findings, confirm)` (the pure
+    confirm gate) + `checkReloadPolicyGuardrail(confirm)` (the entry point).
+- **`config.go`**: `ReloadConfig`/`ReloadZoneConfig` kept as thin wrappers that call
+  new `reloadConfig(confirm)`/`reloadZoneConfig(ctx, confirm)`;
+  `ReloadConfigConfirm`/`ReloadZoneConfigConfirm` added for the confirm-carrying
+  API path. `checkReloadPolicyGuardrail` runs **first, under `confMu`, before any
+  mutation** → a refusal is atomic.
+- **`api_structs.go`**: `ConfigPost.Confirm`; `ConfigResponse.GuardrailBlocked` +
+  `.GuardrailZones` (with `ReloadGuardrailZone`/`ReloadGuardrailRole`).
+- **`apihandler_funcs.go`**: `reload`/`reload-zones` call the `*Confirm` variants
+  and surface structured findings via `applyReloadGuardrail`.
+- **`cli/config_cmds.go`**: `--confirm` flag on `reload` and `reload-zones`; a rich
+  `renderReloadGuardrail` block on refusal.
+- **Tests** (`config_reload_guardrail_test.go`): the pure predicate (10 cases incl.
+  same-name catch, benign, zero-keys, mid-rollover, relaxed-vs-strict ZSK, CSK);
+  the confirm gate; and an end-to-end `detectStrandingPolicyChanges` over a real
+  KeyDB + live `Zones` (dangerous caught, benign clean, confirm proceeds, removed
+  policy name skipped).
+
+### 9.3 Forks resolved (owner AFK — minimal, safest, "YAML is truth / converge
+behind a confirm gate")
+
+- **§6 coverage scope → v1 = same-name only.** Uses the zone's current bound name
+  vs new policies. A zone rebound FOO→BAR is left to the existing classifier
+  (`PolicyChangeIncompatibleAlg` → refuse). A rare *simultaneous* name-change +
+  same-name alg-edit can produce a fail-**safe** false-positive confirm prompt —
+  accepted (the classifier still handles the rebind correctly).
+- **§6 TOCTOU → simple re-parse.** Dry-parse to scratch → gate → then the real
+  reload re-parses. Both parses are under `confMu` (µs apart, same file); the tiny
+  window is accepted over refactoring `Reload*`. A refusal mutates nothing.
+- **§3.2 hold-vs-refuse → SIGHUP hold is FREE and shipped.** SIGHUP calls
+  `ReloadZoneConfig` (confirm=false) → the gate holds the change and logs ERROR.
+  **True server startup hold is DEFERRED** (see §9.4).
+- **§3.2 "refuse the whole reload atomically" [LEANING] → RATIFIED.** The gate runs
+  before any mutation, so refusal is all-or-nothing and surfaces a latent dangerous
+  edit even to an operator reloading for something unrelated.
+- **Relaxed-mode ZSK → not flagged.** A ZSK alg change in `completeness: relaxed`
+  is a supported gradual FIFO roll (reconcile no-ops); flagging it would refuse a
+  safe op. KSK/CSK changes are flagged in either mode. (Server-side precision the
+  CLI's mode-agnostic predictor lacks.)
+- **Fail-open on error.** If the dry-parse or the keystore correlation errors, the
+  reload proceeds (logged). The guardrail is an additive safety net; an internal
+  hiccup must not brick a legitimate reload.
+- **Predictor consolidation → NOT done.** Server predictor is parallel to the CLI's
+  (§5 note). Deferred.
+
+### 9.4 Deferred (documented, NOT in PR-B)
+
+- **PR-C converge** (`refuse → drop+regenerate` + auto-CDS to bound the DS-break
+  window). PR-B deliberately keeps the signer's REFUSE, so a *confirmed* reload
+  applies the new binding but the signer still refuses to re-sign until the key is
+  rolled (via the auto-rollover engine or, on a test zone, `policy-reset`). The
+  hard sequencing constraint (§7: PR-B before PR-C) is honored.
+- **True startup-hold** for the un-confirmable restart/crash path
+  (`ParseConfig(false)` at first-bind). Needs the DNSSEC error-classification
+  restructure (§8) to hold-and-scream without wiping unrelated `DnssecError`s;
+  riskier and out of scope. Restart remains a way to force a dangerous alg change
+  through — a known, documented limitation.
+- **make-before-break** whole-zone double-signature rollover (§3.1) — future.
+- **`decodeConfigFile` extraction** and **CLI/server predictor consolidation** —
+  de-dup refactors, not behavior.

--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -268,6 +268,7 @@ type ZoneDsyncResponse struct {
 type ConfigPost struct {
 	Command       string   // status | reload | reload-zones | reload-tsig | ...
 	Force         bool     // reload-tsig: overwrite secret conflicts
+	Confirm       bool     `json:"confirm,omitempty"`       // reload / reload-zones: acknowledge a guarded DNSSEC policy algorithm change
 	TsigOverwrite []string `json:"tsigoverwrite,omitempty"` // reload-tsig --interactive: per-key overwrite
 }
 
@@ -281,9 +282,29 @@ type ConfigResponse struct {
 	Msg                  string
 	Error                bool
 	ErrorMsg             string
-	TsigConflicts        []string      `json:"tsigconflicts,omitempty"`
-	TsigWithheldRemovals []string      `json:"tsigwithheldremovals,omitempty"`
-	ServerErrors         []ServerError `json:"servererrors,omitempty"` // active server-wide error conditions
+	TsigConflicts        []string              `json:"tsigconflicts,omitempty"`
+	TsigWithheldRemovals []string              `json:"tsigwithheldremovals,omitempty"`
+	ServerErrors         []ServerError         `json:"servererrors,omitempty"`     // active server-wide error conditions
+	GuardrailBlocked     bool                  `json:"guardrailblocked,omitempty"` // reload refused by the DNSSEC policy-change guardrail
+	GuardrailZones       []ReloadGuardrailZone `json:"guardrailzones,omitempty"`   // per-zone would-strand findings (with GuardrailBlocked)
+}
+
+// ReloadGuardrailZone is one signed zone a config reload would strand: its bound
+// DNSSEC policy's algorithm changed under the same name to something the zone's
+// active keys cannot provide, which the signer refuses to re-sign (no automatic
+// key-algorithm rollover). See config_reload_guardrail.go.
+type ReloadGuardrailZone struct {
+	Zone       string
+	PolicyName string
+	Roles      []ReloadGuardrailRole
+}
+
+// ReloadGuardrailRole is one role (KSK/ZSK/CSK) of a stranded zone: the algorithm
+// the new policy wants vs the algorithm(s) the zone's active keys of that role carry.
+type ReloadGuardrailRole struct {
+	Role     string   // KSK | ZSK | CSK
+	WantAlg  string   // algorithm the new policy requires
+	HaveAlgs []string // algorithm(s) the zone's active keys of this role carry
 }
 
 type DelegationPost struct {

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -335,18 +335,20 @@ func APIconfig(conf *Config) func(w http.ResponseWriter, r *http.Request) {
 		switch cp.Command {
 		case "reload":
 			lgApi.Info("reloading configuration")
-			resp.Msg, err = conf.ReloadConfig()
+			resp.Msg, err = conf.ReloadConfigConfirm(cp.Confirm)
 			if err != nil {
 				resp.Error = true
 				resp.ErrorMsg = err.Error()
+				applyReloadGuardrail(&resp, err)
 			}
 
 		case "reload-zones":
 			lgApi.Info("reloading zones")
-			resp.Msg, err = conf.ReloadZoneConfig(r.Context())
+			resp.Msg, err = conf.ReloadZoneConfigConfirm(r.Context(), cp.Confirm)
 			if err != nil {
 				resp.Error = true
 				resp.ErrorMsg = err.Error()
+				applyReloadGuardrail(&resp, err)
 			}
 
 		case "reload-tsig":

--- a/v2/cli/config_cmds.go
+++ b/v2/cli/config_cmds.go
@@ -163,7 +163,12 @@ func runConfigCmd(role, command string, showVerboseStatus, confirm bool) {
 	}
 
 	resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: command, Confirm: confirm})
-	if err != nil {
+	// A daemon-side error is carried structurally on resp (resp.Error, and for a
+	// guardrail refusal resp.GuardrailBlocked) *and* returned as a non-nil err by
+	// SendConfigCommand. Let the resp.Error block below handle those so the guardrail
+	// refusal renders; only bail here on a transport-level error (err set, resp not
+	// populated by the daemon).
+	if err != nil && !resp.Error {
 		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}

--- a/v2/cli/config_cmds.go
+++ b/v2/cli/config_cmds.go
@@ -24,21 +24,27 @@ func NewConfigCmd(role string) *cobra.Command {
 		Short: "Commands to reload config, reload zones, etc",
 	}
 
+	var reloadConfirm bool
 	reload := &cobra.Command{
 		Use:   "reload",
 		Short: "Send config reload command to tdns-" + role,
 		Run: func(cmd *cobra.Command, args []string) {
-			runConfigCmd(role, "reload", false)
+			runConfigCmd(role, "reload", false, reloadConfirm)
 		},
 	}
+	reload.Flags().BoolVar(&reloadConfirm, "confirm", false,
+		"apply even if the reload would strand a signed zone by a same-name DNSSEC policy algorithm change")
 
+	var reloadZonesConfirm bool
 	reloadZones := &cobra.Command{
 		Use:   "reload-zones",
 		Short: "Send reload-zones command to tdns-" + role,
 		Run: func(cmd *cobra.Command, args []string) {
-			runConfigCmd(role, "reload-zones", false)
+			runConfigCmd(role, "reload-zones", false, reloadZonesConfirm)
 		},
 	}
+	reloadZones.Flags().BoolVar(&reloadZonesConfirm, "confirm", false,
+		"apply even if the reload would strand a signed zone by a same-name DNSSEC policy algorithm change")
 
 	var force, interactive bool
 	reloadTsig := &cobra.Command{
@@ -58,7 +64,7 @@ overwrite all conflicts, or --interactive to prompt per conflict.`,
 		Use:   "status",
 		Short: "Send config status command to tdns-" + role,
 		Run: func(cmd *cobra.Command, args []string) {
-			runConfigCmd(role, "status", true)
+			runConfigCmd(role, "status", true, false)
 		},
 	}
 
@@ -149,19 +155,23 @@ func reloadTsigWithheld(resp tdns.ConfigResponse) bool {
 // runConfigCmd posts a ConfigPost with the given command and prints the
 // response. showVerboseStatus expands the verbose dump used by the
 // "status" subcommand.
-func runConfigCmd(role, command string, showVerboseStatus bool) {
+func runConfigCmd(role, command string, showVerboseStatus, confirm bool) {
 	api, err := GetApiClient(role, true)
 	if err != nil {
 		fmt.Printf("Error creating API client: %v\n", err)
 		os.Exit(1)
 	}
 
-	resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: command})
+	resp, err := SendConfigCommand(api, tdns.ConfigPost{Command: command, Confirm: confirm})
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())
 		os.Exit(1)
 	}
 	if resp.Error {
+		if resp.GuardrailBlocked {
+			renderReloadGuardrail(resp)
+			os.Exit(1)
+		}
 		fmt.Printf("Error from %s: %s\n", resp.AppName, resp.ErrorMsg)
 		os.Exit(1)
 	}
@@ -235,6 +245,33 @@ func runConfigCmd(role, command string, showVerboseStatus bool) {
 	if resp.Msg != "" {
 		fmt.Printf("%s\n", resp.Msg)
 	}
+}
+
+// renderReloadGuardrail prints the DNSSEC policy-change guardrail refusal returned
+// by a `config reload` / `reload-zones` (server-side gate): the per-zone would-be
+// stranding and how to proceed. The server already refused atomically — nothing on
+// the running server changed.
+func renderReloadGuardrail(resp tdns.ConfigResponse) {
+	fmt.Printf("Reload REFUSED by %s — a DNSSEC policy algorithm change would strand %d signed zone(s):\n\n",
+		resp.AppName, len(resp.GuardrailZones))
+	for _, z := range resp.GuardrailZones {
+		for _, r := range z.Roles {
+			have := strings.Join(r.HaveAlgs, ", ")
+			if have == "" {
+				have = "none"
+			}
+			fmt.Printf("  - %s (policy %q): %s algorithm is now %s, but the zone's active %s key(s) are [%s]\n",
+				z.Zone, z.PolicyName, r.Role, r.WantAlg, r.Role, have)
+		}
+	}
+	fmt.Println()
+	fmt.Println("The running server was NOT changed — these zones keep serving under their current keys.")
+	fmt.Println("The signer has no automatic key-algorithm rollover, so applying this as-is would freeze")
+	fmt.Println("their signatures until expiry, then go BOGUS. To proceed, either:")
+	fmt.Println("  * roll the key deliberately via the auto-rollover engine, or")
+	fmt.Println("  * (test zones) run `tdns-cli auth zone dnssec policy-reset` to drop+regenerate keys, or")
+	fmt.Println("  * re-run this command with --confirm to apply the config anyway (the signer will still")
+	fmt.Println("    refuse to re-sign until the key is rolled).")
 }
 
 func SendConfigCommand(api *tdns.ApiClient, data tdns.ConfigPost) (tdns.ConfigResponse, error) {

--- a/v2/config.go
+++ b/v2/config.go
@@ -602,9 +602,29 @@ func (conf *Config) KaspPropagationDelay() time.Duration {
 	return d
 }
 
-func (conf *Config) ReloadConfig() (string, error) {
+// ReloadConfig reloads the full configuration. Kept for existing callers and
+// SIGHUP-style triggers that cannot consent — it never sets confirm, so the
+// DNSSEC policy-algorithm guardrail (checkReloadPolicyGuardrail) holds a dangerous
+// same-name algorithm change rather than applying it. Use ReloadConfigConfirm to
+// carry an operator's explicit confirm.
+func (conf *Config) ReloadConfig() (string, error) { return conf.reloadConfig(false) }
+
+// ReloadConfigConfirm is ReloadConfig with the operator's confirm flag: confirm
+// lets a guarded DNSSEC policy-algorithm change through the reload gate.
+func (conf *Config) ReloadConfigConfirm(confirm bool) (string, error) {
+	return conf.reloadConfig(confirm)
+}
+
+func (conf *Config) reloadConfig(confirm bool) (string, error) {
 	confMu.Lock()
 	defer confMu.Unlock()
+	// Guardrail (plan §3.2): correlate the incoming DNSSEC policies against the
+	// running zones' active keys BEFORE mutating anything, and refuse a
+	// would-strand same-name algorithm change unless confirmed. Runs first so a
+	// refusal is atomic — the running config is left completely untouched.
+	if gerr := conf.checkReloadPolicyGuardrail(confirm); gerr != nil {
+		return "", gerr
+	}
 	err := conf.ParseConfig(true) // true: reload, not initial parsing
 	if err != nil {
 		lgConfig.Error("error parsing config", "err", err)
@@ -649,10 +669,34 @@ func (conf *Config) ReloadTsigConfig(opts TsigReconcileOptions) (TsigReconcileRe
 	return result, err
 }
 
+// ReloadZoneConfig reloads the zones + dnssec blocks. Kept for existing callers
+// and the SIGHUP watcher, which cannot consent — it never sets confirm, so the
+// DNSSEC policy-algorithm guardrail holds a dangerous same-name algorithm change
+// automatically ("free SIGHUP coverage"). Use ReloadZoneConfigConfirm to carry an
+// operator's explicit confirm.
 func (conf *Config) ReloadZoneConfig(ctx context.Context) (string, error) {
+	return conf.reloadZoneConfig(ctx, false)
+}
+
+// ReloadZoneConfigConfirm is ReloadZoneConfig with the operator's confirm flag.
+func (conf *Config) ReloadZoneConfigConfirm(ctx context.Context, confirm bool) (string, error) {
+	return conf.reloadZoneConfig(ctx, confirm)
+}
+
+func (conf *Config) reloadZoneConfig(ctx context.Context, confirm bool) (string, error) {
 	confMu.Lock()
 	if ctx == nil {
 		ctx = context.Background()
+	}
+
+	// Guardrail (plan §3.2): correlate the incoming DNSSEC policies against the
+	// running zones' active keys BEFORE any live state is mutated (before
+	// templates/dnssec/zones are re-read), and refuse a would-strand same-name
+	// algorithm change unless confirmed. Atomic — a refusal leaves every zone
+	// exactly as it is. confMu is held manually on this path, so unlock on refuse.
+	if gerr := conf.checkReloadPolicyGuardrail(confirm); gerr != nil {
+		confMu.Unlock()
+		return "", gerr
 	}
 
 	// Re-read config file to pick up template changes

--- a/v2/config_reload_guardrail.go
+++ b/v2/config_reload_guardrail.go
@@ -336,7 +336,11 @@ func (conf *Config) checkReloadPolicyGuardrail(confirm bool) error {
 	}
 	findings, err := conf.detectStrandingPolicyChanges(newPolicies, relaxed)
 	if err != nil {
-		lgConfig.Warn("reload guardrail: correlation failed; allowing reload (fail-open)", "err", err)
+		// Fail-open: the guardrail is an additive safety net, never worse than the
+		// pre-guardrail behavior. But a safety control that silently fails open must
+		// not slip by unnoticed, and tdns has no metrics endpoint to count it, so log
+		// this loudly at Error rather than Warn.
+		lgConfig.Error("reload guardrail FAILED OPEN: correlation error; reload allowed WITHOUT the same-name DNSSEC algorithm-change safety check — investigate", "err", err)
 		return nil
 	}
 	if derr := reloadGuardrailDecision(findings, confirm); derr != nil {

--- a/v2/config_reload_guardrail.go
+++ b/v2/config_reload_guardrail.go
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Config-reload DNSSEC-policy-change guardrail (guardrail-plan PR-B,
+ * docs/2026-07-17-config-reload-policy-guardrail-plan.md).
+ *
+ * The transactional-reload classifier (classifyPolicyChange, zone_policy_apply.go)
+ * resolves BOTH the applied and the intent policy BY NAME from the same live
+ * snapshot, so a SAME-NAME algorithm edit — the operator changes policy FOO's KSK
+ * algorithm Ed25519->FALCON512 in the YAML while a zone stays bound to FOO — is
+ * invisible to it: applied and intent both resolve to the *new* FOO, classify
+ * returns None, and the zone is silently rebound WITHOUT a re-sign or key roll.
+ * The mismatch only surfaces later, at the next sign, where
+ * reconcileActiveKeyAlgorithms (sign.go) REFUSES (no automatic KSK/ZSK-algorithm
+ * rollover exists) — the zone keeps serving its now-frozen signatures until they
+ * expire, then goes BOGUS. This is the Finding-A blind spot.
+ *
+ * This guardrail closes it at the reload HANDLER: before any live config is
+ * mutated it dry-parses the incoming DNSSEC policies into a throwaway Config and
+ * correlates them against the running signed zones' ACTIVE keys — the same
+ * comparison reconcileActiveKeyAlgorithms makes, run as a read-only dry-run. When
+ * a would-strand algorithm change is found it refuses the WHOLE reload atomically
+ * (nothing is mutated) unless the operator passes confirm=true. Governing axiom:
+ * "YAML is truth; converge, not refuse — behind an explicit confirm gate." The
+ * gate lives server-side (not in tdns-cli) so a SIGHUP or a direct API reload hits
+ * it too: neither can set confirm=true, so a dangerous converge is held-and-logged
+ * automatically ("free SIGHUP coverage").
+ *
+ * NOTE: this PR keeps the reconcile REFUSE. Turning the confirmed path into an
+ * abrupt drop-and-regenerate converge (+ auto-CDS to bound the DS-break window) is
+ * PR-C, deliberately sequenced AFTER this gate — a naked converge is a DS footgun
+ * without it.
+ */
+
+package tdns
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// ---------------------------------------------------------------------------
+// Pure dry-run of reconcileActiveKeyAlgorithms
+// ---------------------------------------------------------------------------
+
+// policyRoleAlgs is the algorithm set a DNSSEC policy requires, by role. Codepoints
+// (uint8), not names: the guardrail runs entirely in-process, so the policy and
+// the active keys share this deployment's codepoint assignments — no name-mapping
+// dance (that is only needed across the CLI/daemon boundary in config_check_cmds.go).
+type policyRoleAlgs struct {
+	mode string // DnssecPolicyModeCSK | DnssecPolicyModeKSKZSK
+	ksk  uint8  // KSK (split) or CSK (csk mode) algorithm
+	zsk  uint8  // ZSK algorithm (split mode only)
+}
+
+// zoneActiveAlgs is a zone's active-key algorithm codepoints, split by the SEP bit
+// (flags & 1): ksk = SEP-set keys (KSK/CSK), zsk = SEP-clear keys (ZSK). Same
+// convention the signer and the backfill predicate (zoneActiveKeysMatchAlgs) use.
+type zoneActiveAlgs struct {
+	ksk map[uint8]bool
+	zsk map[uint8]bool
+}
+
+// policyAlgMiss is one role whose new-policy algorithm no active key of that role
+// provides — the roles a reload would strand.
+type policyAlgMiss struct {
+	role    string // "KSK" | "ZSK" | "CSK"
+	wantAlg uint8
+	have    []uint8
+}
+
+// policyAlgStrandsActiveKeys is the pure dry-run of reconcileActiveKeyAlgorithms
+// (sign.go): it reports the roles whose NEW policy algorithm the zone's current
+// ACTIVE keys cannot provide, i.e. the roles a reload would strand (the signer
+// then refuses to re-sign and the zone eventually goes bogus).
+//
+// Lenient, matching the operator-facing `config check` predictor
+// (cli.missingRoleAlgs): a role is a miss only when it HAS active keys but NONE
+// carries the wanted algorithm. Two deliberate non-findings:
+//   - zero active keys for a role -> not a miss: the signer generates fresh keys of
+//     the policy algorithm on first sign, it does not refuse.
+//   - the wanted algorithm present alongside a wrong-algorithm key (mid-rollover,
+//     both old+new active) -> not a miss: the zone can already sign under the new
+//     algorithm.
+//
+// relaxed reflects the NEW dnssec.completeness: a ZSK algorithm change in relaxed
+// mode is carried by the gradual FIFO ZSK roll (reconcile no-ops on it), so it is
+// NOT a strand and is not flagged — flagging it would refuse a supported, safe
+// transition. A KSK/CSK algorithm change is a strand in either mode (no automatic
+// KSK-algorithm rollover exists). Pure and dependency-free so it is unit-testable.
+func policyAlgStrandsActiveKeys(want policyRoleAlgs, active zoneActiveAlgs, relaxed bool) []policyAlgMiss {
+	var miss []policyAlgMiss
+	check := func(role string, wantAlg uint8, have map[uint8]bool) {
+		if wantAlg == 0 || len(have) == 0 || have[wantAlg] {
+			return
+		}
+		miss = append(miss, policyAlgMiss{role: role, wantAlg: wantAlg, have: sortedAlgs(have)})
+	}
+	if want.mode == DnssecPolicyModeCSK {
+		check("CSK", want.ksk, active.ksk)
+		return miss
+	}
+	check("KSK", want.ksk, active.ksk)
+	if !relaxed {
+		check("ZSK", want.zsk, active.zsk)
+	}
+	return miss
+}
+
+func sortedAlgs(m map[uint8]bool) []uint8 {
+	out := make([]uint8, 0, len(m))
+	for a := range m {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// (algName is defined in api_structs.go.)
+
+// ---------------------------------------------------------------------------
+// Correlation: new policies vs running zones' active keys
+// ---------------------------------------------------------------------------
+
+// loadZoneActiveAlgs reads a zone's active DNSSEC keys and returns their algorithm
+// codepoints split by SEP bit.
+func loadZoneActiveAlgs(kdb *KeyDB, zone string) (zoneActiveAlgs, error) {
+	out := zoneActiveAlgs{ksk: map[uint8]bool{}, zsk: map[uint8]bool{}}
+	keys, err := GetDnssecKeysByState(kdb, zone, DnskeyStateActive)
+	if err != nil {
+		return out, err
+	}
+	for _, k := range keys {
+		if k.Flags&0x0001 == 0x0001 { // SEP set -> KSK/CSK
+			out.ksk[k.Algorithm] = true
+		} else {
+			out.zsk[k.Algorithm] = true
+		}
+	}
+	return out, nil
+}
+
+// detectStrandingPolicyChanges is the guardrail correlation (plan §5.2): a
+// read-only loop over the running Zones. For each live SIGNED zone it looks up the
+// NEW policy under the zone's CURRENT bound name (newPolicies[zd.DnssecPolicyName])
+// and dry-runs the reconcile against the zone's active keys. A binding-name change
+// (zone rebound FOO->BAR) is deliberately out of scope — the transactional
+// classifier already detects and refuses that (PolicyChangeIncompatibleAlg); this
+// guardrail targets the same-name blind spot the classifier is structurally blind
+// to. relaxed is the NEW dnssec.completeness mode (from the dry-parse).
+//
+// Never mutates anything. Returns the zones a reload would strand, sorted by name.
+func (conf *Config) detectStrandingPolicyChanges(newPolicies map[string]DnssecPolicy, relaxed bool) ([]ReloadGuardrailZone, error) {
+	kdb := conf.Internal.KeyDB
+	if kdb == nil || len(newPolicies) == 0 {
+		return nil, nil
+	}
+
+	var findings []ReloadGuardrailZone
+	for _, zname := range Zones.Keys() {
+		zd, ok := Zones.Get(zname)
+		if !ok || zd == nil {
+			continue
+		}
+		zd.mu.Lock()
+		signed := zd.Options[OptOnlineSigning] || zd.Options[OptInlineSigning]
+		polName := zd.DnssecPolicyName
+		zd.mu.Unlock()
+		if !signed || polName == "" {
+			continue
+		}
+
+		newPol, ok := newPolicies[polName]
+		if !ok || newPol.Error != "" {
+			// The bound policy name was removed from the YAML, or the new
+			// definition is broken. Those are the deleted-policy / broken-policy
+			// cases the parse fail-closed and keepBindingOrQuarantineForBadIntent
+			// paths already handle; they are not an algorithm-change strand, so the
+			// guardrail leaves them alone.
+			continue
+		}
+
+		active, err := loadZoneActiveAlgs(kdb, zd.ZoneName)
+		if err != nil {
+			return nil, fmt.Errorf("guardrail: list active keys for zone %s: %w", zd.ZoneName, err)
+		}
+
+		want := policyRoleAlgs{mode: newPol.Mode, ksk: newPol.KSKAlgorithm, zsk: newPol.ZSKAlgorithm}
+		if want.mode == "" {
+			want.mode = DnssecPolicyModeKSKZSK
+		}
+		miss := policyAlgStrandsActiveKeys(want, active, relaxed)
+		if len(miss) == 0 {
+			continue
+		}
+		findings = append(findings, ReloadGuardrailZone{
+			Zone:       zd.ZoneName,
+			PolicyName: polName,
+			Roles:      missesToRoles(miss),
+		})
+	}
+	sort.Slice(findings, func(i, j int) bool { return findings[i].Zone < findings[j].Zone })
+	return findings, nil
+}
+
+func missesToRoles(miss []policyAlgMiss) []ReloadGuardrailRole {
+	roles := make([]ReloadGuardrailRole, 0, len(miss))
+	for _, m := range miss {
+		have := make([]string, 0, len(m.have))
+		for _, a := range m.have {
+			have = append(have, algName(a))
+		}
+		roles = append(roles, ReloadGuardrailRole{Role: m.role, WantAlg: algName(m.wantAlg), HaveAlgs: have})
+	}
+	return roles
+}
+
+// ---------------------------------------------------------------------------
+// Dry-parse of the incoming DNSSEC policies (no side effects)
+// ---------------------------------------------------------------------------
+
+// dryParseDnssecPolicies re-reads the dnssec: block from the config file into a
+// throwaway scratch Config and parses it, WITHOUT touching the live conf. It
+// returns the would-be-new policy set and whether the new dnssec.completeness is
+// relaxed, so the guardrail can correlate the incoming policies against the running
+// zones' active keys before any live state is mutated. ok=false — a nil file
+// (embedded use), an unreadable file, or a parse error — means the caller skips the
+// guardrail and lets the normal reload path surface any error. Mirrors
+// reloadDnssecFromFile's read+decode, but into a scratch receiver.
+func (conf *Config) dryParseDnssecPolicies() (policies map[string]DnssecPolicy, relaxed bool, ok bool) {
+	cfgfile := conf.Internal.CfgFile
+	if cfgfile == "" {
+		return nil, false, false
+	}
+	configMap, _, err := processConfigFile(cfgfile, filepath.Dir(cfgfile), 0)
+	if err != nil {
+		lgConfig.Warn("reload guardrail: could not read config for dry-run; skipping guardrail", "err", err)
+		return nil, false, false
+	}
+	var partial struct {
+		Dnssec DnssecConf `yaml:"dnssec"`
+	}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "yaml", Result: &partial})
+	if err != nil {
+		lgConfig.Warn("reload guardrail: decoder init failed; skipping guardrail", "err", err)
+		return nil, false, false
+	}
+	if err := decoder.Decode(configMap); err != nil {
+		lgConfig.Warn("reload guardrail: could not decode dnssec block; skipping guardrail", "err", err)
+		return nil, false, false
+	}
+	scratch := &Config{}
+	scratch.Dnssec = partial.Dnssec
+	if err := scratch.parseDnssecConfig(); err != nil {
+		lgConfig.Warn("reload guardrail: could not parse dnssec policies; skipping guardrail", "err", err)
+		return nil, false, false
+	}
+	return scratch.Internal.DnssecPolicies, scratch.Internal.Completeness == CompletenessRelaxed, true
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+// ReloadGuardrailError is returned by a reload handler when the DNSSEC
+// policy-algorithm guardrail refuses the reload. It carries the per-zone findings
+// so the API handler can surface them structurally (ConfigResponse.GuardrailZones)
+// and the CLI can render a rich message plus the --confirm hint.
+type ReloadGuardrailError struct {
+	Zones []ReloadGuardrailZone
+}
+
+func (e *ReloadGuardrailError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "config reload refused: %d signed zone(s) would be stranded by a DNSSEC policy algorithm change that no key rollover handles:\n", len(e.Zones))
+	for _, z := range e.Zones {
+		for _, r := range z.Roles {
+			have := strings.Join(r.HaveAlgs, ", ")
+			if have == "" {
+				have = "none"
+			}
+			fmt.Fprintf(&b, "  - zone %s (policy %q): %s algorithm changed to %s, but the zone's active %s key(s) are [%s]\n",
+				z.Zone, z.PolicyName, r.Role, r.WantAlg, r.Role, have)
+		}
+	}
+	b.WriteString("These zones would keep serving their current signatures until expiry, then go BOGUS.\n")
+	b.WriteString("Re-run with confirm=true (CLI: --confirm) to apply anyway, roll the key deliberately via the auto-rollover engine, or on a test zone run `tdns-cli auth zone dnssec policy-reset`.")
+	return b.String()
+}
+
+// applyReloadGuardrail surfaces a reload guardrail refusal structurally on the
+// API response: when err is a *ReloadGuardrailError it sets GuardrailBlocked and
+// copies the per-zone findings so the CLI can render them and prompt for --confirm.
+// A no-op for any other error.
+func applyReloadGuardrail(resp *ConfigResponse, err error) {
+	var ge *ReloadGuardrailError
+	if errors.As(err, &ge) {
+		resp.GuardrailBlocked = true
+		resp.GuardrailZones = ge.Zones
+	}
+}
+
+// reloadGuardrailDecision gates a reload on the guardrail findings: a
+// *ReloadGuardrailError when there are findings and the operator did NOT confirm,
+// nil otherwise (no findings, or confirm=true). Pure — the testable seam for the
+// confirm gate.
+func reloadGuardrailDecision(findings []ReloadGuardrailZone, confirm bool) error {
+	if len(findings) == 0 || confirm {
+		return nil
+	}
+	return &ReloadGuardrailError{Zones: findings}
+}
+
+// checkReloadPolicyGuardrail runs the DNSSEC policy-algorithm reload guardrail: it
+// dry-parses the incoming policies, correlates them against the running signed
+// zones' active keys, and returns a *ReloadGuardrailError when a same-name
+// algorithm change would strand a zone and the operator did not confirm. Returns
+// nil — the reload proceeds — when there is nothing to guard, when confirm is set,
+// when the dry-run could not run (the normal reload path then surfaces any parse
+// error), or when the correlation itself failed (fail-open: additive safety net,
+// never worse than the pre-guardrail behavior).
+//
+// MUST be called under confMu, BEFORE any live config is mutated, so a refusal
+// leaves the running server completely untouched (atomic refuse). The signer keeps
+// its REFUSE on the same mismatch, so a confirmed reload does not silently converge
+// (that is PR-C).
+func (conf *Config) checkReloadPolicyGuardrail(confirm bool) error {
+	newPolicies, relaxed, ok := conf.dryParseDnssecPolicies()
+	if !ok {
+		return nil
+	}
+	findings, err := conf.detectStrandingPolicyChanges(newPolicies, relaxed)
+	if err != nil {
+		lgConfig.Warn("reload guardrail: correlation failed; allowing reload (fail-open)", "err", err)
+		return nil
+	}
+	if derr := reloadGuardrailDecision(findings, confirm); derr != nil {
+		lgConfig.Error("reload guardrail: refusing config reload (dangerous DNSSEC policy algorithm change)",
+			"zones", len(findings))
+		return derr
+	}
+	if len(findings) > 0 {
+		lgConfig.Warn("reload guardrail: applying CONFIRMED dangerous DNSSEC policy algorithm change; the signer will still refuse to re-sign until the key is rolled",
+			"zones", len(findings))
+	}
+	return nil
+}

--- a/v2/config_reload_guardrail_test.go
+++ b/v2/config_reload_guardrail_test.go
@@ -288,3 +288,54 @@ func TestDetectStrandingSkipsRemovedPolicyName(t *testing.T) {
 		t.Fatalf("a removed policy name must not be flagged as an alg-change strand, got %+v", findings)
 	}
 }
+
+// The collector must forward the relaxed (dnssec.completeness) flag end-to-end: a
+// same-name ZSK algorithm change strands in strict mode but is carried by the
+// gradual FIFO ZSK roll in relaxed mode (not flagged), while a KSK algorithm change
+// strands in either mode. (The pure predicate's relaxed behavior is covered by
+// TestPolicyAlgStrandsActiveKeys; this pins the collector's forwarding of the flag.)
+func TestDetectStrandingRelaxedForwardsZSKSkip(t *testing.T) {
+	withCompleteness(t, CompletenessStrict)
+	kdb := newTestKeyDB(t)
+	conf := &Config{}
+	conf.Internal.KeyDB = kdb
+
+	zone := "relaxed.example."
+	addSignedZone(t, kdb, zone, "foo", dns.ED25519, dns.ED25519)
+
+	// NEW "foo" changes ONLY the ZSK algorithm; the KSK stays Ed25519.
+	zskChange := map[string]DnssecPolicy{
+		"foo": {Name: "foo", Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.RSASHA256},
+	}
+
+	// Strict mode (relaxed=false): the ZSK algorithm change strands the zone.
+	strict, err := conf.detectStrandingPolicyChanges(zskChange, false)
+	if err != nil {
+		t.Fatalf("detectStrandingPolicyChanges (strict): %v", err)
+	}
+	if len(strict) != 1 || len(strict[0].Roles) != 1 || strict[0].Roles[0].Role != "ZSK" {
+		t.Fatalf("strict: want 1 ZSK strand, got %+v", strict)
+	}
+
+	// Relaxed mode (relaxed=true): the same ZSK change is carried by the gradual roll,
+	// so the collector must forward the flag and NOT flag it.
+	relaxed, err := conf.detectStrandingPolicyChanges(zskChange, true)
+	if err != nil {
+		t.Fatalf("detectStrandingPolicyChanges (relaxed): %v", err)
+	}
+	if len(relaxed) != 0 {
+		t.Fatalf("relaxed: a ZSK-only alg change must not strand, got %+v", relaxed)
+	}
+
+	// A KSK algorithm change is a strand even in relaxed mode.
+	kskChange := map[string]DnssecPolicy{
+		"foo": {Name: "foo", Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.ED25519},
+	}
+	stillStrands, err := conf.detectStrandingPolicyChanges(kskChange, true)
+	if err != nil {
+		t.Fatalf("detectStrandingPolicyChanges (relaxed KSK): %v", err)
+	}
+	if len(stillStrands) != 1 || len(stillStrands[0].Roles) != 1 || stillStrands[0].Roles[0].Role != "KSK" {
+		t.Fatalf("relaxed: a KSK alg change must still strand, got %+v", stillStrands)
+	}
+}

--- a/v2/config_reload_guardrail_test.go
+++ b/v2/config_reload_guardrail_test.go
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ *
+ * Tests for the config-reload DNSSEC-policy-change guardrail (PR-B).
+ */
+
+package tdns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// ---------------------------------------------------------------------------
+// Pure predicate: policyAlgStrandsActiveKeys
+// ---------------------------------------------------------------------------
+
+func ksz(ksk, zsk uint8) policyRoleAlgs {
+	return policyRoleAlgs{mode: DnssecPolicyModeKSKZSK, ksk: ksk, zsk: zsk}
+}
+func csk(alg uint8) policyRoleAlgs { return policyRoleAlgs{mode: DnssecPolicyModeCSK, ksk: alg} }
+func active(ksk, zsk []uint8) zoneActiveAlgs {
+	a := zoneActiveAlgs{ksk: map[uint8]bool{}, zsk: map[uint8]bool{}}
+	for _, k := range ksk {
+		a.ksk[k] = true
+	}
+	for _, z := range zsk {
+		a.zsk[z] = true
+	}
+	return a
+}
+
+func TestPolicyAlgStrandsActiveKeys(t *testing.T) {
+	const (
+		ed  = dns.ED25519
+		rsa = dns.RSASHA256
+		// A stand-in "new" algorithm; codepoint value is irrelevant to the pure
+		// predicate (it compares codepoints), only that it differs from ed/rsa.
+		fal = uint8(200)
+	)
+
+	tests := []struct {
+		name     string
+		want     policyRoleAlgs
+		active   zoneActiveAlgs
+		relaxed  bool
+		wantMiss []string // roles expected to be flagged, in order
+	}{
+		{
+			// The core blind spot: KSK Ed25519 -> new alg, zone still bound to the
+			// same policy, active KSK is Ed25519 -> STRAND.
+			name:     "same-name KSK alg change caught",
+			want:     ksz(fal, ed),
+			active:   active([]uint8{ed}, []uint8{ed}),
+			wantMiss: []string{"KSK"},
+		},
+		{
+			name:     "benign: active keys match the new policy",
+			want:     ksz(ed, ed),
+			active:   active([]uint8{ed}, []uint8{ed}),
+			wantMiss: nil,
+		},
+		{
+			// Zero active keys for the ZSK role: the signer would generate fresh
+			// keys of the policy algorithm, so this is not a strand.
+			name:     "zero active keys for a role is not a strand",
+			want:     ksz(ed, fal),
+			active:   active([]uint8{ed}, nil),
+			wantMiss: nil,
+		},
+		{
+			// Mid-rollover: both the old and the wanted KSK alg are active -> the
+			// zone can already sign under the new alg, so not a strand.
+			name:     "mid-rollover (wanted alg already present) is not a strand",
+			want:     ksz(fal, ed),
+			active:   active([]uint8{ed, fal}, []uint8{ed}),
+			wantMiss: nil,
+		},
+		{
+			// ZSK alg change is carried by the gradual FIFO roll in relaxed mode.
+			name:     "ZSK alg change in relaxed mode is not flagged",
+			want:     ksz(ed, fal),
+			active:   active([]uint8{ed}, []uint8{ed}),
+			relaxed:  true,
+			wantMiss: nil,
+		},
+		{
+			name:     "ZSK alg change in strict mode is flagged",
+			want:     ksz(ed, fal),
+			active:   active([]uint8{ed}, []uint8{ed}),
+			relaxed:  false,
+			wantMiss: []string{"ZSK"},
+		},
+		{
+			// KSK change is a strand in relaxed mode too (no automatic KSK-alg roll).
+			name:     "KSK alg change is flagged even in relaxed mode",
+			want:     ksz(fal, ed),
+			active:   active([]uint8{ed}, []uint8{ed}),
+			relaxed:  true,
+			wantMiss: []string{"KSK"},
+		},
+		{
+			name:     "both roles change -> both flagged (strict)",
+			want:     ksz(fal, fal),
+			active:   active([]uint8{ed}, []uint8{rsa}),
+			wantMiss: []string{"KSK", "ZSK"},
+		},
+		{
+			name:     "CSK alg change caught",
+			want:     csk(fal),
+			active:   active([]uint8{ed}, nil),
+			wantMiss: []string{"CSK"},
+		},
+		{
+			name:     "CSK match is benign",
+			want:     csk(ed),
+			active:   active([]uint8{ed}, nil),
+			wantMiss: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			miss := policyAlgStrandsActiveKeys(tc.want, tc.active, tc.relaxed)
+			var got []string
+			for _, m := range miss {
+				got = append(got, m.role)
+			}
+			if strings.Join(got, ",") != strings.Join(tc.wantMiss, ",") {
+				t.Fatalf("roles flagged = %v, want %v", got, tc.wantMiss)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The confirm gate: reloadGuardrailDecision
+// ---------------------------------------------------------------------------
+
+func TestReloadGuardrailDecision(t *testing.T) {
+	findings := []ReloadGuardrailZone{{
+		Zone:       "example.",
+		PolicyName: "foo",
+		Roles:      []ReloadGuardrailRole{{Role: "KSK", WantAlg: "FALCON512", HaveAlgs: []string{"ED25519"}}},
+	}}
+
+	// No findings -> always proceed.
+	if err := reloadGuardrailDecision(nil, false); err != nil {
+		t.Fatalf("no findings, no confirm: want nil, got %v", err)
+	}
+	// Findings without confirm -> refuse with a *ReloadGuardrailError.
+	err := reloadGuardrailDecision(findings, false)
+	if err == nil {
+		t.Fatal("findings without confirm: want a refusal, got nil")
+	}
+	var ge *ReloadGuardrailError
+	if !asReloadGuardrailError(err, &ge) {
+		t.Fatalf("want *ReloadGuardrailError, got %T", err)
+	}
+	if len(ge.Zones) != 1 || ge.Zones[0].Zone != "example." {
+		t.Fatalf("guardrail error lost its findings: %+v", ge.Zones)
+	}
+	msg := err.Error()
+	for _, want := range []string{"example.", "foo", "KSK", "FALCON512", "ED25519", "--confirm"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("guardrail message missing %q:\n%s", want, msg)
+		}
+	}
+	// Findings WITH confirm -> proceed (the gate lets it through).
+	if err := reloadGuardrailDecision(findings, true); err != nil {
+		t.Fatalf("findings with confirm: want nil (proceed), got %v", err)
+	}
+}
+
+// asReloadGuardrailError is a tiny local errors.As wrapper kept out of the
+// production file's import set.
+func asReloadGuardrailError(err error, target **ReloadGuardrailError) bool {
+	if e, ok := err.(*ReloadGuardrailError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Collector end-to-end: detectStrandingPolicyChanges over live Zones + keystore
+// ---------------------------------------------------------------------------
+
+// addSignedZone registers a signed zone in the global Zones map bound to policyName
+// with the given active keys, and returns it (auto-removed on cleanup).
+func addSignedZone(t *testing.T, kdb *KeyDB, zone, policyName string, kskAlg, zskAlg uint8) *ZoneData {
+	t.Helper()
+	if _, _, err := kdb.GenerateKeypair(zone, "test", DnskeyStateActive, dns.TypeDNSKEY, kskAlg, "KSK", nil); err != nil {
+		t.Fatalf("generate KSK for %s: %v", zone, err)
+	}
+	if _, _, err := kdb.GenerateKeypair(zone, "test", DnskeyStateActive, dns.TypeDNSKEY, zskAlg, "ZSK", nil); err != nil {
+		t.Fatalf("generate ZSK for %s: %v", zone, err)
+	}
+	zd := &ZoneData{
+		ZoneName:         zone,
+		Options:          map[ZoneOption]bool{OptOnlineSigning: true},
+		DnssecPolicyName: policyName,
+	}
+	Zones.Set(zone, zd)
+	t.Cleanup(func() { Zones.Remove(zone) })
+	return zd
+}
+
+func TestDetectStrandingPolicyChanges(t *testing.T) {
+	withCompleteness(t, CompletenessStrict)
+	kdb := newTestKeyDB(t)
+	conf := &Config{}
+	conf.Internal.KeyDB = kdb
+
+	// Two zones, both bound to policy "foo", both currently keyed with Ed25519.
+	danger := "danger.example."
+	benign := "benign.example."
+	addSignedZone(t, kdb, danger, "foo", dns.ED25519, dns.ED25519)
+	addSignedZone(t, kdb, benign, "foo", dns.ED25519, dns.ED25519)
+
+	// The NEW "foo" changes the KSK algorithm; a same-name edit. RSASHA256 stands
+	// in for "a different algorithm than the active Ed25519 keys".
+	newPolicies := map[string]DnssecPolicy{
+		"foo": {Name: "foo", Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.ED25519},
+	}
+
+	findings, err := conf.detectStrandingPolicyChanges(newPolicies, false)
+	if err != nil {
+		t.Fatalf("detectStrandingPolicyChanges: %v", err)
+	}
+	// Both zones share policy foo, so both would strand on the KSK alg change.
+	if len(findings) != 2 {
+		t.Fatalf("want 2 stranded zones, got %d: %+v", len(findings), findings)
+	}
+	for _, f := range findings {
+		if f.PolicyName != "foo" || len(f.Roles) != 1 || f.Roles[0].Role != "KSK" {
+			t.Fatalf("unexpected finding: %+v", f)
+		}
+		if f.Roles[0].WantAlg != dns.AlgorithmToString[dns.RSASHA256] {
+			t.Errorf("want KSK alg %s, got %s", dns.AlgorithmToString[dns.RSASHA256], f.Roles[0].WantAlg)
+		}
+	}
+
+	// Benign reload: the NEW foo keeps the algorithms the active keys already have.
+	benignPolicies := map[string]DnssecPolicy{
+		"foo": {Name: "foo", Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.ED25519, ZSKAlgorithm: dns.ED25519},
+	}
+	findings, err = conf.detectStrandingPolicyChanges(benignPolicies, false)
+	if err != nil {
+		t.Fatalf("detectStrandingPolicyChanges (benign): %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("benign reload must produce no findings, got %+v", findings)
+	}
+
+	// The confirm gate lets the dangerous change through unchanged.
+	dangerFindings, _ := conf.detectStrandingPolicyChanges(newPolicies, false)
+	if err := reloadGuardrailDecision(dangerFindings, true); err != nil {
+		t.Fatalf("confirm=true must let the reload proceed, got %v", err)
+	}
+	if err := reloadGuardrailDecision(dangerFindings, false); err == nil {
+		t.Fatal("confirm=false must refuse the dangerous reload")
+	}
+}
+
+// A zone bound to a policy NAME that the new config removed is out of scope for the
+// guardrail (handled by the parse fail-closed / keep-binding paths), so it must not
+// be flagged as an algorithm-change strand.
+func TestDetectStrandingSkipsRemovedPolicyName(t *testing.T) {
+	withCompleteness(t, CompletenessStrict)
+	kdb := newTestKeyDB(t)
+	conf := &Config{}
+	conf.Internal.KeyDB = kdb
+
+	addSignedZone(t, kdb, "gone.example.", "removed-policy", dns.ED25519, dns.ED25519)
+
+	// New config no longer defines "removed-policy" (only "other").
+	newPolicies := map[string]DnssecPolicy{
+		"other": {Name: "other", Mode: DnssecPolicyModeKSKZSK, KSKAlgorithm: dns.RSASHA256, ZSKAlgorithm: dns.RSASHA256},
+	}
+	findings, err := conf.detectStrandingPolicyChanges(newPolicies, false)
+	if err != nil {
+		t.Fatalf("detectStrandingPolicyChanges: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("a removed policy name must not be flagged as an alg-change strand, got %+v", findings)
+	}
+}


### PR DESCRIPTION
## What & why

Implements the **config-reload policy-change guardrail** (guardrail-plan **PR-B**,
`docs/2026-07-17-config-reload-policy-guardrail-plan.md`).

The transactional-reload classifier (`classifyPolicyChange`) resolves both the
*applied* and the *intent* policy **by name** from the same live snapshot. So a
**same-name algorithm edit** — operator changes policy `FOO`'s KSK
Ed25519→FALCON512 in the YAML while a zone stays bound to `FOO` — is invisible to
it: both sides resolve to the *new* `FOO`, `classifyPolicyChange` returns `None`,
and the zone is silently rebound with **no re-sign and no key roll**.
`reconcileActiveKeyAlgorithms` then **REFUSES** at the next sign (there is no
automatic key-algorithm rollover), freezing the zone's signatures until they
expire — then **bogus**. This is the Finding-A blind spot, still real on `main`
after PR-2 (#292) merged.

This PR closes it at the **reload handler**: before mutating any live state it
dry-parses the incoming DNSSEC policies into a throwaway `Config` and correlates
them against the running signed zones' **active keys** — a read-only dry-run of
the signer's reconcile. A would-strand same-name change **refuses the whole reload
atomically** unless the operator passes `confirm=true`.

Governing axiom (from the plan): **YAML is truth; converge, not refuse — behind an
explicit confirm gate.** The gate is server-side, so a **SIGHUP** or a direct API
reload hits it too and, unable to set `confirm`, **holds-and-logs** automatically
(free SIGHUP coverage).

## What it does NOT do

Keeps the signer's `REFUSE`. Turning the *confirmed* path into an abrupt
drop-and-regenerate **converge** (+ auto-CDS to bound the DS-break window) is
**PR-C**, deliberately sequenced *after* this gate — a naked converge is a DS
footgun without it. So today `--confirm` applies the new binding but the signer
still refuses to re-sign until the key is rolled (auto-rollover engine, or on a
test zone `tdns-cli auth zone dnssec policy-reset`).

## Verification against current `main` (recorded in the plan §9)

| Plan item | Status | Action |
|---|---|---|
| PR-2 (#292) | **merged** — precondition met | — |
| §1 blind spot | **still real** | guardrail built |
| §4 template fail-closed (PR-A) | **already fixed** on main | dropped |
| PR-D `tdns-checkconf` | **already shipped** as `config check` (#303, client-side) | reused as prior art |
| PR-C converge | not built; must follow PR-B | deferred |

## Forks resolved (owner was AFK — minimal, safest, plan-aligned)

- **Coverage → same-name only (v1).** Uses the zone's current bound name vs new
  policies; a zone rebound `FOO`→`BAR` is left to the existing classifier
  (refuse). A rare simultaneous name-change + alg-edit yields a fail-**safe**
  confirm prompt.
- **TOCTOU → simple re-parse.** Dry-parse to scratch → gate → real reload
  re-parses; both under `confMu`. Refusal mutates nothing.
- **"Refuse whole reload atomically" [LEANING] → ratified.**
- **SIGHUP hold → free & shipped; true startup-hold → deferred** (needs the DNSSEC
  error-classification restructure to hold-and-scream safely; restart remains a
  documented way to force a change through).
- **Relaxed-mode ZSK → not flagged** (supported gradual FIFO roll); KSK/CSK flagged
  in either mode.
- **Fail-open** on a dry-parse/keystore error (additive safety net, never bricks a
  legit reload).
- **Predictor consolidation → deferred** (server predictor parallel to the CLI's).

## Changes

- `v2/config_reload_guardrail.go` (new): `policyAlgStrandsActiveKeys` (pure dry-run),
  `dryParseDnssecPolicies`, `detectStrandingPolicyChanges`, `ReloadGuardrailError`,
  `reloadGuardrailDecision`, `checkReloadPolicyGuardrail`.
- `v2/config.go`: `ReloadConfig`/`ReloadZoneConfig` kept as `confirm=false`
  wrappers; `ReloadConfigConfirm`/`ReloadZoneConfigConfirm` added; gate runs first
  under `confMu`.
- `v2/api_structs.go`: `ConfigPost.Confirm`; `ConfigResponse.GuardrailBlocked` /
  `.GuardrailZones` (`ReloadGuardrailZone` / `ReloadGuardrailRole`).
- `v2/apihandler_funcs.go`: `reload`/`reload-zones` use the `*Confirm` variants and
  surface the structured findings.
- `v2/cli/config_cmds.go`: `--confirm` flag on `reload`/`reload-zones` + a rich
  refusal render.
- `docs/2026-07-17-config-reload-policy-guardrail-plan.md`: updated in place (§9
  authoritative layer + inline drift notes).

## Tests / gate

- New `v2/config_reload_guardrail_test.go`: pure predicate (10 cases: same-name
  catch, benign, zero-keys, mid-rollover, relaxed-vs-strict ZSK, CSK), the confirm
  gate, and an end-to-end `detectStrandingPolicyChanges` over a real KeyDB + live
  `Zones` (dangerous caught, benign clean, confirm proceeds, removed-policy-name
  skipped).
- Full `v2` `-race` suite green; `v2/cli` `-race` green; `gofmt`/`go vet` clean;
  `tdns-auth` and `tdns-cli` build via `make`.

Additive and behavior-neutral for reloads that do not hit the guarded case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protection against DNSSEC configuration reloads that could leave signed zones without compatible active algorithms.
  - Reload responses now identify affected zones, policies, and roles when an operation is blocked.
  - Added confirmation support for API reload requests and the `config reload` and `config reload-zones` commands.
  - CLI messages explain the affected zones and available next steps, including retrying with confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->