### PR TITLE
DNSSEC chain fixes: imr DS-backfill + auth secure-referral DS

### DIFF
--- a/v2/cache/rrset_validate.go
+++ b/v2/cache/rrset_validate.go
@@ -666,6 +666,17 @@ func (rrcache *RRsetCacheT) ValidateDNSKEYs(ctx context.Context, rrset *core.RRs
 	var dsRRs *CachedRRset
 	if name != "." {
 		dsRRs = rrcache.Get(name, dns.TypeDS)
+		if dsRRs == nil {
+			// Backfill: the DS for this zone is not cached, so the chain of
+			// trust cannot be anchored yet. Fetch and validate it on demand
+			// (mirroring the DNSKEY on-demand fetch a few lines above) instead
+			// of giving up with Indeterminate. This is what lets a cold
+			// resolution of a signed child's data validate without a prior
+			// explicit DS query — a secure delegation is never conveyed to us
+			// as a referral when the same server is authoritative for both
+			// parent and child, so the DS must be fetched explicitly here.
+			dsRRs = rrcache.backfillDS(ctx, name, fetcher)
+		}
 		// If DS exists but is not secure, we cannot validate DNSKEYs
 		if dsRRs != nil && dsRRs.State != ValidationStateSecure {
 			// Mark zone with same state as DS and return
@@ -869,6 +880,70 @@ func (rrcache *RRsetCacheT) ValidateDNSKEYs(ctx context.Context, rrset *core.RRs
 		}
 	}
 	return ValidationStateIndeterminate, nil
+}
+
+// backfillDS fetches and validates the DS RRset for `name` when it is not
+// already cached, so ValidateDNSKEYs can anchor the zone's DNSKEY to its parent
+// without depending on a prior explicit DS query. The DS lives in the parent
+// zone (signed by the parent's ZSK); fetching it drives its own validation up
+// the chain to the trust anchor. On success the validated DS is cached so
+// subsequent lookups hit the fast path; returns nil (leaving the caller to
+// report Indeterminate) when the DS cannot be obtained.
+//
+// Scope: this handles the SECURE case (a DS exists). An authenticated NODATA
+// (proof of no DS ⇒ an insecure delegation) is returned by the fetcher as an
+// empty answer here and left as Indeterminate; proper insecure-delegation
+// handling via NSEC/NSEC3 proof is separate, future work.
+//
+// Termination: validating the fetched DS needs the PARENT's DNSKEY, which may
+// recurse into ValidateDNSKEYs(parent) → backfillDS(parent) → … strictly
+// UP the tree, ending at the root / a configured trust anchor. It never
+// re-enters for `name` itself, so there is no unbounded recursion.
+func (rrcache *RRsetCacheT) backfillDS(ctx context.Context, name string, fetcher RRsetFetcher) *CachedRRset {
+	if fetcher == nil || name == "." {
+		return nil
+	}
+	_, servers, err := rrcache.FindClosestKnownZone(name)
+	if err != nil {
+		return nil
+	}
+	if len(servers) == 0 {
+		if sm, ok := rrcache.ServerMap.Get("."); ok {
+			servers = sm
+		}
+	}
+	if len(servers) == 0 {
+		return nil
+	}
+	fetched, err := fetcher(ctx, name, dns.TypeDS, servers)
+	if err != nil || fetched == nil || len(fetched.RRs) == 0 {
+		// Fetch failed, or authenticated NODATA (no DS ⇒ insecure delegation,
+		// out of scope here). Leave the zone unresolved: caller → Indeterminate.
+		if rrcache.Verbose {
+			log.Printf("backfillDS: no DS obtained for %q (err=%v); leaving chain unanchored", name, err)
+		}
+		return nil
+	}
+	// Validate the fetched DS against the parent's DNSKEY (recurses up-tree).
+	// This also marks the zone Secure in ZoneMap on success (see ValidateRRset's
+	// DS special-case).
+	vstate, err := rrcache.ValidateRRset(ctx, fetched, fetcher)
+	if err != nil {
+		return nil
+	}
+	entry := &CachedRRset{
+		Name:       name,
+		RRtype:     dns.TypeDS,
+		RRset:      fetched,
+		Context:    ContextAnswer,
+		State:      vstate,
+		Expiration: time.Now().Add(GetMinTTL(fetched.RRs)),
+	}
+	rrcache.Set(name, dns.TypeDS, entry)
+	if rrcache.Verbose {
+		log.Printf("backfillDS: fetched+validated DS for %q (state=%s)", name, ValidationStateToString[vstate])
+	}
+	return entry
 }
 
 func (rrcache *RRsetCacheT) ValidateNegativeResponse(ctx context.Context, qname string, qtype uint16, rcode uint8,

--- a/v2/cache/rrset_validate.go
+++ b/v2/cache/rrset_validate.go
@@ -905,6 +905,9 @@ func (rrcache *RRsetCacheT) backfillDS(ctx context.Context, name string, fetcher
 	}
 	_, servers, err := rrcache.FindClosestKnownZone(name)
 	if err != nil {
+		if rrcache.Verbose {
+			log.Printf("backfillDS: FindClosestKnownZone(%q) failed: %v", name, err)
+		}
 		return nil
 	}
 	if len(servers) == 0 {
@@ -929,6 +932,9 @@ func (rrcache *RRsetCacheT) backfillDS(ctx context.Context, name string, fetcher
 	// DS special-case).
 	vstate, err := rrcache.ValidateRRset(ctx, fetched, fetcher)
 	if err != nil {
+		if rrcache.Verbose {
+			log.Printf("backfillDS: ValidateRRset for DS %q failed: %v", name, err)
+		}
 		return nil
 	}
 	entry := &CachedRRset{

--- a/v2/cache/rrset_validate_test.go
+++ b/v2/cache/rrset_validate_test.go
@@ -220,3 +220,66 @@ func TestValidator_ExplicitValidVerdictIsReused(t *testing.T) {
 		t.Errorf("expected ValidationStateSecure reused from cache, got %v", got)
 	}
 }
+
+// TestValidateDNSKEYs_BackfillsMissingDS is the regression test for the
+// DS-backfill fix. To anchor a zone's DNSKEY the validator needs the zone's
+// DS; pre-fix it only ever looked in the cache and, on a miss, returned
+// Indeterminate without fetching — so a cold resolution of a signed child
+// (whose DS was never cached, e.g. because the same server is authoritative
+// for both parent and child, so no DS-bearing referral is ever emitted) could
+// never validate. The fix fetches the missing DS on demand via the fetcher.
+//
+// This asserts the load-bearing behaviour: on a DS cache miss, ValidateDNSKEYs
+// ASKS the fetcher for the DS at all. (The mock returns no DS, so the verdict
+// stays Indeterminate — the point is purely that the fetch is attempted, which
+// pre-fix it never was.)
+func TestValidateDNSKEYs_BackfillsMissingDS(t *testing.T) {
+	rrcache := NewRRsetCache(log.New(os.Stderr, "test ", 0), false, false)
+
+	// Seed root servers so backfillDS can reach the fetcher (same
+	// FindClosestKnownZone + ServerMap["."] path the DNSKEY fetch uses).
+	rrcache.ServerMap.Set(".", map[string]*AuthServer{"a.root.": {}})
+
+	const child = "falcon512-mayo2.pq.axfr.net."
+	ksk := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: child, Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ED25519,
+		PublicKey: "l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4=",
+	}
+	sig := &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: child, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+		TypeCovered: dns.TypeDNSKEY,
+		Algorithm:   dns.ED25519,
+		Labels:      4,
+		OrigTtl:     3600,
+		Inception:   uint32(time.Now().Add(-time.Hour).Unix()),
+		Expiration:  uint32(time.Now().Add(24 * time.Hour).Unix()),
+		KeyTag:      ksk.KeyTag(),
+		SignerName:  child,
+		Signature:   "AAAA",
+	}
+	dnskeyRRset := &core.RRset{
+		Name:   child,
+		Class:  dns.ClassINET,
+		RRtype: dns.TypeDNSKEY,
+		RRs:    []dns.RR{ksk},
+		RRSIGs: []dns.RR{sig},
+	}
+
+	var askedDS bool
+	fetcher := func(ctx context.Context, qname string, qtype uint16, servers map[string]*AuthServer) (*core.RRset, error) {
+		if dns.Fqdn(qname) == child && qtype == dns.TypeDS {
+			askedDS = true
+		}
+		return nil, nil // no DS returned; verdict stays Indeterminate
+	}
+
+	if _, err := rrcache.ValidateDNSKEYs(context.Background(), dnskeyRRset, fetcher); err != nil {
+		t.Fatalf("ValidateDNSKEYs error: %v", err)
+	}
+	if !askedDS {
+		t.Fatalf("ValidateDNSKEYs did not fetch the missing DS for %s on a cache miss — DS-backfill regression", child)
+	}
+}

--- a/v2/queryresponder.go
+++ b/v2/queryresponder.go
@@ -377,9 +377,27 @@ func (zd *ZoneData) sendReferral(m *dns.Msg, w dns.ResponseWriter, cdd *ChildDel
 	m.Extra = append(m.Extra, cdd.A_glue...)
 	m.Extra = append(m.Extra, cdd.AAAA_glue...)
 
-	// RFC 9824, Section 3.4: Add NSEC for unsigned referrals
 	if msgoptions.DO {
-		addReferralNSEC(m, cdd, apex, zd.ZoneName, signFunc)
+		if cdd.DS_rrset != nil && len(cdd.DS_rrset.RRs) > 0 {
+			// Secure delegation (RFC 4035 §3.1.4.1): include the DS RRset and
+			// its RRSIG in the authority section so a validating resolver can
+			// establish the child's chain of trust straight from the referral,
+			// without a separate DS query. A signing failure is non-fatal — the
+			// referral itself is still valid and the resolver falls back to an
+			// explicit DS query — so on error we omit the DS rather than emit an
+			// unsigned (useless) one.
+			ds := *cdd.DS_rrset
+			if signed, err := signFunc(ds, cdd.ChildName); err != nil {
+				lgHandler.Error("referral: failed to sign DS RRset; omitting DS from referral",
+					"child", cdd.ChildName, "err", err)
+			} else {
+				m.Ns = append(m.Ns, signed.RRs...)
+				m.Ns = append(m.Ns, signed.RRSIGs...)
+			}
+		} else {
+			// Insecure delegation (RFC 9824 §3.4): NSEC proving no DS exists.
+			addReferralNSEC(m, cdd, apex, zd.ZoneName, signFunc)
+		}
 	}
 
 	w.WriteMsg(m)

--- a/v2/referral_ds_test.go
+++ b/v2/referral_ds_test.go
@@ -1,6 +1,7 @@
 package tdns
 
 import (
+	"fmt"
 	"testing"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -83,5 +84,89 @@ func TestSendReferral_NonDNSSECHasNoDS(t *testing.T) {
 		if rr.Header().Rrtype == dns.TypeDS || rr.Header().Rrtype == dns.TypeNSEC {
 			t.Fatalf("DO=0 referral must not carry DNSSEC records, got %s", dns.TypeToString[rr.Header().Rrtype])
 		}
+	}
+}
+
+// TestSendReferral_SignFailureIsNonFatal confirms the documented behavior that a
+// DS signing failure does not abort the referral: the NS is still served and the
+// DS is omitted (an unsigned DS would be useless), rather than SERVFAIL.
+func TestSendReferral_SignFailureIsNonFatal(t *testing.T) {
+	zd := &ZoneData{ZoneName: "pq.axfr.net."}
+	const child = "falcon512-mayo2.pq.axfr.net."
+	nsRR := mustRR(t, child+" 3600 IN NS ns.pq.axfr.net.")
+	dsRR := mustRR(t, child+" 3600 IN DS 23388 208 2 87C97FD4C8748E1507B76F098C398B47EBBC2145DBCEB45D004D650D537EF841")
+	cdd := &ChildDelegationData{
+		ChildName: child,
+		NS_rrset:  &core.RRset{Name: child, RRtype: dns.TypeNS, Class: dns.ClassINET, RRs: []dns.RR{nsRR}},
+		DS_rrset:  &core.RRset{Name: child, RRtype: dns.TypeDS, Class: dns.ClassINET, RRs: []dns.RR{dsRR}},
+	}
+	signFunc := func(rrset core.RRset, name string) (core.RRset, error) {
+		return core.RRset{}, fmt.Errorf("simulated signing failure")
+	}
+
+	w := &fakeRW{remote: udpAddr("127.0.0.1")}
+	m := new(dns.Msg)
+	zd.sendReferral(m, w, cdd, nil, &edns0.MsgOptions{DO: true}, signFunc)
+
+	if w.written == nil {
+		t.Fatal("sendReferral wrote no response")
+	}
+	var sawNS, sawDS bool
+	for _, rr := range w.written.Ns {
+		switch rr.Header().Rrtype {
+		case dns.TypeNS:
+			sawNS = true
+		case dns.TypeDS:
+			sawDS = true
+		}
+	}
+	if !sawNS {
+		t.Fatal("referral must still carry NS after a DS signing failure")
+	}
+	if sawDS {
+		t.Fatal("DS must be omitted when signing fails (an unsigned DS is useless)")
+	}
+}
+
+// TestSendReferral_InsecureDelegationHasNSEC confirms the insecure branch: a DO=1
+// referral for a delegation with no DS carries an NSEC proving no DS (RFC 9824
+// §3.4) and no DS. addReferralNSEC reads apex.RRtypes for the SOA min-TTL, so a
+// non-nil apex is required.
+func TestSendReferral_InsecureDelegationHasNSEC(t *testing.T) {
+	zd := &ZoneData{ZoneName: "pq.axfr.net."}
+	const child = "insecure.pq.axfr.net."
+	nsRR := mustRR(t, child+" 3600 IN NS ns.pq.axfr.net.")
+	cdd := &ChildDelegationData{
+		ChildName: child,
+		NS_rrset:  &core.RRset{Name: child, RRtype: dns.TypeNS, Class: dns.ClassINET, RRs: []dns.RR{nsRR}},
+		// DS_rrset nil → insecure delegation
+	}
+	apex := &OwnerData{Name: zd.ZoneName, RRtypes: NewRRTypeStore()}
+	soa := mustRR(t, zd.ZoneName+" 3600 IN SOA ns.pq.axfr.net. hostmaster.pq.axfr.net. 1 3600 600 86400 600")
+	apex.RRtypes.Set(dns.TypeSOA, core.RRset{Name: zd.ZoneName, RRtype: dns.TypeSOA, Class: dns.ClassINET, RRs: []dns.RR{soa}})
+
+	signFunc := func(rrset core.RRset, name string) (core.RRset, error) { return rrset, nil }
+
+	w := &fakeRW{remote: udpAddr("127.0.0.1")}
+	m := new(dns.Msg)
+	zd.sendReferral(m, w, cdd, apex, &edns0.MsgOptions{DO: true}, signFunc)
+
+	if w.written == nil {
+		t.Fatal("sendReferral wrote no response")
+	}
+	var sawNSEC, sawDS bool
+	for _, rr := range w.written.Ns {
+		switch rr.Header().Rrtype {
+		case dns.TypeNSEC:
+			sawNSEC = true
+		case dns.TypeDS:
+			sawDS = true
+		}
+	}
+	if !sawNSEC {
+		t.Fatal("insecure (no-DS) referral must carry an NSEC proving no DS")
+	}
+	if sawDS {
+		t.Fatal("insecure delegation must not carry a DS")
 	}
 }

--- a/v2/referral_ds_test.go
+++ b/v2/referral_ds_test.go
@@ -1,0 +1,87 @@
+package tdns
+
+import (
+	"testing"
+
+	core "github.com/johanix/tdns/v2/core"
+	edns0 "github.com/johanix/tdns/v2/edns0"
+	"github.com/miekg/dns"
+)
+
+// TestSendReferral_SecureDelegationIncludesDS is the regression test for the
+// tdns-auth secure-referral fix (RFC 4035 §3.1.4.1): a DO=1 referral for a
+// secure delegation must carry the DS RRset and its RRSIG in the authority
+// section, so a validating resolver can establish the child's chain of trust
+// straight from the referral. Pre-fix, sendReferral added only NS + glue (and,
+// wrongly, a no-DS NSEC), never the DS.
+func TestSendReferral_SecureDelegationIncludesDS(t *testing.T) {
+	zd := &ZoneData{ZoneName: "pq.axfr.net."}
+	const child = "falcon512-mayo2.pq.axfr.net."
+
+	nsRR := mustRR(t, child+" 3600 IN NS ns.pq.axfr.net.")
+	dsRR := mustRR(t, child+" 3600 IN DS 23388 208 2 87C97FD4C8748E1507B76F098C398B47EBBC2145DBCEB45D004D650D537EF841")
+	cdd := &ChildDelegationData{
+		ChildName: child,
+		NS_rrset:  &core.RRset{Name: child, RRtype: dns.TypeNS, Class: dns.ClassINET, RRs: []dns.RR{nsRR}},
+		DS_rrset:  &core.RRset{Name: child, RRtype: dns.TypeDS, Class: dns.ClassINET, RRs: []dns.RR{dsRR}},
+	}
+
+	// Stub signer: attach a marker RRSIG(DS) so we can assert the DS was signed
+	// and added, without needing a real signing key in the test.
+	signFunc := func(rrset core.RRset, name string) (core.RRset, error) {
+		rrset.RRSIGs = []dns.RR{mustRR(t, name+" 3600 IN RRSIG DS 15 4 3600 20260805122917 20260722122719 16089 pq.axfr.net. AA==")}
+		return rrset, nil
+	}
+
+	w := &fakeRW{remote: udpAddr("127.0.0.1")}
+	m := new(dns.Msg)
+	zd.sendReferral(m, w, cdd, nil, &edns0.MsgOptions{DO: true}, signFunc)
+
+	if w.written == nil {
+		t.Fatal("sendReferral wrote no response")
+	}
+	var sawDS, sawDSSig bool
+	for _, rr := range w.written.Ns {
+		switch v := rr.(type) {
+		case *dns.RRSIG:
+			if v.TypeCovered == dns.TypeDS {
+				sawDSSig = true
+			}
+		default:
+			if rr.Header().Rrtype == dns.TypeDS {
+				sawDS = true
+			}
+		}
+	}
+	if !sawDS || !sawDSSig {
+		t.Fatalf("secure referral must include DS (%v) and RRSIG(DS) (%v) in the authority section", sawDS, sawDSSig)
+	}
+}
+
+// TestSendReferral_NonDNSSECHasNoDS confirms a plain (DO=0) referral carries no
+// DNSSEC records — no DS, no NSEC.
+func TestSendReferral_NonDNSSECHasNoDS(t *testing.T) {
+	zd := &ZoneData{ZoneName: "pq.axfr.net."}
+	const child = "falcon512-mayo2.pq.axfr.net."
+	nsRR := mustRR(t, child+" 3600 IN NS ns.pq.axfr.net.")
+	dsRR := mustRR(t, child+" 3600 IN DS 23388 208 2 87C97FD4C8748E1507B76F098C398B47EBBC2145DBCEB45D004D650D537EF841")
+	cdd := &ChildDelegationData{
+		ChildName: child,
+		NS_rrset:  &core.RRset{Name: child, RRtype: dns.TypeNS, Class: dns.ClassINET, RRs: []dns.RR{nsRR}},
+		DS_rrset:  &core.RRset{Name: child, RRtype: dns.TypeDS, Class: dns.ClassINET, RRs: []dns.RR{dsRR}},
+	}
+	signFunc := func(rrset core.RRset, name string) (core.RRset, error) { return rrset, nil }
+
+	w := &fakeRW{remote: udpAddr("127.0.0.1")}
+	m := new(dns.Msg)
+	zd.sendReferral(m, w, cdd, nil, &edns0.MsgOptions{DO: false}, signFunc)
+
+	if w.written == nil {
+		t.Fatal("sendReferral wrote no response")
+	}
+	for _, rr := range w.written.Ns {
+		if rr.Header().Rrtype == dns.TypeDS || rr.Header().Rrtype == dns.TypeNSEC {
+			t.Fatalf("DO=0 referral must not carry DNSSEC records, got %s", dns.TypeToString[rr.Header().Rrtype])
+		}
+	}
+}

--- a/v2/referral_ds_test.go
+++ b/v2/referral_ds_test.go
@@ -145,7 +145,15 @@ func TestSendReferral_InsecureDelegationHasNSEC(t *testing.T) {
 	soa := mustRR(t, zd.ZoneName+" 3600 IN SOA ns.pq.axfr.net. hostmaster.pq.axfr.net. 1 3600 600 86400 600")
 	apex.RRtypes.Set(dns.TypeSOA, core.RRset{Name: zd.ZoneName, RRtype: dns.TypeSOA, Class: dns.ClassINET, RRs: []dns.RR{soa}})
 
-	signFunc := func(rrset core.RRset, name string) (core.RRset, error) { return rrset, nil }
+	// Stub signer that attaches a marker RRSIG(NSEC), so the test also proves
+	// the NSEC's signature reaches the wire — an NSEC without its RRSIG proves
+	// nothing to a validator.
+	signFunc := func(rrset core.RRset, name string) (core.RRset, error) {
+		if len(rrset.RRs) > 0 && rrset.RRs[0].Header().Rrtype == dns.TypeNSEC {
+			rrset.RRSIGs = []dns.RR{mustRR(t, name+" 3600 IN RRSIG NSEC 15 3 3600 20260805122917 20260722122719 16089 pq.axfr.net. AA==")}
+		}
+		return rrset, nil
+	}
 
 	w := &fakeRW{remote: udpAddr("127.0.0.1")}
 	m := new(dns.Msg)
@@ -154,17 +162,27 @@ func TestSendReferral_InsecureDelegationHasNSEC(t *testing.T) {
 	if w.written == nil {
 		t.Fatal("sendReferral wrote no response")
 	}
-	var sawNSEC, sawDS bool
+	var sawNSEC, sawNSECSig, sawDS bool
 	for _, rr := range w.written.Ns {
-		switch rr.Header().Rrtype {
-		case dns.TypeNSEC:
-			sawNSEC = true
-		case dns.TypeDS:
-			sawDS = true
+		switch v := rr.(type) {
+		case *dns.RRSIG:
+			if v.TypeCovered == dns.TypeNSEC {
+				sawNSECSig = true
+			}
+		default:
+			switch rr.Header().Rrtype {
+			case dns.TypeNSEC:
+				sawNSEC = true
+			case dns.TypeDS:
+				sawDS = true
+			}
 		}
 	}
 	if !sawNSEC {
 		t.Fatal("insecure (no-DS) referral must carry an NSEC proving no DS")
+	}
+	if !sawNSECSig {
+		t.Fatal("insecure (no-DS) referral must carry the RRSIG covering that NSEC")
 	}
 	if sawDS {
 		t.Fatal("insecure delegation must not carry a DS")


### PR DESCRIPTION
## What

Two related DNSSEC chain-of-trust fixes surfaced while testing IMR validation of PQ split-alg zones (a signed child's SOA validated `indeterminate` on a cold query, but `secure` if its DS was queried explicitly first).

### 1. tdns-imr: backfill missing DS on demand (`v2/cache/rrset_validate.go`)

`ValidateDNSKEYs` needs a zone's DS to anchor its DNSKEY to the parent, but it only ever did a **cache lookup**; on a miss (no cached DS, no trust anchor, no seeded DS) it returned `Indeterminate` **without fetching** — despite holding the very `fetcher` it uses for on-demand DNSKEY. So a cold resolution of a signed child's data validated the child DNSKEY, found no cached DS, and gave up. This is worst when the same server is authoritative for **both parent and child**: the child is answered authoritatively (never via a DS-bearing referral), so the DS is never cached as a side effect and the chain can never be built.

Fix: on a DS cache miss, `backfillDS` fetches the DS via the fetcher (mirroring the existing DNSKEY fetch), validates it against the parent's DNSKEY (recursing strictly up-tree to the trust anchor — it never re-enters for the same name, so it terminates), caches the validated DS, and continues into the existing secure-DS fast path. Scoped to the **DS-exists (secure)** case; authenticated-NODATA / insecure-delegation handling (NSEC/NSEC3 proof) is deliberately left as separate future work.

### 2. tdns-auth: include DS+RRSIG in secure referrals (`v2/queryresponder.go`)

`sendReferral` added only NS + glue and, for DO=1, **unconditionally emitted a no-DS NSEC** — even for a *secure* delegation. That both omits the DS a validator needs (RFC 4035 §3.1.4.1) and actively, wrongly, denies the DS exists. Fix: a secure delegation (`cdd.DS_rrset` present) now puts the signed DS RRset in the authority section and skips the NSEC; an insecure delegation keeps the RFC 9824 no-DS NSEC. A DS signing failure is non-fatal (omit the DS; the resolver falls back to an explicit DS query) rather than SERVFAIL. Only reachable for a genuine cross-server delegation; the common auth-for-both topology answers the child authoritatively and never hits this path.

These are complementary: fix #2 lets a validator get the DS "for free" from a real referral; fix #1 is the mechanism that always works (and is required for the auth-for-both topology where no referral is ever emitted).

## Test evidence

- **New regression tests, both mutation-verified** (fail on unfixed code, pass with the fix):
  - `TestValidateDNSKEYs_BackfillsMissingDS` — on a DS cache miss, `ValidateDNSKEYs` now asks the fetcher for the DS (pre-fix it never did).
  - `TestSendReferral_SecureDelegationIncludesDS` — a DO=1 secure referral carries DS + RRSIG(DS) in the authority section; plus a DO=0 no-DNSSEC sanity check.
- Full `v2` and `v2/cache` suites green under `-race`; gofmt clean; `tdns-auth` and `tdns-imr` build via make.

## Not included / follow-ups

- Insecure-delegation handling in the backfill (authenticated NODATA proof of no-DS) — currently stays `Indeterminate`.
- Negative caching of failed DS backfills (a cold indeterminate zone re-fetches per query until it resolves; secure zones cache after the first fetch).

Two GPG-signed commits. Not merging — merge decision is yours.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSSEC validation to automatically fetch and validate missing delegation security records when they’re absent from cache.
  * DNSSEC-enabled referrals now include signed delegation security records for secure delegations when available.
  * Referral behavior is more resilient: signing failures no longer produce unsigned delegation security records, and insecure delegations keep the correct non-DNSSEC proof.
* **Tests**
  * Added regression tests for missing delegation security retrieval during DNSKEY validation and for referral handling across secure, insecure, and signing-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->