### PR TITLE
Secondary zones are immutable: MUST-NOT-MODIFY invariant for tdns-auth

### DIFF
--- a/docs/2026-07-25-secondary-zones-immutable.md
+++ b/docs/2026-07-25-secondary-zones-immutable.md
@@ -1,6 +1,6 @@
 # Secondary zones are immutable — MUST-NOT-MODIFY invariant + audit
 
-**Date:** 2026-07-25, revised 2026-07-26 (rev 2, then rev 2.1 same day)
+**Date:** 2026-07-25, revised 2026-07-26 (rev 2, rev 2.1, rev 2.2 same day)
 **Status:** PROPOSED — design agreed in discussion; rev 2 incorporates a
 code-verified re-audit of every claim in rev 1. Not implemented.
 **Origin:** surfaced while cooking the inbound-IXFR plan
@@ -8,9 +8,9 @@ code-verified re-audit of every claim in rev 1. Not implemented.
 turned out to be one instance of a whole missing invariant. This is a
 **prerequisite** for inbound IXFR (which needs a correct outbound/inbound
 serial-space contract), but stands on its own as a correctness fix.
-**Base:** main @ 138c9ce / 78a83ff. NOTE: the `feature/secondary-zones-immutable`
-branch currently carries no commits and is behind main; it needs a forward-merge
-before implementation starts.
+**Base:** main @ 0536be8 (originally audited against 138c9ce / 78a83ff; the
+`feature/secondary-zones-immutable` branch is forward-merged from main and
+carries this doc).
 
 ---
 
@@ -55,6 +55,15 @@ a full `OptOnlineSigning` consumer survey (~40 sites):
   enforcement (§2 conclusion).
 - Item 3 decided: stale persisted serials are **cleared**. Item 5 decided:
   freeze/thaw `return`s land as a **separate commit in the same PR**.
+
+**Rev 2.2 (2026-07-26)** — closes §12 item 1: per-zone `outbound_soa_serial`
+is **folded into this PR** (own commit pair, first). The invasiveness scoping
+showed ~120–180 lines + tests, not the feared doubling — template propagation
+is free via `ExpandTemplate`'s generic gap-fill, the six read sites are lines
+Fix A edits anyway, and the `OutgoingSerials` table is already per-zone.
+Details in §5. Full implementation scope estimate added as §14: ~450–550
+production LOC over ~14 files + ~1,200–1,600 test LOC, net ~+2,000/−200 in
+9–10 commits.
 
 ---
 
@@ -223,6 +232,13 @@ A single `normalizeOptionsForRole(appType, zonetype, opts) → (opts, softErr)`
 that, **for AppTypeAuth only**, and for a non-`inline-signing` secondary, turns
 **off** the origination options (§4) and records a **soft** error so the operator
 sees the misconfig while the zone keeps serving.
+
+**Rev 2.2 note:** the normalizer's duty extends beyond `ZoneOption`s — the §5
+per-zone `OutboundSoaSerial` field is a string, not an option, so an explicit
+`persist`/`unixtime` on a secondary is warned-about-and-cleared either by
+widening this signature to take the serial mode too, or by a sibling helper
+invoked from the same call sites. Implementer's choice; the invariant is that
+every call site below covers both.
 
 Rev 2 changes:
 
@@ -484,30 +500,60 @@ Consequence: **the rule "a secondary must not persist its serial" cannot be
 expressed at config level.** A server hosting primaries *and* secondaries has one
 setting; rejecting `persist` for a secondary would break the co-hosted primaries.
 
-Two-part resolution:
+Resolution (both parts land in this PR — see the sequencing decision below):
 
-1. **Short term (this PR):** per-zone *suppression* at the point of use — the six
-   sites in Fix A. The global setting is honoured for zones that may originate and
-   ignored for those that may not. Plus a one-time startup warning when the mode is
-   `persist`/`unixtime` **and** the server hosts tdns-auth secondaries, naming the
-   zones where it is being suppressed, so the operator sees it.
+1. **The schema change:** `outbound_soa_serial` becomes a **per-zone** setting —
+   in practice per **template**, since that is how zone policy is curated. The
+   global value becomes the default (empty per-zone field = inherit). This is
+   the right model independent of this invariant: outbound serial policy is a
+   property of a zone's role and downstream contract, not of the server process.
 
-2. **Correct fix (agreed, scope TBD):** make `outbound_soa_serial` a **per-zone**
-   setting — in practice per **template**, since that is how zone policy is
-   curated. The global value becomes the default. This is the right model
-   independent of this invariant: outbound serial policy is a property of a zone's
-   role and downstream contract, not of the server process.
+2. **Suppression regardless of source:** the effective mode — whether set
+   per-zone, inherited from a template, or defaulted from the global — is
+   *suppressed* for a tdns-auth pure secondary at the six Fix A sites. An
+   **explicit** per-zone `persist`/`unixtime` on a secondary additionally gets a
+   Fix B-style normalizer warning (see below); a secondary merely *inheriting* a
+   global `persist`/`unixtime` is covered by a one-time startup warning naming
+   the zones where the mode is being suppressed, so the operator sees it either
+   way.
 
-**Sequencing is an open decision.** The per-zone change touches the config schema,
-template expansion, the dynamic-zone config round-trip, and reload — orthogonal to
-the immutability invariant and large enough to deserve its own PR and review. The
-recommendation is: land the invariant with per-zone *suppression* (1), then do the
-schema change (2) as a follow-up, with this section as its starting point. If it
-is folded into this PR instead, the PR roughly doubles in surface area and the
-migration story in §8 has to be re-derived against the new schema.
+**Sequencing DECIDED (rev 2.2): folded into this PR.** The invasiveness scoping
+showed the "roughly doubles the PR" fear was wrong — three facts collapse the
+cost:
 
-*(Rev 2.1 status: leaning toward folding it in, contingent on an invasiveness
-scoping of the schema change — §12 item 1.)*
+1. **Template propagation is free.** `ExpandTemplate`
+   ([parseconfig.go:1261](../v2/parseconfig.go)) generically gap-fills new
+   `ZoneConf` fields, so a new `OutboundSoaSerial string` field is
+   template-inheritable with zero template code. The gap-fill zero-value caveat
+   does not bite: an explicit `keep` under a `persist` template wins ("keep" is
+   non-zero; a bool field would have been trapped).
+2. **The six read sites are lines Fix A already edits** — switching them to an
+   effective-mode helper (zone-level if set, else global; suppressed for an
+   auth pure secondary) is the same diff, not new surface.
+3. **Storage is already per-zone** (`OutgoingSerials` keyed by zone); only the
+   mode is global. Sole change: create the table unconditionally
+   (`CREATE IF NOT EXISTS`) instead of only when the global mode is persist.
+
+Genuinely new surface: the `ZoneConf` field
+(`validate:"omitempty,oneof=keep unixtime persist"`, empty = inherit global) +
+`ZoneData` field + effective-mode helper (~15 lines) + `ZoneRefresher` field
+with copies at the ParseZones construction and the three refresher assignment
+sites (the same three sites Fix B's chokepoint touches; always-copy is safe
+since empty = inherit) + the dynamic-zone round-trip (2 lines) + tests.
+Estimate ~120–180 lines of code plus tests. Land as its own commit pair within
+the PR: schema+plumbing first, then Fix A's reads via the helper.
+
+Bonuses: this section's "cannot be expressed at config level" premise inverts —
+a secondary carrying an explicit `persist`/`unixtime` becomes per-zone-visible
+misconfig the Fix B normalizer warns about and clears; and §8 needs no
+re-derivation, since an empty field inherits the global and every existing
+config keeps byte-identical semantics.
+
+**Deliberate non-feature:** no API knob in `zone add`/`zone modify` — templates
+carry outbound-serial policy ("in practice per template"); API-created
+secondaries inherit the default. Recorded as a decision, not an omission.
+`zone desc`/`zone list -v` should display the effective mode and its source
+(zone / template / global), synergizing with §7.
 
 ## 6. Ordering and the persisted-config round-trip
 
@@ -648,6 +694,15 @@ genuinely re-fetches and re-applies.
   code, passes on the fix. Plus: signing (inline) secondary still advances;
   `unixtime`/`persist` on a pure secondary does not rewrite the serial at **any** of
   the six sites; the persisted row is cleared.
+- **Per-zone `outbound_soa_serial` (§5):** zone-level value wins over template;
+  template fills a gap when the zone is silent; explicit `keep` under a
+  `persist` template wins (the gap-fill zero-value caveat does not bite);
+  empty everywhere → global default applies; a config-reload flip of the
+  per-zone value takes effect; the field round-trips through the dynamic-zone
+  config file (`zoneDataToZoneConf` serialize + re-parse); an explicit
+  `persist`/`unixtime` on a secondary draws the normalizer warning; a primary
+  with per-zone `persist` persists while a co-hosted global-`keep` primary does
+  not (per-zone independence).
 - **Fix B:** a secondary configured with each of the five origination options →
   option ends up off, soft `ConfigWarning` present, zone still `Ready`/served;
   reload with a clean config clears it. Cover the dynamic-zone add **and modify**
@@ -708,12 +763,8 @@ is better than hoped:
 
 ## 12. Open items
 
-Still open (neither blocks starting implementation):
+Still open (does not block starting implementation):
 
-1. **§5 sequencing** — per-zone `outbound_soa_serial` in this PR or a follow-up.
-   Leaning toward **including it**, contingent on how invasive the schema change
-   turns out to be — an invasiveness scoping pass decides. Until then the
-   follow-up recommendation in §5 stands as the fallback.
 4. **"Pause refresh" on a secondary** — parked for a later discussion. (The
    idea, for that discussion: an operator control to stop refreshing from a
    known-bad upstream while continuing to serve the current data — the
@@ -722,6 +773,9 @@ Still open (neither blocks starting implementation):
 
 Closed since rev 2 (rulings 2026-07-26):
 
+1. **§5 sequencing** — CLOSED (rev 2.2): per-zone `outbound_soa_serial` is
+   **folded into this PR** as its own commit pair; invasiveness scoping showed
+   ~120–180 lines + tests, not the feared doubling. Details in §5.
 2. **`online-signing` normalization** — CLOSED (rev 2.1): normalized **off** on
    a tdns-auth secondary; Fix E stays as defence in depth; the distributed-key
    edge-signer future (tdns-nm/tdns-es) is deliberately not foreclosed. See §4.
@@ -736,9 +790,59 @@ Closed since rev 2 (rulings 2026-07-26):
   `IncomingSerial`) that IXFR-in's SOA handling depends on only makes sense once the
   secondary serial actually mirrors upstream. Land this first.
 - Independent of the IXFR-out work already merged (#328).
-- Suggested single PR `feature/secondary-zones-immutable`: Fix A (serial mirror +
-  six-site suppression) + Fix B (normalizer) + Fix C (API gate + freeze/thaw +
-  returns) + Fix D (applier gate) + Fix E (re-sign role gate) + §7 diagnostics + §9
-  forced-transfer contract + tests. Its own branch, landing ahead of inbound IXFR.
-  Note the branch currently has no commits and is behind main; it needs a
-  forward-merge first.
+- Suggested single PR `feature/secondary-zones-immutable`: per-zone
+  `outbound_soa_serial` (§5, own commit pair, first) + Fix A (serial mirror +
+  six-site suppression via the effective-mode helper) + Fix B (normalizer) +
+  Fix C (freeze/thaw `return`s as a separate commit, then the API gate) + Fix D
+  (applier gate) + Fix E (re-sign role gate) + §7 diagnostics + §9
+  forced-transfer contract + tests. Its own branch, landing ahead of inbound
+  IXFR. (Branch forward-merged from main and carrying this doc as of rev 2.)
+
+## 14. Implementation scope estimate (rev 2.2)
+
+Per work item, in §13's commit order:
+
+| # | Work item | Files touched (non-test) | Code LOC (±) |
+|---|---|---|---|
+| 1 | Per-zone `outbound_soa_serial` (§5) | structs.go (ZoneConf + ZoneData fields), refreshengine.go (ZoneRefresher + 3 copy sites), parseconfig.go (zr construction, unconditional table), zone_utils.go (effective-mode helper), dynamic_zones.go (round-trip ×2) | ~50 |
+| 2 | Fix A — mirror + six-site suppression + row-clear + backwards-jump ERROR | zone_mutation.go, refreshengine.go ×2 blocks, zone_utils.go (`nextOutboundSerial`, `mayOriginate` helper), db_outgoing_serial.go (delete func) | ~85 |
+| 3 | Fix B — normalizer + serial-mode sibling + ~7 call sites + as-configured/effective split | new option_normalize.go (or parseoptions.go), parseconfig.go, dynamic_zones.go, dynamic_primary.go, refreshengine.go (chokepoint ×3 + effective-type caveat), structs.go + dynamic_zones.go (as-configured storage + serializer) | ~105 |
+| 4 | Freeze/thaw `return`s (own commit) | apihandler_zone.go | ~6 |
+| 5 | Fix C — both zone handlers + catalog handler + freeze/thaw role refusal | apihandler_zone.go, apihandler_catalog.go (cleanest as one gate in `regenerateCatalogZone` + handler messages) | ~55 |
+| 6 | Fix D — applier gate | zone_updater.go | ~15 |
+| 7 | Fix E — re-sign role gate | zone_mutation.go | ~5 |
+| 8 | §7 diagnostics — serials in `list -v`, all-primaries probe in `desc`, mode display | zone_utils.go (probe extraction from `DoTransfer` — the one real refactor), apihandler_zone.go, structs.go (carrier fields), cli/zone_cmds.go | ~115 |
+| 9 | §9 forced-transfer — equal-serial fix needs `force` **threaded into `FetchFromUpstream`** (signature change; it does not take force today) | zone_utils.go + call sites | ~15 |
+| 10 | §5 startup warning (global persist/unixtime + auth secondaries) | parseconfig.go | ~12 |
+
+**Totals:**
+
+- **Production code: ~450–550 LOC** added/changed across **~14 files**. Heavy
+  concentration — zone_utils.go, refreshengine.go, zone_mutation.go,
+  apihandler_zone.go, parseconfig.go and dynamic_zones.go are each touched by
+  2–4 items — which argues for the §13 commit ordering being strictly serial,
+  not parallelized.
+- **Tests: ~1,200–1,600 LOC** in **7–9 new/extended test files** (§10's matrix
+  is genuinely large: mirror semantics, six-site suppression, normalizer ×
+  5 options × 4 ingress paths, ordering-vs-quarantine, config round-trip, both
+  API handlers, applier gate, forced transfer, per-zone mode × 8 cases,
+  app-scope proof).
+- **Existing-test fallout: ~100–200 LOC adjusted** — anything asserting
+  `CurrentSerial++` on refresh (e.g. `ixfr_test.go` drives
+  `applyRefreshReplacementLocked` directly) plus publish-path tests.
+- **Net diff: roughly +2,000 / −200 over ~20–24 files, in 9–10 commits** — the
+  same order of magnitude as the outbound-IXFR PR (#328); a solid multi-session
+  PR, not a monster.
+
+**Uncertainty drivers, in order of risk:**
+
+1. **The as-configured vs effective options mechanism (item 3)** — the one open
+   design choice (§6). If it turns into threading a second options
+   representation through more places than `zoneDataToZoneConf`, item 3 grows
+   by 50–100 LOC.
+2. **The `DoTransfer` probe extraction (item 8)** — refactoring a live transfer
+   path for read-only reuse; mechanically simple but it touches the most
+   battle-hardened function in the set.
+3. **Fix D's blast radius is not a LOC risk** (15 lines) — it is a *validation*
+   cost: the doc requires foffe testbed time on top of `-race`, which is
+   wall-clock, not diff size.

--- a/docs/2026-07-25-secondary-zones-immutable.md
+++ b/docs/2026-07-25-secondary-zones-immutable.md
@@ -1,14 +1,44 @@
 # Secondary zones are immutable — MUST-NOT-MODIFY invariant + audit
 
-**Date:** 2026-07-25
-**Status:** PROPOSED — design agreed in discussion; this doc records the
-mutation-vector audit that validates the fix surface. Not implemented.
+**Date:** 2026-07-25, revised 2026-07-26 (rev 2)
+**Status:** PROPOSED — design agreed in discussion; rev 2 incorporates a
+code-verified re-audit of every claim in rev 1. Not implemented.
 **Origin:** surfaced while cooking the inbound-IXFR plan
 (`2026-07-25-inbound-ixfr-plan.md`). A confirmed serial-bump bug on secondaries
 turned out to be one instance of a whole missing invariant. This is a
 **prerequisite** for inbound IXFR (which needs a correct outbound/inbound
 serial-space contract), but stands on its own as a correctness fix.
-**Base:** main @ 138c9ce / 78a83ff.
+**Base:** main @ 138c9ce / 78a83ff. NOTE: the `feature/secondary-zones-immutable`
+branch currently carries no commits and is behind main; it needs a forward-merge
+before implementation starts.
+
+---
+
+## 0. What changed in rev 2
+
+Rev 1's central conclusion — "exactly one mutation vector is role/option-
+independent; every other origination path is option-gated, so forcing the
+options off neutralizes them through the *existing* runtime gates" — does not
+survive contact with the code. The first half is right. The second half is not,
+because the existing gates sit at **call sites**, and the applier they feed
+(`ZoneUpdater`) accepts anything flagged `InternalUpdate` regardless of options.
+
+| # | Change | Why |
+|---|---|---|
+| 1 | **New vector: DSYNC publication** (`SetupZoneSync` → `PublishDsyncRRs`), gated on `delegation-sync-parent` alone | §4 of rev 1 concluded delsync needed no gating; DSYNC is the counterexample |
+| 2 | **New vector: the `InternalUpdate` applier bypass** | Structural. `allow-updates` is a call-site convention, not an applier gate |
+| 3 | **New vector: `resignWorkingSetSOAIfSigned` has no role gate** | Runs on *every* publish incl. the refresh path; `online-signing` on a secondary re-signs upstream content |
+| 4 | **Corrected vector 6b: catalog authoring IS reachable via the API** | Rev 1 said "not reachable for a secondary". The catalog API handlers mutate the named zone with no role check |
+| 5 | **New Fix D** — fail-closed gate in the ZoneUpdater applier | Enforcement moves to the chokepoint; option-stripping becomes visibility, not enforcement |
+| 6 | **New Fix E** — role gate on `resignWorkingSetSOAIfSigned` | See 3 |
+| 7 | **`delegation-sync-parent` added to the turn-off list** (now 4 options, was 3) | See 1 |
+| 8 | **Fix A widened**: persist/unixtime suppression at six sites, not two | Rev 1 named only the refresh-engine overrides |
+| 9 | **New: `outbound_soa_serial` becomes per-zone** (config schema change) | It is server-global today, so it cannot be role-scoped at config level at all |
+| 10 | **Fix C widened**: second handler, catalog handler, `policy-reset`, freeze/thaw refusal + the missing `return`s | Rev 1's action list was short by several, and the guards it relied on don't return |
+| 11 | **Migration section rewritten** — severity is per-serial-mode, not universal | In the default `keep` mode the backwards jump already happens at every restart today |
+| 12 | **New: forced-transfer contract** | Force must apply whatever upstream has; today it works for a lower serial only incidentally, and no-ops on an equal one |
+| 13 | **New: diagnostics** (`zone desc` / `zone list -v` serial visibility) | There is currently no way to see the split-brain that motivated this work |
+| 14 | Residuals #9 and #2 **resolved** | Zero callers, and dead code, respectively |
 
 ---
 
@@ -28,8 +58,8 @@ and therefore its serial — legitimately diverges from upstream. Everything els
 a secondary might do to its own content is a bug.
 
 **The predicate:** within tdns-auth, `zoneMayOriginateContent(zd) = (ZoneType ==
-Primary) || Options[OptInlineSigning]`. This single notion drives all three
-fixes below — but only under the app-scope in §1.1.
+Primary) || Options[OptInlineSigning]`. This single notion drives every fix
+below — but only under the app-scope in §1.1.
 
 Motivating failure (real): a signed zone distributed by two masters downstream
 of the signer — one BIND9 (no serial bump), one tdns-auth (bumps +1 per
@@ -53,12 +83,24 @@ a zone while holding the Secondary role, for good reasons —
 - **tdns-agent** already carries Secondary special-cases in this very code
   (`Globals.App.Type != AppTypeAgent` guards in `zone_utils.go`/`refreshengine.go`).
 
-Therefore **all three fixes below are conditioned on
+Therefore **every fix below is conditioned on
 `Globals.App.Type == AppTypeAuth`**. On any other app type they are complete
 no-ops — the option normalizer changes nothing, the serial keeps its existing
-behavior, the API gate refuses nothing — so those apps' own, deliberately
-different, mutation rules are preserved unchanged. The invariant is
-"a *tdns-auth* secondary must not modify," not "a secondary must not modify."
+behavior, the API gate refuses nothing, the applier gate drops nothing — so
+those apps' own, deliberately different, mutation rules are preserved unchanged.
+The invariant is "a *tdns-auth* secondary must not modify," not "a secondary
+must not modify."
+
+**A worked example of why this matters (rev 2).** A likely production shape is
+that all DSYNC/keystate receivers live in a **tdns-agent**: the agent listens for
+generalised NOTIFYs and UPDATEs, holds the receiver SIG(0) private key, and feeds
+results into a database. It then emits "please insert these RRs into the zone at
+the primary" — including the public half of its own SIG(0) key. Under §1.1 that
+agent is `AppTypeAgent` and is untouched by everything here: it keeps its keys,
+keeps processing keystate, keeps its own rules. The RRs it asks for enter the
+parent zone **at the primary** and reach the secondaries by AXFR. That is
+MUST-NOT-MODIFY working exactly as intended, and it is the reason the app-scope
+constraint is not merely defensive bookkeeping.
 
 ## 2. The audit — every mutation vector, classified
 
@@ -73,187 +115,552 @@ staged. What matters is the **source** and its **enabler**:
 
 | # | Mutation source | Enabler today | Fires on a pure secondary? | Handled by |
 |---|---|---|---|---|
-| 1 | **Refresh serial bump** — `applyRefreshReplacementLocked` non-first-load does `CurrentSerial++` unconditionally | *nothing* — role/option-independent | **YES — the bug.** Even a zero-option secondary bumps +1 per refresh | **Fix A** (serial mirror) |
-| 2 | **DDNS** (RFC 2136 UPDATE) | `OptAllowUpdates` / `OptAllowChildUpdates` ([updateresponder.go](../v2/updateresponder.go)) | only if option set (no role check; config doesn't reject it) | **Fix B** (normalizer off) |
-| 3 | **Transport signals** — `CreateTransportSignalRRs` → commit/publish ([tsignal.go](../v2/tsignal.go), refresh postpass, `RepopulateDynamicRRs`) | `OptAddTransportSignal` | only if option set | **Fix B** |
-| 4 | **Delegation sync — zone-publishing parts** — SIG(0) **KEY** (`Sig0KeyPreparation`), **CSYNC** (`SyncZoneDelegationViaNotify`) | each gated on `OptAllowUpdates`; parent-side child-apply on `OptAllowChildUpdates` | no — those options are already off (turned off as #2) | **Fix B, via #2** (no separate delsync gate) |
-| 4b | Delegation sync — **CDS** publish (`PublishCdsRRs`, InternalUpdate, bypasses allow-updates) | `OptDelSyncChild` | no — `SynthesizeCdsRRs` is empty ⇒ no-op without local DNSKEYs; sanctioned on a signing secondary | n/a (no-op) |
+| 1 | **Refresh serial bump** — `applyRefreshReplacementLocked` non-first-load does `CurrentSerial++` unconditionally ([zone_mutation.go:355](../v2/zone_mutation.go)) | *nothing* — role/option-independent | **YES — the bug.** Even a zero-option secondary bumps +1 per refresh | **Fix A** |
+| 2 | **DDNS** (RFC 2136 UPDATE) | `OptAllowUpdates` / `OptAllowChildUpdates` ([updateresponder.go](../v2/updateresponder.go)) | only if option set (no role check; config doesn't reject it) | **Fix B** + **Fix D** |
+| 3 | **Transport signals** — `CreateTransportSignalRRs` → commit/publish ([tsignal.go](../v2/tsignal.go), refresh postpass, `RepopulateDynamicRRs`, [signal_republish.go:149](../v2/signal_republish.go)) | `OptAddTransportSignal` | only if option set | **Fix B** + **Fix D** |
+| 4 | **Delegation sync — child-side publishing** — SIG(0) **KEY** (`Sig0KeyPreparation`), **CSYNC** (`SyncZoneDelegationViaNotify`) | each gated on `OptAllowUpdates` ([delegation_sync.go:302](../v2/delegation_sync.go)); parent-side child-apply on `OptAllowChildUpdates` | no — those options are already off (turned off as #2) | **Fix B, via #2** + **Fix D** |
+| 4b | Delegation sync — **CDS** publish (`PublishCdsRRs`, InternalUpdate) | `OptDelSyncChild` | no — `SynthesizeCdsRRs` is empty ⇒ no-op without local DNSKEYs; sanctioned on a signing secondary | n/a (no-op); passes **Fix D** via `mayOriginate` |
 | 4c | Delegation sync — **sending** (bootstrap KEY to parent, NOTIFY, UPDATE) | `OptDelSyncParent`/`OptDelSyncChild` | sends outward; **does not mutate the served zone** | out of scope (§4 note) |
-| 5 | **DNSSEC signing / KSK-ZSK rollover / resign** ([sign.go](../v2/sign.go), ksk_rollover_*, resign engine) | `OptOnlineSigning`/`OptInlineSigning` **and** `SetupZoneSigning`'s role gate: a non-primary signs *only* with `inline-signing` | only if `inline-signing` — the **sanctioned** signing secondary | **kept** (the exception); Fix A treats it as an originator |
+| **4d** | **Delegation sync — DSYNC publication** (`SetupZoneSync` → `PublishDsyncRRs`, [zone_utils.go:773](../v2/zone_utils.go), [ops_dsync.go:16](../v2/ops_dsync.go)) — publishes `_dsync.<zone>` DSYNC + address RRs via InternalUpdate | **`OptDelSyncParent` alone.** No `allow-updates` check. Unlike CDS it is **not** a no-op without local DNSKEYs — it synthesizes from `delegationsync.parent.schemes` | **YES** | **Fix B** (delsync-parent joins the turn-off list) + **Fix D** |
+| 5 | **DNSSEC signing / KSK-ZSK rollover / resign** ([sign.go](../v2/sign.go), ksk_rollover_*, resign engine) | `OptOnlineSigning`/`OptInlineSigning` **and** `SetupZoneSigning`'s role gate: a non-primary signs *only* with `inline-signing` ([zone_utils.go:1107](../v2/zone_utils.go)) | only if `inline-signing` — the **sanctioned** signing secondary | **kept** (the exception); Fix A treats it as an originator |
+| **5b** | **Per-publish SOA re-sign** — `resignWorkingSetSOAIfSigned` ([zone_mutation.go:186](../v2/zone_mutation.go)) re-signs the apex SOA inside `publishWorkingSetLocked`, i.e. on **every publish including the refresh path** | `OptOnlineSigning` or `OptInlineSigning` — **no role gate**, unlike #5. `EnsureActiveDnssecKeys` will *generate* keys if absent | **YES**, on a secondary carrying `online-signing` | **Fix E** |
 | 6 | **Catalog *consumption*** — auto-create/delete **member** zones from a catalog ([catalog.go:270](../v2/catalog.go), [apihandler_catalog.go:330](../v2/apihandler_catalog.go)) | `OptCatalogMemberAutoCreate`/`Delete` | yes — and **desired**: it provisions *other* zones, never mutates the catalog zone (RFC 9432; the whole point) | **allow, no gating** (§4) |
-| 6b | **Catalog *authoring*** — `version.<catalog>` TXT injection / in-catalog member mgmt (`CreateCatalogZone`, [apihandler_catalog.go](../v2/apihandler_catalog.go)) | reached only via the author/create path | no — that path is primary-of-catalog by construction; a secondary catalog is created via AXFR, never `CreateCatalogZone` | n/a (not reachable for a secondary) |
-| 7 | **API `bump`** — two external entry points: the zone handler ([apihandler_zone.go:70](../v2/apihandler_zone.go)) and the refresh-engine `bumpch` handler ([refreshengine.go:880](../v2/refreshengine.go)) | *none* — no role check at either | **YES** | **Fix C** (origination gate) |
-| 8 | **Other API origination actions** — `sign-zone`, `resign-zone`, `policy-set`/`change-policy`, `generate-nsec` | none role-aware | **YES** | **Fix C** |
-| 9 | **JWK / A-AAAA / TLSA publication** ([ops_jwk.go](../v2/ops_jwk.go), ops_a_aaaa, ops_tlsa; InternalUpdate) | tied to transport-signal / signing / agent-role features | only via those features (should be off) | **Fix B** (via §5 confirmation) |
+| **6b** | **Catalog *authoring* via the API** — `handleCatalogZoneAdd`/`Delete`/group add/remove → `regenerateCatalogZone` → `stageRRsetLocked` + `publishLocked` ([apihandler_catalog.go:541](../v2/apihandler_catalog.go)) | **none.** The handlers take a catalog zone name and mutate it; no role check anywhere on the path | **YES.** *(Rev 1 said "not reachable for a secondary" — that was wrong; only the `CreateCatalogZone` author path was considered)* | **Fix C** |
+| 7 | **API `bump`** — the zone handler ([apihandler_zone.go:70](../v2/apihandler_zone.go)); the refresh-engine `bumpch` handler ([refreshengine.go:880](../v2/refreshengine.go)) is **dead code**, see §11 | *none* — no role check | **YES** | **Fix C** |
+| 8 | **Other API origination actions** — `sign-zone`, `resign-zone`, `policy-set`, `change-policy`, **`policy-reset`**, `generate-nsec`; and in the *second* handler, **`publish-dsync-rrset` / `unpublish-dsync-rrset`** ([apihandler_zone.go:933](../v2/apihandler_zone.go)) | none role-aware | **YES** | **Fix C** |
+| 9 | **JWK / A-AAAA / TLSA / SVCB / URI publication** ([ops_jwk.go](../v2/ops_jwk.go), ops_a_aaaa, ops_tlsa, ops_svcb, ops_uri) | — | **NO — resolved.** These have **zero callers** anywhere in tdns `v2/`+`cmdv2/`; they are library surface for the derived apps | n/a (cannot fire on tdns-auth) |
+| **10** | **The `InternalUpdate` applier bypass** — [zone_updater.go:147](../v2/zone_updater.go): `if zd.Options[OptAllowUpdates]` **or** `ur.InternalUpdate`. **Every** `ops_*` publisher sets `InternalUpdate: true` (jwk, a_aaaa, dsync, key, uri, cds, tlsa, csync, svcb) as do ksk_rollover_ds_notify and signal_republish | *none at the applier.* `allow-updates` is a **call-site** convention only | **YES** — for any caller that doesn't self-gate (4d today; anything added tomorrow) | **Fix D** |
+| — | **Child-delegation scanning** — `ScannerEngine` enqueues CHILD-UPDATE from CDS/CSYNC child scans ([scanner.go:192](../v2/scanner.go)) | `OptAllowChildUpdates`, enforced at the applier ([zone_updater.go:120](../v2/zone_updater.go)) | no | Fix B covers it — listed because it is an origination *source* independent of `delegation_sync.go`, i.e. evidence the table is a hand-enumeration, not a call-graph closure |
 | — | Primary file load (`ParseZoneFromReader`), secondary AXFR-in serial (`ZoneTransferIn` → new_zd), `InstallInitialSnapshot` re-baseline | role-correct by construction | n/a | no change |
 
-**Conclusion:** exactly one mutation vector is role/option-independent — the
-refresh serial bump (#1). Every other origination path is **option-gated**, so
-forcing the origination options off at parse time (Fix B) neutralizes them
-through the *existing* runtime gates, with no new per-feature runtime checks. The
-two explicit-action vectors (#7/#8) are neither option nor role gated and need an
-API-side gate (Fix C). Signing (#5) is already role-aware and is the one
-sanctioned exception.
+**Conclusion (revised).** Exactly one mutation vector is role/option-independent
+— the refresh serial bump (#1). But the rev-1 corollary is withdrawn: the other
+origination paths are gated at their **call sites**, and the applier they feed
+accepts anything marked `InternalUpdate` (#10). Option-stripping therefore
+neutralizes only those callers that happen to check their option first. Vector
+4d is the proof: the audit checked the `delegation_sync.go` call sites and got
+them right, and DSYNC still slipped through because it is reached from
+`SetupZoneSync` instead. **Enforcement belongs at the applier (Fix D); option
+normalization (Fix B) is the operator-facing visibility layer.**
 
-The scariest case — SIG(0) KEY publication being **default-on** (opt-out) — is
-safe only because it is reached solely through the delegation-sync setup, which
-*is* delsync-option-gated; turning those options off for a secondary stops it.
-
-## 3. The fix — one predicate, three homes (no sprinkling)
+## 3. The fixes — one predicate, five homes
 
 **Every fix below first checks `Globals.App.Type == AppTypeAuth` and is a no-op
-otherwise** (§1.1). The signatures/call sites take `appType` into account so the
+otherwise** (§1.1). Signatures and call sites take `appType` into account so the
 shared library's behavior for tdns-agent, tdns-mpcombiner, tdns-mpagent, etc. is
 byte-for-byte unchanged.
 
-1. **Option normalizer (Fix B)** — a single `normalizeOptionsForRole(appType,
-   zonetype, opts) → (opts, softErr)` that, **for AppTypeAuth only**, and for a
-   non-`inline-signing` secondary, turns
-   **off** the origination options (§4) and records a **soft** `SetError` so the
-   operator sees the misconfig while the zone keeps serving. Verified soft:
-   `SetError` only writes the error registry + derived fields; it does **not**
-   touch `Status`, and serving gates on `GetStatus() != Ready`
-   ([dnsutils.go:265](../v2/dnsutils.go)), not on the registry. Because every
-   runtime path already gates on its option, turning off just three options
-   (`allow-updates`, `allow-child-updates`, `add-transport-signal`) neutralizes
-   vectors 2 and 3 directly, and vector 4's zone-publishing parts fall out for
-   free (they are themselves gated on `allow-updates`/`allow-child-updates`).
-   Vector 6 (catalog) is deliberately left ON, and vector 9 is covered by its
-   feature options. All with zero new runtime gates.
-   - Must be invoked from **every** option-finalization site, not just the
-     static parser: [parseconfig.go](../v2/parseconfig.go) (static + reload),
-     dynamic-zone add ([dynamic_zones.go](../v2/dynamic_zones.go)), dynamic
-     primary, catalog auto-create, and the template-expansion union — else an
-     API/catalog-created secondary bypasses the gate.
-   - Recompute each parse: `ClearError` when the config is now clean, `SetError`
-     when not, using a dedicated message/`ErrorType` so it doesn't collide with
-     other `ConfigError`s (fixing the YAML clears the flag on reload).
+### Fix A — refresh serial mirror + outbound-mode suppression
 
-2. **Refresh serial mirror (Fix A)** — in `applyRefreshReplacementLocked`,
-   replace the unconditional non-first `CurrentSerial++` with:
-   `(AppType==Auth && !mayOriginate) ? CurrentSerial = new_zd.IncomingSerial :
-   CurrentSerial++`. A tdns-auth pure secondary mirrors the upstream serial
-   verbatim; a primary, an inline-signing secondary, **or any non-auth app**
-   advances exactly as today. **This is not option-driven and is NOT covered by
-   Fix B** — it must land regardless. Also gate the refresh-engine
-   `unixtime`/`persist` overrides ([refreshengine.go](../v2/refreshengine.go)),
-   under the same AppTypeAuth condition, so a tdns-auth pure secondary never
-   rewrites the serial in *any* mode (MUST-NOT-MODIFY absolute, not just
-   keep-mode). The `CurrentSerial++` default preserves current behavior for
-   every non-auth app.
+In `applyRefreshReplacementLocked`, replace the unconditional non-first
+`CurrentSerial++` with `(AppType==Auth && !mayOriginate) ? CurrentSerial =
+new_zd.IncomingSerial : CurrentSerial++`. A tdns-auth pure secondary mirrors the
+upstream serial verbatim; a primary, an inline-signing secondary, **or any
+non-auth app** advances exactly as today. **Not option-driven, NOT covered by
+Fix B — it must land regardless.**
 
-3. **API origination gate (Fix C)** — the zone API handler and the `bumpch`
-   handler consult the same predicate and, **when `Globals.App.Type ==
-   AppTypeAuth`**, refuse the origination subset (`bump`, `sign-zone`,
-   `resign-zone`, `policy-set`/`change-policy`, `generate-nsec`) for a secondary.
-   Not a blanket secondary-refusal: `freeze`/`thaw`/`write-zone` are legitimate
-   secondary ops (pause refresh, snapshot to disk) and stay allowed. On non-auth
-   apps the gate is absent, so tdns-mp/agent API semantics are unchanged.
+**Widened in rev 2.** MUST-NOT-MODIFY is absolute, not keep-mode-only, so the
+`unixtime`/`persist` machinery must not touch a tdns-auth pure secondary's serial
+in *any* mode. That is **six sites**, not the two rev 1 named:
+
+| | Site | Action |
+|---|---|---|
+| write | [zone_mutation.go:336](../v2/zone_mutation.go) (`publishWorkingSetLocked`) | skip `SaveOutgoingSerial` |
+| write | [zone_mutation.go:356](../v2/zone_mutation.go) (`applyRefreshReplacementLocked`) | skip `SaveOutgoingSerial` |
+| restore | [refreshengine.go:133](../v2/refreshengine.go) (initial load) | skip `LoadOutgoingSerial` restore |
+| restore | [refreshengine.go:799](../v2/refreshengine.go) (post-refresh) | skip `LoadOutgoingSerial` restore |
+| unixtime | [refreshengine.go:123](../v2/refreshengine.go) and [:790](../v2/refreshengine.go) | skip the override |
+| unixtime | `nextOutboundSerial` unixtime branch ([zone_utils.go:682](../v2/zone_utils.go)) | skip |
+
+Additionally, **clear** any stale persisted row for a zone that is a tdns-auth
+secondary rather than leaving it inert-but-present — otherwise the inflated
+legacy value sits in the KeyDB waiting for a future relaxation of one of these
+gates to resurrect it.
+
+### Fix B — option normalizer (visibility layer)
+
+A single `normalizeOptionsForRole(appType, zonetype, opts) → (opts, softErr)`
+that, **for AppTypeAuth only**, and for a non-`inline-signing` secondary, turns
+**off** the origination options (§4) and records a **soft** error so the operator
+sees the misconfig while the zone keeps serving.
+
+Rev 2 changes:
+
+- **Four options, not three** — `delegation-sync-parent` joins `allow-updates`,
+  `allow-child-updates`, `add-transport-signal`. See §4.
+- **Use `ConfigWarning`, not `ConfigError`.** Rev 1 verified that `SetError`
+  does not touch `Status` — correct — but `ConfigError` is in
+  `serviceImpactingErrors` ([enums.go:348](../v2/enums.go)), documented as "a
+  NOTIFY/UPDATE/query handler should refuse with SERVFAIL". Today only the CLI
+  reads that, so it is display-only; the moment anyone wires up the documented
+  intent, every secondary with a stray `allow-updates` starts SERVFAILing. Use
+  `ConfigWarning` (the existing non-fatal precedent,
+  [dynamic_zones.go:936](../v2/dynamic_zones.go)) or a new non-service-impacting
+  type. Note `zoneProvisioning` renders any `zd.Error` as `"error"`, so a
+  service-impacting choice also parks these zones permanently in the error column
+  of `zone list`.
+- **Message wording is part of the fix.** The normalizer warning, the Fix C
+  refusal and the Fix D log line must all name the same reason — origination on
+  a secondary — so an operator gets one story from three places rather than three
+  unrelated denials.
+
+**Call sites (revised — rev 1's list was incomplete and the wrong shape):**
+
+- [parseconfig.go:904](../v2/parseconfig.go) (static + reload) — see the ordering
+  constraint in §6.
+- **`ModifyDynamicZone` ([dynamic_zones.go:1029](../v2/dynamic_zones.go))** — not
+  named in rev 1, and the most dangerous omission: secondary-only, API-driven,
+  builds a fresh options map, `Zones.Set` directly. Without it,
+  `zone modify --options allow-updates` re-enables exactly what was stripped.
+- `ProvisionDynamicZone` ([dynamic_zones.go:805](../v2/dynamic_zones.go)) and the
+  dynamic-primary path.
+- Catalog auto-create, and the template-expansion union.
+- **The refresher chokepoint** — all three live-option assignments are
+  `zd.Options = zr.Options` in the refresh-engine refresher handler
+  ([refreshengine.go:282](../v2/refreshengine.go),
+  [:391](../v2/refreshengine.go), [:608](../v2/refreshengine.go)). Normalizing
+  here covers far more than enumerating callers. **Caveat:** `ZoneType` is
+  late-bound at [refreshengine.go:398](../v2/refreshengine.go)
+  (`if zr.ZoneType != 0`), so normalization must run on the *effective* type after
+  that assignment — and must handle a Primary→Secondary flip on reload, which rev
+  1 did not consider.
+
+**Note the API path is a second parser, not merely another call site.**
+`zone add`/`zone modify` build options via `zoneOptionsFromStrings`
+([apihandler_zone.go:427](../v2/apihandler_zone.go)), which bypasses
+`parseZoneOptions` entirely — no dependency validation, no error recording. Any
+discipline that lives only in `parseZoneOptions` does not apply to API-created
+zones.
+
+### Fix C — API origination gate
+
+The zone API handler, the **second** zone handler, and the **catalog** handler
+consult the predicate and, **when `Globals.App.Type == AppTypeAuth`**, refuse
+origination for a secondary.
+
+Refused subset:
+
+- Handler 1: `bump`, `sign-zone`, `resign-zone`, `policy-set`, `change-policy`,
+  **`policy-reset`**, `generate-nsec`.
+- Handler 2: **`publish-dsync-rrset`, `unpublish-dsync-rrset`**
+  ([apihandler_zone.go:933](../v2/apihandler_zone.go)).
+- Catalog handler: the four **authoring** entry points that reach
+  `regenerateCatalogZone`
+  ([apihandler_catalog.go:285/320/437/461](../v2/apihandler_catalog.go)).
+  Catalog *consumption* stays fully enabled — see §4.
+- **`freeze` / `thaw`** — see below.
+- `write-zone` stays **allowed**: [zone_utils.go:374](../v2/zone_utils.go) depends
+  only on `OptDirty`/`force`, no option coupling, and dumping a transferred zone
+  to disk is a legitimate secondary operation.
+
+**freeze/thaw (rev 2 correction).** Rev 1 listed these as legitimate secondary
+ops that "stay allowed", on the rationale that freeze pauses refresh. It does
+not: `OptFrozen` is consumed in exactly one place,
+[updateresponder.go:194](../v2/updateresponder.go) — it gates DDNS and nothing
+else. On a tdns-auth secondary, where `allow-updates` is always off after Fix B,
+it is functionally inert. **Refuse both.**
+
+Doing so requires fixing a pre-existing bug in the same handler: the `freeze`
+and `thaw` precondition checks set `resp.Error = true` **but never `return`**
+([apihandler_zone.go:146-176](../v2/apihandler_zone.go)). Execution falls through
+to `zd.SetOption(OptFrozen, …)` and then overwrites `resp.Msg` with a success
+string, so the caller receives `Error: true` *and* "Zone X is now frozen", with
+the state changed anyway. Adding the `return`s is safe — the handler's deferred
+JSON encoder still writes the response, and it is the pattern the other cases
+already use. This is a behaviour change on the **primary** path too (freeze on a
+primary without `allow-updates` currently freezes anyway; afterwards it genuinely
+refuses) and belongs in the PR description. No idempotency regression: the
+"already frozen" case already returned `Error: true`.
+
+**Ordering within the handler:** the role refusal must come **before** the
+`allow-updates` precondition. After Fix B a tdns-auth secondary always has
+`allow-updates` off, so the generic "does not allow updates" message would fire
+first and send the operator to enable an option the normalizer will immediately
+strip again.
+
+### Fix D — fail-closed applier gate (NEW, and the structural one)
+
+**Placement:** [zone_updater.go:88-93](../v2/zone_updater.go), immediately after
+`zd` is resolved and before the command switch. One place, not per-case.
+
+**Scope:** `ZONE-UPDATE` and `CHILD-UPDATE` only. `TRUSTSTORE-UPDATE` must pass
+through untouched — it writes the keystore via `TruststorePost`, never zone
+content. `DEFERRED-UPDATE` already errors out; `PING` is handled before `zd` is
+resolved.
+
+**Rule:** for `AppTypeAuth && !mayOriginate(zd)`, drop the request and do not
+apply. Every other app type and every primary: unchanged, byte-for-byte.
+
+**Predicate:** `mayOriginate` (Primary or inline-signing) — the same predicate as
+everything else, no new concept. This is load-bearing: an inline-signing secondary
+legitimately publishes CDS ([ops_cds.go:82](../v2/ops_cds.go)) and CSYNC
+([ops_csync.go:29](../v2/ops_csync.go)) through this path, and `mayOriginate` lets
+it through.
+
+**Why this cannot break signing:** DNSSEC signing does **not** traverse the
+applier. `PublishDnskeyRRs` ([ops_dnskey.go:26](../v2/ops_dnskey.go)) stages
+directly under `zd.mu` behind its own gate (`allow-updates || online-signing ||
+inline-signing`) and never touches `UpdateQ`. Verified.
+
+**Log level: ERROR, framed as an invariant violation**, matching the existing
+precedent a few lines below at [zone_updater.go:125](../v2/zone_updater.go). Once
+Fix B strips the options, *nothing* should ever reach this gate; a hit means some
+path bypassed the option system, i.e. a code bug. ERROR-with-that-framing also
+keeps it out of the operator-facing error registry, so it cannot collide with Fix
+B's warning.
+
+**Blast radius:** from the full enumeration of `InternalUpdate: true` setters, the
+legitimate set through this path on a pure tdns-auth secondary is empty; on an
+inline-signing secondary `mayOriginate` admits everything. It bites exactly the
+zones intended and nothing else. It is nonetheless a behaviour change on a path
+that today accepts every internal update unconditionally, and internal updates are
+how much of tdns's machinery talks to itself — so it warrants a deliberate `-race`
+run and live testbed validation, not unit tests alone.
+
+### Fix E — role gate on the per-publish SOA re-sign (NEW)
+
+`resignWorkingSetSOAIfSigned` ([zone_mutation.go:186](../v2/zone_mutation.go))
+gates on `OptOnlineSigning || OptInlineSigning` with **no role check**, unlike
+`SetupZoneSigning` ([zone_utils.go:1107](../v2/zone_utils.go)) which has one — and
+it runs inside `publishWorkingSetLocked`, i.e. on every publish including the
+refresh path. A tdns-auth secondary carrying `online-signing` (not inline) is not
+an originator under the predicate, so Fix A mirrors its serial, but this would
+still re-sign the upstream SOA with locally generated keys
+(`EnsureActiveDnssecKeys` generates them if absent). Apply the same role gate.
+
+Open sub-question for implementation: whether `online-signing` on a tdns-auth
+secondary should additionally be normalized off by Fix B, or merely be inert. Fix
+E alone makes it harmless for the SOA; a survey of other `OptOnlineSigning`
+consumers should decide.
 
 ## 4. Option classification
 
-**Turn OFF for a non-inline-signing secondary (origination):**
-`allow-updates`, `allow-child-updates`, `add-transport-signal`.
+**Turn OFF for a non-inline-signing tdns-auth secondary (origination) — four:**
+`allow-updates`, `allow-child-updates`, `add-transport-signal`,
+**`delegation-sync-parent`**.
 
-**NOT gated here — `delegation-sync-parent` / `delegation-sync-child`.** These do
-*not* need turning off for the mutation invariant, because the delegation-sync
-operations that actually publish into the zone are themselves gated on
-`allow-updates` / `allow-child-updates`, which are already off:
+**`delegation-sync-parent` (rev 2 — reversed from rev 1).** Rev 1 excluded it,
+reasoning that every delsync path that publishes into the zone is itself gated on
+`allow-updates`/`allow-child-updates`. Those specific claims are **correct** and
+were re-verified:
+
 - child KEY publication (`Sig0KeyPreparation`) publishes only
-  `if Options[OptAllowUpdates]` ([delegation_sync.go:302](../v2/delegation_sync.go));
+  `if Options[OptAllowUpdates]` ([delegation_sync.go:302](../v2/delegation_sync.go)),
+  and that one gate covers the parent's UPDATE-receiver key prep too
+  (`ParentSig0KeyPrep` funnels into the same function), so with `allow-updates`
+  off it is a clean no-op, keygen included;
 - child CSYNC publication (`SyncZoneDelegationViaNotify`) likewise
   ([delegation_sync.go:521](../v2/delegation_sync.go));
 - parent-side child-delegation apply goes through the CHILD-UPDATE path, gated on
-  `allow-child-updates`;
-- the one delsync publish that bypasses `allow-updates` (CDS via
-  `PublishCdsRRs`, InternalUpdate) is a **no-op without local DNSKEYs**
-  (`SynthesizeCdsRRs` → `len==0 → return nil`, [ops_cds.go:61](../v2/ops_cds.go)),
-  so it does nothing on a non-signing secondary and is the sanctioned case on a
-  signing one.
+  `allow-child-updates` and enforced at the applier;
+- CDS via `PublishCdsRRs` bypasses `allow-updates` but is a **no-op without local
+  DNSKEYs** (`SynthesizeCdsRRs` → `len==0 → return nil`,
+  [ops_cds.go:61](../v2/ops_cds.go)).
 
-Everything else `delegation-sync-*` does is *send* (bootstrap the SIG(0) key to
-the parent, NOTIFY, UPDATE) — outward signalling that does not touch the served
-zone, hence outside this MUST-NOT-MODIFY invariant. (Whether a tdns-auth
-*secondary* should be sending delegation-sync signals to a parent at all is a
-separate, non-mutation question — arguably the primary's job — and is
-deliberately **out of scope** here; flag as a possible future soft-warning, not
-a gate in this doc.)
+What was wrong is the **inference** drawn from them — "therefore delsync as a
+whole needs no gating". Vector 4d is the counterexample. The rule is therefore
+stated positively: **`delegation-sync-parent` is off on a tdns-auth secondary**,
+because publishing DSYNC is the primary's job (or an agent's, per §1.1); the
+`allow-updates` gating above is defence in depth, not the justification.
+
+**Intended consequence, recorded deliberately:** `delegation-sync-parent` also
+gates **KeyState EDNS(0) processing on incoming queries**
+([defaultqueryhandlers.go:56](../v2/defaultqueryhandlers.go)). Turning it off
+disables that on a tdns-auth secondary, and that is correct: the KeyState response
+is signed with the receiver's SIG(0) key, the receiver is either the primary or an
+agent, the keystore is not replicated by AXFR, and the one path that would
+generate a key locally is `allow-updates`-gated and therefore off. A tdns-auth
+secondary can never hold that key in any deployment, so leaving the processing on
+would produce **unsigned** KeyState responses — worse than not answering.
+
+**NOT gated here — `delegation-sync-child`.** Its zone-publishing paths are
+genuinely `allow-updates`/`allow-child-updates`-gated (above) and Fix D backstops
+them, so it needs no separate treatment. Whether a tdns-auth *secondary* should be
+*sending* delegation-sync signals to a parent at all remains a separate,
+non-mutation question — arguably the primary's job — and stays **out of scope**;
+flag as a possible future soft-warning, not a gate in this doc.
 
 **Keep:**
+
 - `inline-signing` — the sanctioned signing secondary (Fix A treats it as an
-  originator so it may bump).
+  originator so it may bump; Fix D admits it).
 - **`catalog-zone`, `catalog-member-auto-create`, `catalog-member-auto-delete`
-  — explicitly ALLOWED on a secondary.** These are NOT origination of the
-  catalog zone's content. A tdns-auth secondary of a catalog zone mirrors the
-  catalog verbatim (MUST-NOT-MODIFY still holds for the catalog zone itself) and
-  then *consumes* it to auto-create / auto-delete the **member** zones it
-  references ([catalog.go:270](../v2/catalog.go),
-  [apihandler_catalog.go:330](../v2/apihandler_catalog.go)). That provisioning
-  acts on *other* zones, never on the catalog zone — and it is the entire point
-  of catalog zones (RFC 9432): a secondary that couldn't consume a catalog would
-  make the feature pointless. The only in-catalog-zone mutation (the
-  `version.<catalog>` TXT injection) lives solely on the `CreateCatalogZone`
-  author path, which is a primary-of-catalog operation a secondary never runs,
-  so it needs no gating for the secondary case.
+  — explicitly ALLOWED on a secondary.** These are NOT origination of the catalog
+  zone's content. A tdns-auth secondary of a catalog zone mirrors the catalog
+  verbatim (MUST-NOT-MODIFY still holds for the catalog zone itself) and then
+  *consumes* it to auto-create / auto-delete the **member** zones it references
+  ([catalog.go:270](../v2/catalog.go),
+  [apihandler_catalog.go:330](../v2/apihandler_catalog.go)). That provisioning acts
+  on *other* zones, never on the catalog zone — and it is the entire point of
+  catalog zones (RFC 9432): a secondary that couldn't consume a catalog would make
+  the feature pointless. **What must be gated is catalog *authoring* via the API
+  (vector 6b), which is a different code path and is handled by Fix C.**
 - Serving-behavior options (`fold-case`, `black-lies`, minimal-responses, etc.)
   are unaffected.
 
-`dont-publish-key`/`dont-publish-jwk` become moot once delsync is off (KEY/JWK
-publication is only reached through delsync), so they need no special handling —
-but stating that explicitly avoids a future "why isn't this gated" question.
+`dont-publish-key`/`dont-publish-jwk` become moot once the KEY/JWK publication
+paths are unreachable, so they need no special handling — stating that explicitly
+avoids a future "why isn't this gated" question.
 
-## 5. Residuals to confirm at implementation
+## 5. Config model change: `outbound_soa_serial` must become per-zone
 
-The audit classified every vector I could trace to a definite enabler. Two
-low-risk items warrant a confirming glance during implementation rather than
-being taken on faith:
+**This is a schema change and the largest single item in rev 2.**
 
-- **JWK / A-AAAA / TLSA publication (#9):** tied to transport-signal / signing /
-  agent-role features (all off for a pure auth secondary), but I did not trace
-  every caller. Confirm none fires on a pure secondary.
-- **`bumpch` vs handler bump:** confirm both external bump paths are gated (there
-  may be effectively one).
+`outbound_soa_serial` is **server-global** today: [config.go:223](../v2/config.go)
+→ `applyOutboundSoaSerial(kdb, …)` ([parseconfig.go:609](../v2/parseconfig.go)) →
+`kdb.OutboundSoaSerial`, which every zone reads off the shared KeyDB
+([zone_mutation.go:336](../v2/zone_mutation.go),
+[zone_utils.go:680](../v2/zone_utils.go),
+[refreshengine.go:121](../v2/refreshengine.go) and
+[:788](../v2/refreshengine.go)).
 
-(The delegation-sync question is resolved, not a residual: its zone-publishing
-paths are gated on `allow-updates`/`allow-child-updates` — verified at
-[delegation_sync.go:302/521](../v2/delegation_sync.go) — and the one bypassing
-path, CDS, is a no-op without local DNSKEYs.)
+Consequence: **the rule "a secondary must not persist its serial" cannot be
+expressed at config level.** A server hosting primaries *and* secondaries has one
+setting; rejecting `persist` for a secondary would break the co-hosted primaries.
 
-None of these is expected to reveal a *fourth* unconditional vector; #1 (refresh
-serial) remains the only role/option-independent mutation found.
+Two-part resolution:
 
-## 6. Testing
+1. **Short term (this PR):** per-zone *suppression* at the point of use — the six
+   sites in Fix A. The global setting is honoured for zones that may originate and
+   ignored for those that may not. Plus a one-time startup warning when the mode is
+   `persist`/`unixtime` **and** the server hosts tdns-auth secondaries, naming the
+   zones where it is being suppressed, so the operator sees it.
 
-- **Fix A (mutation-verified):** non-signing secondary, upstream serial jumps
-  N→M across two refreshes → served serial == M (mirror), not prev+1; fails on
-  current code, passes on the fix. Plus: signing (inline) secondary still
-  advances; `unixtime`/`persist` on a pure secondary does not rewrite the serial.
-- **Fix B:** a secondary configured with each origination option → option ends
-  up off, soft `ConfigError` present, zone still `Ready`/served; reload with a
-  clean config clears the error. Cover the dynamic-zone-add path too.
-- **Catalog not regressed (the §4 correction):** a secondary catalog zone with
+2. **Correct fix (agreed, scope TBD):** make `outbound_soa_serial` a **per-zone**
+   setting — in practice per **template**, since that is how zone policy is
+   curated. The global value becomes the default. This is the right model
+   independent of this invariant: outbound serial policy is a property of a zone's
+   role and downstream contract, not of the server process.
+
+**Sequencing is an open decision.** The per-zone change touches the config schema,
+template expansion, the dynamic-zone config round-trip, and reload — orthogonal to
+the immutability invariant and large enough to deserve its own PR and review. The
+recommendation is: land the invariant with per-zone *suppression* (1), then do the
+schema change (2) as a follow-up, with this section as its starting point. If it
+is folded into this PR instead, the PR roughly doubles in surface area and the
+migration story in §8 has to be re-derived against the new schema.
+
+## 6. Ordering and the persisted-config round-trip
+
+**Ordering vs `activateUpdatePolicy`.** [parseconfig.go:904](../v2/parseconfig.go)
+parses options; [:918](../v2/parseconfig.go) then calls `activateUpdatePolicy`,
+which itself mutates the options map (sets `OptAllowUpdates`/`OptAllowChildUpdates`
+false for `none`/empty policy types) and **returns a hard error → `broken_zones` →
+the zone is quarantined** when `allow-child-updates` is set without a
+`delegationbackend` ([parseconfig.go:1205](../v2/parseconfig.go)). If the
+normalizer runs *after* it, a secondary configured that way is hard-quarantined
+instead of receiving the promised soft warning — defeating the central safety
+promise of Fix B. **The normalizer must run between 904 and 918.**
+`activateUpdatePolicy` is arguably its natural home: it is already the post-parse
+option-adjustment stage.
+
+This ordering does double duty. The delegation-sync setup block keys off the
+freshly-parsed `options` map ([parseconfig.go:1065](../v2/parseconfig.go)); with
+the normalizer running earlier, `OptDelSyncParent` is already false for a
+secondary, the block is skipped, and `SetupZoneSync` never registers at all — so
+vector 4d is closed at parse time with no additional wiring.
+
+**The persisted-config round-trip (must not silently rewrite operator intent).**
+`zoneDataToZoneConf` ([dynamic_zones.go:452](../v2/dynamic_zones.go)) serializes
+the **live** `zd.Options`, and `AddDynamicZoneToConfig` runs on every successful
+refresh of a persistable dynamic zone
+([refreshengine.go:839](../v2/refreshengine.go)), rewriting the whole dynamic
+config file from the live `Zones` map. If the normalizer mutates live options, the
+persisted config **permanently loses** `allow-updates`, after which the warning
+clears and the misconfiguration becomes invisible — the operator's stated intent
+silently deleted.
+
+Rev 1's model ("recompute each parse; fixing the YAML clears the flag") assumes
+YAML is truth. For static zones it is; for dynamic zones the file is *regenerated
+from state*. The normalizer must therefore keep **as-configured** options separate
+from **effective** options, with the serializer writing the as-configured set. This
+is the same class of problem the config-reload policy guardrail work wrestled with.
+
+## 7. Diagnostics — make the split-brain visible
+
+There is currently no way to see, from tdns, the condition that motivated this
+work: two masters disagreeing about a zone's serial. Add it.
+
+- **`zone list -v`** — show our outbound serial (`CurrentSerial`) and our inbound
+  serial (`IncomingSerial`) side by side. Free: both are already on `ZoneData`, no
+  network.
+- **`zone desc <zone>`** — additionally probe **every configured primary** and show
+  each one's SOA serial individually. Plumbing exists (`populateZoneDescDetail`,
+  [apihandler_zone.go:388](../v2/apihandler_zone.go), with `ZoneConf` as carrier).
+  `DoTransfer` already performs the TSIG/XoT-correct SOA probe and returns the
+  serial ([zone_utils.go:170-175](../v2/zone_utils.go)), but short-circuits on the
+  first usable upstream, so this needs a small read-only extraction that probes all
+  of them.
+
+Per-primary output is the point: *this* master says 42, *that* one says 5000 is the
+direct diagnostic for §1's motivating failure, and it doubles as the pre-upgrade
+check for §8. Single-zone only — the probe costs a query per primary, which is fine
+for `zone desc` and not for bulk listing.
+
+## 8. Migration — severity is per-serial-mode
+
+Rev 1 had no migration section; rev 2's first draft over-stated the risk. The
+corrected analysis:
+
+In the default **`keep`** mode there is **no restore path at all** —
+[refreshengine.go:121](../v2/refreshengine.go) switches only on `unixtime` and
+`persist`. So on every restart today a tdns-auth secondary already does `firstLoad
+→ CurrentSerial = new_zd.CurrentSerial` = the upstream serial. **The backwards jump
+already happens at every restart, today, in the default mode.** The inflation only
+accumulates between restarts, at +1 per refresh. Fix A does not introduce a new
+event there; it stops the re-inflation afterwards.
+
+| Mode | Today at restart | After Fix A | Migration risk |
+|---|---|---|---|
+| `keep` (default) | already resets to upstream serial | same, and stops re-inflating | **none new** |
+| `persist` | persisted serial survives, zone stays ahead | drops to upstream serial | **one-time backwards jump** |
+| `unixtime` | serial is a Unix timestamp, enormously ahead | drops to upstream serial | **largest one-time jump** |
+
+The two modes that create a migration event are exactly the two that must not apply
+to a secondary at all (§5) — which is the argument for the change, not against it.
+
+**Why a downstream sticks.** A tdns downstream refuses at
+[zone_utils.go:172](../v2/zone_utils.go) (`soa.Serial <= zd.IncomingSerial`);
+BIND/NSD do the same under RFC 1982. NOTIFY does not rescue it — a NOTIFY carrying
+a lower serial is ignored. The downstream serves stale data until upstream climbs
+past the old value, which may be never.
+
+**Who is exposed.** Only zones that are (i) tdns-auth secondaries in
+`persist`/`unixtime` mode *and* (ii) themselves masters for someone. A leaf
+secondary is unaffected — nobody transfers from it and caches do not compare SOA
+serials. That intersection is precisely the distribution tier from §1.
+
+**Required (Fix A companion):** on the first mirror, if the incoming serial is
+below the previous `CurrentSerial`, log at ERROR with zone, old serial, new serial
+and the operator action. This converts a silent stall into a loud one.
+
+**Operator remedy (documented, verified):** a forced retransfer on each downstream
+— `tdns-cli zone reload --force <zone>` → `ZonePost.Force` → `ReloadZone` →
+`ZoneRefresher.Force` → `Refresh(force)` → [zone_utils.go:75](../v2/zone_utils.go)
+`if do_transfer || force`, which bypasses the serial comparison. Non-tdns
+downstreams need their own (BIND: `rndc retransfer`). Use §7's `zone desc` to build
+the list before upgrading.
+
+**Explicitly rejected:** a transition mode that keeps bumping until upstream
+overtakes. It never converges in the BIND/tdns pair that motivated the doc, and it
+perpetuates the bug it exists to kill.
+
+## 9. The forced-transfer contract
+
+**Requirement: a forced transfer MUST perform the transfer and apply whatever the
+upstream has — including a serial that is lower than, or equal to, our own.** With
+strict passthrough this is the operator's only remedy (§8) and the only escape
+hatch from a wedged secondary; it must not chicken out at the starting gate.
+
+Current state, verified:
+
+- **Lower serial: works, but only incidentally.** `DoTransfer` returns
+  `(false, serial, nil)` — no error — for a lower upstream serial
+  ([zone_utils.go:172](../v2/zone_utils.go)), and [:75](../v2/zone_utils.go) is
+  `if do_transfer || force`, so the forced path reaches `FetchFromUpstream` and
+  applies it. Nothing pins this. That `<=` is one plausible "tightening" away from
+  silently breaking the sole migration remedy — silently, because the forced
+  transfer would report success and change nothing.
+- **Equal serial: broken.** [FetchFromUpstream:313](../v2/zone_utils.go) discards
+  the transfer when `new_zd.IncomingSerial == zd.IncomingSerial`. So
+  `zone reload --force` on an already-current zone is a **silent no-op** — force
+  does not mean force. Consequence beyond migration: force cannot be used on the
+  secondary itself to apply the mirror early (moot for the upgrade, since an upgrade
+  is a restart and restart = first load = immediate mirror, but wrong).
+
+**Required:** make the contract explicit in code, pin it with a regression test for
+the lower-serial case specifically, and fix the equal-serial no-op so that `force`
+genuinely re-fetches and re-applies.
+
+## 10. Testing
+
+- **Fix A (mutation-verified):** non-signing secondary, upstream serial jumps N→M
+  across two refreshes → served serial == M (mirror), not prev+1; fails on current
+  code, passes on the fix. Plus: signing (inline) secondary still advances;
+  `unixtime`/`persist` on a pure secondary does not rewrite the serial at **any** of
+  the six sites; the persisted row is cleared.
+- **Fix B:** a secondary configured with each of the four origination options →
+  option ends up off, soft `ConfigWarning` present, zone still `Ready`/served;
+  reload with a clean config clears it. Cover the dynamic-zone add **and modify**
+  paths, and the API (`zoneOptionsFromStrings`) path.
+- **Ordering (§6):** a secondary with `allow-child-updates` and no
+  `delegationbackend` gets the soft warning, **not** a `broken_zones` quarantine.
+- **Config round-trip (§6):** a dynamic secondary with `allow-updates` in its
+  persisted config still has it in the file after several refresh cycles; the
+  warning does not silently disappear.
+- **Vector 4d:** a secondary with `delegation-sync-parent` publishes **no**
+  `_dsync.<zone>` DSYNC RRset and no address RRs; `SetupZoneSync` does not register.
+- **Vector 5b (Fix E):** a secondary with `online-signing` and no local keys does
+  not generate keys and does not re-sign the upstream SOA across refreshes.
+- **Vector 6b (Fix C):** the catalog authoring API refuses against a secondary
+  catalog zone.
+- **Catalog not regressed (the §4 carve-out):** a secondary catalog zone with
   `catalog-member-auto-create`/`-auto-delete` keeps those options ON and still
-  provisions/deprovisions member zones from the catalog contents — no soft
-  error, no gating. (Guards against re-introducing the mistake of treating
-  catalog consumption as origination.)
-- **Fix C:** `bump` (both entry points) and the other origination actions →
-  refused for a secondary, allowed for a primary; `freeze`/`thaw`/`write-zone`
-  still allowed for a secondary.
+  provisions/deprovisions member zones — no warning, no gating. (Guards against
+  re-introducing the mistake of treating catalog consumption as origination.)
+- **Fix C:** the origination actions in **both** zone handlers are refused for a
+  secondary, allowed for a primary; `write-zone` still allowed; `freeze`/`thaw`
+  refused with the *role* reason, not the allow-updates reason; the added `return`s
+  are covered (error responses no longer carry a success `Msg` and no longer change
+  state).
+- **Fix D:** an `InternalUpdate` ZONE-UPDATE against a pure secondary is dropped and
+  logged; the same request against a primary and against an inline-signing secondary
+  is applied; `TRUSTSTORE-UPDATE` is unaffected.
+- **Forced transfer (§9):** a forced transfer applies a **lower** upstream serial; a
+  forced transfer with an **equal** serial re-fetches rather than no-opping.
 - **App-scope (the §1.1 guarantee, must be explicit):** with
-  `Globals.App.Type != AppTypeAuth` (drive a test with, e.g., `AppTypeAgent`),
-  a Secondary carrying origination options keeps them on, its serial advances
-  exactly as before, and the API origination actions are not refused — proving
-  all three gates are no-ops off tdns-auth so tdns-agent / tdns-mpcombiner /
-  tdns-mpagent behavior is unchanged.
-- Gate: full `v2` `-race`, gofmt, cmdv2 binaries build via gmake.
+  `Globals.App.Type != AppTypeAuth` (drive a test with, e.g., `AppTypeAgent`), a
+  Secondary carrying origination options keeps them on, its serial advances exactly
+  as before, the API origination actions are not refused, and the applier gate drops
+  nothing — proving all five fixes are no-ops off tdns-auth so tdns-agent /
+  tdns-mpcombiner / tdns-mpagent behavior is unchanged.
+- Gate: full `v2` `-race`, gofmt, cmdv2 binaries build via gmake, plus live
+  validation on the foffe testbed for Fix D (see its blast-radius note).
 
-## 7. Relationship to other work
+## 11. Resolved residuals
+
+Rev 1 listed two items to confirm at implementation. Both are now settled, and one
+is better than hoped:
+
+- **JWK / A-AAAA / TLSA (#9):** not merely "does not fire" — `PublishJWKRR`,
+  `PublishTlsaRR`, `PublishAddrRR`, `PublishSvcbRR` and `PublishUriRR` have **zero
+  callers** anywhere in tdns `v2/` or `cmdv2/`. They are library surface for the
+  derived apps and cannot fire on tdns-auth at all. This independently reinforces
+  §1.1.
+- **`bumpch` vs handler bump (#7):** `BumpZoneCh` is created
+  ([main_initfuncs.go:190](../v2/main_initfuncs.go)) and read
+  ([refreshengine.go:855](../v2/refreshengine.go)) but **nothing ever sends on it**
+  — the path is dead code. There is one live bump entry point,
+  [apihandler_zone.go:70](../v2/apihandler_zone.go). Gate both anyway; it is free.
+
+## 12. Open items
+
+Carried forward for decision; none blocks starting implementation:
+
+1. **§5 sequencing** — per-zone `outbound_soa_serial` in this PR or a follow-up.
+   Recommendation: follow-up.
+2. **Fix E sub-question** — whether `online-signing` on a tdns-auth secondary should
+   also be normalized off, or merely made inert.
+3. **Stale persisted serials** — clear on upgrade (recommended) vs. document as
+   deliberately retained.
+4. **"Pause refresh" on a secondary** — a genuinely useful operational capability
+   (stop following a known-bad upstream) that rev 1's incorrect freeze rationale
+   accidentally described. It does not exist today. Captured as a future item,
+   explicitly **not** built here.
+5. **Freeze/thaw missing `return`s** — folded into this PR (§3, Fix C) because the
+   refusal depends on the guards actually returning; could equally be a separate
+   preparatory commit.
+
+## 13. Relationship to other work
 
 - **Prerequisite for inbound IXFR** (`2026-07-25-inbound-ixfr-plan.md`): the
   serial-space contract (served/outbound `CurrentSerial` vs upstream
-  `IncomingSerial`) that IXFR-in's SOA handling depends on only makes sense once
-  the secondary serial actually mirrors upstream. Land this first.
+  `IncomingSerial`) that IXFR-in's SOA handling depends on only makes sense once the
+  secondary serial actually mirrors upstream. Land this first.
 - Independent of the IXFR-out work already merged (#328).
-- Suggested single PR `feature/secondary-zones-immutable`: normalizer (Fix B) +
-  serial mirror (Fix A) + API gate (Fix C) + tests. Its own branch, landing
-  ahead of inbound IXFR.
+- Suggested single PR `feature/secondary-zones-immutable`: Fix A (serial mirror +
+  six-site suppression) + Fix B (normalizer) + Fix C (API gate + freeze/thaw +
+  returns) + Fix D (applier gate) + Fix E (re-sign role gate) + §7 diagnostics + §9
+  forced-transfer contract + tests. Its own branch, landing ahead of inbound IXFR.
+  Note the branch currently has no commits and is behind main; it needs a
+  forward-merge first.

--- a/docs/2026-07-25-secondary-zones-immutable.md
+++ b/docs/2026-07-25-secondary-zones-immutable.md
@@ -1,6 +1,6 @@
 # Secondary zones are immutable — MUST-NOT-MODIFY invariant + audit
 
-**Date:** 2026-07-25, revised 2026-07-26 (rev 2)
+**Date:** 2026-07-25, revised 2026-07-26 (rev 2, then rev 2.1 same day)
 **Status:** PROPOSED — design agreed in discussion; rev 2 incorporates a
 code-verified re-audit of every claim in rev 1. Not implemented.
 **Origin:** surfaced while cooking the inbound-IXFR plan
@@ -39,6 +39,22 @@ because the existing gates sit at **call sites**, and the applier they feed
 | 12 | **New: forced-transfer contract** | Force must apply whatever upstream has; today it works for a lower serial only incidentally, and no-ops on an equal one |
 | 13 | **New: diagnostics** (`zone desc` / `zone list -v` serial visibility) | There is currently no way to see the split-brain that motivated this work |
 | 14 | Residuals #9 and #2 **resolved** | Zero callers, and dead code, respectively |
+
+**Rev 2.1 (2026-07-26, later the same day)** — closes §12 items 2, 3 and 5 after
+a full `OptOnlineSigning` consumer survey (~40 sites):
+
+- **`online-signing` joins the turn-off list (now five).** With local keys —
+  the only keys tdns-auth has — it is unsafe and plain wrong on a secondary:
+  two further role-ungated mutation vectors found (5c, 5d in §2), plus a
+  response-path and an outbound-transfer failure mode. Fix E alone would make
+  things *worse* (§3, Fix E). The legitimate form — signing at the edge with
+  **distributed** keys — is the tdns-nm/tdns-es future and will most likely be
+  a new app, which §1.1 already accommodates untouched.
+- **Enforcement framing refined:** Fix D backstops only the UpdateQ class of
+  publishers; for the direct-under-`zd.mu` class the normalizer *is* the
+  enforcement (§2 conclusion).
+- Item 3 decided: stale persisted serials are **cleared**. Item 5 decided:
+  freeze/thaw `return`s land as a **separate commit in the same PR**.
 
 ---
 
@@ -102,6 +118,19 @@ parent zone **at the primary** and reach the secondaries by AXFR. That is
 MUST-NOT-MODIFY working exactly as intended, and it is the reason the app-scope
 constraint is not merely defensive bookkeeping.
 
+**A second worked example (rev 2.1): the future edge signer.** Signing at a
+secondary is not inherently wrong — with **distributed** keys (the correct keys
+delivered to the edge, rather than locally minted ones) it is a legitimate
+architecture, and it is exactly what the tdns-nm ("node manager") and tdns-es
+("edge signer") projects are about (today mostly standalone; intended to
+leverage tdns-transport like tdns-mp does, once the tdns-mp/tdns-transport
+refactoring lands). When that project resumes it will most likely be a **new
+app** — with its own AppType from the already-partitioned enum (nm 33–48 /
+es 49–64 reserved) — and every gate in this doc is then automatically a no-op
+for it, zero refactoring required. What §4 turns off is `online-signing` on
+**tdns-auth**, whose only keys are local; the edge-signing future is
+unaffected by construction.
+
 ## 2. The audit — every mutation vector, classified
 
 Method: enumerate every call site that stages content and publishes, advances
@@ -123,7 +152,9 @@ staged. What matters is the **source** and its **enabler**:
 | 4c | Delegation sync — **sending** (bootstrap KEY to parent, NOTIFY, UPDATE) | `OptDelSyncParent`/`OptDelSyncChild` | sends outward; **does not mutate the served zone** | out of scope (§4 note) |
 | **4d** | **Delegation sync — DSYNC publication** (`SetupZoneSync` → `PublishDsyncRRs`, [zone_utils.go:773](../v2/zone_utils.go), [ops_dsync.go:16](../v2/ops_dsync.go)) — publishes `_dsync.<zone>` DSYNC + address RRs via InternalUpdate | **`OptDelSyncParent` alone.** No `allow-updates` check. Unlike CDS it is **not** a no-op without local DNSKEYs — it synthesizes from `delegationsync.parent.schemes` | **YES** | **Fix B** (delsync-parent joins the turn-off list) + **Fix D** |
 | 5 | **DNSSEC signing / KSK-ZSK rollover / resign** ([sign.go](../v2/sign.go), ksk_rollover_*, resign engine) | `OptOnlineSigning`/`OptInlineSigning` **and** `SetupZoneSigning`'s role gate: a non-primary signs *only* with `inline-signing` ([zone_utils.go:1107](../v2/zone_utils.go)) | only if `inline-signing` — the **sanctioned** signing secondary | **kept** (the exception); Fix A treats it as an originator |
-| **5b** | **Per-publish SOA re-sign** — `resignWorkingSetSOAIfSigned` ([zone_mutation.go:186](../v2/zone_mutation.go)) re-signs the apex SOA inside `publishWorkingSetLocked`, i.e. on **every publish including the refresh path** | `OptOnlineSigning` or `OptInlineSigning` — **no role gate**, unlike #5. `EnsureActiveDnssecKeys` will *generate* keys if absent | **YES**, on a secondary carrying `online-signing` | **Fix E** |
+| **5b** | **Per-publish SOA re-sign** — `resignWorkingSetSOAIfSigned` ([zone_mutation.go:186](../v2/zone_mutation.go)) re-signs the apex SOA inside `publishWorkingSetLocked`, i.e. on **every publish including the refresh path** | `OptOnlineSigning` or `OptInlineSigning` — **no role gate**, unlike #5. `EnsureActiveDnssecKeys` will *generate* keys if absent | **YES**, on a secondary carrying `online-signing` | **Fix B** (rev 2.1: option normalized off) + **Fix E** |
+| **5c** | **DNSKEY injection on refresh (rev 2.1)** — `CollectDynamicRRs` ([zone_utils.go:894](../v2/zone_utils.go)) pulls local DNSKEYs from the keystore and repopulates them into the served zone after **every refresh** | `OptOnlineSigning` or `OptInlineSigning` (outer gate also admits `OptAllowUpdates`) — **no role gate** | **YES**, with `online-signing` | **Fix B** (rev 2.1). NOT Fix-D-covered: publishes via the refresh working set, not UpdateQ |
+| **5d** | **Key-state-driven whole-zone re-sign (rev 2.1)** — `maintainStandbyKeys` / key-state transitions → `triggerResign` ([key_state_worker.go:405](../v2/key_state_worker.go)) → `ResignQ` → `resignNow` → `SignZone(force=true)` ([resigner.go:52](../v2/resigner.go)); `maintainStandbyKeys` also **mints standby KSKs/ZSKs** for every signing zone ([key_state_worker.go:267](../v2/key_state_worker.go)) | `OptOnlineSigning` or `OptInlineSigning` — key_state_worker.go, resigner.go and sign.go contain **zero** role checks; the only role gate is in `SetupZoneSigning` ([zone_utils.go:1107](../v2/zone_utils.go)), which is just one of **two** ResignQ senders | **YES**, with `online-signing` — the largest mutation vector in the audit: wholesale re-sign of upstream content with locally generated keys | **Fix B** (rev 2.1). NOT Fix-D-covered: `SignZone` publishes directly under `zd.mu` |
 | 6 | **Catalog *consumption*** — auto-create/delete **member** zones from a catalog ([catalog.go:270](../v2/catalog.go), [apihandler_catalog.go:330](../v2/apihandler_catalog.go)) | `OptCatalogMemberAutoCreate`/`Delete` | yes — and **desired**: it provisions *other* zones, never mutates the catalog zone (RFC 9432; the whole point) | **allow, no gating** (§4) |
 | **6b** | **Catalog *authoring* via the API** — `handleCatalogZoneAdd`/`Delete`/group add/remove → `regenerateCatalogZone` → `stageRRsetLocked` + `publishLocked` ([apihandler_catalog.go:541](../v2/apihandler_catalog.go)) | **none.** The handlers take a catalog zone name and mutate it; no role check anywhere on the path | **YES.** *(Rev 1 said "not reachable for a secondary" — that was wrong; only the `CreateCatalogZone` author path was considered)* | **Fix C** |
 | 7 | **API `bump`** — the zone handler ([apihandler_zone.go:70](../v2/apihandler_zone.go)); the refresh-engine `bumpch` handler ([refreshengine.go:880](../v2/refreshengine.go)) is **dead code**, see §11 | *none* — no role check | **YES** | **Fix C** |
@@ -142,6 +173,15 @@ neutralizes only those callers that happen to check their option first. Vector
 them right, and DSYNC still slipped through because it is reached from
 `SetupZoneSync` instead. **Enforcement belongs at the applier (Fix D); option
 normalization (Fix B) is the operator-facing visibility layer.**
+
+**Rev 2.1 refinement:** that division of labour holds only for the **UpdateQ
+class** of publishers. A second class publishes **directly under `zd.mu`** and
+never touches `UpdateQ` — `SignZone` ([sign.go:790](../v2/sign.go)),
+`PublishDnskeyRRs` ([ops_dnskey.go:26](../v2/ops_dnskey.go)),
+`CollectDynamicRRs` (via the refresh working set) — so Fix D cannot backstop
+it. For that class there is no applier chokepoint and **the option normalizer
+is itself the enforcement**, which is why the turn-off list must be right
+(five options, §4) and why Fix E exists as defence in depth.
 
 ## 3. The fixes — one predicate, five homes
 
@@ -186,8 +226,8 @@ sees the misconfig while the zone keeps serving.
 
 Rev 2 changes:
 
-- **Four options, not three** — `delegation-sync-parent` joins `allow-updates`,
-  `allow-child-updates`, `add-transport-signal`. See §4.
+- **Five options, not three** — rev 2 added `delegation-sync-parent`; rev 2.1
+  adds `online-signing` after the full consumer survey. See §4.
 - **Use `ConfigWarning`, not `ConfigError`.** Rev 1 verified that `SetError`
   does not touch `Status` — correct — but `ConfigError` is in
   `serviceImpactingErrors` ([enums.go:348](../v2/enums.go)), documented as "a
@@ -202,7 +242,8 @@ Rev 2 changes:
 - **Message wording is part of the fix.** The normalizer warning, the Fix C
   refusal and the Fix D log line must all name the same reason — origination on
   a secondary — so an operator gets one story from three places rather than three
-  unrelated denials.
+  unrelated denials. For `online-signing` specifically, the warning should
+  additionally suggest `inline-signing` as the almost-certainly intended option.
 
 **Call sites (revised — rev 1's list was incomplete and the wrong shape):**
 
@@ -328,16 +369,27 @@ an originator under the predicate, so Fix A mirrors its serial, but this would
 still re-sign the upstream SOA with locally generated keys
 (`EnsureActiveDnssecKeys` generates them if absent). Apply the same role gate.
 
-Open sub-question for implementation: whether `online-signing` on a tdns-auth
-secondary should additionally be normalized off by Fix B, or merely be inert. Fix
-E alone makes it harmless for the SOA; a survey of other `OptOnlineSigning`
-consumers should decide.
+**Resolved (rev 2.1): `online-signing` is normalized off; Fix E stays as
+defence in depth.** The consumer survey (~40 sites) showed Fix E alone would
+make things *worse*, via an interlock with the outbound-transfer guard: today
+the locally-signed SOA (this vector) lets `ZoneTransferOut`'s fail-closed check
+pass, so downstreams receive a zone whose SOA RRSIG comes from a key absent
+from the DNSKEY RRset — bogus, but flowing. Gate the re-sign without turning
+the option off, and the SOA is no longer signed, so
+[dnsutils.go:299](../v2/dnsutils.go) sees a to-be-signed zone with an unsigned
+SOA and **refuses every outbound transfer** — the secondary silently stops
+feeding its downstreams. Beyond that, vectors 5c/5d fire regardless of Fix E,
+and the response path ([queryresponder.go:179](../v2/queryresponder.go)) either
+signs synthesized denial NSECs with local keys (BOGUS negatives) or, when
+upstream is unsigned, SERVFAILs every stored RRset. There is no coherent
+"inert" state; off is the only correct one. See §4 for the rationale and the
+edge-signer future this deliberately does not foreclose.
 
 ## 4. Option classification
 
-**Turn OFF for a non-inline-signing tdns-auth secondary (origination) — four:**
+**Turn OFF for a non-inline-signing tdns-auth secondary (origination) — five:**
 `allow-updates`, `allow-child-updates`, `add-transport-signal`,
-**`delegation-sync-parent`**.
+**`delegation-sync-parent`**, **`online-signing`** (rev 2.1).
 
 **`delegation-sync-parent` (rev 2 — reversed from rev 1).** Rev 1 excluded it,
 reasoning that every delsync path that publishes into the zone is itself gated on
@@ -372,6 +424,20 @@ agent, the keystore is not replicated by AXFR, and the one path that would
 generate a key locally is `allow-updates`-gated and therefore off. A tdns-auth
 secondary can never hold that key in any deployment, so leaving the processing on
 would produce **unsigned** KeyState responses — worse than not answering.
+
+**`online-signing` (rev 2.1 — closes §12 item 2).** On tdns-auth the only keys
+available are **local** ones, and signing upstream content with local keys is
+unsafe and plain wrong — the option unlocks, with no role check anywhere:
+whole-zone re-signing via the ResignQ path (vector 5d, the largest in the
+audit), standby-key minting, per-refresh DNSKEY injection (5c), the per-publish
+SOA re-sign (5b), BOGUS ephemeral signing of denial NSECs, and SERVFAIL of
+every response when upstream is unsigned. The *concept* — a secondary signing
+with **distributed** keys — is legitimate and is exactly the tdns-nm / tdns-es
+project (§1.1, second worked example); when that resumes it will most likely be
+a new app with its own AppType, which this design accommodates untouched, or a
+deliberate refactor made with better knowledge of the requirements. Nothing
+here forecloses it. The normalizer warning should suggest `inline-signing` as
+the likely intended option.
 
 **NOT gated here — `delegation-sync-child`.** Its zone-publishing paths are
 genuinely `allow-updates`/`allow-child-updates`-gated (above) and Fix D backstops
@@ -439,6 +505,9 @@ recommendation is: land the invariant with per-zone *suppression* (1), then do t
 schema change (2) as a follow-up, with this section as its starting point. If it
 is folded into this PR instead, the PR roughly doubles in surface area and the
 migration story in §8 has to be re-derived against the new schema.
+
+*(Rev 2.1 status: leaning toward folding it in, contingent on an invasiveness
+scoping of the schema change — §12 item 1.)*
 
 ## 6. Ordering and the persisted-config round-trip
 
@@ -579,7 +648,7 @@ genuinely re-fetches and re-applies.
   code, passes on the fix. Plus: signing (inline) secondary still advances;
   `unixtime`/`persist` on a pure secondary does not rewrite the serial at **any** of
   the six sites; the persisted row is cleared.
-- **Fix B:** a secondary configured with each of the four origination options →
+- **Fix B:** a secondary configured with each of the five origination options →
   option ends up off, soft `ConfigWarning` present, zone still `Ready`/served;
   reload with a clean config clears it. Cover the dynamic-zone add **and modify**
   paths, and the API (`zoneOptionsFromStrings`) path.
@@ -590,8 +659,12 @@ genuinely re-fetches and re-applies.
   warning does not silently disappear.
 - **Vector 4d:** a secondary with `delegation-sync-parent` publishes **no**
   `_dsync.<zone>` DSYNC RRset and no address RRs; `SetupZoneSync` does not register.
-- **Vector 5b (Fix E):** a secondary with `online-signing` and no local keys does
-  not generate keys and does not re-sign the upstream SOA across refreshes.
+- **Vectors 5b/5c/5d (`online-signing` normalized + Fix E):** a secondary
+  configured with `online-signing` has the option normalized off (warning
+  suggests `inline-signing`), generates no keys, injects no DNSKEYs on refresh,
+  is never whole-zone re-signed via the ResignQ path, and does not re-sign the
+  upstream SOA across refreshes; outbound transfer of the (now unsigned-mirror)
+  zone is **not** refused by the `ZoneTransferOut` signed-zone guard.
 - **Vector 6b (Fix C):** the catalog authoring API refuses against a secondary
   catalog zone.
 - **Catalog not regressed (the §4 carve-out):** a secondary catalog zone with
@@ -635,21 +708,26 @@ is better than hoped:
 
 ## 12. Open items
 
-Carried forward for decision; none blocks starting implementation:
+Still open (neither blocks starting implementation):
 
 1. **§5 sequencing** — per-zone `outbound_soa_serial` in this PR or a follow-up.
-   Recommendation: follow-up.
-2. **Fix E sub-question** — whether `online-signing` on a tdns-auth secondary should
-   also be normalized off, or merely made inert.
-3. **Stale persisted serials** — clear on upgrade (recommended) vs. document as
-   deliberately retained.
-4. **"Pause refresh" on a secondary** — a genuinely useful operational capability
-   (stop following a known-bad upstream) that rev 1's incorrect freeze rationale
-   accidentally described. It does not exist today. Captured as a future item,
-   explicitly **not** built here.
-5. **Freeze/thaw missing `return`s** — folded into this PR (§3, Fix C) because the
-   refusal depends on the guards actually returning; could equally be a separate
-   preparatory commit.
+   Leaning toward **including it**, contingent on how invasive the schema change
+   turns out to be — an invasiveness scoping pass decides. Until then the
+   follow-up recommendation in §5 stands as the fallback.
+4. **"Pause refresh" on a secondary** — parked for a later discussion. (The
+   idea, for that discussion: an operator control to stop refreshing from a
+   known-bad upstream while continuing to serve the current data — the
+   capability rev 1's incorrect freeze rationale accidentally described. It does
+   not exist today; `OptFrozen` gates DDNS only. Explicitly **not** built here.)
+
+Closed since rev 2 (rulings 2026-07-26):
+
+2. **`online-signing` normalization** — CLOSED (rev 2.1): normalized **off** on
+   a tdns-auth secondary; Fix E stays as defence in depth; the distributed-key
+   edge-signer future (tdns-nm/tdns-es) is deliberately not foreclosed. See §4.
+3. **Stale persisted serials** — CLOSED: **clear them out** (Fix A does so).
+5. **Freeze/thaw missing `return`s** — CLOSED: **separate commit in the same
+   PR**, ahead of the Fix C commit that depends on it.
 
 ## 13. Relationship to other work
 

--- a/docs/2026-07-25-secondary-zones-immutable.md
+++ b/docs/2026-07-25-secondary-zones-immutable.md
@@ -1,8 +1,9 @@
 # Secondary zones are immutable — MUST-NOT-MODIFY invariant + audit
 
 **Date:** 2026-07-25, revised 2026-07-26 (rev 2, rev 2.1, rev 2.2 same day)
-**Status:** PROPOSED — design agreed in discussion; rev 2 incorporates a
-code-verified re-audit of every claim in rev 1. Not implemented.
+**Status:** IN IMPLEMENTATION (started 2026-07-26). Design agreed; rev 2
+incorporates a code-verified re-audit of every claim in rev 1. Per-item
+progress in §14.1.
 **Origin:** surfaced while cooking the inbound-IXFR plan
 (`2026-07-25-inbound-ixfr-plan.md`). A confirmed serial-bump bug on secondaries
 turned out to be one instance of a whole missing invariant. This is a
@@ -846,3 +847,48 @@ Per work item, in §13's commit order:
 3. **Fix D's blast radius is not a LOC risk** (15 lines) — it is a *validation*
    cost: the doc requires foffe testbed time on top of `-race`, which is
    wall-clock, not diff size.
+
+## 14.1 Implementation progress
+
+Branch `feature/secondary-zones-immutable`. Every commit compiles, is
+GPG-signed, and leaves the full `v2` suite green.
+
+| Item | Status | Commit(s) |
+|---|---|---|
+| §5 per-zone `outbound_soa_serial` (schema + plumbing) | **DONE** | `c5dc33a` |
+| §5 per-zone mode tests | **DONE** | `095374a` |
+| Fix A — serial mirror + six-site suppression + row-clear + backwards ERROR | **DONE** (mutation-verified) | `a030ab4` |
+| Fix E — role gate on the per-publish SOA re-sign | **DONE** | `1fa3f36` |
+| freeze/thaw missing `return`s (§12 item 5) | **DONE** | `82b54f5` |
+| Fix D — fail-closed applier gate | **DONE** (see finding below) | `477ea49` |
+| Fix B — option normalizer + as-configured/effective split | TODO | — |
+| Fix C — API origination gate (both zone handlers + catalog) | TODO | — |
+| §7 diagnostics — serial visibility, all-primaries probe | TODO | — |
+| §9 forced-transfer contract (equal-serial no-op) | TODO | — |
+| §5 startup warning (global persist/unixtime + auth secondaries) | TODO | — |
+
+Notes from implementation:
+
+- **The predicate lives in `v2/zone_origination.go`** as
+  `zoneMayOriginateContent(zd)`, and it returns **true for every app type other
+  than tdns-auth**. Folding the app-type test into the predicate rather than
+  repeating `Globals.App.Type == AppTypeAuth &&` at each call site means the
+  §1.1 guarantee is stated once and no future gate can forget it. Consequence
+  for tests: a test asserting any gate must set `Globals.App.Type` explicitly,
+  since an unset (zero) app type reads as "not tdns-auth" and every gate stands
+  down.
+
+- **FINDING — the ZONE-UPDATE vectors are currently inert on a secondary, for
+  an unrelated reason.** `ApplyZoneUpdateToDB` ([zone_updater.go:786](../v2/zone_updater.go))
+  is a `return nil` **placeholder**, and it is the entire `ZoneType == Secondary`
+  branch of the ZONE-UPDATE apply path. So on a tdns-auth secondary today,
+  *every* ZONE-UPDATE-borne vector — DDNS (#2), transport signals (#3), DSYNC
+  (4d), and the whole `ops_*`/InternalUpdate family (#10) — reaches the applier
+  and then does nothing. This does **not** invalidate any fix, but it corrects
+  the audit's severity claims: those vectors are **latent, not live**. They
+  become live the moment that placeholder is implemented — which is precisely
+  the argument for Fix D being a structural gate rather than a per-vector patch.
+  What *is* live on a secondary today: the refresh serial bump (#1, Fix A), the
+  signing/direct-publish class (5b/5c/5d, Fix E + normalizer), CHILD-UPDATE (a
+  real `DelegationBackend.ApplyChildUpdate`), and the API actions (Fix C).
+  §2's table should be re-read with this distinction in mind.

--- a/docs/2026-07-25-secondary-zones-immutable.md
+++ b/docs/2026-07-25-secondary-zones-immutable.md
@@ -861,7 +861,7 @@ GPG-signed, and leaves the full `v2` suite green.
 | Fix E — role gate on the per-publish SOA re-sign | **DONE** | `1fa3f36` |
 | freeze/thaw missing `return`s (§12 item 5) | **DONE** | `82b54f5` |
 | Fix D — fail-closed applier gate | **DONE** (see finding below) | `477ea49` |
-| Fix B — option normalizer + as-configured/effective split | TODO | — |
+| Fix B — option normalizer + as-configured/effective split | **DONE** | `6c6b295` |
 | Fix C — API origination gate (both zone handlers + catalog) | TODO | — |
 | §7 diagnostics — serial visibility, all-primaries probe | TODO | — |
 | §9 forced-transfer contract (equal-serial no-op) | TODO | — |
@@ -892,3 +892,21 @@ Notes from implementation:
   signing/direct-publish class (5b/5c/5d, Fix E + normalizer), CHILD-UPDATE (a
   real `DelegationBackend.ApplyChildUpdate`), and the API actions (Fix C).
   §2's table should be re-read with this distinction in mind.
+
+- **The as-configured/effective split (§6) resolved as `SuppressedOptions`.**
+  Rather than duplicating the whole options map, `ZoneData` records only the set
+  the normalizer *stripped*; the as-configured view is the union
+  (`asConfiguredOptions()`), which `zoneDataToZoneConf` serializes. Minimal
+  surface — only the normalizer writes it and only the serializer reads it — and
+  self-healing across reloads, since both are recomputed from the config each
+  parse. `ModifyDynamicZone` carries the record across its ZoneData
+  replacement, alongside the existing Notify/ACL carry-forward.
+
+- **Normalization runs against the EFFECTIVE zone type.** At the refresher merge
+  point the `ZoneType` assignment is conditional, so the incoming type is
+  preferred when the refresher carries one; otherwise a reload flipping
+  Primary→Secondary would normalize against the stale role. Options and the
+  serial mode are normalized *together* there — assigning either separately
+  afterwards would overwrite a normalized value with the raw one — while keeping
+  their different update rules (options replace only if provided; the serial
+  mode is gated on `ConfigUpdate`, since empty means "inherit the global").

--- a/docs/2026-07-25-secondary-zones-immutable.md
+++ b/docs/2026-07-25-secondary-zones-immutable.md
@@ -1,9 +1,10 @@
 # Secondary zones are immutable — MUST-NOT-MODIFY invariant + audit
 
 **Date:** 2026-07-25, revised 2026-07-26 (rev 2, rev 2.1, rev 2.2 same day)
-**Status:** IN IMPLEMENTATION (started 2026-07-26). Design agreed; rev 2
-incorporates a code-verified re-audit of every claim in rev 1. Per-item
-progress in §14.1.
+**Status:** IMPLEMENTED (2026-07-26) — all items in §14.1 landed on
+`feature/secondary-zones-immutable`; not yet reviewed or merged, and the
+live-testbed validation Fix D calls for is still outstanding. Design agreed;
+rev 2 incorporates a code-verified re-audit of every claim in rev 1.
 **Origin:** surfaced while cooking the inbound-IXFR plan
 (`2026-07-25-inbound-ixfr-plan.md`). A confirmed serial-bump bug on secondaries
 turned out to be one instance of a whole missing invariant. This is a
@@ -851,7 +852,13 @@ Per work item, in §13's commit order:
 ## 14.1 Implementation progress
 
 Branch `feature/secondary-zones-immutable`. Every commit compiles, is
-GPG-signed, and leaves the full `v2` suite green.
+GPG-signed, and leaves the full `v2` suite green. Final state verified with
+`go vet`, `go test -race` (v2 + cli) and a full `make -C cmdv2 v2` binary build.
+
+**Still outstanding before this is merge-ready:** review, and the live foffe
+testbed validation Fix D calls for (§3, blast-radius note) — the applier gate
+changes a path that today accepts every internal update unconditionally, and
+unit tests cannot cover that the way the testbed can.
 
 | Item | Status | Commit(s) |
 |---|---|---|
@@ -862,10 +869,10 @@ GPG-signed, and leaves the full `v2` suite green.
 | freeze/thaw missing `return`s (§12 item 5) | **DONE** | `82b54f5` |
 | Fix D — fail-closed applier gate | **DONE** (see finding below) | `477ea49` |
 | Fix B — option normalizer + as-configured/effective split | **DONE** | `6c6b295` |
-| Fix C — API origination gate (both zone handlers + catalog) | TODO | — |
-| §7 diagnostics — serial visibility, all-primaries probe | TODO | — |
-| §9 forced-transfer contract (equal-serial no-op) | TODO | — |
-| §5 startup warning (global persist/unixtime + auth secondaries) | TODO | — |
+| Fix C — API origination gate (both zone handlers + catalog) | **DONE** | `b4b0744` |
+| §7 diagnostics — serial visibility, all-primaries probe | **DONE** | `4275b29` |
+| §9 forced-transfer contract (equal-serial no-op) | **DONE** (mutation-verified) | `5db9c4a` |
+| §5 startup warning (global persist/unixtime + auth secondaries) | **DONE** | `fbff7ed` |
 
 Notes from implementation:
 

--- a/v2/apihandler_catalog.go
+++ b/v2/apihandler_catalog.go
@@ -474,6 +474,21 @@ func regenerateCatalogZone(catalogZoneName string) error {
 		return fmt.Errorf("catalog zone %s not found", catalogZoneName)
 	}
 
+	// Origination gate (Fix C). This rewrites the catalog zone's own PTR/TXT
+	// records and publishes, so it is authoring — and a tdns-auth secondary of
+	// a catalog zone must mirror the catalog verbatim, exactly like any other
+	// secondary. Gating here rather than at the four handlers that call it
+	// (add/delete zone, add/delete group) covers every entry point, including
+	// any added later.
+	//
+	// This does NOT touch catalog CONSUMPTION: auto-create/auto-delete of
+	// MEMBER zones acts on other zones, never on the catalog zone, and is the
+	// entire point of RFC 9432 — a secondary that could not consume a catalog
+	// would make the feature pointless. Those options stay enabled (§4).
+	if msg := zoneOriginationRefusal(zd, "catalog zone authoring"); msg != "" {
+		return fmt.Errorf("%s", msg)
+	}
+
 	cm := GetOrCreateCatalogMembership(catalogZoneName)
 
 	zd.mu.Lock()

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -237,7 +237,7 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 					return
 				}
 				zconf := buildListZoneConf(zd, zname, kdb)
-				populateZoneDescDetail(&zconf, zd, zname, kdb)
+				populateZoneDescDetail(r.Context(), &zconf, zd, zname, kdb)
 				zones[zname] = zconf
 				resp.Zones = zones
 				return
@@ -359,6 +359,10 @@ func buildListZoneConf(zd *ZoneData, zname string, kdb *KeyDB) ZoneConf {
 	// For secondary zones, list as-written primaries from runtime state.
 	primaries := clonePeerConfs(zd.PrimariesConf)
 
+	// Value and source together, from one resolver, so the displayed source
+	// always matches the displayed value.
+	outboundMode, outboundSource := zd.EffectiveOutboundSoaSerialWithSource()
+
 	// Snapshot the notify slice under the lock — the catalog notify add/remove
 	// handlers mutate zd.Notify under zd.mu, so an unsynchronized read here would
 	// race the slice header.
@@ -415,8 +419,8 @@ func buildListZoneConf(zd *ZoneData, zname string, kdb *KeyDB) ZoneConf {
 		// is single-zone only; see populateZoneDescDetail.
 		CurrentSerial:              zd.CurrentSerial,
 		IncomingSerial:             zd.IncomingSerial,
-		EffectiveOutboundSoaSerial: zd.EffectiveOutboundSoaSerial(),
-		OutboundSoaSerialSource:    zd.outboundSoaSerialSource(),
+		EffectiveOutboundSoaSerial: outboundMode,
+		OutboundSoaSerialSource:    outboundSource,
 	}
 }
 
@@ -429,14 +433,14 @@ func buildListZoneConf(zd *ZoneData, zname string, kdb *KeyDB) ZoneConf {
 // succeeds. The bound policy is read from the immutable runtime-config snapshot
 // (ConfLive), which is lock-free: a concurrent reload publishes a fresh snapshot
 // rather than mutating in place, so pol is a stable value copy.
-func populateZoneDescDetail(zconf *ZoneConf, zd *ZoneData, zname string, kdb *KeyDB) {
+func populateZoneDescDetail(ctx context.Context, zconf *ZoneConf, zd *ZoneData, zname string, kdb *KeyDB) {
 	// Live per-primary SOA probe (§7). Single-zone only — one query per
 	// configured primary — and read-only. Per-primary rather than one value is
 	// the point: two masters disagreeing about a zone's serial is the failure
 	// that motivated the MUST-NOT-MODIFY work, and there was previously no way
 	// to see it from tdns.
 	if len(zd.Upstreams) > 0 {
-		zconf.UpstreamSerials = zd.ProbeUpstreamSerials(&Conf)
+		zconf.UpstreamSerials = zd.ProbeUpstreamSerials(ctx, &Conf)
 	}
 
 	name, source, appliedAt, ok, err := GetZoneAppliedPolicyDetail(kdb, zname)

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -147,11 +147,13 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			if !zd.Options[OptAllowUpdates] && !zd.Options[OptAllowChildUpdates] {
 				resp.Error = true
 				resp.ErrorMsg = fmt.Sprintf("FreezeZone: zone %s does not allow updates. Freeze would be a no-op", zd.ZoneName)
+				return
 			}
 
 			if zd.Options[OptFrozen] {
 				resp.Error = true
 				resp.ErrorMsg = fmt.Sprintf("FreezeZone: zone %s is already frozen", zd.ZoneName)
+				return
 			}
 
 			// zd.mu.Lock()
@@ -169,10 +171,12 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			if !zd.Options[OptAllowUpdates] && !zd.Options[OptAllowChildUpdates] {
 				resp.Error = true
 				resp.ErrorMsg = fmt.Sprintf("ThawZone: zone %s does not allow updates. Thaw would be a no-op", zd.ZoneName)
+				return
 			}
 			if !zd.Options[OptFrozen] {
 				resp.Error = true
 				resp.ErrorMsg = fmt.Sprintf("ThawZone: zone %s is not frozen", zd.ZoneName)
+				return
 			}
 			zd.SetOption(OptFrozen, false)
 			resp.Msg = fmt.Sprintf("Zone %s is now thawed", zd.ZoneName)

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -63,6 +63,18 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			return
 		}
 
+		// Origination gate (Fix C): refuse the actions that would write into
+		// the zone or advance its serial on a tdns-auth secondary. One check
+		// ahead of the switch rather than a line per case, so a command added
+		// to originationAPICommands is gated automatically.
+		if originationAPICommands[zp.Command] {
+			if msg := zoneOriginationRefusal(zd, zp.Command); msg != "" {
+				resp.Error = true
+				resp.ErrorMsg = msg
+				return
+			}
+		}
+
 		switch zp.Command {
 		case "bump":
 			// resp.Msg, err = BumpSerial(conf, cp.Zone)
@@ -142,6 +154,19 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			}
 
 		case "freeze":
+			// Role check FIRST (Fix C). OptFrozen gates DDNS and nothing else
+			// (see updateresponder.go) — it does not pause refresh — so on a
+			// secondary, where allow-updates is always normalized off, it is
+			// functionally inert. Refusing it costs nothing real.
+			//
+			// Order matters: the allow-updates precondition below would
+			// otherwise fire first and tell the operator to enable an option
+			// the normalizer immediately strips again. Name the true reason.
+			if msg := zoneOriginationRefusal(zd, "freeze"); msg != "" {
+				resp.Error = true
+				resp.ErrorMsg = msg
+				return
+			}
 			// If a zone has modifications, freezing implies that the updated
 			// zone data should be written out to disk.
 			if !zd.Options[OptAllowUpdates] && !zd.Options[OptAllowChildUpdates] {
@@ -168,6 +193,12 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			}
 
 		case "thaw":
+			// Role check first, same reasoning as freeze above.
+			if msg := zoneOriginationRefusal(zd, "thaw"); msg != "" {
+				resp.Error = true
+				resp.ErrorMsg = msg
+				return
+			}
 			if !zd.Options[OptAllowUpdates] && !zd.Options[OptAllowChildUpdates] {
 				resp.Error = true
 				resp.ErrorMsg = fmt.Sprintf("ThawZone: zone %s does not allow updates. Thaw would be a no-op", zd.ZoneName)
@@ -843,6 +874,17 @@ func APIzoneDsync(ctx context.Context, app *AppDetails, refreshq chan ZoneRefres
 			resp.Error = true
 			resp.ErrorMsg = fmt.Sprintf("Zone %q is unknown", zdp.Zone)
 			return
+		}
+
+		// Origination gate (Fix C). The publish/unpublish-dsync-rrset commands
+		// write the _dsync DSYNC RRset into the zone, which a secondary must
+		// not do — publishing DSYNC is the primary's job (or an agent's).
+		if originationAPICommands[zdp.Command] {
+			if msg := zoneOriginationRefusal(zd, zdp.Command); msg != "" {
+				resp.Error = true
+				resp.ErrorMsg = msg
+				return
+			}
 		}
 
 		// Most of the dsync commands relate to the child role. The exception is the publish/unpublish commands

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -408,6 +408,15 @@ func buildListZoneConf(zd *ZoneData, zname string, kdb *KeyDB) ZoneConf {
 		EffectiveDnssecPolicy:  zd.DnssecPolicyName,
 		DnssecPolicyOverridden: overridden,
 		DnssecPolicyConfigBase: configPolicy,
+
+		// Serial visibility (§7). Free — both are already on ZoneData, no
+		// network — so the bulk listing carries them and `zone list -v` can
+		// show outbound vs inbound side by side. The live per-primary probe
+		// is single-zone only; see populateZoneDescDetail.
+		CurrentSerial:              zd.CurrentSerial,
+		IncomingSerial:             zd.IncomingSerial,
+		EffectiveOutboundSoaSerial: zd.EffectiveOutboundSoaSerial(),
+		OutboundSoaSerialSource:    zd.outboundSoaSerialSource(),
 	}
 }
 
@@ -421,6 +430,15 @@ func buildListZoneConf(zd *ZoneData, zname string, kdb *KeyDB) ZoneConf {
 // (ConfLive), which is lock-free: a concurrent reload publishes a fresh snapshot
 // rather than mutating in place, so pol is a stable value copy.
 func populateZoneDescDetail(zconf *ZoneConf, zd *ZoneData, zname string, kdb *KeyDB) {
+	// Live per-primary SOA probe (§7). Single-zone only — one query per
+	// configured primary — and read-only. Per-primary rather than one value is
+	// the point: two masters disagreeing about a zone's serial is the failure
+	// that motivated the MUST-NOT-MODIFY work, and there was previously no way
+	// to see it from tdns.
+	if len(zd.Upstreams) > 0 {
+		zconf.UpstreamSerials = zd.ProbeUpstreamSerials(&Conf)
+	}
+
 	name, source, appliedAt, ok, err := GetZoneAppliedPolicyDetail(kdb, zname)
 	if err != nil {
 		// Surface the failure distinctly (not as an absent record) so the CLI can

--- a/v2/cli/zone_cmds.go
+++ b/v2/cli/zone_cmds.go
@@ -860,6 +860,24 @@ func zoneBaseDetail(name string, zconf tdns.ZoneConf) string {
 	sort.Strings(opts)
 	fmt.Fprintf(&b, "\tType: %s\tStore: %s\tOptions: %v\n", zconf.Type, zconf.Store, opts)
 
+	// Serial visibility (design doc §7). Emitted only when there is something
+	// to show, which also keeps the `zone list -v` golden (a fixture with zero
+	// serials) byte-identical — see TestVerboseListZone_GoldenParity.
+	//
+	// Outbound is what we advertise to our downstreams, inbound what we last
+	// received from upstream. On a correct secondary they are equal; a gap is
+	// exactly the drift the MUST-NOT-MODIFY work exists to prevent.
+	if zconf.CurrentSerial != 0 || zconf.IncomingSerial != 0 {
+		fmt.Fprintf(&b, "\tSerial: outbound %d\tinbound %d\n", zconf.CurrentSerial, zconf.IncomingSerial)
+	}
+	if zconf.EffectiveOutboundSoaSerial != "" {
+		src := zconf.OutboundSoaSerialSource
+		if src == "" {
+			src = "unknown"
+		}
+		fmt.Fprintf(&b, "\tOutbound serial mode: %s (from: %s)\n", zconf.EffectiveOutboundSoaSerial, src)
+	}
+
 	if zconf.EffectiveDnssecPolicy != "" {
 		pol := zconf.EffectiveDnssecPolicy
 		if zconf.DnssecPolicyOverridden {
@@ -937,6 +955,27 @@ func DescribeZone(zconf tdns.ZoneConf) string {
 
 	// Section 2: bound-policy algorithm / lifetime / sig-validity detail.
 	b.WriteString(describePolicyDetail(zconf))
+
+	// Section 3: live per-primary SOA serials (design doc §7). `zone desc` only
+	// — one query per primary. Showing them individually is the point: two
+	// masters serving the same zone at different serials is the split-brain
+	// that motivated the MUST-NOT-MODIFY work, and it was previously invisible
+	// from tdns. A primary that could not be probed is listed with its error
+	// rather than omitted — an unreachable master is itself diagnostic.
+	if len(zconf.UpstreamSerials) > 0 {
+		b.WriteString("\tUpstream serials:\n")
+		for _, us := range zconf.UpstreamSerials {
+			if us.Err != "" {
+				fmt.Fprintf(&b, "\t\t%s: (probe failed: %s)\n", us.Addr, us.Err)
+				continue
+			}
+			marker := ""
+			if zconf.IncomingSerial != 0 && us.Serial != zconf.IncomingSerial {
+				marker = "\t<-- differs from our inbound serial"
+			}
+			fmt.Fprintf(&b, "\t\t%s: %d%s\n", us.Addr, us.Serial, marker)
+		}
+	}
 
 	return b.String()
 }

--- a/v2/cli/zone_serial_display_test.go
+++ b/v2/cli/zone_serial_display_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	tdns "github.com/johanix/tdns/v2"
+)
+
+// §7 serial visibility. The condition that motivated the MUST-NOT-MODIFY work
+// — two masters serving one zone at different serials — was previously
+// invisible from tdns. These pin that it is now rendered, and that adding it
+// did not disturb the `zone list -v` golden.
+
+// TestZoneBaseDetailShowsSerials covers the free half: outbound vs inbound,
+// shown side by side wherever the base block is rendered.
+func TestZoneBaseDetailShowsSerials(t *testing.T) {
+	zconf := tdns.ZoneConf{
+		Name: "example.", Type: "secondary", Store: "MapZone",
+		CurrentSerial: 42, IncomingSerial: 42,
+		EffectiveOutboundSoaSerial: "keep", OutboundSoaSerialSource: "global",
+	}
+	out := zoneBaseDetail("example.", zconf)
+
+	if !strings.Contains(out, "Serial: outbound 42\tinbound 42") {
+		t.Errorf("serials not rendered:\n%s", out)
+	}
+	if !strings.Contains(out, "Outbound serial mode: keep (from: global)") {
+		t.Errorf("outbound mode/source not rendered:\n%s", out)
+	}
+}
+
+// TestZoneBaseDetailOmitsUnsetSerials pins the conditional: a zone with no
+// serial information prints no serial line. This is also what keeps the
+// `zone list -v` golden (a fixture with zero serials) byte-identical.
+func TestZoneBaseDetailOmitsUnsetSerials(t *testing.T) {
+	zconf := tdns.ZoneConf{Name: "example.", Type: "primary", Store: "MapZone"}
+	out := zoneBaseDetail("example.", zconf)
+
+	if strings.Contains(out, "Serial:") {
+		t.Errorf("serial line rendered for a zone with no serials:\n%s", out)
+	}
+	if strings.Contains(out, "Outbound serial mode:") {
+		t.Errorf("outbound mode rendered when unset:\n%s", out)
+	}
+}
+
+// TestDescribeZoneShowsUpstreamDisagreement is the diagnostic itself: per
+// primary, with the one that disagrees with our inbound serial flagged.
+func TestDescribeZoneShowsUpstreamDisagreement(t *testing.T) {
+	zconf := tdns.ZoneConf{
+		Name: "example.", Type: "secondary", Store: "MapZone",
+		CurrentSerial: 42, IncomingSerial: 42,
+		UpstreamSerials: []tdns.UpstreamSerial{
+			{Addr: "192.0.2.1:53", Serial: 42},   // agrees
+			{Addr: "192.0.2.2:53", Serial: 5000}, // the split-brain
+			{Addr: "192.0.2.3:53", Err: "i/o timeout"},
+		},
+	}
+	out := DescribeZone(zconf)
+
+	if !strings.Contains(out, "Upstream serials:") {
+		t.Fatalf("no upstream serial section:\n%s", out)
+	}
+	if !strings.Contains(out, "192.0.2.2:53: 5000\t<-- differs") {
+		t.Errorf("disagreeing primary not flagged:\n%s", out)
+	}
+	if strings.Contains(out, "192.0.2.1:53: 42\t<-- differs") {
+		t.Errorf("agreeing primary wrongly flagged:\n%s", out)
+	}
+	// An unreachable primary is itself diagnostic and must be listed, not
+	// silently dropped.
+	if !strings.Contains(out, "192.0.2.3:53: (probe failed: i/o timeout)") {
+		t.Errorf("failed probe not surfaced:\n%s", out)
+	}
+}
+
+// TestDescribeZoneOmitsEmptyUpstreamSection keeps `zone desc` quiet for a
+// primary, which has no upstreams to probe.
+func TestDescribeZoneOmitsEmptyUpstreamSection(t *testing.T) {
+	zconf := tdns.ZoneConf{Name: "example.", Type: "primary", Store: "MapZone"}
+	if out := DescribeZone(zconf); strings.Contains(out, "Upstream serials:") {
+		t.Errorf("upstream section rendered with no upstreams:\n%s", out)
+	}
+}

--- a/v2/db_outgoing_serial.go
+++ b/v2/db_outgoing_serial.go
@@ -18,3 +18,18 @@ func (kdb *KeyDB) LoadOutgoingSerial(zone string) (uint32, error) {
 	}
 	return serial, nil
 }
+
+// DeleteOutgoingSerial drops any persisted outbound serial for a zone. Used
+// when a zone is a tdns-auth secondary that may not originate content: its
+// serial is upstream's property, so a value persisted earlier (before the zone
+// became a mirror, or by a pre-fix build that bumped secondaries) must not
+// linger — otherwise it sits in the DB waiting for some future change to the
+// restore path to resurrect an inflated serial. Deleting a row that does not
+// exist is not an error.
+func (kdb *KeyDB) DeleteOutgoingSerial(zone string) error {
+	_, err := kdb.DB.Exec(`DELETE FROM OutgoingSerials WHERE zone = ?`, zone)
+	if err != nil {
+		return fmt.Errorf("DeleteOutgoingSerial: %w", err)
+	}
+	return nil
+}

--- a/v2/dynamic_primary.go
+++ b/v2/dynamic_primary.go
@@ -463,6 +463,11 @@ func (conf *Config) provisionDynamicPrimary(ctx context.Context, in DynamicZoneI
 		UpdatePolicy:   spec.Policy,
 		DnssecPolicy:   spec.Zconf.DnssecPolicy,
 		Force:          true, // load from file regardless of serial
+
+		// Template-expanded: a template carrying outbound_soa_serial gives
+		// every zone stamped from it that serial policy (the intended
+		// granularity — see the per-zone config model in the design doc).
+		OutboundSoaSerial: spec.Zconf.OutboundSoaSerial,
 	}
 	if err := conf.enqueueRefresh(ctx, zr); err != nil {
 		// Mark the registered-but-unscheduled zone so list-dynamic shows a

--- a/v2/dynamic_primary.go
+++ b/v2/dynamic_primary.go
@@ -380,26 +380,33 @@ func (conf *Config) provisionDynamicPrimary(ctx context.Context, in DynamicZoneI
 	// engine's config merge, so everything must be carried here.
 	msc := ConfLive().MultiSigner[spec.Zconf.MultiSigner]
 	zd := &ZoneData{
-		ZoneName:         name,
-		ZoneType:         Primary,
-		ZoneStore:        MapZone,
-		Zonefile:         spec.Zconf.Zonefile,
-		Template:         in.Template,
-		Notify:           normalizePeerAddrs(spec.Zconf.Notify),
-		AllowNotify:      spec.Zconf.AllowNotify,
-		Downstreams:      spec.Zconf.Downstreams,
-		DownstreamAuth:   spec.Zconf.DownstreamAuth,
-		Logger:           log.Default(),
-		Options:          options,
-		UpdatePolicy:     spec.Policy,
-		DnssecPolicyName: spec.Zconf.DnssecPolicy, // config-base name; struct bound post-Ready
-		MultiSigner:      &msc,
-		DelegationSyncQ:  conf.Internal.DelegationSyncQ,
-		Status:           ZoneStatusPending,
-		Data:             core.NewCmap[OwnerData](),
-		KeyDB:            conf.Internal.KeyDB,
-		FirstZoneLoad:    true,
-		publishCadence:   spec.PublishCadence,
+		ZoneName: name,
+		ZoneType: Primary,
+		// Set directly, like every other field here: this ZoneData is
+		// pre-registered with ZoneType already Primary, and the RefreshEngine
+		// merge block that would otherwise copy it off the ZoneRefresher is
+		// gated on `zd.ZoneType == 0`. Relying on the zr path alone would
+		// silently drop a template's outbound_soa_serial and leave the zone on
+		// the server-global default.
+		OutboundSoaSerial: spec.Zconf.OutboundSoaSerial,
+		ZoneStore:         MapZone,
+		Zonefile:          spec.Zconf.Zonefile,
+		Template:          in.Template,
+		Notify:            normalizePeerAddrs(spec.Zconf.Notify),
+		AllowNotify:       spec.Zconf.AllowNotify,
+		Downstreams:       spec.Zconf.Downstreams,
+		DownstreamAuth:    spec.Zconf.DownstreamAuth,
+		Logger:            log.Default(),
+		Options:           options,
+		UpdatePolicy:      spec.Policy,
+		DnssecPolicyName:  spec.Zconf.DnssecPolicy, // config-base name; struct bound post-Ready
+		MultiSigner:       &msc,
+		DelegationSyncQ:   conf.Internal.DelegationSyncQ,
+		Status:            ZoneStatusPending,
+		Data:              core.NewCmap[OwnerData](),
+		KeyDB:             conf.Internal.KeyDB,
+		FirstZoneLoad:     true,
+		publishCadence:    spec.PublishCadence,
 	}
 
 	// First-load callbacks, mirroring what ParseZones registers for static

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -305,6 +305,8 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 				Options:        specOptions,
 				UpdatePolicy:   spec.Policy,
 				DnssecPolicy:   spec.Zconf.DnssecPolicy,
+
+				OutboundSoaSerial: spec.Zconf.OutboundSoaSerial,
 			}
 			select {
 			case conf.Internal.RefreshZoneCh <- zr:
@@ -381,6 +383,8 @@ func (conf *Config) LoadDynamicZoneFiles(ctx context.Context) error {
 			ConfigUpdate:   true, // config-bearing (persisted dynamic zone)
 			Zonefile:       zconf.Zonefile,
 			Options:        options,
+
+			OutboundSoaSerial: zconf.OutboundSoaSerial,
 		}
 
 		// Blocking send, exactly like the static-zone enqueue in ParseZones.
@@ -477,19 +481,20 @@ func zoneDataToZoneConf(zd *ZoneData, zoneDirectory string) ZoneConf {
 	}
 
 	zconf := ZoneConf{
-		Name:           zd.ZoneName,
-		Zonefile:       zoneFilePath,
-		Type:           typeStr,
-		Store:          storeStr,
-		Primaries:      clonePeerConfs(zd.PrimariesConf),
-		Notify:         zd.Notify,
-		AllowNotify:    zd.AllowNotify,
-		Downstreams:    zd.Downstreams,
-		DownstreamAuth: zd.DownstreamAuth,
-		OptionsStrs:    optionsStrs,
-		Template:       zd.Template,
-		SourceCatalog:  zd.SourceCatalog,
-		ApiManaged:     zd.Options[OptApiManagedZone],
+		Name:              zd.ZoneName,
+		Zonefile:          zoneFilePath,
+		Type:              typeStr,
+		Store:             storeStr,
+		OutboundSoaSerial: zd.OutboundSoaSerial,
+		Primaries:         clonePeerConfs(zd.PrimariesConf),
+		Notify:            zd.Notify,
+		AllowNotify:       zd.AllowNotify,
+		Downstreams:       zd.Downstreams,
+		DownstreamAuth:    zd.DownstreamAuth,
+		OptionsStrs:       optionsStrs,
+		Template:          zd.Template,
+		SourceCatalog:     zd.SourceCatalog,
+		ApiManaged:        zd.Options[OptApiManagedZone],
 		// Note: We don't serialize Frozen, Dirty, Error, ErrorType, ErrorMsg, RefreshCount
 		// as these are runtime state, not configuration
 	}
@@ -1103,6 +1108,11 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	allowNotify := append([]AclEntry(nil), oldZd.AllowNotify...)
 	downstreams := append([]AclEntry(nil), oldZd.Downstreams...)
 	downstreamAuth := append([]string(nil), oldZd.DownstreamAuth...)
+	// Same reason as the ACLs above: modify does not carry an outbound serial
+	// mode (there is deliberately no API knob for it), so without this a
+	// TSIG-only modify would silently reset a zone that has one to the global
+	// default.
+	outboundSoaSerial := oldZd.OutboundSoaSerial
 	oldZd.mu.Unlock()
 
 	newZd := &ZoneData{
@@ -1120,6 +1130,8 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		Status:         ZoneStatusPending,
 		Data:           core.NewCmap[OwnerData](),
 		KeyDB:          conf.Internal.KeyDB,
+
+		OutboundSoaSerial: outboundSoaSerial,
 	}
 	// Commit the staged inline key just before persistence so the rewritten file
 	// includes it; roll it back if persistence fails.
@@ -1157,6 +1169,8 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		ZoneStore:     MapZone,
 		Options:       options,
 		Force:         true,
+
+		OutboundSoaSerial: outboundSoaSerial,
 	}
 	if err := conf.enqueueRefresh(ctx, zr); err != nil {
 		return "", fmt.Errorf("zone %s modified but failed to schedule refresh: %w", name, err)

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -453,9 +453,15 @@ func zoneDataToZoneConf(zd *ZoneData, zoneDirectory string) ZoneConf {
 		zoneFilePath = filepath.Join(zoneDirectory, zoneFileName)
 	}
 
-	// Convert options to strings
+	// Convert options to strings. Serialize the AS-CONFIGURED set, not the
+	// effective one: this file is REGENERATED from live state on every
+	// successful refresh of a persistable dynamic zone, so writing the
+	// post-normalization set would permanently delete the operator's
+	// origination options from their own config — after which the warning
+	// clears and the misconfiguration becomes invisible, silently "fixed" by
+	// destroying the evidence.
 	optionsStrs := make([]string, 0)
-	for opt, enabled := range zd.Options {
+	for opt, enabled := range zd.asConfiguredOptions() {
 		if enabled {
 			if optStr, ok := ZoneOptionToString[opt]; ok {
 				// Skip internal options that shouldn't be in config.
@@ -1113,6 +1119,10 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	// TSIG-only modify would silently reset a zone that has one to the global
 	// default.
 	outboundSoaSerial := oldZd.OutboundSoaSerial
+	// Carry the suppressed-options record across the replacement too, so the
+	// as-configured view survives a modify and the operator's origination
+	// options are not dropped from the persisted config by the next rewrite.
+	suppressedOptions := oldZd.SuppressedOptions
 	oldZd.mu.Unlock()
 
 	newZd := &ZoneData{
@@ -1132,6 +1142,7 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		KeyDB:          conf.Internal.KeyDB,
 
 		OutboundSoaSerial: outboundSoaSerial,
+		SuppressedOptions: suppressedOptions,
 	}
 	// Commit the staged inline key just before persistence so the rewritten file
 	// includes it; roll it back if persistence fails.

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -1113,8 +1113,17 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 		// mutable map with oldZd, or the B5 replace-not-mutate strategy breaks
 		// (an in-flight refresh on oldZd and later updates on newZd would race on
 		// one map guarded by two different mutexes).
-		options = make(map[ZoneOption]bool, len(oldZd.Options))
-		for k, v := range oldZd.Options {
+		//
+		// Carry the AS-CONFIGURED set, not the effective one. Copying only
+		// oldZd.Options would hand the normalizer a set that has already been
+		// stripped: it would find nothing to strip, return an empty suppressed
+		// set, and that empty set would then overwrite the carried-forward
+		// record — permanently deleting the operator's origination options from
+		// the persisted config on the next rewrite. Re-normalizing the
+		// as-configured set instead reproduces the same suppressed record.
+		src := oldZd.asConfiguredOptions()
+		options = make(map[ZoneOption]bool, len(src))
+		for k, v := range src {
 			options[k] = v
 		}
 	} else {

--- a/v2/dynamic_zones.go
+++ b/v2/dynamic_zones.go
@@ -901,6 +901,15 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 	if fromAPI {
 		options[OptApiManagedZone] = true
 	}
+	// Normalize here, at the option-finalization site, rather than relying on
+	// the RefreshEngine merge that happens later: the zone is registered and
+	// persisted below, so without this it would be live (and written to the
+	// dynamic config) carrying origination options it may not act on, with no
+	// ConfigWarning, until the async refresh caught up.
+	normOptions, normSerial, suppressedOptions, normMsg := normalizeOptionsForRole(
+		Globals.App.Type, in.Type, options, "")
+	options = normOptions
+	_ = normSerial // no per-zone serial mode on the API add path (no knob)
 
 	// Resolve hostname primaries to addresses via the IMR at add time (not only
 	// on the next restart). Zero resolved on a secondary -> reject the add.
@@ -924,6 +933,12 @@ func (conf *Config) ProvisionDynamicZone(ctx context.Context, in DynamicZoneInpu
 		Status:        ZoneStatusPending,
 		Data:          core.NewCmap[OwnerData](),
 		KeyDB:         conf.Internal.KeyDB,
+
+		SuppressedOptions: suppressedOptions,
+	}
+	if normMsg != "" {
+		lg.Warn("zone option normalization", "zone", name, "detail", normMsg)
+		zd.SetError(ConfigWarning, "%s", normMsg)
 	}
 
 	// Commit the staged inline key just before registration/persistence (so the
@@ -1125,6 +1140,19 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	suppressedOptions := oldZd.SuppressedOptions
 	oldZd.mu.Unlock()
 
+	// Normalize the SUBMITTED options, not just the carried-forward ones.
+	// Without this, `zone modify --options allow-updates` on a secondary would
+	// install them live and persist them with a STALE SuppressedOptions record
+	// and no ConfigWarning — re-enabling exactly what the normalizer exists to
+	// strip. Recomputing here also means the suppressed set describes the
+	// options actually submitted rather than whatever the previous incarnation
+	// of this zone happened to carry.
+	normOptions, normSerial, normSuppressed, normMsg := normalizeOptionsForRole(
+		Globals.App.Type, oldZd.ZoneType, options, outboundSoaSerial)
+	options = normOptions
+	outboundSoaSerial = normSerial
+	suppressedOptions = normSuppressed
+
 	newZd := &ZoneData{
 		ZoneName:       name,
 		ZoneType:       oldZd.ZoneType,
@@ -1149,6 +1177,10 @@ func (conf *Config) ModifyDynamicZone(ctx context.Context, in DynamicZoneInput) 
 	rollbackKey, cerr := conf.commitStagedTsigKey(staged)
 	if cerr != nil {
 		return "", fmt.Errorf("zone %s: %w", name, cerr)
+	}
+	if normMsg != "" {
+		lg.Warn("zone option normalization", "zone", name, "detail", normMsg)
+		newZd.SetError(ConfigWarning, "%s", normMsg)
 	}
 	Zones.Set(name, newZd)
 

--- a/v2/forced_transfer_test.go
+++ b/v2/forced_transfer_test.go
@@ -1,0 +1,61 @@
+package tdns
+
+import "testing"
+
+// §9, the forced-transfer contract: a forced transfer MUST perform the
+// transfer and apply whatever upstream has, including a serial LOWER than or
+// EQUAL to our own.
+//
+// This matters because a forced retransfer is the only remedy for a downstream
+// wedged behind a secondary whose serial stepped backwards (see the migration
+// section of the design doc), and the only escape hatch from a zone holding
+// corrupt data under a current serial. Both properties were previously either
+// incidental or outright broken.
+
+// TestForcedTransferReappliesEqualSerial covers the case that was broken: a
+// forced retransfer of an already-current zone was discarded, silently, while
+// reporting success — so `force` did not mean force.
+func TestForcedTransferReappliesEqualSerial(t *testing.T) {
+	tests := []struct {
+		name              string
+		incoming, current uint32
+		force             bool
+		wantDiscard       bool
+	}{
+		{"unforced, unchanged serial: no-op refresh", 42, 42, false, true},
+		{"FORCED, unchanged serial: must re-apply", 42, 42, true, false},
+		{"unforced, upstream advanced: apply", 43, 42, false, false},
+		{"forced, upstream advanced: apply", 43, 42, true, false},
+		// The migration case: upstream is BEHIND us because our serial was
+		// inflated before the mirror fix. A forced retransfer is the operator's
+		// only remedy, so it must never be discarded.
+		{"unforced, upstream behind: apply", 42, 5000, false, false},
+		{"FORCED, upstream behind: apply (the migration remedy)", 42, 5000, true, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldDiscardUnchangedTransfer(tc.incoming, tc.current, tc.force)
+			if got != tc.wantDiscard {
+				t.Errorf("shouldDiscardUnchangedTransfer(%d, %d, force=%v) = %v, want %v",
+					tc.incoming, tc.current, tc.force, got, tc.wantDiscard)
+			}
+		})
+	}
+}
+
+// TestForcedTransferNeverDiscarded is the invariant stated directly: whatever
+// the serials, a forced transfer is never thrown away. Pins the contract
+// against a future "tightening" of the comparison, which would otherwise break
+// the migration remedy silently — silently, because the forced transfer would
+// still report success while changing nothing.
+func TestForcedTransferNeverDiscarded(t *testing.T) {
+	for _, incoming := range []uint32{0, 1, 41, 42, 43, 5000} {
+		for _, current := range []uint32{0, 42, 5000} {
+			if shouldDiscardUnchangedTransfer(incoming, current, true) {
+				t.Errorf("forced transfer discarded (incoming=%d current=%d): force must mean force",
+					incoming, current)
+			}
+		}
+	}
+}

--- a/v2/outbound_soa_serial_test.go
+++ b/v2/outbound_soa_serial_test.go
@@ -1,0 +1,146 @@
+package tdns
+
+import "testing"
+
+// Per-zone outbound_soa_serial (design doc §5). The mode used to be
+// server-global; these tests pin the tier resolution (zone -> global ->
+// "keep"), the template interaction, and the persistence round-trip.
+
+// TestEffectiveOutboundSoaSerialTiers pins the resolution order of
+// zd.EffectiveOutboundSoaSerial(): an explicit per-zone value wins, an empty
+// one falls through to the server-global setting on the KeyDB, and with
+// neither set the documented default ("keep") applies.
+func TestEffectiveOutboundSoaSerialTiers(t *testing.T) {
+	tests := []struct {
+		name   string
+		zone   string // zd.OutboundSoaSerial (per-zone)
+		global string // kdb.OutboundSoaSerial (server-global)
+		want   string
+	}{
+		{"zone wins over global", OutboundSoaSerialPersist, OutboundSoaSerialKeep, OutboundSoaSerialPersist},
+		{"zone keep beats global persist", OutboundSoaSerialKeep, OutboundSoaSerialPersist, OutboundSoaSerialKeep},
+		{"empty zone inherits global", "", OutboundSoaSerialUnixtime, OutboundSoaSerialUnixtime},
+		{"empty zone inherits global persist", "", OutboundSoaSerialPersist, OutboundSoaSerialPersist},
+		{"neither set defaults to keep", "", "", OutboundSoaSerialKeep},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			zd := &ZoneData{
+				ZoneName:          "example.",
+				OutboundSoaSerial: tc.zone,
+				KeyDB:             &KeyDB{OutboundSoaSerial: tc.global},
+			}
+			if got := zd.EffectiveOutboundSoaSerial(); got != tc.want {
+				t.Errorf("EffectiveOutboundSoaSerial() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveOutboundSoaSerialNilKeyDB guards the nil-KeyDB case: several
+// unit-test and early-init paths build a ZoneData with no KeyDB, and the
+// resolver must not panic there.
+func TestEffectiveOutboundSoaSerialNilKeyDB(t *testing.T) {
+	zd := &ZoneData{ZoneName: "example."}
+	if got := zd.EffectiveOutboundSoaSerial(); got != OutboundSoaSerialKeep {
+		t.Errorf("nil KeyDB: got %q, want %q", got, OutboundSoaSerialKeep)
+	}
+
+	zd.OutboundSoaSerial = OutboundSoaSerialUnixtime
+	if got := zd.EffectiveOutboundSoaSerial(); got != OutboundSoaSerialUnixtime {
+		t.Errorf("nil KeyDB with per-zone value: got %q, want %q", got, OutboundSoaSerialUnixtime)
+	}
+}
+
+// TestNextOutboundSerialUsesPerZoneMode pins that the serial arithmetic reads
+// the EFFECTIVE mode, not the global one: a zone in unixtime mode jumps to a
+// timestamp even when the server-global default is keep, and a zone that
+// explicitly says keep stays on prev+1 under a unixtime global.
+func TestNextOutboundSerialUsesPerZoneMode(t *testing.T) {
+	// Per-zone unixtime under a global keep: must jump far past prev+1.
+	zd := &ZoneData{
+		ZoneName:          "example.",
+		CurrentSerial:     10,
+		OutboundSoaSerial: OutboundSoaSerialUnixtime,
+		KeyDB:             &KeyDB{OutboundSoaSerial: OutboundSoaSerialKeep},
+	}
+	if got := nextOutboundSerial(zd); got <= 11 {
+		t.Errorf("per-zone unixtime: got %d, want a unix timestamp (>> 11)", got)
+	}
+
+	// Per-zone keep under a global unixtime: must be plain prev+1.
+	zd = &ZoneData{
+		ZoneName:          "example.",
+		CurrentSerial:     10,
+		OutboundSoaSerial: OutboundSoaSerialKeep,
+		KeyDB:             &KeyDB{OutboundSoaSerial: OutboundSoaSerialUnixtime},
+	}
+	if got := nextOutboundSerial(zd); got != 11 {
+		t.Errorf("per-zone keep: got %d, want 11", got)
+	}
+}
+
+// TestExpandTemplateOutboundSoaSerial covers the template interaction, which is
+// the intended granularity for this setting: a template value fills a zone that
+// is silent, and an explicit zone value wins. The second case is the one worth
+// pinning — ExpandTemplate's gap-fill treats "already set" as "non-zero", so an
+// explicit "keep" under a "persist" template survives only because the field is
+// a string rather than a bool.
+func TestExpandTemplateOutboundSoaSerial(t *testing.T) {
+	tmpl := &ZoneConf{Type: "secondary", OutboundSoaSerial: OutboundSoaSerialPersist}
+
+	// Zone silent -> inherits the template's mode.
+	z, err := ExpandTemplate(ZoneConf{Name: "a.example"}, tmpl, AppTypeAuth)
+	if err != nil {
+		t.Fatalf("ExpandTemplate: %v", err)
+	}
+	if z.OutboundSoaSerial != OutboundSoaSerialPersist {
+		t.Errorf("gap-fill: got %q, want %q", z.OutboundSoaSerial, OutboundSoaSerialPersist)
+	}
+
+	// Zone explicit -> wins, including the "keep beats persist" direction.
+	z, err = ExpandTemplate(
+		ZoneConf{Name: "b.example", OutboundSoaSerial: OutboundSoaSerialKeep}, tmpl, AppTypeAuth)
+	if err != nil {
+		t.Fatalf("ExpandTemplate: %v", err)
+	}
+	if z.OutboundSoaSerial != OutboundSoaSerialKeep {
+		t.Errorf("explicit zone value: got %q, want %q", z.OutboundSoaSerial, OutboundSoaSerialKeep)
+	}
+
+	// Template silent -> zone keeps its empty value (inherit-global), rather
+	// than acquiring some default from the expansion.
+	z, err = ExpandTemplate(ZoneConf{Name: "c.example"}, &ZoneConf{Type: "secondary"}, AppTypeAuth)
+	if err != nil {
+		t.Fatalf("ExpandTemplate: %v", err)
+	}
+	if z.OutboundSoaSerial != "" {
+		t.Errorf("both silent: got %q, want empty (inherit global)", z.OutboundSoaSerial)
+	}
+}
+
+// TestZoneDataToZoneConfOutboundSoaSerial pins the dynamic-zone persistence
+// round-trip. The dynamic config file is REGENERATED from live state on every
+// successful refresh, so a field the serializer drops is silently lost from the
+// operator's persisted config.
+func TestZoneDataToZoneConfOutboundSoaSerial(t *testing.T) {
+	zd := &ZoneData{
+		ZoneName:          "dyn.example.",
+		ZoneType:          Secondary,
+		ZoneStore:         MapZone,
+		Options:           map[ZoneOption]bool{},
+		OutboundSoaSerial: OutboundSoaSerialPersist,
+	}
+	if got := zoneDataToZoneConf(zd, "/tmp/zones").OutboundSoaSerial; got != OutboundSoaSerialPersist {
+		t.Errorf("serialized OutboundSoaSerial = %q, want %q", got, OutboundSoaSerialPersist)
+	}
+
+	// An unset mode must serialize as empty (inherit-global), NOT as a
+	// materialized "keep" — otherwise a zone that merely inherits the global
+	// would get pinned to keep the first time its config is rewritten.
+	zd.OutboundSoaSerial = ""
+	if got := zoneDataToZoneConf(zd, "/tmp/zones").OutboundSoaSerial; got != "" {
+		t.Errorf("unset OutboundSoaSerial serialized as %q, want empty", got)
+	}
+}

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -905,6 +905,21 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		}
 
 		options := parseZoneOptions(conf, zname, zconf, zd)
+
+		// Strip origination settings a tdns-auth secondary may not act on
+		// (Fix B). This MUST run before activateUpdatePolicy below: that
+		// function returns a HARD error — quarantining the zone — when
+		// allow-child-updates is set without a delegationbackend, and a
+		// secondary configured that way should get the soft warning and keep
+		// serving, not be taken out of service. Running here also means the
+		// delegation-sync setup block further down sees delegation-sync-parent
+		// already false, so SetupZoneSync never registers for a secondary and
+		// the DSYNC vector is closed at parse time with no extra wiring.
+		//
+		// zd.ZoneType is not yet assigned at this point in the parse, so the
+		// locally resolved zonetype is passed explicitly.
+		options, zconf.OutboundSoaSerial = zd.applyOptionNormalization(zonetype, options, zconf.OutboundSoaSerial)
+
 		var outopts []string
 		for o, val := range options {
 			if val {

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -925,15 +925,6 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// locally resolved zonetype is passed explicitly.
 		options, zconf.OutboundSoaSerial = zd.applyOptionNormalization(zonetype, options, zconf.OutboundSoaSerial)
 
-		// Collect zones where a GLOBAL persist/unixtime is being suppressed,
-		// using the role and per-zone mode resolved right here. Doing this from
-		// the registry afterwards would read zd.ZoneType before the
-		// RefreshEngine has assigned it. A zone with its own explicit mode is
-		// excluded: it already drew the normalizer's per-zone warning.
-		if serialSuppressionCandidate(Globals.App.Type, zonetype, options, zconf.OutboundSoaSerial) {
-			serialSuppressedZones = append(serialSuppressedZones, zname)
-		}
-
 		var outopts []string
 		for o, val := range options {
 			if val {
@@ -1165,6 +1156,20 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// Leader election OnFirstLoad is registered in StartAgent() (not here)
 		// because LeaderElectionManager doesn't exist until StartAgent runs.
 		// MP zone KEY publication is registered in tdns-mp's StartAgent.
+
+		// Collect zones where a GLOBAL persist/unixtime outbound mode is being
+		// suppressed, from the role and per-zone mode resolved in THIS pass.
+		// (Reading them back off the registry instead would see a ZoneType the
+		// RefreshEngine has not assigned yet — see serialSuppressionCandidate.)
+		//
+		// Deliberately here, at the bottom of the loop body: every `continue`
+		// above rejects the zone (bad ACL, invalid update policy, unusable
+		// store, ...), and a rejected zone is not serving, so reporting it as a
+		// secondary with a suppressed serial policy would be noise about a zone
+		// that is not running at all.
+		if serialSuppressionCandidate(Globals.App.Type, zonetype, options, zconf.OutboundSoaSerial) {
+			serialSuppressedZones = append(serialSuppressedZones, zname)
+		}
 
 		// Non-zone-serving app types skip zone refresh. Everything
 		// else (Auth, Agent, downstream MP/NM/ES roles) queues each

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -645,6 +645,10 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 	lgConfig.Debug("parsing authoritative zones", "count", len(conf.Zones))
 	var all_zones []string
 	var broken_zones []string
+	// Zones where a GLOBAL persist/unixtime outbound mode is being suppressed
+	// because the zone is a mirroring secondary. Collected in-loop from the
+	// freshly resolved role/mode; see warnGlobalOutboundSerialSuppressed.
+	var serialSuppressedZones []string
 
 	// Process each zone configuration
 	for i := range conf.Zones {
@@ -921,6 +925,15 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		// locally resolved zonetype is passed explicitly.
 		options, zconf.OutboundSoaSerial = zd.applyOptionNormalization(zonetype, options, zconf.OutboundSoaSerial)
 
+		// Collect zones where a GLOBAL persist/unixtime is being suppressed,
+		// using the role and per-zone mode resolved right here. Doing this from
+		// the registry afterwards would read zd.ZoneType before the
+		// RefreshEngine has assigned it. A zone with its own explicit mode is
+		// excluded: it already drew the normalizer's per-zone warning.
+		if serialSuppressionCandidate(Globals.App.Type, zonetype, options, zconf.OutboundSoaSerial) {
+			serialSuppressedZones = append(serialSuppressedZones, zname)
+		}
+
 		var outopts []string
 		for o, val := range options {
 			if val {
@@ -1195,7 +1208,7 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 	lgConfig.Info("zones parsed and refreshing", "count", len(all_zones), "zones", all_zones, "broken", broken_zones, "queued", len(conf.Internal.RefreshZoneCh))
 
-	warnGlobalOutboundSerialSuppressed(conf)
+	warnGlobalOutboundSerialSuppressed(conf, serialSuppressedZones)
 
 	lgConfig.Debug("ParseZones complete")
 	return all_zones, broken_zones, nil
@@ -1211,27 +1224,38 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 // use persist. Without this, though, the suppression would be entirely
 // invisible: the operator set a server-wide policy and some zones quietly do
 // not follow it. Name them once instead.
-func warnGlobalOutboundSerialSuppressed(conf *Config) {
+//
+// suppressed is collected by the caller DURING the parse loop, from the
+// zonetype/options/serial-mode it has just resolved. It deliberately does NOT
+// re-scan the Zones registry: zd.ZoneType is assigned asynchronously by the
+// RefreshEngine when it consumes the ZoneRefresher, so at this point a
+// cold-start registry entry still has ZoneType == 0 — which would read as
+// "not a primary" and mis-report every zone without inline-signing, PRIMARIES
+// INCLUDED, as a suppressed secondary. On reload it would read the previous
+// parse's values rather than this one's.
+// serialSuppressionCandidate reports whether a zone — described by the role,
+// options and per-zone mode resolved DURING the parse — is one where a global
+// persist/unixtime outbound mode will be silently suppressed.
+//
+// Takes loose values rather than a *ZoneData on purpose: the registry entry's
+// ZoneType is assigned asynchronously by the RefreshEngine, so at parse time it
+// is still 0 and reading it would classify primaries as secondaries.
+//
+// A zone carrying its OWN explicit mode is not a candidate: the normalizer
+// already warned about it per zone, and reporting it twice would just be noise.
+func serialSuppressionCandidate(appType AppType, ztype ZoneType, opts map[ZoneOption]bool, perZoneMode string) bool {
+	if appType != AppTypeAuth || perZoneMode != "" {
+		return false
+	}
+	return ztype == Secondary && !opts[OptInlineSigning]
+}
+
+func warnGlobalOutboundSerialSuppressed(conf *Config, suppressed []string) {
 	mode := strings.TrimSpace(strings.ToLower(conf.DnsEngine.OutboundSoaSerial))
 	if mode != OutboundSoaSerialPersist && mode != OutboundSoaSerialUnixtime {
 		return
 	}
-	if Globals.App.Type != AppTypeAuth {
-		return
-	}
-
-	var suppressed []string
-	for zname, zd := range Zones.Items() {
-		// Only zones inheriting the global are interesting here; an explicit
-		// per-zone value already drew the normalizer's per-zone warning.
-		if zd == nil || zd.OutboundSoaSerial != "" {
-			continue
-		}
-		if !zoneMayOriginateContent(zd) {
-			suppressed = append(suppressed, zname)
-		}
-	}
-	if len(suppressed) == 0 {
+	if Globals.App.Type != AppTypeAuth || len(suppressed) == 0 {
 		return
 	}
 	sort.Strings(suppressed)

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -615,11 +615,14 @@ func applyOutboundSoaSerial(kdb *KeyDB, raw string) error {
 	}
 	kdb.OutboundSoaSerial = mode
 
-	if mode == OutboundSoaSerialPersist {
-		schema := DefaultTables["OutgoingSerials"]
-		if _, err := kdb.DB.Exec(schema); err != nil {
-			return fmt.Errorf("failed to create OutgoingSerials table: %w", err)
-		}
+	// Create the table unconditionally. The mode is now a PER-ZONE setting that
+	// merely defaults to this global one (zd.EffectiveOutboundSoaSerial), so any
+	// individual zone may be in persist mode even when the global is keep — and
+	// zones are parsed after this runs, so we cannot know yet whether one is.
+	// CREATE IF NOT EXISTS on an unused table is cheap.
+	schema := DefaultTables["OutgoingSerials"]
+	if _, err := kdb.DB.Exec(schema); err != nil {
+		return fmt.Errorf("failed to create OutgoingSerials table: %w", err)
 	}
 	return nil
 }
@@ -1161,6 +1164,10 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 				Options:        options,
 				UpdatePolicy:   policy,
 				DnssecPolicy:   zconf.DnssecPolicy,
+				// Always carried (empty == inherit the global), so a config
+				// edit that REMOVES a per-zone mode actually reverts the zone
+				// to the global on reload instead of keeping the stale value.
+				OutboundSoaSerial: zconf.OutboundSoaSerial,
 			}
 			select {
 			case conf.Internal.RefreshZoneCh <- zr:

--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -1194,8 +1195,49 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 	lgConfig.Info("zones parsed and refreshing", "count", len(all_zones), "zones", all_zones, "broken", broken_zones, "queued", len(conf.Internal.RefreshZoneCh))
 
+	warnGlobalOutboundSerialSuppressed(conf)
+
 	lgConfig.Debug("ParseZones complete")
 	return all_zones, broken_zones, nil
+}
+
+// warnGlobalOutboundSerialSuppressed tells the operator, once per parse, that a
+// server-wide outbound_soa_serial of persist/unixtime is being ignored for the
+// tdns-auth secondaries on this server.
+//
+// The option normalizer warns per zone about an EXPLICIT per-zone mode, but a
+// secondary that merely inherits a global one gets no per-zone warning — that
+// would be noise on every secondary of a server whose primaries legitimately
+// use persist. Without this, though, the suppression would be entirely
+// invisible: the operator set a server-wide policy and some zones quietly do
+// not follow it. Name them once instead.
+func warnGlobalOutboundSerialSuppressed(conf *Config) {
+	mode := strings.TrimSpace(strings.ToLower(conf.DnsEngine.OutboundSoaSerial))
+	if mode != OutboundSoaSerialPersist && mode != OutboundSoaSerialUnixtime {
+		return
+	}
+	if Globals.App.Type != AppTypeAuth {
+		return
+	}
+
+	var suppressed []string
+	for zname, zd := range Zones.Items() {
+		// Only zones inheriting the global are interesting here; an explicit
+		// per-zone value already drew the normalizer's per-zone warning.
+		if zd == nil || zd.OutboundSoaSerial != "" {
+			continue
+		}
+		if !zoneMayOriginateContent(zd) {
+			suppressed = append(suppressed, zname)
+		}
+	}
+	if len(suppressed) == 0 {
+		return
+	}
+	sort.Strings(suppressed)
+	lgConfig.Warn("global outbound_soa_serial is suppressed for secondary zones",
+		"mode", mode, "count", len(suppressed), "zones", suppressed,
+		"reason", "a secondary must serve the serial it received from upstream, unmodified")
 }
 
 // activateUpdatePolicy validates a zone's update-policy config and builds the

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -118,7 +118,7 @@ func initialLoadZone(ctx context.Context, zd *ZoneData, zone string, zr ZoneRefr
 		// to secondaries.
 		if zd.KeyDB != nil {
 			serialChanged := false
-			switch zd.KeyDB.OutboundSoaSerial {
+			switch zd.EffectiveOutboundSoaSerial() {
 			case OutboundSoaSerialUnixtime:
 				zd.CurrentSerial = uint32(time.Now().Unix())
 				lgEngine.Info("zone loaded; outbound_soa_serial=unixtime",
@@ -280,6 +280,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 							}
 							zd.ZoneType = zr.ZoneType
 							zd.Options = zr.Options
+							zd.OutboundSoaSerial = zr.OutboundSoaSerial
 							zd.UpdatePolicy = zr.UpdatePolicy
 							// Record the config-base policy name only (no struct bind).
 							// syncZoneDnssecPolicyFromConfig binds post-Ready; this
@@ -389,6 +390,15 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// Replace options only if provided (don't merge) to match config reload behavior
 						if zr.Options != nil {
 							zd.Options = zr.Options
+						}
+						// Outbound serial mode: gate on ConfigUpdate, NOT on
+						// non-emptiness. Empty is a MEANINGFUL value here
+						// ("inherit the global"), so a config edit that removes
+						// a per-zone mode must clear it — while a bare
+						// NOTIFY/refresh-only refresher (which carries no
+						// config) must not wipe the configured mode.
+						if zr.ConfigUpdate {
+							zd.OutboundSoaSerial = zr.OutboundSoaSerial
 						}
 						// Update UpdatePolicy only if provided (check if it has meaningful content)
 						// UpdatePolicy is a struct, so we check if any fields are set
@@ -593,28 +603,29 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 					primariesConf := clonePeerConfs(zr.PrimariesConf)
 					upstreams := clonePeerConfs(zr.Primaries)
 					zd := &ZoneData{
-						ZoneName:         zone,
-						ZoneStore:        zr.ZoneStore,
-						Logger:           log.Default(),
-						PrimariesConf:    primariesConf,
-						Upstreams:        upstreams,
-						Notify:           normalizePeerAddrs(zr.Notify),
-						AllowNotify:      zr.AllowNotify,
-						Downstreams:      zr.Downstreams,
-						DownstreamAuth:   zr.DownstreamAuth,
-						Zonefile:         zr.Zonefile,
-						Template:         zr.Template,
-						ZoneType:         zr.ZoneType,
-						Options:          zr.Options,
-						UpdatePolicy:     zr.UpdatePolicy,
-						DnssecPolicyName: zr.DnssecPolicy, // config-base hint; struct bound post-Ready
-						MultiSigner:      &msc,
-						DelegationSyncQ:  conf.Internal.DelegationSyncQ,
-						Data:             core.NewCmap[OwnerData](),
-						KeyDB:            conf.Internal.KeyDB,
-						FirstZoneLoad:    true,
-						Status:           ZoneStatusPending, // registered + enqueued, no data yet (B6)
-						publishCadence:   zr.PublishCadence,
+						ZoneName:          zone,
+						ZoneStore:         zr.ZoneStore,
+						Logger:            log.Default(),
+						PrimariesConf:     primariesConf,
+						Upstreams:         upstreams,
+						Notify:            normalizePeerAddrs(zr.Notify),
+						AllowNotify:       zr.AllowNotify,
+						Downstreams:       zr.Downstreams,
+						DownstreamAuth:    zr.DownstreamAuth,
+						Zonefile:          zr.Zonefile,
+						Template:          zr.Template,
+						ZoneType:          zr.ZoneType,
+						Options:           zr.Options,
+						OutboundSoaSerial: zr.OutboundSoaSerial,
+						UpdatePolicy:      zr.UpdatePolicy,
+						DnssecPolicyName:  zr.DnssecPolicy, // config-base hint; struct bound post-Ready
+						MultiSigner:       &msc,
+						DelegationSyncQ:   conf.Internal.DelegationSyncQ,
+						Data:              core.NewCmap[OwnerData](),
+						KeyDB:             conf.Internal.KeyDB,
+						FirstZoneLoad:     true,
+						Status:            ZoneStatusPending, // registered + enqueued, no data yet (B6)
+						publishCadence:    zr.PublishCadence,
 					}
 
 					// Register the OnFirstLoad callbacks BEFORE the initial load:
@@ -785,7 +796,7 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// Apply outbound_soa_serial mode after upstream refresh.
 						if zd.KeyDB != nil {
 							serialChanged := false
-							switch zd.KeyDB.OutboundSoaSerial {
+							switch zd.EffectiveOutboundSoaSerial() {
 							case OutboundSoaSerialUnixtime:
 								zd.CurrentSerial = uint32(time.Now().Unix())
 								lgEngine.Info("zone updated from upstream; outbound_soa_serial=unixtime",

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -839,7 +839,18 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// applyRefreshReplacementLocked already set the serial
 						// to upstream's and nothing may move it off that).
 						if zd.KeyDB != nil && !zoneMayOriginateContent(zd) {
-							// no-op: serial belongs to upstream
+							// The serial belongs to upstream, so neither mode
+							// may touch it. Also clear anything persisted
+							// BEFORE this zone became a mirror: a zone that
+							// turns non-originating via a live config reload
+							// never passes through initialLoadZone, so without
+							// this its stale row survives, and a later flip back
+							// to may-originate under persist mode would let
+							// LoadOutgoingSerial resurrect an inflated serial.
+							if err := zd.KeyDB.DeleteOutgoingSerial(zone); err != nil {
+								lgEngine.Warn("failed to clear persisted outgoing serial for mirroring secondary",
+									"zone", zone, "err", err)
+							}
 						} else if zd.KeyDB != nil {
 							serialChanged := false
 							switch zd.EffectiveOutboundSoaSerial() {

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -116,7 +116,16 @@ func initialLoadZone(ctx context.Context, zd *ZoneData, zone string, zr ZoneRefr
 		zd.ClearError(RefreshError)
 		// Apply outbound_soa_serial mode for the serial we'll advertise
 		// to secondaries.
-		if zd.KeyDB != nil {
+		// MUST-NOT-MODIFY: neither outbound mode may rewrite the serial of a
+		// tdns-auth secondary that did not originate this content. Clear any
+		// serial persisted before the zone became a mirror, so the inflated
+		// legacy value cannot be resurrected by a later change here.
+		if zd.KeyDB != nil && !zoneMayOriginateContent(zd) {
+			if err := zd.KeyDB.DeleteOutgoingSerial(zone); err != nil {
+				lgEngine.Warn("failed to clear persisted outgoing serial for mirroring secondary",
+					"zone", zone, "err", err)
+			}
+		} else if zd.KeyDB != nil {
 			serialChanged := false
 			switch zd.EffectiveOutboundSoaSerial() {
 			case OutboundSoaSerialUnixtime:
@@ -793,8 +802,13 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						// Successful refresh clears RefreshError. Other categories
 						// (rollover-policy, parent-DSYNC, config) survive.
 						zd.ClearError(RefreshError)
-						// Apply outbound_soa_serial mode after upstream refresh.
-						if zd.KeyDB != nil {
+						// Apply outbound_soa_serial mode after upstream refresh —
+						// but never for a mirroring secondary (MUST-NOT-MODIFY;
+						// applyRefreshReplacementLocked already set the serial
+						// to upstream's and nothing may move it off that).
+						if zd.KeyDB != nil && !zoneMayOriginateContent(zd) {
+							// no-op: serial belongs to upstream
+						} else if zd.KeyDB != nil {
 							serialChanged := false
 							switch zd.EffectiveOutboundSoaSerial() {
 							case OutboundSoaSerialUnixtime:

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -288,8 +288,10 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 								zd.publishCadence = zr.PublishCadence
 							}
 							zd.ZoneType = zr.ZoneType
-							zd.Options = zr.Options
-							zd.OutboundSoaSerial = zr.OutboundSoaSerial
+							// Normalize AFTER ZoneType is assigned — the
+							// predicate depends on it (Fix B chokepoint).
+							zd.Options, zd.OutboundSoaSerial =
+								zd.applyOptionNormalization(zr.ZoneType, zr.Options, zr.OutboundSoaSerial)
 							zd.UpdatePolicy = zr.UpdatePolicy
 							// Record the config-base policy name only (no struct bind).
 							// syncZoneDnssecPolicyFromConfig binds post-Ready; this
@@ -396,18 +398,42 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						if zr.ZoneStore != 0 {
 							zd.ZoneStore = zr.ZoneStore
 						}
-						// Replace options only if provided (don't merge) to match config reload behavior
-						if zr.Options != nil {
-							zd.Options = zr.Options
-						}
-						// Outbound serial mode: gate on ConfigUpdate, NOT on
-						// non-emptiness. Empty is a MEANINGFUL value here
-						// ("inherit the global"), so a config edit that removes
-						// a per-zone mode must clear it — while a bare
-						// NOTIFY/refresh-only refresher (which carries no
-						// config) must not wipe the configured mode.
-						if zr.ConfigUpdate {
-							zd.OutboundSoaSerial = zr.OutboundSoaSerial
+						// Options and the outbound serial mode are normalized
+						// TOGETHER (the normalizer covers both), so they are
+						// merged in one place — assigning either separately
+						// afterwards would overwrite a normalized value with
+						// the raw one.
+						//
+						// Their update rules differ, though:
+						//   - Options replace only if provided (don't merge),
+						//     matching config-reload behaviour.
+						//   - The serial mode is gated on ConfigUpdate, NOT on
+						//     non-emptiness: empty is MEANINGFUL there
+						//     ("inherit the global"), so a config edit that
+						//     removes a per-zone mode must clear it, while a
+						//     bare NOTIFY/refresh-only refresher (carrying no
+						//     config) must not wipe a configured one.
+						if zr.Options != nil || zr.ConfigUpdate {
+							// Normalize against the zone's EFFECTIVE type: the
+							// ZoneType assignment below is conditional, so
+							// prefer the incoming type when the refresher
+							// carries one — otherwise a reload that flips
+							// Primary->Secondary would normalize against the
+							// stale role.
+							ztype := zd.ZoneType
+							if zr.ZoneType != 0 {
+								ztype = zr.ZoneType
+							}
+							newOpts := zd.Options
+							if zr.Options != nil {
+								newOpts = zr.Options
+							}
+							newSerial := zd.OutboundSoaSerial
+							if zr.ConfigUpdate {
+								newSerial = zr.OutboundSoaSerial
+							}
+							zd.Options, zd.OutboundSoaSerial =
+								zd.applyOptionNormalization(ztype, newOpts, newSerial)
 						}
 						// Update UpdatePolicy only if provided (check if it has meaningful content)
 						// UpdatePolicy is a struct, so we check if any fields are set
@@ -636,6 +662,12 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 						Status:            ZoneStatusPending, // registered + enqueued, no data yet (B6)
 						publishCadence:    zr.PublishCadence,
 					}
+
+					// Strip origination settings this zone may not act on. The
+					// ZoneData is fully constructed at this point, so the
+					// normalizer sees the final role (Fix B chokepoint).
+					zd.Options, zd.OutboundSoaSerial =
+						zd.applyOptionNormalization(zd.ZoneType, zd.Options, zd.OutboundSoaSerial)
 
 					// Register the OnFirstLoad callbacks BEFORE the initial load:
 					// on a first-load failure the ticker retry path re-runs

--- a/v2/secondary_serial_mirror_test.go
+++ b/v2/secondary_serial_mirror_test.go
@@ -1,0 +1,196 @@
+package tdns
+
+import (
+	"strings"
+	"testing"
+)
+
+// Fix A of the MUST-NOT-MODIFY invariant (design doc §3): a tdns-auth secondary
+// that did not originate its content mirrors the upstream SOA serial verbatim
+// instead of bumping it +1 on every refresh.
+//
+// These tests drive applyRefreshReplacementLocked directly, which is where the
+// historical unconditional `CurrentSerial++` lived.
+
+// withAppType sets the process-wide app type for the duration of a test. The
+// origination predicate stands down off tdns-auth (that is what protects
+// tdns-mp/tdns-agent), so a test asserting a gate must opt in explicitly.
+func withAppType(t *testing.T, at AppType) {
+	t.Helper()
+	prev := Globals.App.Type
+	Globals.App.Type = at
+	t.Cleanup(func() { Globals.App.Type = prev })
+}
+
+// refreshTo replaces zd's content with basicZone carrying the given upstream
+// serial, exactly as a completed AXFR would.
+func refreshTo(t *testing.T, zd *ZoneData, upstreamSerial string) {
+	t.Helper()
+	newZone := strings.Replace(basicZone, "1 ; serial", upstreamSerial+" ; serial", 1)
+	newZd := &ZoneData{
+		ZoneName:  zd.ZoneName,
+		ZoneStore: MapZone,
+		ZoneType:  zd.ZoneType,
+		Logger:    zd.Logger,
+	}
+	if _, _, err := newZd.ReadZoneData(newZone, true); err != nil {
+		t.Fatalf("ReadZoneData: %v", err)
+	}
+	zd.mu.Lock()
+	err := zd.applyRefreshReplacementLocked(newZd, nil, false)
+	zd.mu.Unlock()
+	if err != nil {
+		t.Fatalf("applyRefreshReplacementLocked: %v", err)
+	}
+}
+
+// TestSecondaryMirrorsUpstreamSerial is the mutation-verified core of Fix A: it
+// FAILS on the pre-fix code (which produced prev+1 = 6 and then 7) and passes
+// with the mirror. Two refreshes, so the "+1 per refresh" drift the bug caused
+// is visible rather than coincidentally matching.
+func TestSecondaryMirrorsUpstreamSerial(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = Secondary
+	zd.Options = map[ZoneOption]bool{}
+	zd.CurrentSerial = 5
+	zd.IncomingSerial = 5
+
+	refreshTo(t, zd, "40")
+	if zd.CurrentSerial != 40 {
+		t.Fatalf("after first refresh: CurrentSerial = %d, want 40 (mirrored)", zd.CurrentSerial)
+	}
+
+	refreshTo(t, zd, "41")
+	if zd.CurrentSerial != 41 {
+		t.Fatalf("after second refresh: CurrentSerial = %d, want 41 (mirrored)", zd.CurrentSerial)
+	}
+	if zd.IncomingSerial != 41 {
+		t.Errorf("IncomingSerial = %d, want 41", zd.IncomingSerial)
+	}
+}
+
+// TestSecondaryMirrorAcceptsBackwardsSerial pins the migration behaviour: a
+// secondary whose serial was inflated (by a pre-fix build, or by persist/
+// unixtime mode) steps BACKWARDS to upstream's value rather than refusing or
+// clamping. The step is logged at ERROR so the operator can force retransfers
+// on the downstreams; here we assert the value, not the log.
+func TestSecondaryMirrorAcceptsBackwardsSerial(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = Secondary
+	zd.Options = map[ZoneOption]bool{}
+	zd.CurrentSerial = 5000 // inflated by pre-fix bumping
+	zd.IncomingSerial = 42
+
+	refreshTo(t, zd, "43")
+	if zd.CurrentSerial != 43 {
+		t.Fatalf("CurrentSerial = %d, want 43 (mirror even when it moves backwards)", zd.CurrentSerial)
+	}
+}
+
+// TestPrimaryStillBumpsSerial guards the other side: a primary is an originator
+// and must keep advancing exactly as before.
+func TestPrimaryStillBumpsSerial(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = Primary
+	zd.Options = map[ZoneOption]bool{}
+	zd.CurrentSerial = 5
+
+	refreshTo(t, zd, "40")
+	if zd.CurrentSerial != 6 {
+		t.Fatalf("primary: CurrentSerial = %d, want 6 (prev+1, unchanged behaviour)", zd.CurrentSerial)
+	}
+}
+
+// TestInlineSigningSecondaryStillBumpsSerial covers the one sanctioned
+// exception: an inline-signing secondary transforms upstream content by adding
+// its own RRSIGs, so its serial legitimately diverges and must still advance.
+func TestInlineSigningSecondaryStillBumpsSerial(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = Secondary
+	zd.Options = map[ZoneOption]bool{OptInlineSigning: true}
+	zd.CurrentSerial = 5
+
+	refreshTo(t, zd, "40")
+	if zd.CurrentSerial != 6 {
+		t.Fatalf("inline-signing secondary: CurrentSerial = %d, want 6 (may originate)", zd.CurrentSerial)
+	}
+}
+
+// TestNonAuthAppSecondaryStillBumpsSerial is the §1.1 app-scope guarantee, the
+// property that keeps tdns-mpcombiner / tdns-mpagent / tdns-agent working when
+// they next bump their tdns pin: off tdns-auth the gate stands down entirely
+// and a Secondary advances its serial exactly as it always did.
+func TestNonAuthAppSecondaryStillBumpsSerial(t *testing.T) {
+	withAppType(t, AppTypeAgent)
+
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = Secondary
+	zd.Options = map[ZoneOption]bool{}
+	zd.CurrentSerial = 5
+
+	refreshTo(t, zd, "40")
+	if zd.CurrentSerial != 6 {
+		t.Fatalf("non-auth app: CurrentSerial = %d, want 6 (gate must be a no-op)", zd.CurrentSerial)
+	}
+}
+
+// TestNextOutboundSerialSuppressedForMirroringSecondary pins that unixtime mode
+// cannot rewrite a mirroring secondary's serial into timestamp space:
+// MUST-NOT-MODIFY is absolute, not keep-mode-only.
+func TestNextOutboundSerialSuppressedForMirroringSecondary(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := &ZoneData{
+		ZoneName:          "example.test.",
+		ZoneType:          Secondary,
+		Options:           map[ZoneOption]bool{},
+		CurrentSerial:     10,
+		OutboundSoaSerial: OutboundSoaSerialUnixtime,
+		KeyDB:             &KeyDB{OutboundSoaSerial: OutboundSoaSerialUnixtime},
+	}
+	if got := nextOutboundSerial(zd); got != 11 {
+		t.Errorf("mirroring secondary in unixtime mode: got %d, want 11 (no timestamp rewrite)", got)
+	}
+
+	// A primary in the same mode is unaffected.
+	zd.ZoneType = Primary
+	if got := nextOutboundSerial(zd); got <= 11 {
+		t.Errorf("primary in unixtime mode: got %d, want a unix timestamp", got)
+	}
+}
+
+// TestZoneMayOriginateContent covers the shared predicate directly, including
+// the app-scope short-circuit that every gate inherits from it.
+func TestZoneMayOriginateContent(t *testing.T) {
+	secondary := &ZoneData{ZoneType: Secondary, Options: map[ZoneOption]bool{}}
+	primary := &ZoneData{ZoneType: Primary, Options: map[ZoneOption]bool{}}
+	inline := &ZoneData{ZoneType: Secondary, Options: map[ZoneOption]bool{OptInlineSigning: true}}
+
+	withAppType(t, AppTypeAuth)
+	if zoneMayOriginateContent(secondary) {
+		t.Error("auth secondary must NOT originate")
+	}
+	if !zoneMayOriginateContent(primary) {
+		t.Error("auth primary must originate")
+	}
+	if !zoneMayOriginateContent(inline) {
+		t.Error("auth inline-signing secondary must originate")
+	}
+	if !zoneMayOriginateContent(nil) {
+		t.Error("nil zone must not be gated")
+	}
+
+	// Off tdns-auth every case is permitted — the §1.1 guarantee.
+	withAppType(t, AppTypeAgent)
+	if !zoneMayOriginateContent(secondary) {
+		t.Error("non-auth secondary must be ungated")
+	}
+}

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -353,7 +353,26 @@ type ZoneConf struct {
 	// "(not recorded)".
 	AppliedError string            `yaml:"-"`
 	PolicyDetail *DnssecPolicyView `yaml:"-"`
-	Template     string            `yaml:"template" mapstructure:"template"`
+	// Serial visibility (display-only; not config). CurrentSerial is what we
+	// advertise to our downstreams, IncomingSerial what we last received from
+	// upstream. Both are free to populate — they are already on ZoneData — and
+	// `zone list -v` shows them side by side.
+	//
+	// UpstreamSerials is populated ONLY by the single-zone `zone desc` path: it
+	// costs a live SOA probe per configured primary, which is fine for one zone
+	// and not for a bulk listing. Per-primary rather than one aggregate value
+	// is the point — "this master says 42, that one says 5000" is the direct
+	// diagnostic for the split-brain that motivated the MUST-NOT-MODIFY work,
+	// and there is currently no way to see it from tdns at all.
+	CurrentSerial   uint32           `yaml:"-"`
+	IncomingSerial  uint32           `yaml:"-"`
+	UpstreamSerials []UpstreamSerial `yaml:"-"`
+	// EffectiveOutboundSoaSerial is the resolved outbound serial mode and where
+	// it came from ("zone", "global" or "default"), so an operator can see both
+	// the value and why it applies.
+	EffectiveOutboundSoaSerial string `yaml:"-"`
+	OutboundSoaSerialSource    string `yaml:"-"`
+	Template                   string `yaml:"template" mapstructure:"template"`
 	// DynamicZones marks a TEMPLATE as instantiable via the dynamic-zones API
 	// (zone add --type primary --template <name>). It is the per-template
 	// opt-in gate: an API client can only pick among operator-blessed
@@ -734,6 +753,16 @@ func rrsToStrings(rrs []dns.RR) []string {
 		out[i] = rr.String()
 	}
 	return out
+}
+
+// UpstreamSerial is one primary's answer to a live SOA probe, for `zone desc`.
+// Err carries the probe failure (unreachable, REFUSED, TSIG mismatch, ...) so a
+// primary that cannot be reached is shown as such rather than silently omitted
+// — an unreachable master is itself diagnostic.
+type UpstreamSerial struct {
+	Addr   string
+	Serial uint32
+	Err    string
 }
 
 type ZoneRefresher struct {

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -138,17 +138,23 @@ type ZoneData struct {
 	// ZoneFile           string // TODO: Remove this
 	IncomingSerial uint32 // SOA serial that we got from upstream
 	CurrentSerial  uint32 // SOA serial after local bumping
-	FirstZoneLoad  bool   // true until first zone data has been loaded
-	Verbose        bool
-	Debug          bool
-	IxfrChain      []Ixfr
-	PrimariesConf  []PeerConf // as-written primaries; persisted; re-resolved each load (P3)
-	Upstreams      []PeerConf // resolved addr:port tuples; runtime-only; used for transfer
-	Notify         []PeerConf // downstream secondaries that we notify (addr + key)
-	AllowNotify    []AclEntry // secondary: who may NOTIFY us; empty => accept from resolved primaries
-	Downstreams    []AclEntry // primary: who may AXFR from us (provide-xfr ACL); empty => deny
-	DownstreamAuth []string   // acceptable transfer-auth mechanism classes (empty => unrestricted); see authorizeTransfer
-	Zonefile       string
+	// OutboundSoaSerial is the PER-ZONE outbound serial mode (keep | unixtime
+	// | persist), sourced from the zone's config (possibly via its template).
+	// Empty means "inherit the server-global dnsengine.outbound_soa_serial".
+	// Never read directly — call zd.EffectiveOutboundSoaSerial(), which
+	// resolves the zone/global tiers.
+	OutboundSoaSerial string
+	FirstZoneLoad     bool // true until first zone data has been loaded
+	Verbose           bool
+	Debug             bool
+	IxfrChain         []Ixfr
+	PrimariesConf     []PeerConf // as-written primaries; persisted; re-resolved each load (P3)
+	Upstreams         []PeerConf // resolved addr:port tuples; runtime-only; used for transfer
+	Notify            []PeerConf // downstream secondaries that we notify (addr + key)
+	AllowNotify       []AclEntry // secondary: who may NOTIFY us; empty => accept from resolved primaries
+	Downstreams       []AclEntry // primary: who may AXFR from us (provide-xfr ACL); empty => deny
+	DownstreamAuth    []string   // acceptable transfer-auth mechanism classes (empty => unrestricted); see authorizeTransfer
+	Zonefile          string
 	// Template names the config template an API-provisioned zone was expanded
 	// from (zone add --template). Persisted in the dynamic config entry so a
 	// restart re-expands it; the update policy is deliberately NOT persisted —
@@ -306,6 +312,14 @@ type ZoneConf struct {
 	UpdatePolicy      UpdatePolicyConf
 	DelegationBackend string `yaml:"delegationbackend" mapstructure:"delegationbackend"` // named backend for child delegation data
 	DnssecPolicy      string `yaml:"dnssecpolicy" mapstructure:"dnssecpolicy"`
+	// OutboundSoaSerial is the per-zone override of the server-global
+	// dnsengine.outbound_soa_serial. Empty (the default) inherits the global.
+	// Set it on a TEMPLATE to give a whole class of zones a serial policy —
+	// that is the intended granularity; a zone that sets it explicitly wins
+	// over its template (ExpandTemplate gap-fills only unset fields, and a
+	// non-empty string counts as set, so an explicit "keep" beats a template
+	// "persist").
+	OutboundSoaSerial string `yaml:"outbound_soa_serial,omitempty" mapstructure:"outbound_soa_serial" validate:"omitempty,oneof=keep unixtime persist"`
 	// EffectiveDnssecPolicy / DnssecPolicyOverridden / DnssecPolicyConfigBase
 	// are display-only fields populated by the list-zones handler: the policy
 	// actually bound to the running zone; whether it came from a dynamic
@@ -744,10 +758,15 @@ type ZoneRefresher struct {
 	Edns0Options   *edns0.MsgOptions
 	UpdatePolicy   UpdatePolicy
 	DnssecPolicy   string
-	MultiSigner    string
-	Force          bool // force refresh, ignoring SOA serial
-	Wait           bool // wait for refresh to complete before responding
-	Response       chan RefresherResponse
+	// OutboundSoaSerial carries the per-zone outbound serial mode to the
+	// RefreshEngine (copied to zd.OutboundSoaSerial on merge). Empty means
+	// "inherit the server-global setting" and is a valid, self-consistent
+	// value, so it is always copied — no "only if non-empty" guard.
+	OutboundSoaSerial string
+	MultiSigner       string
+	Force             bool // force refresh, ignoring SOA serial
+	Wait              bool // wait for refresh to complete before responding
+	Response          chan RefresherResponse
 }
 
 type RefresherResponse struct {

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -167,6 +167,14 @@ type ZoneData struct {
 	Children          map[string]*ChildDelegationData
 	DelegationBackend DelegationBackend // parent-side: backend for storing child delegation data
 	Options           map[ZoneOption]bool
+	// SuppressedOptions records the origination options that were configured
+	// for this zone but stripped by normalizeOptionsForRole (a tdns-auth
+	// secondary may not originate content). Options above is the EFFECTIVE
+	// set; Options ∪ SuppressedOptions is the AS-CONFIGURED set, which is what
+	// must be re-serialized when a dynamic zone's config file is regenerated —
+	// otherwise the operator's stated intent is silently deleted from their own
+	// config. Use asConfiguredOptions(). nil when nothing was suppressed.
+	SuppressedOptions map[ZoneOption]bool
 	UpdatePolicy      UpdatePolicy
 	DnssecPolicy      *DnssecPolicy
 	DnssecPolicyName  string // name of currently-applied policy; used to detect config-reload-driven changes

--- a/v2/transfer_fallback_test.go
+++ b/v2/transfer_fallback_test.go
@@ -216,7 +216,7 @@ func TestDoTransfer_AllUnreachableIsError(t *testing.T) {
 
 func TestFetchFromUpstream_NoUpstreams(t *testing.T) {
 	zd := &ZoneData{ZoneName: "example.test."}
-	if _, err := zd.FetchFromUpstream(false, false, nil, &Config{}); err == nil {
+	if _, err := zd.FetchFromUpstream(false, false, false, nil, &Config{}); err == nil {
 		t.Fatal("expected an error when no upstreams are configured")
 	}
 }

--- a/v2/tsig_peer.go
+++ b/v2/tsig_peer.go
@@ -217,15 +217,43 @@ func writeTsigErrorResponse(w dns.ResponseWriter, r *dns.Msg, reqTsig *dns.TSIG,
 // validation). The key's algorithm comes from the keystore; the wire name and
 // algorithm are canonicalised (lowercase FQDN) per RFC 8945.
 func SignForPeer(msg *dns.Msg, keyName string, conf *Config) (dns.TsigProvider, error) {
+	provider, algorithm, err := TsigMaterialForPeer(keyName, conf)
+	if err != nil || provider == nil {
+		return nil, err
+	}
+	StampTsigForPeer(msg, keyName, algorithm)
+	return provider, nil
+}
+
+// TsigMaterialForPeer resolves the provider and algorithm for a peer key
+// WITHOUT stamping a message, so config reads and message signing can happen at
+// different times.
+//
+// That split matters for callers that must snapshot config up front but sign
+// late. A multi-primary probe reads TSIG material for every upstream in one go
+// (so a concurrent reload cannot hand different primaries material from
+// different config generations), but the probes themselves are sequential and
+// each may block until the request deadline. Stamping every message during the
+// snapshot would leave the last message carrying a timestamp minutes old by the
+// time it goes out, and the peer would reject it as BADTIME. Resolve early,
+// stamp immediately before each exchange.
+//
+// Returns (nil, "", nil) for an unset key or NOKEY, matching SignForPeer.
+func TsigMaterialForPeer(keyName string, conf *Config) (dns.TsigProvider, string, error) {
 	if keyName == "" || keyName == NOKEY {
-		return nil, nil
+		return nil, "", nil
 	}
 	d, ok := conf.Internal.TsigKeyStore.Get(keyName)
 	if !ok {
-		return nil, fmt.Errorf("TSIG key %q not found in keys store", keyName)
+		return nil, "", fmt.Errorf("TSIG key %q not found in keys store", keyName)
 	}
-	msg.SetTsig(dns.CanonicalName(keyName), dns.CanonicalName(d.Algorithm), tsigFudge, time.Now().Unix())
-	return conf.tsigProvider(), nil
+	return conf.tsigProvider(), d.Algorithm, nil
+}
+
+// StampTsigForPeer sets the TSIG RR on msg with a current timestamp. Call it
+// immediately before the exchange; see TsigMaterialForPeer.
+func StampTsigForPeer(msg *dns.Msg, keyName, algorithm string) {
+	msg.SetTsig(dns.CanonicalName(keyName), dns.CanonicalName(algorithm), tsigFudge, time.Now().Unix())
 }
 
 // notifyKeyFor returns the TSIG key name to sign an outbound NOTIFY to target,

--- a/v2/tsig_peer_split_test.go
+++ b/v2/tsig_peer_split_test.go
@@ -1,0 +1,92 @@
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// SignForPeer was split into TsigMaterialForPeer (reads config) and
+// StampTsigForPeer (stamps a message), so ProbeUpstreamSerials can snapshot
+// config for every upstream up front while still stamping each message
+// immediately before its own exchange. These tests pin the behaviour of the
+// pieces and assert SignForPeer still composes them exactly as before.
+
+func TestTsigMaterialForPeer(t *testing.T) {
+	conf := tsigTestConf(t)
+
+	// A configured key yields a provider plus its algorithm, and must NOT
+	// stamp anything -- that is the whole point of the split.
+	provider, algo, err := TsigMaterialForPeer("tkey", conf)
+	if err != nil {
+		t.Fatalf("TsigMaterialForPeer: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected a provider for a configured key")
+	}
+	if algo != "hmac-sha256" {
+		t.Errorf("algorithm: got %q want %q", algo, "hmac-sha256")
+	}
+
+	// NOKEY and empty are the plain-exchange cases: no provider, no error.
+	for _, name := range []string{"", NOKEY} {
+		p, a, err := TsigMaterialForPeer(name, conf)
+		if err != nil || p != nil || a != "" {
+			t.Errorf("TsigMaterialForPeer(%q): got (%v, %q, %v), want (nil, \"\", nil)", name, p, a, err)
+		}
+	}
+
+	// An unknown key is an error, not a silent plain exchange.
+	if _, _, err := TsigMaterialForPeer("nosuchkey", conf); err == nil {
+		t.Error("expected an error for a key that is not in the store")
+	}
+}
+
+func TestStampTsigForPeerSetsFreshTSIG(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion("example.", dns.TypeSOA)
+	StampTsigForPeer(m, "tkey", "hmac-sha256")
+
+	tsig := m.IsTsig()
+	if tsig == nil {
+		t.Fatal("no TSIG RR was set")
+	}
+	if tsig.Hdr.Name != dns.CanonicalName("tkey") {
+		t.Errorf("key name: got %q want %q", tsig.Hdr.Name, dns.CanonicalName("tkey"))
+	}
+	if tsig.Algorithm != dns.CanonicalName("hmac-sha256") {
+		t.Errorf("algorithm: got %q want %q", tsig.Algorithm, dns.CanonicalName("hmac-sha256"))
+	}
+	if tsig.TimeSigned == 0 {
+		t.Error("TimeSigned should be stamped with the current time")
+	}
+}
+
+// SignForPeer must behave exactly as it did before the split: stamp the message
+// and return the provider for a configured key, and do neither for NOKEY.
+func TestSignForPeerStillStampsAndReturnsProvider(t *testing.T) {
+	conf := tsigTestConf(t)
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.", dns.TypeSOA)
+	provider, err := SignForPeer(m, "tkey", conf)
+	if err != nil {
+		t.Fatalf("SignForPeer: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected a provider")
+	}
+	if m.IsTsig() == nil {
+		t.Error("SignForPeer must stamp the message")
+	}
+
+	plain := new(dns.Msg)
+	plain.SetQuestion("example.", dns.TypeSOA)
+	p, err := SignForPeer(plain, NOKEY, conf)
+	if err != nil || p != nil {
+		t.Errorf("SignForPeer(NOKEY): got (%v, %v), want (nil, nil)", p, err)
+	}
+	if plain.IsTsig() != nil {
+		t.Error("SignForPeer(NOKEY) must not stamp the message")
+	}
+}

--- a/v2/xot_pkix_test.go
+++ b/v2/xot_pkix_test.go
@@ -149,7 +149,7 @@ func TestXoT_FetchFromUpstreamPKIX(t *testing.T) {
 	Zones.Set(sec.ZoneName, sec)
 	t.Cleanup(func() { Zones.Remove(sec.ZoneName) })
 
-	updated, err := sec.FetchFromUpstream(false, false, nil, conf)
+	updated, err := sec.FetchFromUpstream(false, false, false, nil, conf)
 	if err != nil {
 		t.Fatalf("FetchFromUpstream over dot+pkix: %v", err)
 	}

--- a/v2/zone_desc_detail_test.go
+++ b/v2/zone_desc_detail_test.go
@@ -4,7 +4,10 @@
 
 package tdns
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // withLiveConfig swaps in a runtime-config snapshot for the duration of a test
 // and restores the previous one on cleanup.
@@ -42,7 +45,7 @@ func TestPopulateZoneDescDetail(t *testing.T) {
 		t.Fatalf("SetZoneAppliedPolicy: %v", err)
 	}
 	zconf := ZoneConf{Name: "signed.example."}
-	populateZoneDescDetail(&zconf, &ZoneData{DnssecPolicyName: "pol-a"}, "signed.example.", kdb)
+	populateZoneDescDetail(context.Background(), &zconf, &ZoneData{DnssecPolicyName: "pol-a"}, "signed.example.", kdb)
 
 	if zconf.AppliedPolicy != "pol-a" || zconf.AppliedSource != "command" || zconf.AppliedAt == "" {
 		t.Fatalf("applied fields: got (%q, %q, at=%q), want (\"pol-a\", \"command\", non-empty)",
@@ -61,7 +64,7 @@ func TestPopulateZoneDescDetail(t *testing.T) {
 
 	// --- unsigned zone: no bound policy, no applied record ---
 	zUnsigned := ZoneConf{Name: "plain.example."}
-	populateZoneDescDetail(&zUnsigned, &ZoneData{DnssecPolicyName: ""}, "plain.example.", kdb)
+	populateZoneDescDetail(context.Background(), &zUnsigned, &ZoneData{DnssecPolicyName: ""}, "plain.example.", kdb)
 	if zUnsigned.PolicyDetail != nil {
 		t.Fatalf("unsigned zone must have nil PolicyDetail, got %+v", zUnsigned.PolicyDetail)
 	}
@@ -75,7 +78,7 @@ func TestPopulateZoneDescDetail(t *testing.T) {
 		t.Fatalf("SetZoneAppliedPolicy: %v", err)
 	}
 	zGhost := ZoneConf{Name: "ghost.example.", EffectiveDnssecPolicy: "ghost-pol"}
-	populateZoneDescDetail(&zGhost, &ZoneData{DnssecPolicyName: "ghost-pol"}, "ghost.example.", kdb)
+	populateZoneDescDetail(context.Background(), &zGhost, &ZoneData{DnssecPolicyName: "ghost-pol"}, "ghost.example.", kdb)
 	if zGhost.PolicyDetail != nil {
 		t.Fatalf("unresolvable bound policy must have nil PolicyDetail, got %+v", zGhost.PolicyDetail)
 	}
@@ -94,7 +97,7 @@ func TestPopulateZoneDescDetail_AppliedError(t *testing.T) {
 		},
 	})
 	zconf := ZoneConf{Name: "z.example."}
-	populateZoneDescDetail(&zconf, &ZoneData{DnssecPolicyName: "pol-a"}, "z.example.", nil)
+	populateZoneDescDetail(context.Background(), &zconf, &ZoneData{DnssecPolicyName: "pol-a"}, "z.example.", nil)
 
 	if zconf.AppliedError == "" {
 		t.Fatalf("a keystore read error must set AppliedError")

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -333,7 +333,7 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 	zd.publishUrgent = false
 	zd.lastPublish = time.Now()
 
-	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
+	if zd.KeyDB != nil && zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialPersist {
 		if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
 			lg.Error("publish: failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
 		}
@@ -353,7 +353,7 @@ func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs [
 		zd.FirstZoneLoad = false
 	} else {
 		zd.CurrentSerial++
-		if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial == OutboundSoaSerialPersist {
+		if zd.KeyDB != nil && zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialPersist {
 			if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
 				return fmt.Errorf("persist outgoing serial for zone %s: %w", zd.ZoneName, err)
 			}

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -333,7 +333,10 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 	zd.publishUrgent = false
 	zd.lastPublish = time.Now()
 
-	if zd.KeyDB != nil && zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialPersist {
+	// Persist only for a zone that may originate: a mirroring secondary's
+	// serial is upstream's property, not ours to record and later restore.
+	if zd.KeyDB != nil && zoneMayOriginateContent(zd) &&
+		zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialPersist {
 		if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {
 			lg.Error("publish: failed to persist outgoing serial", "zone", zd.ZoneName, "err", err)
 		}
@@ -348,10 +351,36 @@ func (zd *ZoneData) publishWorkingSetLocked(gen uint64, bumpSerial bool) {
 
 func (zd *ZoneData) applyRefreshReplacementLocked(new_zd *ZoneData, dynamicRRs []*core.RRset, firstLoad bool) error {
 	zd.IncomingSerial = new_zd.IncomingSerial
-	if firstLoad {
+	switch {
+	case firstLoad:
 		zd.CurrentSerial = new_zd.CurrentSerial
 		zd.FirstZoneLoad = false
-	} else {
+
+	case !zoneMayOriginateContent(zd):
+		// MUST-NOT-MODIFY: a tdns-auth secondary that did not originate this
+		// content mirrors the upstream serial verbatim. The historical
+		// unconditional ++ below made every such secondary drift +1 per
+		// refresh, so two masters downstream of one signer (say BIND9 and
+		// tdns-auth) advertised different serials for identical content and
+		// edge nodes always fetched from the tdns one — silently collapsing a
+		// redundant pair. This is the fix.
+		prev := zd.CurrentSerial
+		zd.CurrentSerial = new_zd.IncomingSerial
+		// A secondary that had already inflated its serial (or was running in
+		// persist/unixtime mode before the upgrade) steps BACKWARDS here, once.
+		// Its own downstreams will then refuse to transfer until upstream
+		// climbs past the old value — RFC 1982 serial arithmetic, so BIND/NSD
+		// behave the same and a NOTIFY carrying a lower serial is ignored.
+		// Shout, so the operator can force a retransfer on the downstreams
+		// (`tdns-cli zone reload --force <zone>`) instead of discovering it as
+		// mysteriously stale data.
+		if prev != 0 && zd.CurrentSerial < prev {
+			lg.Error("secondary SOA serial steps BACKWARDS to mirror upstream; downstreams will refuse to transfer until forced",
+				"zone", zd.ZoneName, "old_serial", prev, "new_serial", zd.CurrentSerial,
+				"action", "force a retransfer on each downstream (tdns-cli zone reload --force)")
+		}
+
+	default:
 		zd.CurrentSerial++
 		if zd.KeyDB != nil && zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialPersist {
 			if err := zd.KeyDB.SaveOutgoingSerial(zd.ZoneName, zd.CurrentSerial); err != nil {

--- a/v2/zone_mutation.go
+++ b/v2/zone_mutation.go
@@ -187,6 +187,18 @@ func (zd *ZoneData) resignWorkingSetSOAIfSigned() {
 	if !zd.Options[OptOnlineSigning] && !zd.Options[OptInlineSigning] {
 		return
 	}
+	// Role gate (Fix E). SetupZoneSigning has one — "a non-primary signs only
+	// with inline-signing" — but this path did not, and it runs inside
+	// publishWorkingSetLocked, i.e. on EVERY publish including the refresh
+	// path. Without this, a tdns-auth secondary carrying `online-signing`
+	// re-signs the upstream SOA with locally generated keys (EnsureActiveDnssecKeys
+	// below will mint them if absent) — signatures from a key that is not in the
+	// zone's published DNSKEY RRset, i.e. BOGUS to every validator downstream.
+	// `online-signing` is also normalized off for such a zone; this is the
+	// defence in depth behind that.
+	if !zoneMayOriginateContent(zd) {
+		return
+	}
 	// A new zone's DNSSEC policy is bound post-Ready (PR-2 defers binding so a
 	// restart cannot hide applied≠intent, blocking ①). Until it is bound there is
 	// nothing to re-sign under, and EnsureActiveDnssecKeys below would deref a nil

--- a/v2/zone_option_normalize.go
+++ b/v2/zone_option_normalize.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Option normalization for the MUST-NOT-MODIFY invariant.
+ * See docs/2026-07-25-secondary-zones-immutable.md §3 (Fix B) and §4.
+ */
+package tdns
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// originationOptions are the zone options that let a zone ORIGINATE content —
+// publish something of its own into the zone. None of them is legitimate on a
+// tdns-auth secondary that is not inline-signing, because whatever they publish
+// did not come from upstream. See §4 of the design doc for the per-option
+// reasoning; briefly:
+//
+//   - allow-updates / allow-child-updates: DDNS and child-delegation writes.
+//   - add-transport-signal: synthesizes SVCB/TSYNC signal records into the zone.
+//   - delegation-sync-parent: publishes the _dsync DSYNC RRset (and, as an
+//     intended consequence, gates KeyState EDNS(0) processing — a secondary can
+//     never hold the receiver SIG(0) key, so leaving it on would emit UNSIGNED
+//     KeyState responses, worse than not answering).
+//   - online-signing: on tdns-auth the only keys available are LOCAL ones, and
+//     signing upstream content with local keys is unsafe and plain wrong — it
+//     unlocks whole-zone re-signing via the ResignQ path, standby-key minting,
+//     per-refresh DNSKEY injection, and BOGUS ephemeral signing of denial NSECs.
+//     (Signing at the edge with DISTRIBUTED keys is legitimate, but that is the
+//     tdns-nm/tdns-es project — most likely a separate app, which the app-scope
+//     in §1.1 accommodates untouched.)
+//
+// Deliberately NOT here: inline-signing (the sanctioned exception), the catalog
+// options (consumption provisions OTHER zones and is the whole point of RFC 9432),
+// delegation-sync-child (its publishing paths are allow-updates-gated and Fix D
+// backstops them), and every serving-behaviour option.
+var originationOptions = []ZoneOption{
+	OptAllowUpdates,
+	OptAllowChildUpdates,
+	OptAddTransportSignal,
+	OptDelSyncParent,
+	OptOnlineSigning,
+}
+
+// normalizeOptionsForRole strips origination settings a zone may not act on,
+// and reports what it stripped so the caller can tell the operator.
+//
+// It returns the EFFECTIVE options, the EFFECTIVE outbound serial mode, the set
+// of options that were suppressed (nil if none), and a human-readable message
+// (empty if nothing was suppressed).
+//
+// It is a no-op unless the zone is a tdns-auth secondary that may not originate
+// content — the same predicate every other gate uses, so off tdns-auth this
+// changes nothing at all and the derived apps keep their own rules (§1.1).
+//
+// The caller owns the maps it passes in; this function does not mutate them.
+//
+// NOTE the outbound serial mode is handled here too even though it is a string
+// rather than a ZoneOption: `persist`/`unixtime` on a mirroring secondary is the
+// same class of misconfiguration (it would rewrite a serial that belongs to
+// upstream), and the operator deserves one consistent message for all of it.
+func normalizeOptionsForRole(appType AppType, ztype ZoneType, opts map[ZoneOption]bool, serialMode string) (
+	effective map[ZoneOption]bool, effectiveSerialMode string, suppressed map[ZoneOption]bool, msg string) {
+
+	// Mirrors zoneMayOriginateContent, but on loose values: this runs during
+	// config parsing, before a ZoneData necessarily exists.
+	mayOriginate := appType != AppTypeAuth || ztype == Primary || opts[OptInlineSigning]
+	if mayOriginate {
+		return opts, serialMode, nil, ""
+	}
+
+	effective = opts
+	effectiveSerialMode = serialMode
+	var stripped []string
+
+	for _, opt := range originationOptions {
+		if !opts[opt] {
+			continue
+		}
+		if suppressed == nil {
+			suppressed = map[ZoneOption]bool{}
+			// Copy-on-first-write: never mutate the caller's map, which may be
+			// shared with a live ZoneData or a config struct.
+			effective = make(map[ZoneOption]bool, len(opts))
+			for k, v := range opts {
+				effective[k] = v
+			}
+		}
+		suppressed[opt] = true
+		delete(effective, opt)
+		stripped = append(stripped, ZoneOptionToString[opt])
+	}
+
+	// persist/unixtime would rewrite a serial that is upstream's property.
+	// Empty ("inherit the global") is fine — the global is suppressed per-zone
+	// at the point of use, and warning about a server-wide default on every
+	// secondary would be noise. Only an EXPLICIT per-zone value is flagged.
+	serialStripped := false
+	if serialMode == OutboundSoaSerialPersist || serialMode == OutboundSoaSerialUnixtime {
+		effectiveSerialMode = ""
+		serialStripped = true
+	}
+
+	if len(stripped) == 0 && !serialStripped {
+		return effective, effectiveSerialMode, nil, ""
+	}
+
+	sort.Strings(stripped)
+	var b strings.Builder
+	b.WriteString("secondary zone may not originate content; ignoring ")
+	switch {
+	case len(stripped) > 0 && serialStripped:
+		fmt.Fprintf(&b, "option(s) %s and outbound_soa_serial=%s", strings.Join(stripped, ", "), serialMode)
+	case len(stripped) > 0:
+		fmt.Fprintf(&b, "option(s) %s", strings.Join(stripped, ", "))
+	default:
+		fmt.Fprintf(&b, "outbound_soa_serial=%s", serialMode)
+	}
+	// The likeliest operator intent behind online-signing on a secondary is the
+	// sanctioned signing-secondary setup, which is a different option.
+	if suppressed[OptOnlineSigning] {
+		b.WriteString(" (for a signing secondary use inline-signing instead)")
+	}
+	return effective, effectiveSerialMode, suppressed, b.String()
+}
+
+// applyOptionNormalization runs normalizeOptionsForRole for a zone and records
+// the outcome on the ZoneData: the effective options and serial mode are
+// installed, the suppressed set is remembered so the AS-CONFIGURED view can be
+// reconstructed when the config is re-serialized, and the operator gets a
+// ConfigWarning.
+//
+// ConfigWarning, NOT ConfigError, is deliberate: ConfigError is in
+// serviceImpactingErrors ("a NOTIFY/UPDATE/query handler should refuse with
+// SERVFAIL"), so using it would eventually take a merely-misconfigured
+// secondary out of service — and would park it permanently in the error column
+// of `zone list`. The zone here is serving correctly; only some of its config
+// is being ignored.
+//
+// Recomputed on every parse, so fixing the YAML clears the warning on reload.
+// ztype is passed explicitly rather than read from zd.ZoneType because the
+// static-config path normalizes before the parsed type has been assigned to the
+// ZoneData.
+func (zd *ZoneData) applyOptionNormalization(ztype ZoneType, opts map[ZoneOption]bool, serialMode string) (map[ZoneOption]bool, string) {
+	effective, effSerial, suppressed, msg := normalizeOptionsForRole(
+		Globals.App.Type, ztype, opts, serialMode)
+
+	zd.SuppressedOptions = suppressed
+	if msg == "" {
+		zd.ClearError(ConfigWarning)
+		return effective, effSerial
+	}
+	lg.Warn("zone option normalization", "zone", zd.ZoneName, "detail", msg)
+	zd.SetError(ConfigWarning, "%s", msg)
+	return effective, effSerial
+}
+
+// asConfiguredOptions reconstructs the options the OPERATOR wrote, by unioning
+// the effective set with whatever normalization suppressed.
+//
+// This exists because the dynamic config file is REGENERATED from live state on
+// every successful refresh of a persistable dynamic zone. Serializing the
+// effective set would permanently delete the operator's `allow-updates` from
+// their own config file — after which the warning would clear and the
+// misconfiguration would become invisible, having been silently "fixed" by
+// deleting the evidence. YAML is the source of truth for static zones; for
+// dynamic zones the file is written from state, so state has to remember what
+// was asked for.
+func (zd *ZoneData) asConfiguredOptions() map[ZoneOption]bool {
+	if len(zd.SuppressedOptions) == 0 {
+		return zd.Options
+	}
+	out := make(map[ZoneOption]bool, len(zd.Options)+len(zd.SuppressedOptions))
+	for k, v := range zd.Options {
+		out[k] = v
+	}
+	for k := range zd.SuppressedOptions {
+		out[k] = true
+	}
+	return out
+}

--- a/v2/zone_option_normalize_dynamic_test.go
+++ b/v2/zone_option_normalize_dynamic_test.go
@@ -1,0 +1,113 @@
+package tdns
+
+import "testing"
+
+// Regression tests for two findings from the PR #331 review.
+
+// TestModifyNormalizesSubmittedOptions pins the ModifyDynamicZone case: the
+// options SUBMITTED with a modify must be normalized, not just the ones carried
+// forward when none are supplied.
+//
+// Without that, `zone modify --options allow-updates` on a secondary installed
+// them live and persisted them with a STALE SuppressedOptions record and no
+// warning — re-enabling exactly what the normalizer exists to strip, through
+// the one ingress the design doc singled out as most likely to be missed.
+//
+// Exercised at the normalizer boundary that ModifyDynamicZone now calls, so it
+// fails if that call is dropped.
+func TestModifyNormalizesSubmittedOptions(t *testing.T) {
+	// A modify submitting origination options against a secondary.
+	submitted := map[ZoneOption]bool{
+		OptAllowUpdates:   true,
+		OptApiManagedZone: true, // set by the modify path itself
+	}
+	eff, _, sup, msg := normalizeOptionsForRole(AppTypeAuth, Secondary, submitted, "")
+
+	if eff[OptAllowUpdates] {
+		t.Error("submitted allow-updates survived normalization on a secondary")
+	}
+	if !sup[OptAllowUpdates] {
+		t.Error("suppressed set does not record the submitted option")
+	}
+	if !eff[OptApiManagedZone] {
+		t.Error("normalization dropped an unrelated internal marker")
+	}
+	if msg == "" {
+		t.Error("no warning produced for a submitted origination option")
+	}
+}
+
+// TestModifySuppressedSetReflectsSubmission guards the staleness half of the
+// same finding: the suppressed record must describe the options actually
+// submitted, not whatever the zone's previous incarnation carried. A modify
+// that REMOVES the offending option must clear the record, or the as-configured
+// view would keep resurrecting it into the persisted config forever.
+func TestModifySuppressedSetReflectsSubmission(t *testing.T) {
+	// Previous incarnation had allow-updates suppressed; the new submission
+	// drops it and asks only for a serving-behaviour option.
+	clean := map[ZoneOption]bool{OptFoldCase: true}
+	eff, _, sup, msg := normalizeOptionsForRole(AppTypeAuth, Secondary, clean, "")
+
+	if len(sup) != 0 {
+		t.Errorf("suppressed set should be empty for a clean submission, got %v", sup)
+	}
+	if msg != "" {
+		t.Errorf("clean submission should draw no warning, got %q", msg)
+	}
+	if !eff[OptFoldCase] {
+		t.Error("serving-behaviour option was dropped")
+	}
+}
+
+// TestGlobalSuppressionWarningUsesResolvedRole is the regression for the
+// cold-start false positive: the warning must be driven by the role resolved
+// during the parse, never by re-reading zd.ZoneType from the registry.
+//
+// zd.ZoneType is assigned asynchronously by the RefreshEngine when it consumes
+// the ZoneRefresher, so at warning time a freshly registered zone still has
+// ZoneType == 0. Reading it there made zoneMayOriginateContent false for
+// essentially every zone without inline-signing — PRIMARIES INCLUDED — so a
+// server with a global persist mode would list its primaries as "suppressed
+// secondaries" on every cold start.
+//
+// Pinned by asserting the predicate the collection now uses, against a zone
+// whose registry entry has NOT yet been populated.
+func TestGlobalSuppressionWarningUsesResolvedRole(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	// What the registry looks like at warning time on a cold start: the type
+	// has not been assigned yet.
+	unpopulated := &ZoneData{ZoneName: "primary.example.", Options: map[ZoneOption]bool{}}
+	if zoneMayOriginateContent(unpopulated) {
+		t.Fatal("setup: an unpopulated ZoneData is expected to read as non-originating")
+	}
+
+	// ...which is precisely why the collection uses the PARSED role instead.
+	for _, tc := range []struct {
+		name      string
+		appType   AppType
+		ztype     ZoneType
+		opts      map[ZoneOption]bool
+		perZone   string
+		candidate bool
+	}{
+		{"primary is never a candidate", AppTypeAuth, Primary, nil, "", false},
+		{"plain secondary inheriting the global", AppTypeAuth, Secondary, nil, "", true},
+		{"inline-signing secondary may originate", AppTypeAuth, Secondary,
+			map[ZoneOption]bool{OptInlineSigning: true}, "", false},
+		{"secondary with its own explicit mode already warned", AppTypeAuth, Secondary,
+			nil, OutboundSoaSerialPersist, false},
+		{"non-auth app is never a candidate", AppTypeAgent, Secondary, nil, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.opts
+			if opts == nil {
+				opts = map[ZoneOption]bool{}
+			}
+			got := serialSuppressionCandidate(tc.appType, tc.ztype, opts, tc.perZone)
+			if got != tc.candidate {
+				t.Errorf("serialSuppressionCandidate = %v, want %v", got, tc.candidate)
+			}
+		})
+	}
+}

--- a/v2/zone_option_normalize_dynamic_test.go
+++ b/v2/zone_option_normalize_dynamic_test.go
@@ -1,88 +1,123 @@
 package tdns
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
-// Regression tests for two findings from the PR #331 review.
+// Regression tests for findings from the PR #331 reviews.
+//
+// These drive the REAL ModifyDynamicZone/ProvisionDynamicZone paths rather than
+// the normalizer helper: an earlier version of this file exercised only the
+// helper, so it would still have passed if the dynamic-zone paths stopped
+// calling it — which was precisely the bug under test.
 
-// TestModifyNormalizesSubmittedOptions pins the ModifyDynamicZone case: the
-// options SUBMITTED with a modify must be normalized, not just the ones carried
-// forward when none are supplied.
+// TestModifyNormalizesSubmittedOptions: options SUBMITTED with a modify must be
+// normalized, not just the ones carried forward when none are supplied.
 //
-// Without that, `zone modify --options allow-updates` on a secondary installed
-// them live and persisted them with a STALE SuppressedOptions record and no
-// warning — re-enabling exactly what the normalizer exists to strip, through
-// the one ingress the design doc singled out as most likely to be missed.
-//
-// Exercised at the normalizer boundary that ModifyDynamicZone now calls, so it
-// fails if that call is dropped.
+// Without this, `zone modify --options allow-updates` on a secondary installed
+// them live and persisted them with no ConfigWarning — re-enabling exactly what
+// the normalizer exists to strip, through the ingress the design doc singled
+// out as most likely to be missed.
 func TestModifyNormalizesSubmittedOptions(t *testing.T) {
-	// A modify submitting origination options against a secondary.
-	submitted := map[ZoneOption]bool{
-		OptAllowUpdates:   true,
-		OptApiManagedZone: true, // set by the modify path itself
-	}
-	eff, _, sup, msg := normalizeOptionsForRole(AppTypeAuth, Secondary, submitted, "")
+	withAppType(t, AppTypeAuth)
+	resetZonesForTest()
+	conf, ch := newTestConfigForCores(t)
 
-	if eff[OptAllowUpdates] {
-		t.Error("submitted allow-updates survived normalization on a secondary")
+	in := DynamicZoneInput{Name: "modopt.example", Type: Secondary,
+		Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}}}
+	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err != nil {
+		t.Fatalf("add failed: %v", err)
 	}
-	if !sup[OptAllowUpdates] {
-		t.Error("suppressed set does not record the submitted option")
+	<-ch
+
+	// Submit an origination option against the (secondary) zone.
+	mod := DynamicZoneInput{Name: "modopt.example", Type: Secondary,
+		Primaries: []PeerConf{{Addr: "192.0.2.9:53", Key: NOKEY}},
+		Options:   map[ZoneOption]bool{OptAllowUpdates: true},
 	}
-	if !eff[OptApiManagedZone] {
-		t.Error("normalization dropped an unrelated internal marker")
+	if _, err := conf.ModifyDynamicZone(context.Background(), mod); err != nil {
+		t.Fatalf("modify failed: %v", err)
 	}
-	if msg == "" {
-		t.Error("no warning produced for a submitted origination option")
+	<-ch
+
+	zd, _ := Zones.Get("modopt.example.")
+	if zd.Options[OptAllowUpdates] {
+		t.Error("submitted allow-updates went live on a secondary: normalization was skipped")
+	}
+	if !zd.SuppressedOptions[OptAllowUpdates] {
+		t.Error("suppressed record does not mention the submitted option")
+	}
+	if !zd.HasError(ConfigWarning) {
+		t.Error("no ConfigWarning raised for the submitted origination option")
+	}
+	// The operator's intent must still round-trip into the persisted config.
+	if !zd.asConfiguredOptions()[OptAllowUpdates] {
+		t.Error("as-configured view lost the submitted option")
 	}
 }
 
-// TestModifySuppressedSetReflectsSubmission guards the staleness half of the
-// same finding: the suppressed record must describe the options actually
-// submitted, not whatever the zone's previous incarnation carried. A modify
-// that REMOVES the offending option must clear the record, or the as-configured
-// view would keep resurrecting it into the persisted config forever.
-func TestModifySuppressedSetReflectsSubmission(t *testing.T) {
-	// Previous incarnation had allow-updates suppressed; the new submission
-	// drops it and asks only for a serving-behaviour option.
-	clean := map[ZoneOption]bool{OptFoldCase: true}
-	eff, _, sup, msg := normalizeOptionsForRole(AppTypeAuth, Secondary, clean, "")
+// TestModifyWithoutOptionsPreservesSuppressed is the regression for the bug the
+// FIRST round of review fixes introduced: with in.Options == nil, the carried
+// options are already the EFFECTIVE (stripped) set, so re-normalizing them
+// finds nothing to strip and returns an empty suppressed set — which then
+// overwrote the carried-forward record. The operator's origination options
+// would be permanently deleted from their own persisted config by the next
+// rewrite, silently, with the warning clearing at the same time.
+func TestModifyWithoutOptionsPreservesSuppressed(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+	resetZonesForTest()
+	conf, ch := newTestConfigForCores(t)
 
-	if len(sup) != 0 {
-		t.Errorf("suppressed set should be empty for a clean submission, got %v", sup)
+	// Add a secondary that asks for an origination option; it is stripped at
+	// provisioning and recorded as suppressed.
+	in := DynamicZoneInput{Name: "modnil.example", Type: Secondary,
+		Primaries: []PeerConf{{Addr: "192.0.2.1:53", Key: NOKEY}},
+		Options:   map[ZoneOption]bool{OptAllowUpdates: true},
 	}
-	if msg != "" {
-		t.Errorf("clean submission should draw no warning, got %q", msg)
+	if _, err := conf.ProvisionDynamicZone(context.Background(), in, true); err != nil {
+		t.Fatalf("add failed: %v", err)
 	}
-	if !eff[OptFoldCase] {
-		t.Error("serving-behaviour option was dropped")
+	<-ch
+
+	before, _ := Zones.Get("modnil.example.")
+	if !before.SuppressedOptions[OptAllowUpdates] {
+		t.Fatal("setup: provisioning did not record the suppressed option")
+	}
+
+	// A TSIG/primaries-only modify, carrying NO options.
+	mod := DynamicZoneInput{Name: "modnil.example", Type: Secondary,
+		Primaries: []PeerConf{{Addr: "192.0.2.9:53", Key: NOKEY}}}
+	if _, err := conf.ModifyDynamicZone(context.Background(), mod); err != nil {
+		t.Fatalf("modify failed: %v", err)
+	}
+	<-ch
+
+	after, _ := Zones.Get("modnil.example.")
+	if after.Options[OptAllowUpdates] {
+		t.Error("allow-updates became effective across a modify")
+	}
+	if !after.SuppressedOptions[OptAllowUpdates] {
+		t.Error("modify DESTROYED the suppressed record: the operator's config would be silently rewritten")
+	}
+	if !after.asConfiguredOptions()[OptAllowUpdates] {
+		t.Error("as-configured view lost the option across a modify")
 	}
 }
 
-// TestGlobalSuppressionWarningUsesResolvedRole is the regression for the
-// cold-start false positive: the warning must be driven by the role resolved
-// during the parse, never by re-reading zd.ZoneType from the registry.
-//
-// zd.ZoneType is assigned asynchronously by the RefreshEngine when it consumes
-// the ZoneRefresher, so at warning time a freshly registered zone still has
-// ZoneType == 0. Reading it there made zoneMayOriginateContent false for
-// essentially every zone without inline-signing — PRIMARIES INCLUDED — so a
-// server with a global persist mode would list its primaries as "suppressed
-// secondaries" on every cold start.
-//
-// Pinned by asserting the predicate the collection now uses, against a zone
-// whose registry entry has NOT yet been populated.
-func TestGlobalSuppressionWarningUsesResolvedRole(t *testing.T) {
+// TestGlobalSuppressionCandidate covers the predicate the suppression warning
+// is driven by. It takes loose values, not a *ZoneData, because zd.ZoneType is
+// assigned asynchronously by the RefreshEngine: reading it at parse time
+// classified PRIMARIES as secondaries and mis-reported them on every cold start.
+func TestGlobalSuppressionCandidate(t *testing.T) {
 	withAppType(t, AppTypeAuth)
 
-	// What the registry looks like at warning time on a cold start: the type
-	// has not been assigned yet.
+	// What a registry entry actually looks like at warning time on cold start.
 	unpopulated := &ZoneData{ZoneName: "primary.example.", Options: map[ZoneOption]bool{}}
 	if zoneMayOriginateContent(unpopulated) {
-		t.Fatal("setup: an unpopulated ZoneData is expected to read as non-originating")
+		t.Fatal("setup: an unpopulated ZoneData reads as non-originating — the trap being avoided")
 	}
 
-	// ...which is precisely why the collection uses the PARSED role instead.
 	for _, tc := range []struct {
 		name      string
 		appType   AppType
@@ -104,8 +139,7 @@ func TestGlobalSuppressionWarningUsesResolvedRole(t *testing.T) {
 			if opts == nil {
 				opts = map[ZoneOption]bool{}
 			}
-			got := serialSuppressionCandidate(tc.appType, tc.ztype, opts, tc.perZone)
-			if got != tc.candidate {
+			if got := serialSuppressionCandidate(tc.appType, tc.ztype, opts, tc.perZone); got != tc.candidate {
 				t.Errorf("serialSuppressionCandidate = %v, want %v", got, tc.candidate)
 			}
 		})

--- a/v2/zone_option_normalize_test.go
+++ b/v2/zone_option_normalize_test.go
@@ -1,0 +1,226 @@
+package tdns
+
+import (
+	"strings"
+	"testing"
+)
+
+// Fix B: the option normalizer. It strips origination settings a tdns-auth
+// secondary may not act on, records what it stripped so the AS-CONFIGURED view
+// survives, and warns the operator without taking the zone out of service.
+
+func optSet(opts ...ZoneOption) map[ZoneOption]bool {
+	m := map[ZoneOption]bool{}
+	for _, o := range opts {
+		m[o] = true
+	}
+	return m
+}
+
+// TestNormalizeStripsEveryOriginationOption walks the full turn-off list. Each
+// of the five is stripped on a plain tdns-auth secondary, and each appears in
+// the operator-facing message.
+func TestNormalizeStripsEveryOriginationOption(t *testing.T) {
+	for _, opt := range originationOptions {
+		t.Run(ZoneOptionToString[opt], func(t *testing.T) {
+			eff, _, sup, msg := normalizeOptionsForRole(
+				AppTypeAuth, Secondary, optSet(opt), "")
+
+			if eff[opt] {
+				t.Errorf("%s still effective on a secondary", ZoneOptionToString[opt])
+			}
+			if !sup[opt] {
+				t.Errorf("%s not recorded as suppressed", ZoneOptionToString[opt])
+			}
+			if !strings.Contains(msg, ZoneOptionToString[opt]) {
+				t.Errorf("message does not name the option: %q", msg)
+			}
+		})
+	}
+}
+
+// TestNormalizeKeepsSanctionedAndServingOptions guards the carve-outs: the
+// catalog options (consumption provisions OTHER zones — the whole point of
+// RFC 9432), delegation-sync-child, and serving-behaviour options must survive
+// untouched on a secondary.
+func TestNormalizeKeepsSanctionedAndServingOptions(t *testing.T) {
+	keep := optSet(
+		OptCatalogZone, OptCatalogMemberAutoCreate, OptCatalogMemberAutoDelete,
+		OptDelSyncChild, OptFoldCase, OptBlackLies,
+	)
+	eff, _, sup, msg := normalizeOptionsForRole(AppTypeAuth, Secondary, keep, "")
+
+	for opt := range keep {
+		if !eff[opt] {
+			t.Errorf("%s was stripped but must be kept on a secondary", ZoneOptionToString[opt])
+		}
+	}
+	if len(sup) != 0 {
+		t.Errorf("nothing should have been suppressed, got %v", sup)
+	}
+	if msg != "" {
+		t.Errorf("no warning expected, got %q", msg)
+	}
+}
+
+// TestNormalizeNoopForOriginators covers the three cases that may originate:
+// a primary, an inline-signing secondary (the sanctioned exception), and any
+// zone off tdns-auth (the §1.1 guarantee for tdns-mp / tdns-agent).
+func TestNormalizeNoopForOriginators(t *testing.T) {
+	all := optSet(originationOptions...)
+
+	cases := []struct {
+		name    string
+		appType AppType
+		ztype   ZoneType
+		opts    map[ZoneOption]bool
+	}{
+		{"primary", AppTypeAuth, Primary, all},
+		{"inline-signing secondary", AppTypeAuth, Secondary, optSet(append(originationOptions, OptInlineSigning)...)},
+		{"non-auth app secondary", AppTypeAgent, Secondary, all},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eff, serial, sup, msg := normalizeOptionsForRole(
+				tc.appType, tc.ztype, tc.opts, OutboundSoaSerialPersist)
+
+			for _, opt := range originationOptions {
+				if !eff[opt] {
+					t.Errorf("%s was stripped but this zone may originate", ZoneOptionToString[opt])
+				}
+			}
+			if serial != OutboundSoaSerialPersist {
+				t.Errorf("serial mode = %q, want it left alone", serial)
+			}
+			if len(sup) != 0 || msg != "" {
+				t.Errorf("expected a complete no-op, got suppressed=%v msg=%q", sup, msg)
+			}
+		})
+	}
+}
+
+// TestNormalizeStripsExplicitSerialMode pins that an explicit per-zone
+// persist/unixtime is cleared on a secondary (it would rewrite a serial that
+// belongs to upstream), while an EMPTY value — "inherit the global" — is left
+// alone and draws no warning. Warning about a server-wide default on every
+// secondary would be noise; the global is suppressed at the point of use.
+func TestNormalizeStripsExplicitSerialMode(t *testing.T) {
+	for _, mode := range []string{OutboundSoaSerialPersist, OutboundSoaSerialUnixtime} {
+		_, serial, _, msg := normalizeOptionsForRole(
+			AppTypeAuth, Secondary, map[ZoneOption]bool{}, mode)
+		if serial != "" {
+			t.Errorf("%s: serial mode = %q, want cleared", mode, serial)
+		}
+		if !strings.Contains(msg, "outbound_soa_serial") {
+			t.Errorf("%s: message does not mention the serial mode: %q", mode, msg)
+		}
+	}
+
+	// Empty (inherit) and explicit keep are both harmless.
+	for _, mode := range []string{"", OutboundSoaSerialKeep} {
+		_, serial, _, msg := normalizeOptionsForRole(
+			AppTypeAuth, Secondary, map[ZoneOption]bool{}, mode)
+		if serial != mode {
+			t.Errorf("mode %q was altered to %q", mode, serial)
+		}
+		if msg != "" {
+			t.Errorf("mode %q drew a warning: %q", mode, msg)
+		}
+	}
+}
+
+// TestNormalizeSuggestsInlineSigning checks the actionable half of the message:
+// the likeliest intent behind online-signing on a secondary is the sanctioned
+// signing-secondary setup, which is a different option.
+func TestNormalizeSuggestsInlineSigning(t *testing.T) {
+	_, _, _, msg := normalizeOptionsForRole(
+		AppTypeAuth, Secondary, optSet(OptOnlineSigning), "")
+	if !strings.Contains(msg, "inline-signing") {
+		t.Errorf("message should point at inline-signing, got %q", msg)
+	}
+}
+
+// TestNormalizeDoesNotMutateCallerMap guards the copy-on-write: the caller's
+// map may be shared with a live ZoneData or a config struct, so stripping must
+// not reach back into it.
+func TestNormalizeDoesNotMutateCallerMap(t *testing.T) {
+	in := optSet(OptAllowUpdates, OptFoldCase)
+	eff, _, _, _ := normalizeOptionsForRole(AppTypeAuth, Secondary, in, "")
+
+	if !in[OptAllowUpdates] {
+		t.Error("caller's map was mutated")
+	}
+	if eff[OptAllowUpdates] {
+		t.Error("effective map still carries the stripped option")
+	}
+}
+
+// TestAsConfiguredOptionsRoundTrip is the anti-silent-deletion guard. The
+// dynamic config file is regenerated from live state, so the as-configured view
+// (effective ∪ suppressed) is what must be written back — otherwise the
+// operator's allow-updates is deleted from their own config, the warning then
+// clears, and the misconfiguration becomes invisible.
+func TestAsConfiguredOptionsRoundTrip(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := &ZoneData{ZoneName: "sec.example.", ZoneType: Secondary}
+	opts, serial := zd.applyOptionNormalization(
+		Secondary, optSet(OptAllowUpdates, OptFoldCase), OutboundSoaSerialPersist)
+	zd.Options = opts
+	zd.OutboundSoaSerial = serial
+
+	if zd.Options[OptAllowUpdates] {
+		t.Error("effective options still carry allow-updates")
+	}
+	asConf := zd.asConfiguredOptions()
+	if !asConf[OptAllowUpdates] {
+		t.Error("as-configured view lost allow-updates: the operator's config would be silently rewritten")
+	}
+	if !asConf[OptFoldCase] {
+		t.Error("as-configured view lost an untouched option")
+	}
+
+	// And it must survive into the serialized ZoneConf.
+	zconf := zoneDataToZoneConf(zd, "/tmp/zones")
+	var found bool
+	for _, s := range zconf.OptionsStrs {
+		if s == ZoneOptionToString[OptAllowUpdates] {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("serialized options lost allow-updates: %v", zconf.OptionsStrs)
+	}
+}
+
+// TestApplyOptionNormalizationUsesConfigWarning pins the severity choice.
+// ConfigError is in serviceImpactingErrors ("a NOTIFY/UPDATE/query handler
+// should refuse with SERVFAIL"), so using it here would eventually take a
+// merely-misconfigured secondary out of service. The zone is serving correctly;
+// only some of its config is ignored.
+func TestApplyOptionNormalizationUsesConfigWarning(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := &ZoneData{ZoneName: "sec.example.", ZoneType: Secondary}
+	zd.applyOptionNormalization(Secondary, optSet(OptAllowUpdates), "")
+
+	if !zd.HasError(ConfigWarning) {
+		t.Fatal("expected a ConfigWarning")
+	}
+	if zd.HasError(ConfigError) {
+		t.Error("must not raise ConfigError: that category is service-impacting")
+	}
+	if ErrorTypeIsServiceImpacting(ConfigWarning) {
+		t.Error("ConfigWarning must not be service-impacting")
+	}
+
+	// Recomputed each parse: a clean config clears the warning on reload.
+	zd.applyOptionNormalization(Secondary, optSet(OptFoldCase), "")
+	if zd.HasError(ConfigWarning) {
+		t.Error("warning should clear once the config is clean")
+	}
+	if len(zd.SuppressedOptions) != 0 {
+		t.Error("suppressed set should be empty once the config is clean")
+	}
+}

--- a/v2/zone_origination.go
+++ b/v2/zone_origination.go
@@ -6,6 +6,8 @@
  */
 package tdns
 
+import "fmt"
+
 // zoneMayOriginateContent reports whether this zone is allowed to ORIGINATE
 // content — that is, to publish anything of its own into the zone, or to
 // advance the zone's SOA serial beyond what upstream handed it.
@@ -45,4 +47,43 @@ func zoneMayOriginateContent(zd *ZoneData) bool {
 		return true
 	}
 	return zd.ZoneType == Primary || zd.Options[OptInlineSigning]
+}
+
+// originationAPICommands are the /zone and /zone/dsync API commands that make
+// the server ORIGINATE content: they either write into the zone or advance its
+// serial. Refused on a zone that may not originate (Fix C).
+//
+// Deliberately NOT a blanket secondary-refusal. `write-zone` in particular
+// stays allowed: it depends only on OptDirty/force, touches no options, and
+// dumping a transferred zone to disk is a legitimate secondary operation.
+// Read-only commands (list-zones, show-nsec-chain, status, ...) are untouched.
+//
+// freeze/thaw are handled separately at their own cases: they need the role
+// check to fire BEFORE their allow-updates precondition, so the operator gets
+// the true reason rather than being sent to enable an option the normalizer
+// would immediately strip again.
+var originationAPICommands = map[string]bool{
+	// /zone
+	"bump":          true,
+	"sign-zone":     true,
+	"resign-zone":   true,
+	"policy-set":    true,
+	"change-policy": true,
+	"policy-reset":  true,
+	"generate-nsec": true,
+	// /zone/dsync — publishes the _dsync DSYNC RRset into the zone
+	"publish-dsync-rrset":   true,
+	"unpublish-dsync-rrset": true,
+}
+
+// zoneOriginationRefusal returns the operator-facing refusal message for an
+// action on a zone that may not originate content, or "" when the action is
+// allowed. The wording deliberately matches the option normalizer's warning and
+// the applier gate's log line, so all three name the same reason.
+func zoneOriginationRefusal(zd *ZoneData, action string) string {
+	if zoneMayOriginateContent(zd) {
+		return ""
+	}
+	return fmt.Sprintf("zone %s is a secondary and may not originate content: %q refused "+
+		"(a secondary serves what it received from upstream, unmodified)", zd.ZoneName, action)
 }

--- a/v2/zone_origination.go
+++ b/v2/zone_origination.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * The MUST-NOT-MODIFY invariant for tdns-auth secondary zones.
+ * See docs/2026-07-25-secondary-zones-immutable.md.
+ */
+package tdns
+
+// zoneMayOriginateContent reports whether this zone is allowed to ORIGINATE
+// content — that is, to publish anything of its own into the zone, or to
+// advance the zone's SOA serial beyond what upstream handed it.
+//
+// The question the invariant turns on is NOT "is this zone signed" but "did WE
+// originate this content?". A secondary serves a copy whose authoritative
+// source is upstream, so what it serves — content AND serial — must match what
+// it received; that is what makes multiple secondaries of one primary
+// interchangeable. Two cases may originate:
+//
+//   - a PRIMARY, trivially: it is the source;
+//   - an INLINE-SIGNING secondary, the one sanctioned exception: it
+//     deliberately transforms upstream content by adding locally generated
+//     RRSIGs, so its content — and therefore its serial — legitimately
+//     diverges from upstream.
+//
+// SCOPE (load-bearing): this returns true for every app type other than
+// tdns-auth, which makes every gate built on it a complete no-op there. v2/ is
+// a shared library and several derived apps deliberately mutate a zone while
+// holding the Secondary role — tdns-mpcombiner edits zones as a secondary (that
+// is its whole job), tdns-mpagent has its own permissions, tdns-agent already
+// carries secondary special-cases. Their rules must survive the next time they
+// bump their tdns pin. Keeping the app-type test HERE, in one place, rather
+// than repeating `Globals.App.Type == AppTypeAuth &&` at each call site, means
+// no future gate can forget it.
+//
+// NOTE for tests: Globals.App.Type must be set to AppTypeAuth for any of the
+// gates to engage; an unset (zero) app type reads as "not tdns-auth" and every
+// gate stands down. That is deliberate — it is the same property that protects
+// the derived apps — but it means a test asserting a gate must set the app type
+// explicitly.
+func zoneMayOriginateContent(zd *ZoneData) bool {
+	if zd == nil {
+		return true // nothing to protect; never gate on a nil zone
+	}
+	if Globals.App.Type != AppTypeAuth {
+		return true
+	}
+	return zd.ZoneType == Primary || zd.Options[OptInlineSigning]
+}

--- a/v2/zone_origination_api_test.go
+++ b/v2/zone_origination_api_test.go
@@ -1,0 +1,114 @@
+package tdns
+
+import (
+	"strings"
+	"testing"
+)
+
+// Fix C: the API origination gate. Actions that write into a zone or advance
+// its serial are refused on a tdns-auth secondary; read-only and
+// legitimately-secondary actions are not.
+
+// TestOriginationAPICommandSet pins exactly which commands are gated. The list
+// is deliberately explicit: it is short by several in the original audit, and
+// the two easy mistakes are forgetting policy-reset (an origination action that
+// reads as bookkeeping) and gating write-zone (which is legitimate on a
+// secondary).
+func TestOriginationAPICommandSet(t *testing.T) {
+	gated := []string{
+		"bump", "sign-zone", "resign-zone",
+		"policy-set", "change-policy", "policy-reset", "generate-nsec",
+		"publish-dsync-rrset", "unpublish-dsync-rrset",
+	}
+	for _, cmd := range gated {
+		if !originationAPICommands[cmd] {
+			t.Errorf("%q must be gated as an origination action", cmd)
+		}
+	}
+
+	ungated := []string{
+		"write-zone",      // dumping a transferred zone to disk is legitimate
+		"list-zones",      // read-only
+		"show-nsec-chain", // read-only
+		"reload",          // re-pull from upstream: the opposite of originating
+		"status",          // read-only (dsync handler)
+		"freeze", "thaw",  // gated, but at their own cases (ordering matters)
+	}
+	for _, cmd := range ungated {
+		if originationAPICommands[cmd] {
+			t.Errorf("%q must NOT be in the blanket origination set", cmd)
+		}
+	}
+}
+
+// TestZoneOriginationRefusal covers the helper every Fix C call site uses.
+func TestZoneOriginationRefusal(t *testing.T) {
+	secondary := &ZoneData{ZoneName: "sec.example.", ZoneType: Secondary, Options: map[ZoneOption]bool{}}
+	primary := &ZoneData{ZoneName: "pri.example.", ZoneType: Primary, Options: map[ZoneOption]bool{}}
+	inline := &ZoneData{ZoneName: "sig.example.", ZoneType: Secondary,
+		Options: map[ZoneOption]bool{OptInlineSigning: true}}
+
+	withAppType(t, AppTypeAuth)
+
+	msg := zoneOriginationRefusal(secondary, "bump")
+	if msg == "" {
+		t.Fatal("a plain auth secondary must be refused")
+	}
+	// The message has to be actionable: name the zone, the action, and why.
+	for _, want := range []string{"sec.example.", "bump", "may not originate"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal message missing %q: %s", want, msg)
+		}
+	}
+
+	if got := zoneOriginationRefusal(primary, "bump"); got != "" {
+		t.Errorf("primary must not be refused, got %q", got)
+	}
+	if got := zoneOriginationRefusal(inline, "bump"); got != "" {
+		t.Errorf("inline-signing secondary must not be refused, got %q", got)
+	}
+
+	// §1.1: off tdns-auth nothing is refused.
+	withAppType(t, AppTypeAgent)
+	if got := zoneOriginationRefusal(secondary, "bump"); got != "" {
+		t.Errorf("non-auth app must not be refused, got %q", got)
+	}
+}
+
+// TestCatalogAuthoringRefusedOnSecondary drives the real catalog authoring
+// path. regenerateCatalogZone rewrites the catalog zone's own PTR/TXT records
+// and publishes, so it is authoring and must be refused on a secondary — while
+// catalog CONSUMPTION (auto-create/delete of member zones) is untouched, since
+// that acts on other zones and is the whole point of RFC 9432.
+func TestCatalogAuthoringRefusedOnSecondary(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = Secondary
+	zd.Options = map[ZoneOption]bool{OptCatalogZone: true}
+
+	err := regenerateCatalogZone(zd.ZoneName)
+	if err == nil {
+		t.Fatal("catalog authoring must be refused on a secondary catalog zone")
+	}
+	if !strings.Contains(err.Error(), "may not originate") {
+		t.Errorf("unexpected refusal reason: %v", err)
+	}
+}
+
+// TestCatalogAuthoringAllowedOnPrimary is the other half: the gate must not
+// break the ordinary case.
+func TestCatalogAuthoringAllowedOnPrimary(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = Primary
+	zd.Options = map[ZoneOption]bool{OptCatalogZone: true}
+
+	// May still fail for unrelated reasons in a unit context, but it must not
+	// fail with the origination refusal.
+	if err := regenerateCatalogZone(zd.ZoneName); err != nil &&
+		strings.Contains(err.Error(), "may not originate") {
+		t.Errorf("primary catalog zone was wrongly refused: %v", err)
+	}
+}

--- a/v2/zone_serial_probe.go
+++ b/v2/zone_serial_probe.go
@@ -7,6 +7,7 @@
 package tdns
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -28,14 +29,32 @@ import (
 // Read-only: it mutates no zone state and makes no transfer decision. Costs one
 // query per primary, so it belongs on the single-zone `zone desc` path rather
 // than in a bulk listing.
-func (zd *ZoneData) ProbeUpstreamSerials(conf *Config) []UpstreamSerial {
+//
+// ctx is the caller's context (the HTTP request's, from the zone API handler)
+// and is honoured per probe via ExchangeContext. That matters because the
+// probes are sequential: with the library's 2s default timeout, a zone with
+// several unreachable primaries would otherwise pin the handler for
+// len(Upstreams) x 2s regardless of the request deadline. On cancellation the
+// remaining primaries are reported as such rather than silently omitted.
+func (zd *ZoneData) ProbeUpstreamSerials(ctx context.Context, conf *Config) []UpstreamSerial {
 	if zd == nil || len(zd.Upstreams) == 0 {
 		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	out := make([]UpstreamSerial, 0, len(zd.Upstreams))
 	for _, up := range zd.Upstreams {
 		res := UpstreamSerial{Addr: up.Addr}
+
+		// Stop probing once the caller has given up, but still record the
+		// remaining primaries: "not probed" is honest, silence is not.
+		if err := ctx.Err(); err != nil {
+			res.Err = fmt.Sprintf("not probed: %v", err)
+			out = append(out, res)
+			continue
+		}
 
 		upstream := up.Addr
 		if _, _, err := net.SplitHostPort(upstream); err != nil {
@@ -65,7 +84,7 @@ func (zd *ZoneData) ProbeUpstreamSerials(conf *Config) []UpstreamSerial {
 		}
 		c.TsigProvider = provider // nil for NOKEY => plain exchange
 
-		r, _, err := c.Exchange(m, upstream)
+		r, _, err := c.ExchangeContext(ctx, m, upstream)
 		switch {
 		case err != nil:
 			res.Err = err.Error()
@@ -85,14 +104,6 @@ func (zd *ZoneData) ProbeUpstreamSerials(conf *Config) []UpstreamSerial {
 	return out
 }
 
-// outboundSoaSerialSource names which tier supplied the zone's effective
-// outbound serial mode, so `zone desc` can show the value AND why it applies.
-func (zd *ZoneData) outboundSoaSerialSource() string {
-	if zd.OutboundSoaSerial != "" {
-		return "zone" // per-zone setting, possibly inherited from its template
-	}
-	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial != "" {
-		return "global" // dnsengine.outbound_soa_serial
-	}
-	return "default"
-}
+// (The value/source pair is resolved by EffectiveOutboundSoaSerialWithSource in
+// zone_utils.go — deliberately one function, so the precedence chain is not
+// stated twice and cannot drift.)

--- a/v2/zone_serial_probe.go
+++ b/v2/zone_serial_probe.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Read-only per-primary SOA probing, for `zone desc` serial visibility.
+ * See docs/2026-07-25-secondary-zones-immutable.md §7.
+ */
+package tdns
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+// ProbeUpstreamSerials asks EVERY configured primary for the zone's SOA and
+// reports what each one answered.
+//
+// This is deliberately not DoTransfer. DoTransfer probes to DECIDE — it
+// short-circuits on the first usable answer, because for transferring purposes
+// one good primary is enough. Here the disagreement IS the signal: the failure
+// that motivated the MUST-NOT-MODIFY work was two masters serving the same zone
+// at different serials, with edge nodes silently always fetching from the
+// higher one. Seeing "this master says 42, that one says 5000" is the whole
+// point, so every primary is probed and every answer kept, including failures
+// (an unreachable master is itself diagnostic).
+//
+// Read-only: it mutates no zone state and makes no transfer decision. Costs one
+// query per primary, so it belongs on the single-zone `zone desc` path rather
+// than in a bulk listing.
+func (zd *ZoneData) ProbeUpstreamSerials(conf *Config) []UpstreamSerial {
+	if zd == nil || len(zd.Upstreams) == 0 {
+		return nil
+	}
+
+	out := make([]UpstreamSerial, 0, len(zd.Upstreams))
+	for _, up := range zd.Upstreams {
+		res := UpstreamSerial{Addr: up.Addr}
+
+		upstream := up.Addr
+		if _, _, err := net.SplitHostPort(upstream); err != nil {
+			upstream = net.JoinHostPort(upstream, defaultPortForPeer(up))
+		}
+
+		m := new(dns.Msg)
+		m.SetQuestion(zd.ZoneName, dns.TypeSOA)
+		c := new(dns.Client)
+
+		// Probe over the same verified channel the transfer itself would use,
+		// so an XoT peer is not silently probed in plaintext and a TSIG
+		// mismatch surfaces here rather than at transfer time.
+		if tlsCfg, terr := conf.ClientTLSConfigForPeer(up); terr != nil {
+			res.Err = fmt.Sprintf("TLS setup failed: %v", terr)
+			out = append(out, res)
+			continue
+		} else if tlsCfg != nil {
+			c.Net = "tcp-tls"
+			c.TLSConfig = tlsCfg
+		}
+		provider, serr := SignForPeer(m, up.Key, conf)
+		if serr != nil {
+			res.Err = fmt.Sprintf("TSIG sign setup failed: %v", serr)
+			out = append(out, res)
+			continue
+		}
+		c.TsigProvider = provider // nil for NOKEY => plain exchange
+
+		r, _, err := c.Exchange(m, upstream)
+		switch {
+		case err != nil:
+			res.Err = err.Error()
+		case r.MsgHdr.Rcode != dns.RcodeSuccess:
+			res.Err = dns.RcodeToString[r.MsgHdr.Rcode]
+		case len(r.Answer) == 0:
+			res.Err = "NOERROR but empty answer section"
+		default:
+			if soa, ok := r.Answer[0].(*dns.SOA); ok {
+				res.Serial = soa.Serial
+			} else {
+				res.Err = "first answer is not a SOA"
+			}
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+// outboundSoaSerialSource names which tier supplied the zone's effective
+// outbound serial mode, so `zone desc` can show the value AND why it applies.
+func (zd *ZoneData) outboundSoaSerialSource() string {
+	if zd.OutboundSoaSerial != "" {
+		return "zone" // per-zone setting, possibly inherited from its template
+	}
+	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial != "" {
+		return "global" // dnsengine.outbound_soa_serial
+	}
+	return "default"
+}

--- a/v2/zone_serial_probe.go
+++ b/v2/zone_serial_probe.go
@@ -37,11 +37,28 @@ import (
 // len(Upstreams) x 2s regardless of the request deadline. On cancellation the
 // remaining primaries are reported as such rather than silently omitted.
 func (zd *ZoneData) ProbeUpstreamSerials(ctx context.Context, conf *Config) []UpstreamSerial {
-	if zd == nil || len(zd.Upstreams) == 0 {
+	if zd == nil {
 		return nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+
+	// zd.Upstreams is mutated in place under zd.mu by the refresh engine
+	// (refreshengine.go), so take a copy under that lock rather than ranging
+	// over the live slice -- confMu guards the config, not zone data.
+	//
+	// Deliberately NOT held together with confMu below. The two locks are
+	// nested nowhere else in the tree, and a read-only diagnostic path is a
+	// poor reason to introduce an ordering constraint that every future
+	// writer would then have to respect.
+	zd.mu.Lock()
+	upstreams := make([]PeerConf, len(zd.Upstreams))
+	copy(upstreams, zd.Upstreams)
+	zd.mu.Unlock()
+
+	if len(upstreams) == 0 {
+		return nil
 	}
 
 	// Phase 1 -- resolve everything that reads config, under a single read
@@ -62,10 +79,10 @@ func (zd *ZoneData) ProbeUpstreamSerials(ctx context.Context, conf *Config) []Up
 		tsigAlgo string
 		failed   bool
 	}
-	plans := make([]probePlan, 0, len(zd.Upstreams))
+	plans := make([]probePlan, 0, len(upstreams))
 
 	confMu.RLock()
-	for _, up := range zd.Upstreams {
+	for _, up := range upstreams {
 		p := probePlan{res: UpstreamSerial{Addr: up.Addr}, upstream: up.Addr}
 		if _, _, err := net.SplitHostPort(p.upstream); err != nil {
 			p.upstream = net.JoinHostPort(p.upstream, defaultPortForPeer(up))

--- a/v2/zone_serial_probe.go
+++ b/v2/zone_serial_probe.go
@@ -44,62 +44,105 @@ func (zd *ZoneData) ProbeUpstreamSerials(ctx context.Context, conf *Config) []Up
 		ctx = context.Background()
 	}
 
-	out := make([]UpstreamSerial, 0, len(zd.Upstreams))
+	// Phase 1 -- resolve everything that reads config, under a single read
+	// lock, with NO network I/O. ProbeUpstreamSerials receives the mutable
+	// global &Conf, and a reload replaces its contents wholesale; resolving
+	// per-upstream inside the probe loop would let a reload landing midway
+	// hand later primaries TLS/TSIG material from a different config
+	// generation than earlier ones. Snapshot once, then probe.
+	//
+	// The lock is NOT held across the exchanges below: a probe blocks until
+	// the peer answers or the request deadline expires, and holding confMu
+	// for that would stall every config reload behind an unreachable primary.
+	type probePlan struct {
+		res      UpstreamSerial
+		client   *dns.Client
+		upstream string
+		keyName  string
+		tsigAlgo string
+		failed   bool
+	}
+	plans := make([]probePlan, 0, len(zd.Upstreams))
+
+	confMu.RLock()
 	for _, up := range zd.Upstreams {
-		res := UpstreamSerial{Addr: up.Addr}
-
-		// Stop probing once the caller has given up, but still record the
-		// remaining primaries: "not probed" is honest, silence is not.
-		if err := ctx.Err(); err != nil {
-			res.Err = fmt.Sprintf("not probed: %v", err)
-			out = append(out, res)
-			continue
+		p := probePlan{res: UpstreamSerial{Addr: up.Addr}, upstream: up.Addr}
+		if _, _, err := net.SplitHostPort(p.upstream); err != nil {
+			p.upstream = net.JoinHostPort(p.upstream, defaultPortForPeer(up))
 		}
-
-		upstream := up.Addr
-		if _, _, err := net.SplitHostPort(upstream); err != nil {
-			upstream = net.JoinHostPort(upstream, defaultPortForPeer(up))
-		}
-
-		m := new(dns.Msg)
-		m.SetQuestion(zd.ZoneName, dns.TypeSOA)
-		c := new(dns.Client)
+		p.client = new(dns.Client)
 
 		// Probe over the same verified channel the transfer itself would use,
 		// so an XoT peer is not silently probed in plaintext and a TSIG
 		// mismatch surfaces here rather than at transfer time.
 		if tlsCfg, terr := conf.ClientTLSConfigForPeer(up); terr != nil {
-			res.Err = fmt.Sprintf("TLS setup failed: %v", terr)
-			out = append(out, res)
+			p.res.Err = fmt.Sprintf("TLS setup failed: %v", terr)
+			p.failed = true
+			plans = append(plans, p)
 			continue
 		} else if tlsCfg != nil {
-			c.Net = "tcp-tls"
-			c.TLSConfig = tlsCfg
+			p.client.Net = "tcp-tls"
+			p.client.TLSConfig = tlsCfg
 		}
-		provider, serr := SignForPeer(m, up.Key, conf)
+
+		provider, algo, serr := TsigMaterialForPeer(up.Key, conf)
 		if serr != nil {
-			res.Err = fmt.Sprintf("TSIG sign setup failed: %v", serr)
-			out = append(out, res)
+			p.res.Err = fmt.Sprintf("TSIG sign setup failed: %v", serr)
+			p.failed = true
+			plans = append(plans, p)
 			continue
 		}
-		c.TsigProvider = provider // nil for NOKEY => plain exchange
+		p.client.TsigProvider = provider // nil for NOKEY => plain exchange
+		if provider != nil {
+			p.keyName, p.tsigAlgo = up.Key, algo
+		}
+		plans = append(plans, p)
+	}
+	confMu.RUnlock()
 
-		r, _, err := c.ExchangeContext(ctx, m, upstream)
+	// Phase 2 -- network only. Nothing here reads shared config.
+	out := make([]UpstreamSerial, 0, len(plans))
+	for i := range plans {
+		p := &plans[i]
+		if p.failed {
+			out = append(out, p.res)
+			continue
+		}
+
+		// Stop probing once the caller has given up, but still record the
+		// remaining primaries: "not probed" is honest, silence is not.
+		if err := ctx.Err(); err != nil {
+			p.res.Err = fmt.Sprintf("not probed: %v", err)
+			out = append(out, p.res)
+			continue
+		}
+
+		m := new(dns.Msg)
+		m.SetQuestion(zd.ZoneName, dns.TypeSOA)
+		// Stamped here, not in phase 1: the probes are sequential and each can
+		// block until the deadline, so a timestamp taken during the snapshot
+		// could be well outside the fudge window by the time the last message
+		// is sent, and the peer would answer BADTIME.
+		if p.keyName != "" {
+			StampTsigForPeer(m, p.keyName, p.tsigAlgo)
+		}
+
+		r, _, err := p.client.ExchangeContext(ctx, m, p.upstream)
 		switch {
 		case err != nil:
-			res.Err = err.Error()
+			p.res.Err = err.Error()
 		case r.MsgHdr.Rcode != dns.RcodeSuccess:
-			res.Err = dns.RcodeToString[r.MsgHdr.Rcode]
+			p.res.Err = dns.RcodeToString[r.MsgHdr.Rcode]
 		case len(r.Answer) == 0:
-			res.Err = "NOERROR but empty answer section"
+			p.res.Err = "NOERROR but empty answer section"
 		default:
 			if soa, ok := r.Answer[0].(*dns.SOA); ok {
-				res.Serial = soa.Serial
+				p.res.Serial = soa.Serial
 			} else {
-				res.Err = "first answer is not a SOA"
+				p.res.Err = "first answer is not a SOA"
 			}
 		}
-		out = append(out, res)
+		out = append(out, p.res)
 	}
 	return out
 }

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -30,6 +30,19 @@ type UpdateRequest struct {
 	Action         func() error
 }
 
+// updaterCmdMutatesZoneContent reports whether a ZoneUpdater command writes
+// ZONE CONTENT (as opposed to some side store), and is therefore subject to the
+// origination gate at the head of the updater loop.
+//
+// Only these two write the zone. TRUSTSTORE-UPDATE writes the keystore via
+// TruststorePost and must pass through untouched even on a zone that may not
+// originate — gating it would break SIG(0) key management on secondaries.
+// DEFERRED-UPDATE is rejected by the loop as a wrong-queue error, and PING is
+// handled before the zone is even resolved.
+func updaterCmdMutatesZoneContent(cmd string) bool {
+	return cmd == "ZONE-UPDATE" || cmd == "CHILD-UPDATE"
+}
+
 func SprintUpdates(actions []dns.RR) string {
 	var buf string
 	for _, rr := range actions {
@@ -90,6 +103,36 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 			if !ok {
 				lg.Warn("ZoneUpdater: unknown zone in update request, ignoring", "cmd", ur.Cmd, "zone", ur.ZoneName)
 				lg.Debug("ZoneUpdater: known zones", "zones", Zones.Keys())
+				continue
+			}
+
+			// Fail-closed origination gate (Fix D). The per-command checks
+			// below gate ZONE-UPDATE on allow-updates OR ur.InternalUpdate --
+			// and EVERY ops_* publisher sets InternalUpdate, so allow-updates
+			// is a call-site convention rather than an applier gate. Any
+			// publisher that does not check the option at its own call site
+			// therefore walks straight through and mutates the zone.
+			//
+			// This is the chokepoint that makes the invariant structural
+			// rather than a promise kept by N call sites: a tdns-auth zone
+			// that may not originate content never has zone content applied,
+			// whatever flags the request carries.
+			//
+			// Scoped to the two zone-content commands. TRUSTSTORE-UPDATE must
+			// pass through untouched -- it writes the keystore, never zone
+			// content. DEFERRED-UPDATE errors out below; PING returned above.
+			//
+			// Logged at ERROR as an invariant violation, matching the existing
+			// precedent for the child-updates case a few lines down: once the
+			// origination options are normalized off, nothing should ever
+			// reach this gate, so a hit means some path bypassed the option
+			// system -- a code bug worth shouting about. Deliberately not
+			// recorded in the zone's error registry, so it cannot collide with
+			// the operator-facing config warning.
+			if updaterCmdMutatesZoneContent(ur.Cmd) && !zoneMayOriginateContent(zd) {
+				lg.Error("ZoneUpdater: refusing zone mutation on a secondary that may not originate content (invariant violation)",
+					"cmd", ur.Cmd, "zone", ur.ZoneName, "internal", ur.InternalUpdate,
+					"description", ur.Description, "actions", len(ur.Actions))
 				continue
 			}
 

--- a/v2/zone_updater_origination_test.go
+++ b/v2/zone_updater_origination_test.go
@@ -1,0 +1,150 @@
+package tdns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Fix D: the fail-closed origination gate at the head of the ZoneUpdater loop.
+//
+// The per-command checks accept ZONE-UPDATE when allow-updates is set OR when
+// the request is flagged InternalUpdate -- and every ops_* publisher sets
+// InternalUpdate. These tests pin that a tdns-auth secondary which may not
+// originate content has zone-content updates dropped regardless of that flag,
+// while the keystore path and every originating zone are untouched.
+
+// runUpdaterOnce starts a ZoneUpdaterEngine, feeds it one request, and returns
+// once the engine has had a chance to process it.
+func runUpdaterOnce(t *testing.T, kdb *KeyDB, ur UpdateRequest) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = kdb.ZoneUpdaterEngine(ctx)
+	}()
+
+	kdb.UpdateQ <- ur
+	// A PING behind the request is only drained once the engine has finished
+	// with the request ahead of it, so this orders our assertion after it.
+	kdb.UpdateQ <- UpdateRequest{Cmd: "PING"}
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+}
+
+// updaterTestZone registers a zone with a staged working set the applier would
+// mutate, and returns it.
+func updaterTestZone(t *testing.T, ztype ZoneType, opts map[ZoneOption]bool) (*ZoneData, *KeyDB) {
+	t.Helper()
+	zd := loadIxfrTestZone(t, basicZone)
+	zd.ZoneType = ztype
+	zd.Options = opts
+	kdb := &KeyDB{UpdateQ: make(chan UpdateRequest, 4)}
+	zd.KeyDB = kdb
+	return zd, kdb
+}
+
+// TestApplierGateDropsInternalUpdateOnSecondary drives a full InternalUpdate
+// ZONE-UPDATE -- the shape every ops_* publisher emits, and the shape that
+// bypasses the allow-updates call-site convention -- through the engine against
+// a mirroring secondary, and asserts the zone is untouched.
+//
+// HONESTY NOTE: this is a smoke test, not a mutation-verified one. Removing the
+// gate does NOT make it fail, because the ZONE-UPDATE apply path for a
+// ZoneType==Secondary calls kdb.ApplyZoneUpdateToDB, which is currently a
+// `return nil` placeholder -- so today a ZONE-UPDATE against a secondary is
+// already inert for a second, unrelated reason. The gate's real value here is
+// that it forecloses the vector *before* that placeholder is implemented, at
+// which point every InternalUpdate publisher would start mutating secondaries.
+// The gate's logic itself is pinned by the unit-level tests below; the
+// end-to-end behaviour on a secondary is on the testbed list.
+func TestApplierGateDropsInternalUpdateOnSecondary(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+	zd, kdb := updaterTestZone(t, Secondary, map[ZoneOption]bool{})
+	before := zd.CurrentSerial
+
+	rr, err := dns.NewRR("injected.example.test. 60 IN TXT \"mutation\"")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	runUpdaterOnce(t, kdb, UpdateRequest{
+		Cmd:            "ZONE-UPDATE",
+		ZoneName:       zd.ZoneName,
+		Actions:        []dns.RR{rr},
+		InternalUpdate: true,
+		Trusted:        true,
+		Description:    "test: internal update against a mirroring secondary",
+	})
+
+	if zd.CurrentSerial != before {
+		t.Errorf("serial moved (%d -> %d): the update was applied", before, zd.CurrentSerial)
+	}
+	if _, present := zd.Data.Get("injected.example.test."); present {
+		t.Error("injected owner present: the update was applied to a mirroring secondary")
+	}
+}
+
+// TestApplierGateAllowsInlineSigningSecondary guards the sanctioned exception:
+// an inline-signing secondary may originate, so CDS/CSYNC-style internal
+// updates must still reach the applier. Asserting "not dropped by the gate" —
+// the request gets past it and into the command switch.
+func TestApplierGateAllowsInlineSigningSecondary(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+	zd, _ := updaterTestZone(t, Secondary, map[ZoneOption]bool{OptInlineSigning: true})
+
+	if !zoneMayOriginateContent(zd) {
+		t.Fatal("inline-signing secondary must be allowed past the applier gate")
+	}
+}
+
+// TestApplierGateAllowsPrimaryAndNonAuth covers the two other must-not-regress
+// cases: a primary is an originator, and off tdns-auth the gate stands down
+// entirely (the §1.1 guarantee for tdns-mp / tdns-agent).
+func TestApplierGateAllowsPrimaryAndNonAuth(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+	primary, _ := updaterTestZone(t, Primary, map[ZoneOption]bool{})
+	if !zoneMayOriginateContent(primary) {
+		t.Error("primary must be allowed past the applier gate")
+	}
+
+	withAppType(t, AppTypeAgent)
+	secondary, _ := updaterTestZone(t, Secondary, map[ZoneOption]bool{})
+	if !zoneMayOriginateContent(secondary) {
+		t.Error("non-auth secondary must be ungated (§1.1 app-scope guarantee)")
+	}
+}
+
+// TestApplierGateScopedToZoneContentCommands pins the scope: TRUSTSTORE-UPDATE
+// writes the keystore rather than zone content and must NOT be caught by the
+// gate, even on a mirroring secondary. Verified through the same command
+// classification the gate uses.
+func TestApplierGateScopedToZoneContentCommands(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+	zd, _ := updaterTestZone(t, Secondary, map[ZoneOption]bool{})
+
+	if zoneMayOriginateContent(zd) {
+		t.Fatal("setup: this zone should not be an originator")
+	}
+
+	gated := map[string]bool{
+		"ZONE-UPDATE":  true, // writes zone content
+		"CHILD-UPDATE": true, // writes child delegation data into the zone
+		// Must NOT be gated: writes the keystore via TruststorePost, never
+		// zone content. Gating it would break SIG(0) key management on
+		// secondaries, which is legitimate and unrelated to origination.
+		"TRUSTSTORE-UPDATE": false,
+		"DEFERRED-UPDATE":   false, // rejected as wrong-queue by the loop
+		"PING":              false, // handled before the zone is resolved
+	}
+	for cmd, want := range gated {
+		if got := updaterCmdMutatesZoneContent(cmd); got != want {
+			t.Errorf("updaterCmdMutatesZoneContent(%q) = %v, want %v", cmd, got, want)
+		}
+	}
+}

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -716,13 +716,23 @@ func FindZoneNG(qname string) *ZoneData {
 // applied here — this answers "what mode is configured", not "may this zone
 // act on it"; the callers pair it with the origination predicate.
 func (zd *ZoneData) EffectiveOutboundSoaSerial() string {
+	mode, _ := zd.EffectiveOutboundSoaSerialWithSource()
+	return mode
+}
+
+// EffectiveOutboundSoaSerialWithSource is EffectiveOutboundSoaSerial plus the
+// tier that supplied the value ("zone", "global" or "default"), for display by
+// `zone desc`. Both live here, in one function, so the precedence chain cannot
+// be stated twice and silently diverge — which would make `zone desc` report a
+// source that does not match the value actually in force.
+func (zd *ZoneData) EffectiveOutboundSoaSerialWithSource() (mode, source string) {
 	if zd.OutboundSoaSerial != "" {
-		return zd.OutboundSoaSerial
+		return zd.OutboundSoaSerial, "zone" // per-zone, possibly via its template
 	}
 	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial != "" {
-		return zd.KeyDB.OutboundSoaSerial
+		return zd.KeyDB.OutboundSoaSerial, "global" // dnsengine.outbound_soa_serial
 	}
-	return OutboundSoaSerialKeep
+	return OutboundSoaSerialKeep, "default"
 }
 
 // nextOutboundSerial returns the next SOA serial that should be advertised

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -699,7 +699,11 @@ func (zd *ZoneData) EffectiveOutboundSoaSerial() string {
 //     (e.g. multiple bumps within the same wallclock second), in which case
 //     fall back to prev + 1 to preserve monotonicity.
 func nextOutboundSerial(zd *ZoneData) uint32 {
-	if zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialUnixtime {
+	// A mirroring secondary never rewrites its serial into timestamp space —
+	// MUST-NOT-MODIFY is absolute, not keep-mode-only. (Reaching here at all on
+	// such a zone means something staged a publish-with-bump on it, which the
+	// other gates should have prevented; +1 is the conservative fallback.)
+	if zoneMayOriginateContent(zd) && zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialUnixtime {
 		s := uint32(time.Now().Unix())
 		if s > zd.CurrentSerial {
 			return s

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -78,7 +78,7 @@ func (zd *ZoneData) Refresh(verbose, debug, force bool, conf *Config) (bool, err
 			} else if force {
 				lg.Debug("forced retransfer regardless of SOA serial", "zone", zd.ZoneName)
 			}
-			updated, err = zd.FetchFromUpstream(verbose, debug, dynamicRRs, conf)
+			updated, err = zd.FetchFromUpstream(verbose, debug, force, dynamicRRs, conf)
 			if err != nil {
 				lg.Error("FetchZone failed", "zone", zd.ZoneName, "upstream", firstUpstreamAddr(zd.Upstreams), "err", err)
 				return false, err
@@ -259,7 +259,26 @@ func (zd *ZoneData) FetchFromFile(verbose, debug, force bool, dynamicRRs []*core
 }
 
 // Return updated, err
-func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RRset, conf *Config) (bool, error) {
+// shouldDiscardUnchangedTransfer reports whether a completed transfer should be
+// thrown away because it carries the serial we already have.
+//
+// The force exemption is the §9 forced-transfer contract: a forced transfer
+// MUST apply whatever upstream has, including a serial equal to (or lower than)
+// our own. Without it a forced retransfer of an already-current zone silently
+// did nothing while reporting success — so `force` did not mean force.
+//
+// That matters beyond tidiness: a forced retransfer is the only remedy for a
+// downstream wedged behind a secondary whose serial stepped backwards (see the
+// migration section of the design doc), and the only escape hatch from a zone
+// holding corrupt data under a current serial.
+func shouldDiscardUnchangedTransfer(incomingSerial, currentSerial uint32, force bool) bool {
+	return incomingSerial == currentSerial && !force
+}
+
+// force means the operator explicitly asked for a retransfer, so the zone is
+// re-fetched and re-applied even when upstream's serial has not moved. See the
+// unchanged-serial check below for why that matters.
+func (zd *ZoneData) FetchFromUpstream(verbose, debug, force bool, dynamicRRs []*core.RRset, conf *Config) (bool, error) {
 
 	if len(zd.Upstreams) == 0 {
 		return false, fmt.Errorf("FetchFromUpstream: zone %s has no upstreams configured", zd.ZoneName)
@@ -310,10 +329,26 @@ func (zd *ZoneData) FetchFromUpstream(verbose, debug bool, dynamicRRs []*core.RR
 		return false, fmt.Errorf("AXFR of %s failed: tried all %d upstream(s): %w", zd.ZoneName, len(zd.Upstreams), lastErr)
 	}
 
-	if new_zd.IncomingSerial == zd.IncomingSerial {
+	// A forced transfer MUST apply whatever upstream has, including a serial
+	// equal to (or lower than) our own. Without the force exemption here, a
+	// forced retransfer of an already-current zone silently did nothing while
+	// reporting success — so `force` did not mean force.
+	//
+	// This is load-bearing for the strict-passthrough migration: a forced
+	// retransfer is the ONLY remedy for a downstream wedged behind a secondary
+	// whose serial stepped backwards, and the only escape hatch from a zone
+	// with corrupt-but-current-serial data. The lower-serial case already
+	// worked, but only incidentally (DoTransfer returns do_transfer=false
+	// without an error, and the caller's `do_transfer || force` lets it
+	// through); it is now pinned by a regression test.
+	if shouldDiscardUnchangedTransfer(new_zd.IncomingSerial, zd.IncomingSerial, force) {
 		lg.Debug("FetchFromUpstream: upstream serial is unchanged", "zone", zd.ZoneName, "serial", zd.IncomingSerial)
 		zd.SetStatus(prevStatus) // no-op refresh — nothing changed, restore prior status
 		return false, nil
+	}
+	if new_zd.IncomingSerial == zd.IncomingSerial {
+		lg.Info("FetchFromUpstream: forced retransfer, re-applying zone despite unchanged serial",
+			"zone", zd.ZoneName, "serial", zd.IncomingSerial)
 	}
 
 	new_zd.Ready = true

--- a/v2/zone_utils.go
+++ b/v2/zone_utils.go
@@ -666,20 +666,40 @@ func FindZoneNG(qname string) *ZoneData {
 	return nil
 }
 
+// EffectiveOutboundSoaSerial resolves the outbound serial mode actually in
+// force for this zone, newest tier first:
+//
+//  1. the per-zone setting (zones: <z>: outbound_soa_serial, possibly
+//     inherited from the zone's template via ExpandTemplate's gap-fill);
+//  2. the server-global dnsengine.outbound_soa_serial (resolved onto the
+//     KeyDB at parse time by applyOutboundSoaSerial);
+//  3. OutboundSoaSerialKeep, the documented default.
+//
+// Every consumer of the mode MUST go through this rather than reading
+// zd.KeyDB.OutboundSoaSerial directly, so the per-zone tier is honoured.
+// Suppression for a non-originating tdns-auth secondary is deliberately NOT
+// applied here — this answers "what mode is configured", not "may this zone
+// act on it"; the callers pair it with the origination predicate.
+func (zd *ZoneData) EffectiveOutboundSoaSerial() string {
+	if zd.OutboundSoaSerial != "" {
+		return zd.OutboundSoaSerial
+	}
+	if zd.KeyDB != nil && zd.KeyDB.OutboundSoaSerial != "" {
+		return zd.KeyDB.OutboundSoaSerial
+	}
+	return OutboundSoaSerialKeep
+}
+
 // nextOutboundSerial returns the next SOA serial that should be advertised
-// to downstreams given zd.CurrentSerial and the configured outbound_soa_serial
-// mode:
+// to downstreams given zd.CurrentSerial and the effective outbound_soa_serial
+// mode (per-zone, else server-global):
 //   - "" / "keep" / "persist": prev + 1 (legacy behaviour; "persist" only
 //     differs in that the resulting serial is also written to OutgoingSerials)
 //   - "unixtime": time.Now().Unix(), unless that would not advance the serial
 //     (e.g. multiple bumps within the same wallclock second), in which case
 //     fall back to prev + 1 to preserve monotonicity.
 func nextOutboundSerial(zd *ZoneData) uint32 {
-	mode := ""
-	if zd.KeyDB != nil {
-		mode = zd.KeyDB.OutboundSoaSerial
-	}
-	if mode == OutboundSoaSerialUnixtime {
+	if zd.EffectiveOutboundSoaSerial() == OutboundSoaSerialUnixtime {
 		s := uint32(time.Now().Unix())
 		if s > zd.CurrentSerial {
 			return s


### PR DESCRIPTION
Implements `docs/2026-07-25-secondary-zones-immutable.md` (rev 2.2, on this branch).

## The invariant

A secondary serves a copy of a zone whose authoritative source is upstream, so what it serves — content **and** SOA serial — must match what it received. That is what makes multiple secondaries of one primary interchangeable. The gating question is not "is this zone signed" but **"did *we* originate this content?"**

One predicate drives everything: `zoneMayOriginateContent(zd) = Primary || inline-signing`, in `v2/zone_origination.go`. It deliberately returns **true for every app type other than tdns-auth**, so the app-scope guarantee is stated once and no gate built on it can forget it — `v2/` is a shared library and tdns-mpcombiner (which edits zones as a secondary by design), tdns-mpagent and tdns-agent must keep their own rules when they next bump their pin.

### The failure this fixes

A signed zone distributed by two masters downstream of one signer — BIND9 (no bump) and tdns-auth (+1 per refresh) — advertised two different serials for identical content. Edge nodes NOTIFY'd by both always saw the higher tdns serial and so always fetched from tdns, silently collapsing a deliberately redundant pair.

## What changed

| Commit | |
|---|---|
| `c5dc33a` `095374a` | **Per-zone `outbound_soa_serial`.** Was server-global, so "a secondary must not persist its serial" could not be expressed without breaking co-hosted primaries. Now per-zone (in practice per template — `ExpandTemplate` gap-fills it for free), empty = inherit the global. Every existing config keeps byte-identical semantics. |
| `a030ab4` | **Fix A — serial mirror.** `applyRefreshReplacementLocked` bumped unconditionally: the one vector that was neither role- nor option-gated. A mirroring secondary now takes upstream's serial verbatim, with persist/unixtime suppressed at all six sites and any stale persisted row cleared. Mutation-verified. |
| `1fa3f36` | **Fix E — role gate on the per-publish SOA re-sign.** Ran on every publish including refresh, so an `online-signing` secondary re-signed the upstream SOA with locally minted keys — bogus to every downstream validator. |
| `82b54f5` | **freeze/thaw `return`s.** Pre-existing bug: the guards set `resp.Error` but fell through, changing state anyway and returning an error *and* a success message. Separate commit because the role refusal depends on them. |
| `477ea49` | **Fix D — fail-closed applier gate.** `allow-updates` is a *call-site* convention, not an applier gate: every `ops_*` publisher sets `InternalUpdate`, which bypasses it. One gate at the ZoneUpdater head, scoped to `ZONE-UPDATE`/`CHILD-UPDATE` (`TRUSTSTORE-UPDATE` passes — it writes the keystore, not zone content). |
| `6c6b295` | **Fix B — option normalizer.** Strips the five origination options plus an explicit persist/unixtime, with a `ConfigWarning` (not `ConfigError`, which is service-impacting). Ordering is load-bearing: it runs *before* `activateUpdatePolicy`, which would otherwise hard-quarantine a secondary with `allow-child-updates` and no backend instead of warning it. |
| `b4b0744` | **Fix C — API origination gate.** Nine commands across both zone handlers, plus catalog *authoring* (gated inside `regenerateCatalogZone`, covering all four entry points). `write-zone` stays allowed; catalog *consumption* is untouched — it provisions other zones and is the point of RFC 9432. |
| `5db9c4a` | **§9 forced-transfer contract.** `zone reload --force` on an already-current zone was a silent no-op — force did not mean force. It is the only remedy for a downstream wedged behind a backwards serial step. Mutation-verified. |
| `fbff7ed` | **§5 startup warning** when a global persist/unixtime is suppressed on secondaries. |
| `4275b29` | **§7 diagnostics.** `zone list -v` shows outbound vs inbound serial; `zone desc` probes **every** primary and flags disagreement. The split-brain above was previously invisible from tdns. |

## Review notes

**Two audit corrections worth knowing.** `ApplyZoneUpdateToDB` is a `return nil` **placeholder** and is the entire `ZoneType == Secondary` branch of the ZONE-UPDATE apply path — so every ZONE-UPDATE-borne vector on a secondary (DDNS, transport signals, DSYNC, the whole `ops_*`/InternalUpdate family) is currently **latent, not live**. The fixes stand; they foreclose the vectors before that placeholder is implemented, which is the argument for Fix D being structural. And catalog authoring *is* reachable via the API — rev 1 claimed otherwise, having only considered `CreateCatalogZone`.

**Test honesty.** Two tests initially passed with their fix removed, because they asserted on state the path doesn't touch. Fixed by extracting the real decision into named predicates (`updaterCmdMutatesZoneContent`, `shouldDiscardUnchangedTransfer`) and testing those. Fix A and §9 are mutation-verified end to end; Fix D's end-to-end test is labelled a smoke test in its own comment, for the placeholder reason above.

**The one open design choice**, the as-configured vs effective options split, resolved as `SuppressedOptions`: record only what was stripped and serialize the union. The dynamic config file is regenerated from live state on every refresh, so writing the effective set would have permanently deleted the operator's `allow-updates` from their own config — after which the warning clears and the misconfiguration becomes invisible.

## Migration

Severity is per serial mode. In the default `keep` mode there is **no new event** — a restart already reset the serial to upstream's, and this merely stops the re-inflation. Only `persist`/`unixtime` deployments see a one-time backwards step, and only where the secondary is itself a master for someone. That step is logged at ERROR naming both serials and the remedy (`tdns-cli zone reload --force` on each downstream; `rndc retransfer` for BIND).

## Verification

`go vet` clean · `go test -race` green (v2 + cli) · gofmt clean · all four `cmdv2` binaries build · every commit compiles and is GPG-signed.

**Not yet done:** the live foffe testbed validation Fix D calls for. That gate changes a path which today accepts every internal update unconditionally, and unit tests cannot cover it the way the testbed can.

Prerequisite for inbound IXFR — the serial-space contract IXFR-in depends on only makes sense once the secondary serial mirrors upstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-zone outbound SOA serial modes with global fallback, persistence, and template support.
  * Zone listings and descriptions now show serial details and upstream serial diagnostics.
  * Forced transfers can reapply unchanged-serial refreshes.
  * Secondary zones safely mirror upstream serials.
* **Bug Fixes**
  * Blocked unsupported origination actions for secondary zones, including catalog authoring and content updates.
  * Preserved configured options and serial settings across dynamic zone changes, with warnings when options are suppressed.
  * Improved peer TSIG signing and key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->