### PR TITLE
keystore: fix DNSSEC/SIG(0) key import over the API; make PQ builds work on NetBSD bmake

### DIFF
--- a/cmdv2/genalgs/Makefile
+++ b/cmdv2/genalgs/Makefile
@@ -4,7 +4,15 @@
 PROG := tdns-genalgs
 GO   ?= go
 
-.PHONY: all clean
+# $(PROG) is .PHONY on purpose. As a file target with no prerequisites it was
+# only ever built when MISSING, so an existing tdns-genalgs was treated as
+# up to date no matter how old it was -- which is how hosts ended up
+# regenerating months-old build config from a stale generator long after the
+# sources were fixed, silently. Listing the .go sources instead would need
+# $(wildcard ...), which is GNU-make-only and unavailable in NetBSD bmake.
+# Deferring to `go build` every time is correct and nearly free: its build
+# cache makes a no-op rebuild a fraction of a second.
+.PHONY: all clean $(PROG)
 
 all: $(PROG)
 

--- a/cmdv2/genalgs/Makefile
+++ b/cmdv2/genalgs/Makefile
@@ -4,19 +4,32 @@
 PROG := tdns-genalgs
 GO   ?= go
 
-# $(PROG) is .PHONY on purpose. As a file target with no prerequisites it was
-# only ever built when MISSING, so an existing tdns-genalgs was treated as
-# up to date no matter how old it was -- which is how hosts ended up
-# regenerating months-old build config from a stale generator long after the
-# sources were fixed, silently. Listing the .go sources instead would need
-# $(wildcard ...), which is GNU-make-only and unavailable in NetBSD bmake.
-# Deferring to `go build` every time is correct and nearly free: its build
-# cache makes a no-op rebuild a fraction of a second.
-.PHONY: all clean $(PROG)
+# Sources are listed explicitly rather than gathered with $(wildcard ...),
+# which is a GNU make function and expands to nothing under NetBSD bmake.
+# Keep this list in step with the .go files here (test files excluded: they
+# are not inputs to the binary).
+SRCS := env.go main.go registry.go
+
+# $(PROG) must NOT be .PHONY, and the prerequisites above are the reason.
+#
+# Without prerequisites it was only ever built when MISSING, so a months-old
+# generator counted as up to date and silently emitted stale build config.
+# Making it .PHONY fixed that but overshot: `go build -o` rewrites the output
+# file on every run, so the binary's mtime always moved, which made the
+# "generated files are current" test in utils/Makefile.common
+# ([ ! $(GENALGS) -nt registered_algs.go ]) fail every time. Every build in
+# every app directory then regenerated -- and, worse, needed the
+# dnssec-algorithms checkout present, so a host that built fine from current
+# generated files would start failing if that path moved.
+#
+# With real prerequisites the binary is relinked only when its sources change,
+# its mtime is stable, and that test does what it was written to do. The
+# always-recurse behaviour lives in Makefile.common, where it belongs.
+.PHONY: all clean
 
 all: $(PROG)
 
-$(PROG):
+$(PROG): $(SRCS)
 	$(GO) build -o $(PROG) .
 
 clean:

--- a/cmdv2/genalgs/env.go
+++ b/cmdv2/genalgs/env.go
@@ -177,12 +177,15 @@ func genLibsMk(needGroups map[string]bool, envByGroup map[string]libEnv) []byte 
 		// moment the value is expanded (which ALGS_ENV below does). It is a
 		// hard build failure on the platform the lab actually runs on.
 		//
-		// Nothing is lost by dropping the "append any pre-existing
-		// PKG_CONFIG_PATH" clause: the paths computed here are exactly the
-		// ones the selected algorithms need, and a caller who wants to add
-		// more can still set PKG_CONFIG_PATH in the environment, which
-		// pkg-config itself merges.
-		fmt.Fprintf(&b, "PKG_CONFIG_PATH := %s\n", strings.Join(pkgPaths, ":"))
+		// Note the ALGS_ prefix: the make variable must NOT be named after the
+		// environment variable it feeds. GNU make re-exports any variable that
+		// originated in the environment, so a make variable called
+		// PKG_CONFIG_PATH would overwrite the caller's value in the recipe's
+		// environment -- and the shell expansion in ALGS_ENV below would then
+		// append the generated paths to themselves instead of to the caller's.
+		// (bmake does not re-export, so this only misbehaved under GNU make:
+		// exactly the kind of divergence worth avoiding outright.)
+		fmt.Fprintf(&b, "ALGS_PKG_CONFIG_PATH := %s\n", strings.Join(pkgPaths, ":"))
 		varNames = append(varNames, "PKG_CONFIG_PATH")
 	}
 	otherNames := make([]string, 0, len(others))
@@ -198,7 +201,7 @@ func genLibsMk(needGroups map[string]bool, envByGroup map[string]libEnv) []byte 
 		if isPathListVar(n) {
 			sep = ":"
 		}
-		fmt.Fprintf(&b, "%s := %s\n", n, strings.Join(others[n], sep))
+		fmt.Fprintf(&b, "ALGS_%s := %s\n", n, strings.Join(others[n], sep))
 		varNames = append(varNames, n)
 	}
 
@@ -207,7 +210,22 @@ func genLibsMk(needGroups map[string]bool, envByGroup map[string]libEnv) []byte 
 		if i > 0 {
 			b.WriteByte(' ')
 		}
-		fmt.Fprintf(&b, `%s="$(%s)"`, n, n)
+		if isPathListVar(n) {
+			// Append whatever the caller already had. ALGS_ENV is used as a
+			// command prefix ("PKG_CONFIG_PATH=... go build"), which OVERRIDES
+			// the inherited environment rather than adding to it, so a caller
+			// who had set PKG_CONFIG_PATH would silently lose it.
+			//
+			// $(NAME) is expanded by make (the generated paths); $${NAME}
+			// survives make as a literal ${NAME} and is expanded by the shell
+			// that runs the recipe, using the inherited value. That keeps the
+			// conditional out of make entirely, so it works under GNU make and
+			// NetBSD bmake alike -- unlike $(if ...), which is GNU-only and is
+			// what made this file a hard parse error under bmake.
+			fmt.Fprintf(&b, `%s="$(ALGS_%s)$${%s:+:$${%s}}"`, n, n, n, n)
+		} else {
+			fmt.Fprintf(&b, `%s="$(ALGS_%s)"`, n, n)
+		}
 	}
 	b.WriteByte('\n')
 	return []byte(b.String())

--- a/cmdv2/genalgs/env.go
+++ b/cmdv2/genalgs/env.go
@@ -171,8 +171,18 @@ func genLibsMk(needGroups map[string]bool, envByGroup map[string]libEnv) []byte 
 
 	varNames := []string{}
 	if len(pkgPaths) > 0 {
-		fmt.Fprintf(&b, "PKG_CONFIG_PATH := %s$(if $(PKG_CONFIG_PATH),:$(PKG_CONFIG_PATH))\n",
-			strings.Join(pkgPaths, ":"))
+		// Plain assignment only. This file is read by NetBSD bmake as well as
+		// GNU make, and $(if ...) is a GNU-only function: bmake parses it as a
+		// variable modifier and fails with `Unknown modifier "<path>"` the
+		// moment the value is expanded (which ALGS_ENV below does). It is a
+		// hard build failure on the platform the lab actually runs on.
+		//
+		// Nothing is lost by dropping the "append any pre-existing
+		// PKG_CONFIG_PATH" clause: the paths computed here are exactly the
+		// ones the selected algorithms need, and a caller who wants to add
+		// more can still set PKG_CONFIG_PATH in the environment, which
+		// pkg-config itself merges.
+		fmt.Fprintf(&b, "PKG_CONFIG_PATH := %s\n", strings.Join(pkgPaths, ":"))
 		varNames = append(varNames, "PKG_CONFIG_PATH")
 	}
 	otherNames := make([]string, 0, len(others))

--- a/cmdv2/genalgs/main_test.go
+++ b/cmdv2/genalgs/main_test.go
@@ -235,14 +235,24 @@ func TestGenLibsMkPathListJoin(t *testing.T) {
 	if strings.Contains(out, "export ") {
 		t.Errorf("algs-libs.mk must not use GNU-make-only `export` (breaks under bmake):\n%s", out)
 	}
-	if !strings.Contains(out, "LD_LIBRARY_PATH := /b/lib:/a/lib") {
-		t.Errorf("LD_LIBRARY_PATH must be colon-joined:\n%s", out)
+	// Generated variables are ALGS_-prefixed so they cannot collide with a
+	// value the operator already has in the environment; ALGS_ENV then splices
+	// them onto the go build command line under their real names.
+	if !strings.Contains(out, "ALGS_LD_LIBRARY_PATH := /b/lib:/a/lib") {
+		t.Errorf("ALGS_LD_LIBRARY_PATH must be colon-joined:\n%s", out)
 	}
-	if !strings.Contains(out, "CGO_LDFLAGS := -lqruov -lsqisign") {
-		t.Errorf("CGO_LDFLAGS must stay space-joined:\n%s", out)
+	if !strings.Contains(out, "ALGS_CGO_LDFLAGS := -lqruov -lsqisign") {
+		t.Errorf("ALGS_CGO_LDFLAGS must stay space-joined:\n%s", out)
 	}
-	if !strings.Contains(out, `CGO_LDFLAGS="$(CGO_LDFLAGS)"`) || !strings.Contains(out, `LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)"`) {
-		t.Errorf("ALGS_ENV must inline every variable for splicing onto the go build command line:\n%s", out)
+	if !strings.Contains(out, `CGO_LDFLAGS="$(ALGS_CGO_LDFLAGS)"`) {
+		t.Errorf("ALGS_ENV must splice the flag list under its real name:\n%s", out)
+	}
+	// A path list must APPEND to whatever the caller already had, and the
+	// inherited half must survive make as a literal for the shell to expand --
+	// hence $$. Getting this wrong silently drops the operator's own
+	// LD_LIBRARY_PATH, since ALGS_ENV is a command prefix, not an addition.
+	if !strings.Contains(out, `LD_LIBRARY_PATH="$(ALGS_LD_LIBRARY_PATH)$${LD_LIBRARY_PATH:+:$${LD_LIBRARY_PATH}}"`) {
+		t.Errorf("ALGS_ENV must append the inherited path list using escaped $$ references:\n%s", out)
 	}
 }
 
@@ -282,7 +292,7 @@ func stubEnvScript(t *testing.T, algrepo, group, rel string) {
 // relative path works. The test runs from a scratch cwd with a relative
 // path to the fixture repo, selecting a liboqs-backed algorithm.
 func TestRunRelativeAlgrepo(t *testing.T) {
-	algrepo := writeFixture(t)               // has registry/registry.go
+	algrepo := writeFixture(t) // has registry/registry.go
 	stubEnvScript(t, algrepo, "liboqs", "liboqs/liboqs-env.sh")
 
 	// A working directory a fixed number of levels below algrepo's parent,

--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -82,9 +82,14 @@ build: generate
 # prerequisites it only ever ran when the binary was MISSING, so a generator
 # built months earlier kept silently emitting stale output long after its
 # sources were updated -- a host could pull hundreds of commits of fixes and
-# still regenerate months-old build config, with no error anywhere. Delegating
-# unconditionally lets the generator's own Makefile decide; a no-op go build
-# costs almost nothing thanks to the build cache.
+# still regenerate months-old build config, with no error anywhere.
+#
+# So the recursion is unconditional and the DECISION belongs to the
+# generator's own Makefile, which lists its sources: it relinks only when they
+# changed, leaving the binary's mtime alone otherwise. That is what keeps the
+# "generated files are current" test below meaningful -- if this rule caused a
+# relink on every build, that test could never pass and every build would
+# regenerate (and would need the dnssec-algorithms checkout to be present).
 .PHONY: $(GENALGS)
 $(GENALGS):
 	@$(MAKE) -C $(GENALGS_DIR)

--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -31,7 +31,11 @@ version:
 	/bin/sh ../../utils/make-version.sh $(VERSION)-$(BRANCH)-$(COMMIT) $(APPDATE) $(PROG)
 
 # Path to the genalgs binary (built from cmdv2/genalgs). Overridable.
-GENALGS ?= ../genalgs/tdns-genalgs
+# The directory is spelled out rather than derived with $(dir ...): that is a
+# GNU-make function which NetBSD bmake does not have, and it would expand to
+# nothing there.
+GENALGS_DIR ?= ../genalgs
+GENALGS ?= $(GENALGS_DIR)/tdns-genalgs
 
 # Algorithm code generation.
 #
@@ -72,14 +76,23 @@ build: generate
 	@/bin/sh ../../utils/make-version.sh --if-changed $(VERSION)-$(BRANCH)-$(COMMIT) $(APPDATE) $(PROG)
 	$(ALGS_ENV) $(GO) build $(GOFLAGS) -o ${PROG}
 
-# Ensure the generator binary exists (cmdv2/Makefile also builds it first).
+# Ensure the generator binary exists AND IS CURRENT.
+#
+# This target is deliberately .PHONY. As a plain file rule with no
+# prerequisites it only ever ran when the binary was MISSING, so a generator
+# built months earlier kept silently emitting stale output long after its
+# sources were updated -- a host could pull hundreds of commits of fixes and
+# still regenerate months-old build config, with no error anywhere. Delegating
+# unconditionally lets the generator's own Makefile decide; a no-op go build
+# costs almost nothing thanks to the build cache.
+.PHONY: $(GENALGS)
 $(GENALGS):
-	$(MAKE) -C $(dir $(GENALGS))
+	@$(MAKE) -C $(GENALGS_DIR)
 
 generate: $(GENALGS)
 	@if [ ! -f algs.list ]; then \
 	   : "no algs.list -> standalone build, genalgs not run"; \
-	 elif [ -f registered_algs.go ] && [ ! algs.list -nt registered_algs.go ] && [ -f algs-libs.mk ] && [ -f ../algs-env.mk ]; then \
+	 elif [ -f registered_algs.go ] && [ ! algs.list -nt registered_algs.go ] && [ ! $(GENALGS) -nt registered_algs.go ] && [ -f algs-libs.mk ] && [ -f ../algs-env.mk ]; then \
 	   : "generated files are current"; \
 	 elif [ -n "$(ALGREPO)" ]; then \
 	   echo "  algs.list changed (or no generated files); running genalgs --algrepo $(ALGREPO)"; \

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -29,8 +29,18 @@ func (kdb *KeyDB) APIkeystore(conf *Config) func(w http.ResponseWriter, r *http.
 			// fields up to the point of failure, so carrying on here meant
 			// operating on a half-built request — which is how a partially
 			// decoded key ended up being handed to the PKCS#8 marshaller.
+			//
+			// Answer with a KeystoreResponse, not http.Error: every other
+			// path out of this handler writes application/json, so a client
+			// that decodes JSON unconditionally (as it must for all of them)
+			// would choke on a text/plain body.
 			lgApi.Error("error decoding keystore post", "err", err)
-			http.Error(w, fmt.Sprintf("malformed keystore request: %v", err), http.StatusBadRequest)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(&KeystoreResponse{
+				Error:    true,
+				ErrorMsg: fmt.Sprintf("malformed keystore request: %v", err),
+			})
 			return
 		}
 

--- a/v2/apihandler_funcs.go
+++ b/v2/apihandler_funcs.go
@@ -25,7 +25,13 @@ func (kdb *KeyDB) APIkeystore(conf *Config) func(w http.ResponseWriter, r *http.
 		var kp KeystorePost
 		err := decoder.Decode(&kp)
 		if err != nil {
-			lgApi.Warn("error decoding keystore post", "err", err)
+			// Do NOT continue on a failed decode. json.Decode populates
+			// fields up to the point of failure, so carrying on here meant
+			// operating on a half-built request — which is how a partially
+			// decoded key ended up being handed to the PKCS#8 marshaller.
+			lgApi.Error("error decoding keystore post", "err", err)
+			http.Error(w, fmt.Sprintf("malformed keystore request: %v", err), http.StatusBadRequest)
+			return
 		}
 
 		lgApi.Debug("received /keystore request", "cmd", kp.Command, "subcmd", kp.SubCommand, "from", r.RemoteAddr)

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -97,8 +97,19 @@ SELECT zonename, state, keyid, algorithm, creator, privatekey, keyrr FROM Sig0Ke
 		// Convert private key to PEM format for storage
 		// If pkc.K is nil (e.g., when received via JSON API), reconstruct it from pkc.PrivateKey
 		var privkey crypto.PrivateKey
-		if pkc.K != nil {
-			privkey = pkc.K
+		// K is json:"-" so it is nil for anything that arrived over the API;
+		// it is only populated in-process. Type-assert rather than nil-check:
+		// a decode that half-succeeded could leave a non-nil but unusable
+		// value here, and every real private key type implements crypto.Signer.
+		if signer, ok := pkc.K.(crypto.Signer); ok {
+			privkey = signer
+		} else if pkc.PrivateKeyPEM != "" {
+			// The normal API path. PKCS#8 PEM covers every algorithm,
+			// including RSA, which the BIND-base64 route below cannot.
+			privkey, err = PEMToPrivateKey(pkc.PrivateKeyPEM)
+			if err != nil {
+				return &resp, fmt.Errorf("failed to parse private key PEM: %v", err)
+			}
 		} else {
 			// Reconstruct from PrivateKey string (BIND format) and public key RR
 			// We need to parse the private key using the public key RR
@@ -395,8 +406,19 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 		// Convert private key to PEM format for storage
 		// If pkc.K is nil (e.g., when received via JSON API), reconstruct it from pkc.PrivateKey
 		var privkey crypto.PrivateKey
-		if pkc.K != nil {
-			privkey = pkc.K
+		// K is json:"-" so it is nil for anything that arrived over the API;
+		// it is only populated in-process. Type-assert rather than nil-check:
+		// a decode that half-succeeded could leave a non-nil but unusable
+		// value here, and every real private key type implements crypto.Signer.
+		if signer, ok := pkc.K.(crypto.Signer); ok {
+			privkey = signer
+		} else if pkc.PrivateKeyPEM != "" {
+			// The normal API path. PKCS#8 PEM covers every algorithm,
+			// including RSA, which the BIND-base64 route below cannot.
+			privkey, err = PEMToPrivateKey(pkc.PrivateKeyPEM)
+			if err != nil {
+				return &resp, fmt.Errorf("failed to parse private key PEM: %v", err)
+			}
 		} else {
 			// Reconstruct from PrivateKey string (BIND format) and public key RR
 			// We need to parse the private key using the public key RR

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -5,7 +5,6 @@ package tdns
 
 import (
 	"context"
-	"crypto"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -94,38 +93,9 @@ SELECT zonename, state, keyid, algorithm, creator, privatekey, keyrr FROM Sig0Ke
 		pkc := kp.PrivateKeyCache
 		lgSigner.Info("importing private key", "type", fmt.Sprintf("%T", pkc.K))
 
-		// Convert private key to PEM format for storage
-		// If pkc.K is nil (e.g., when received via JSON API), reconstruct it from pkc.PrivateKey
-		var privkey crypto.PrivateKey
-		// K is json:"-" so it is nil for anything that arrived over the API;
-		// it is only populated in-process. Type-assert rather than nil-check:
-		// a decode that half-succeeded could leave a non-nil but unusable
-		// value here, and every real private key type implements crypto.Signer.
-		if signer, ok := pkc.K.(crypto.Signer); ok {
-			privkey = signer
-		} else if pkc.PrivateKeyPEM != "" {
-			// The normal API path. PKCS#8 PEM covers every algorithm,
-			// including RSA, which the BIND-base64 route below cannot.
-			privkey, err = PEMToPrivateKey(pkc.PrivateKeyPEM)
-			if err != nil {
-				return &resp, fmt.Errorf("failed to parse private key PEM: %v", err)
-			}
-		} else {
-			// Reconstruct from PrivateKey string (BIND format) and public key RR
-			// We need to parse the private key using the public key RR
-			if pkc.KeyType == dns.TypeKEY {
-				bindFormat, err := PrivKeyToBindFormat(pkc.PrivateKey, dns.AlgorithmToString[pkc.Algorithm])
-				if err != nil {
-					return &resp, fmt.Errorf("failed to convert private key to BIND format: %v", err)
-				}
-				reconstructedPkc, err := PrepareKeyCache(bindFormat, pkc.KeyRR.String())
-				if err != nil {
-					return &resp, fmt.Errorf("failed to reconstruct private key: %v", err)
-				}
-				privkey = reconstructedPkc.K
-			} else {
-				return &resp, fmt.Errorf("unsupported key type for reconstruction: %d", pkc.KeyType)
-			}
+		privkey, err := reconstructSigningKey(pkc, pkc.KeyRR.String(), dns.TypeKEY)
+		if err != nil {
+			return &resp, err
 		}
 
 		privkeyPEM, err := PrivateKeyToPEM(privkey)
@@ -405,36 +375,9 @@ SELECT zonename, state, keyid, flags, algorithm, creator, privatekey, keyrr FROM
 
 		// Convert private key to PEM format for storage
 		// If pkc.K is nil (e.g., when received via JSON API), reconstruct it from pkc.PrivateKey
-		var privkey crypto.PrivateKey
-		// K is json:"-" so it is nil for anything that arrived over the API;
-		// it is only populated in-process. Type-assert rather than nil-check:
-		// a decode that half-succeeded could leave a non-nil but unusable
-		// value here, and every real private key type implements crypto.Signer.
-		if signer, ok := pkc.K.(crypto.Signer); ok {
-			privkey = signer
-		} else if pkc.PrivateKeyPEM != "" {
-			// The normal API path. PKCS#8 PEM covers every algorithm,
-			// including RSA, which the BIND-base64 route below cannot.
-			privkey, err = PEMToPrivateKey(pkc.PrivateKeyPEM)
-			if err != nil {
-				return &resp, fmt.Errorf("failed to parse private key PEM: %v", err)
-			}
-		} else {
-			// Reconstruct from PrivateKey string (BIND format) and public key RR
-			// We need to parse the private key using the public key RR
-			if pkc.KeyType == dns.TypeDNSKEY {
-				bindFormat, err := PrivKeyToBindFormat(pkc.PrivateKey, dns.AlgorithmToString[pkc.Algorithm])
-				if err != nil {
-					return &resp, fmt.Errorf("failed to convert private key to BIND format: %v", err)
-				}
-				reconstructedPkc, err := PrepareKeyCache(bindFormat, pkc.DnskeyRR.String())
-				if err != nil {
-					return &resp, fmt.Errorf("failed to reconstruct private key: %v", err)
-				}
-				privkey = reconstructedPkc.K
-			} else {
-				return &resp, fmt.Errorf("unsupported key type for reconstruction: %d", pkc.KeyType)
-			}
+		privkey, err := reconstructSigningKey(pkc, pkc.DnskeyRR.String(), dns.TypeDNSKEY)
+		if err != nil {
+			return &resp, err
 		}
 
 		privkeyPEM, err := PrivateKeyToPEM(privkey)

--- a/v2/keystore.go
+++ b/v2/keystore.go
@@ -1022,16 +1022,14 @@ SELECT keyid, algorithm, privatekey, keyrr FROM Sig0KeyStore WHERE zonename=? AN
 		}
 
 		// Parse private key, detecting old BIND format or new PEM format
-		_, alg, bindFormat, err := ParsePrivateKeyFromDB(privatekey, algorithm, keyrrstr)
+		// PrivateKeyCacheFromDB, NOT ParsePrivateKeyFromDB + PrepareKeyCache: the
+		// latter pair re-derives a BIND blob from an already-parsed PEM and
+		// re-parses it via NewPrivateKey, which dispatches on the algorithm
+		// codepoint and fails ("dns: bad private key") for any key stored under
+		// a codepoint that has since been renumbered.
+		pkc, alg, err := PrivateKeyCacheFromDB(privatekey, algorithm, keyrrstr)
 		if err != nil {
-			lgSigner.Error("ParsePrivateKeyFromDB failed", "err", err)
-			return nil, err
-		}
-
-		// Use PrepareKeyCache with the BIND format (it handles both old and new keys this way)
-		pkc, err := PrepareKeyCache(bindFormat, keyrrstr)
-		if err != nil {
-			lgSigner.Error("PrepareKeyCache failed", "err", err)
+			lgSigner.Error("PrivateKeyCacheFromDB failed", "err", err)
 			return nil, err
 		}
 

--- a/v2/keystore_db_read_test.go
+++ b/v2/keystore_db_read_test.go
@@ -2,8 +2,13 @@ package tdns
 
 import (
 	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -108,5 +113,130 @@ func TestPrivateKeyCacheFromDBAcceptsLegacyBareBase64(t *testing.T) {
 	}
 	if _, ok := pkc.K.(crypto.Signer); !ok {
 		t.Fatalf("legacy key did not come back usable: %T", pkc.K)
+	}
+}
+
+// --- registered (non-built-in) algorithm coverage -----------------------
+
+// orphanedAlg is a registered algorithm whose BIND private-key parser always
+// fails. That is precisely what a renumbered codepoint looks like from the
+// keystore's side: the stored PEM is fine, but anything that re-parses it by
+// dispatching on the algorithm number cannot reconstruct the key.
+//
+// Everything else is ed25519 underneath, so the key material is real and the
+// PKCS#8 encoding goes through the stdlib marshaller.
+type orphanedAlg struct{}
+
+func (orphanedAlg) Name() string      { return testOrphanAlgName }
+func (orphanedAlg) Hash() crypto.Hash { return 0 }
+
+func (orphanedAlg) Generate(bits int) (crypto.PrivateKey, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	return priv, err
+}
+
+func (orphanedAlg) PublicKeyFromWire(keybuf []byte) (crypto.PublicKey, error) {
+	if len(keybuf) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("bad public key size %d", len(keybuf))
+	}
+	return ed25519.PublicKey(keybuf), nil
+}
+
+func (orphanedAlg) PublicKeyToWire(pub crypto.PublicKey) ([]byte, error) {
+	k, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an ed25519 public key: %T", pub)
+	}
+	return k, nil
+}
+
+// ReadPrivateKey is the orphaned half: the codepoint no longer resolves to a
+// usable parser. This is the failure the fix must not depend on.
+func (orphanedAlg) ReadPrivateKey(map[string]string) (crypto.PrivateKey, error) {
+	return nil, fmt.Errorf("dns: bad private key")
+}
+
+func (orphanedAlg) PrivateKeyToString(priv crypto.PrivateKey) (string, error) {
+	k, ok := priv.(ed25519.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("not an ed25519 private key: %T", priv)
+	}
+	return "PrivateKey: " + base64.StdEncoding.EncodeToString(k.Seed()) + "\n", nil
+}
+
+// SignaturePostProcess is pass-through, as it is for ED25519.
+func (orphanedAlg) SignaturePostProcess(sig []byte) ([]byte, error) { return sig, nil }
+
+func (orphanedAlg) Verify(pub crypto.PublicKey, hashed, sig []byte) error {
+	k, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return fmt.Errorf("not an ed25519 public key: %T", pub)
+	}
+	if !ed25519.Verify(k, hashed, sig) {
+		return dns.ErrSig
+	}
+	return nil
+}
+
+const (
+	// 253 is private use, so it cannot collide with a real assignment.
+	testOrphanAlgCode = 253
+	testOrphanAlgName = "TESTORPHAN253"
+)
+
+// TestPrivateKeyCacheFromDBHandlesRegisteredAlgorithm is the test that actually
+// covers the bug this change was written for. The other cases here use
+// built-in algorithms, whose BIND round trip works -- so they would pass with
+// or without the fix. This one uses a REGISTERED algorithm whose BIND parser
+// fails, which is what a renumbered codepoint leaves behind, and asserts both
+// halves: the old route breaks, the new one does not.
+func TestPrivateKeyCacheFromDBHandlesRegisteredAlgorithm(t *testing.T) {
+	if err := dns.RegisterAlgorithm(testOrphanAlgCode, orphanedAlg{}); err != nil &&
+		!errors.Is(err, dns.ErrAlgRegistered) {
+		t.Fatalf("registering test algorithm: %v", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal PKCS#8: %v", err)
+	}
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+	rr := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: "orphan.example.", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: testOrphanAlgCode,
+		PublicKey: base64.StdEncoding.EncodeToString(pub),
+	}
+	keyrr := rr.String()
+
+	// The fix: straight from PEM, no codepoint-dispatched re-parse.
+	pkc, alg, err := PrivateKeyCacheFromDB(privPEM, testOrphanAlgName, keyrr)
+	if err != nil {
+		t.Fatalf("PrivateKeyCacheFromDB must read a registered algorithm's stored PEM: %v", err)
+	}
+	if alg != testOrphanAlgCode {
+		t.Errorf("algorithm = %d, want %d", alg, testOrphanAlgCode)
+	}
+	if pkc.CS == nil {
+		t.Fatal("no crypto.Signer produced")
+	}
+	if got, ok := pkc.CS.Public().(ed25519.PublicKey); !ok || !got.Equal(pub) {
+		t.Error("the signer does not carry the key that was stored")
+	}
+
+	// And the shape of the old route, to show this test would have caught it:
+	// ParsePrivateKeyFromDB hands back BIND format, and re-parsing that
+	// dispatches on the codepoint -- which is exactly what no longer works.
+	if _, _, bindFormat, perr := ParsePrivateKeyFromDB(privPEM, testOrphanAlgName, keyrr); perr == nil {
+		if _, cerr := PrepareKeyCache(bindFormat, keyrr); cerr == nil {
+			t.Error("expected the BIND re-parse route to fail for an orphaned codepoint; " +
+				"if this now succeeds the regression this test pins has changed shape")
+		}
 	}
 }

--- a/v2/keystore_db_read_test.go
+++ b/v2/keystore_db_read_test.go
@@ -1,0 +1,112 @@
+package tdns
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Regression test for reading stored keys out of the keystore.
+//
+// Keys are stored as PKCS#8 PEM. The old path (ParsePrivateKeyFromDB followed
+// by PrepareKeyCache) parsed that PEM correctly and then discarded the result,
+// re-deriving a BIND-format blob with dns.DNSKEY.PrivateKeyString() and handing
+// that back to PrepareKeyCache -- which re-parsed it through
+// dns.DNSKEY.NewPrivateKey(), a dispatch on the algorithm CODEPOINT. Any key
+// written under a codepoint that had since been renumbered then failed with a
+// bare "dns: bad private key", despite the PEM parsing cleanly. On the gocpt101
+// testbed that silently killed signing for slhdsa128s.foo and cpt.p.axfr.net:
+// the zones answered, but every signing operation failed.
+//
+// PrivateKeyCacheFromDB keeps the PEM and lets PrepareKeyCache's PEM branch do
+// the work, so no codepoint dispatch is involved at all.
+func TestPrivateKeyCacheFromDBKeepsPEM(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		alg  uint8
+		bits int
+	}{
+		{"ED25519", dns.ED25519, 256},
+		{"ECDSAP256SHA256", dns.ECDSAP256SHA256, 256},
+		{"RSASHA256", dns.RSASHA256, 2048},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := &dns.DNSKEY{
+				Hdr:       dns.RR_Header{Name: "example.", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+				Flags:     257,
+				Protocol:  3,
+				Algorithm: tc.alg,
+			}
+			priv, err := key.Generate(tc.bits)
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			der, err := x509.MarshalPKCS8PrivateKey(priv)
+			if err != nil {
+				t.Fatalf("MarshalPKCS8: %v", err)
+			}
+			stored := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+			pkc, alg, err := PrivateKeyCacheFromDB(stored, dns.AlgorithmToString[tc.alg], key.String())
+			if err != nil {
+				t.Fatalf("PrivateKeyCacheFromDB: %v", err)
+			}
+			if alg != tc.alg {
+				t.Errorf("algorithm: got %d want %d", alg, tc.alg)
+			}
+			if pkc.Algorithm != tc.alg {
+				t.Errorf("pkc.Algorithm: got %d want %d", pkc.Algorithm, tc.alg)
+			}
+			if _, ok := pkc.K.(crypto.Signer); !ok {
+				t.Fatalf("stored key did not come back usable: %T", pkc.K)
+			}
+			if pkc.CS == nil {
+				t.Error("CS (crypto.Signer) not populated")
+			}
+			if !strings.HasPrefix(pkc.PrivateKeyPEM, "-----BEGIN PRIVATE KEY-----") {
+				t.Error("PrivateKeyPEM should be populated for a PEM-stored key")
+			}
+		})
+	}
+}
+
+// The legacy row format -- bare base64 with no "Private-key-format:" header --
+// must keep working, since existing keystores still hold rows written that way.
+func TestPrivateKeyCacheFromDBAcceptsLegacyBareBase64(t *testing.T) {
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: "example.", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     256,
+		Protocol:  3,
+		Algorithm: dns.ED25519,
+	}
+	priv, err := key.Generate(256)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Extract just the base64, the way legacy rows stored it.
+	var bare string
+	for _, line := range strings.Split(key.PrivateKeyString(priv), "\n") {
+		if strings.HasPrefix(line, "PrivateKey:") {
+			bare = strings.TrimSpace(strings.TrimPrefix(line, "PrivateKey:"))
+		}
+	}
+	if bare == "" {
+		t.Fatal("could not extract the legacy base64 form")
+	}
+
+	pkc, alg, err := PrivateKeyCacheFromDB(bare, "ED25519", key.String())
+	if err != nil {
+		t.Fatalf("PrivateKeyCacheFromDB (legacy): %v", err)
+	}
+	if alg != dns.ED25519 {
+		t.Errorf("algorithm: got %d want %d", alg, dns.ED25519)
+	}
+	if _, ok := pkc.K.(crypto.Signer); !ok {
+		t.Fatalf("legacy key did not come back usable: %T", pkc.K)
+	}
+}

--- a/v2/keystore_import_api_test.go
+++ b/v2/keystore_import_api_test.go
@@ -1,0 +1,172 @@
+package tdns
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// Regression test for the DNSSEC key import failing with
+//
+//	Error: failed to convert private key to PEM: failed to marshal private key
+//	       to PKCS#8: dnssec-algorithms/pkcs8: codec does not support this key/OID
+//
+// tdns-cli reads the key files locally and POSTs the whole PrivateKeyCache to
+// tdns-auth. PrivateKeyCache used to ship its interface fields (K, CS, RR) as
+// JSON: an ed25519.PrivateKey is a []byte, so it marshalled to a base64 string,
+// which then decoded fine into the empty interface crypto.PrivateKey but FAILED
+// against the non-empty crypto.Signer. The server logged that decode error and
+// continued, leaving K holding a plain string that reached the PKCS#8
+// marshaller — hence the misleading "codec does not support this key/OID".
+//
+// The interface fields are now json:"-"; the wire form carries PrivateKey
+// (base64) + DnskeyRR, which is all the server needs to rebuild the key.
+func TestDnssecImportSurvivesAPIRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		alg  uint8
+	}{
+		{"ED25519", dns.ED25519},
+		{"ECDSAP256SHA256", dns.ECDSAP256SHA256},
+		{"RSASHA256", dns.RSASHA256},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bits := 256
+			if tc.alg == dns.RSASHA256 {
+				bits = 2048
+			}
+			dir := t.TempDir()
+			base := filepath.Join(dir, "Kp.axfr.net.+015+32445")
+
+			key := &dns.DNSKEY{
+				Hdr:       dns.RR_Header{Name: "p.axfr.net.", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+				Flags:     256,
+				Protocol:  3,
+				Algorithm: tc.alg,
+			}
+			priv, err := key.Generate(bits)
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			der, err := x509.MarshalPKCS8PrivateKey(priv)
+			if err != nil {
+				t.Fatalf("MarshalPKCS8: %v", err)
+			}
+			// .private as PKCS#8 PEM, matching what `keystore ... export` writes.
+			if err := os.WriteFile(base+".private",
+				pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(base+".key", []byte(key.String()+"\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			// --- tdns-cli side ---
+			pkc, err := ReadPrivateKey(base + ".key")
+			if err != nil {
+				t.Fatalf("ReadPrivateKey: %v", err)
+			}
+			if _, ok := pkc.K.(crypto.Signer); !ok {
+				t.Fatalf("client: K should be a usable key, got %T", pkc.K)
+			}
+
+			// --- the API hop ---
+			wire, err := json.Marshal(KeystorePost{
+				Command: "dnssec-mgmt", SubCommand: "add",
+				Zone: "p.axfr.net.", PrivateKeyCache: pkc, State: "created",
+			})
+			if err != nil {
+				t.Fatalf("json.Marshal: %v", err)
+			}
+			var got KeystorePost
+			if err := json.Unmarshal(wire, &got); err != nil {
+				t.Fatalf("json.Unmarshal must succeed (it used to fail on CS): %v", err)
+			}
+			srv := got.PrivateKeyCache
+
+			if srv.K != nil {
+				t.Errorf("K must not cross the API, got %T", srv.K)
+			}
+			if srv.CS != nil {
+				t.Errorf("CS must not cross the API, got %T", srv.CS)
+			}
+			if srv.PrivateKeyPEM == "" {
+				t.Fatal("PrivateKeyPEM must cross the API; it is what the server rebuilds from")
+			}
+
+			// --- tdns-auth side: the guard in keystore.go "add" ---
+			var privkey crypto.PrivateKey
+			if signer, ok := srv.K.(crypto.Signer); ok {
+				privkey = signer
+			} else if srv.PrivateKeyPEM != "" {
+				privkey, err = PEMToPrivateKey(srv.PrivateKeyPEM)
+				if err != nil {
+					t.Fatalf("PEMToPrivateKey: %v", err)
+				}
+			} else {
+				t.Fatal("no usable private key crossed the API")
+			}
+
+			if _, err := PrivateKeyToPEM(privkey); err != nil {
+				t.Fatalf("PrivateKeyToPEM: %v", err)
+			}
+		})
+	}
+}
+
+// TestDnssecImportRSACarriesPEM records why the wire form is PKCS#8 PEM rather
+// than the BIND single-field base64.
+//
+// RSA's BIND private-key format has eight fields — Modulus, PublicExponent,
+// PrivateExponent, Prime1, Prime2, Exponent1, Exponent2, Coefficient — and no
+// single "PrivateKey:" line, so PrepareKeyCache cannot fill pkc.PrivateKey for
+// it. Rebuilding the key server-side from that base64 therefore only ever
+// worked for the single-field algorithms (Ed25519, ECDSA, the PQ ones). The PEM
+// is algorithm-agnostic and is what the server now uses.
+func TestDnssecImportRSACarriesPEM(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "Krsa.example.+008+00000")
+
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: "rsa.example.", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     256,
+		Protocol:  3,
+		Algorithm: dns.RSASHA256,
+	}
+	priv, err := key.Generate(2048)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8: %v", err)
+	}
+	os.WriteFile(base+".private", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0600)
+	os.WriteFile(base+".key", []byte(key.String()+"\n"), 0644)
+
+	pkc, err := ReadPrivateKey(base + ".key")
+	if err != nil {
+		t.Fatalf("ReadPrivateKey: %v", err)
+	}
+	if pkc.PrivateKey != "" {
+		t.Logf("note: RSA now also yields a single-field base64 %q", pkc.PrivateKey)
+	} else {
+		t.Log("as expected: RSA yields no single-field BIND base64")
+	}
+	if pkc.PrivateKeyPEM == "" {
+		t.Fatal("RSA must still get a PKCS#8 PEM -- that is what makes RSA import work")
+	}
+	back, err := PEMToPrivateKey(pkc.PrivateKeyPEM)
+	if err != nil {
+		t.Fatalf("PEMToPrivateKey: %v", err)
+	}
+	if _, ok := back.(crypto.Signer); !ok {
+		t.Fatalf("round-tripped RSA key is not usable: %T", back)
+	}
+}

--- a/v2/keystore_import_api_test.go
+++ b/v2/keystore_import_api_test.go
@@ -147,8 +147,13 @@ func TestDnssecImportRSACarriesPEM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalPKCS8: %v", err)
 	}
-	os.WriteFile(base+".private", pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0600)
-	os.WriteFile(base+".key", []byte(key.String()+"\n"), 0644)
+	if err := os.WriteFile(base+".private",
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(base+".key", []byte(key.String()+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	pkc, err := ReadPrivateKey(base + ".key")
 	if err != nil {

--- a/v2/keystore_import_api_test.go
+++ b/v2/keystore_import_api_test.go
@@ -5,8 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -173,5 +176,91 @@ func TestDnssecImportRSACarriesPEM(t *testing.T) {
 	}
 	if _, ok := back.(crypto.Signer); !ok {
 		t.Fatalf("round-tripped RSA key is not usable: %T", back)
+	}
+}
+
+// TestReconstructSigningKeyRejectsMismatchedKeyType covers the guard that used
+// to sit behind the two branches that actually run: a SIG(0) cache offered to
+// the DNSSEC import (or the reverse) must be refused, not stored in the wrong
+// table under a zero-valued RR.
+func TestReconstructSigningKeyRejectsMismatchedKeyType(t *testing.T) {
+	k := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: "example.", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ED25519,
+	}
+	priv, err := k.Generate(256)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	pem, err := PrivateKeyToPEM(priv)
+	if err != nil {
+		t.Fatalf("to PEM: %v", err)
+	}
+
+	// A SIG(0) cache, as it would arrive over the API: K is json:"-" so it is
+	// nil, and the usable material is in PrivateKeyPEM.
+	sig0Cache := &PrivateKeyCache{
+		KeyType:       dns.TypeKEY,
+		Algorithm:     dns.ED25519,
+		PrivateKeyPEM: pem,
+	}
+	if _, err := reconstructSigningKey(sig0Cache, k.String(), dns.TypeDNSKEY); err == nil {
+		t.Error("a TypeKEY cache must be refused by the DNSSEC import path")
+	}
+
+	// The matching type still works.
+	dnssecCache := &PrivateKeyCache{
+		KeyType:       dns.TypeDNSKEY,
+		Algorithm:     dns.ED25519,
+		PrivateKeyPEM: pem,
+	}
+	if _, err := reconstructSigningKey(dnssecCache, k.String(), dns.TypeDNSKEY); err != nil {
+		t.Errorf("a matching cache must still be accepted: %v", err)
+	}
+}
+
+// TestAPIkeystoreRejectsMalformedJSON covers the decode-failure path added with
+// the import fix. The handler used to log a decode error and carry on, which is
+// how a half-decoded PrivateKeyCache reached the PKCS#8 marshaller in the first
+// place. It must now answer 400, in JSON (every other exit from this handler is
+// JSON, so a text/plain body would break any client that decodes
+// unconditionally), and start no keystore work at all.
+func TestAPIkeystoreRejectsMalformedJSON(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	handler := kdb.APIkeystore(&Config{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/keystore",
+		strings.NewReader(`{"command":"dnssec-mgmt","subcommand":"add","privatekeycache":`))
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", res.StatusCode, http.StatusBadRequest)
+	}
+	if ct := res.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var kr KeystoreResponse
+	if err := json.NewDecoder(res.Body).Decode(&kr); err != nil {
+		t.Fatalf("response body must be a decodable KeystoreResponse: %v", err)
+	}
+	if !kr.Error || kr.ErrorMsg == "" {
+		t.Errorf("malformed request must be reported as an error, got %+v", kr)
+	}
+
+	// Nothing may have been written: a rejected request must not leave a
+	// partially-built key behind.
+	var n int
+	if err := kdb.QueryRow("SELECT COUNT(*) FROM DnssecKeyStore").Scan(&n); err != nil {
+		t.Fatalf("counting DnssecKeyStore: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("a rejected request must not touch the keystore, found %d row(s)", n)
 	}
 }

--- a/v2/readkey.go
+++ b/v2/readkey.go
@@ -335,6 +335,19 @@ func PrepareKeyCache(privkey, pubkey string) (*PrivateKeyCache, error) {
 	// "PrivateKey:" line, so pkc.PrivateKey is empty for RSA and the server
 	// has nothing to rebuild from. PEM covers every algorithm uniformly,
 	// including the registered PQ ones.
+	//
+	// NOTE, for whoever adds the next algorithm: this makes a PKCS#8 codec a
+	// hard requirement for SIGNING, not just for export. PrepareKeyCache is on
+	// the READ path -- PrivateKeyCacheFromDB calls it for the signing-keys
+	// snapshot and for every SIG(0) key load -- so an algorithm that can sign
+	// but has no codec would not merely fail to export, it would fail to load
+	// at all, and its zones would stop signing.
+	//
+	// That is safe today because every algorithm in dnssec-algorithms/registry
+	// ships a pkcs8.go whose init() calls dnsalgpkcs8.Register, and the codec
+	// therefore links in with the algorithm package that genalgs pulls in --
+	// the two cannot be separated by accident. Keep it that way: an algorithm
+	// package without a PKCS#8 codec is not usable in tdns.
 	pkc.PrivateKeyPEM, err = PrivateKeyToPEM(pkc.K)
 	if err != nil {
 		return nil, fmt.Errorf("error encoding private key for algorithm %s as PKCS#8 PEM: %v",

--- a/v2/readkey.go
+++ b/v2/readkey.go
@@ -645,7 +645,20 @@ func ReadPubKeys(keydir string) (map[string]dns.KEY, error) {
 // rrstr is the matching public-key RR (KEY or DNSKEY) and wantType the RR type
 // the caller expects, so a mismatched cache is rejected rather than silently
 // reconstructed against the wrong record.
+//
+// The wantType check is FIRST, deliberately. It used to guard only the legacy
+// branch below, which meant the two paths that actually run — an in-process K,
+// or PrivateKeyPEM over the API — accepted a SIG(0) cache on the DNSSEC import
+// and vice versa. The key then went into the wrong table, and for the DNSSEC
+// direction pkc.DnskeyRR was zero-valued, so the row was written with an empty
+// zone name. Both in-tree callers build the cache through PrepareKeyCache,
+// which always sets KeyType, so requiring it costs nothing and closes the hole
+// the comment above always claimed was closed.
 func reconstructSigningKey(pkc *PrivateKeyCache, rrstr string, wantType uint16) (crypto.PrivateKey, error) {
+	if pkc.KeyType != wantType {
+		return nil, fmt.Errorf("key cache is for %s, but this operation needs %s (KeyType %d, wanted %d)",
+			dns.TypeToString[pkc.KeyType], dns.TypeToString[wantType], pkc.KeyType, wantType)
+	}
 	if signer, ok := pkc.K.(crypto.Signer); ok {
 		return signer, nil
 	}
@@ -655,9 +668,6 @@ func reconstructSigningKey(pkc *PrivateKeyCache, rrstr string, wantType uint16) 
 			return nil, fmt.Errorf("failed to parse private key PEM: %v", err)
 		}
 		return privkey, nil
-	}
-	if pkc.KeyType != wantType {
-		return nil, fmt.Errorf("unsupported key type for reconstruction: %d", pkc.KeyType)
 	}
 	bindFormat, err := PrivKeyToBindFormat(pkc.PrivateKey, dns.AlgorithmToString[pkc.Algorithm])
 	if err != nil {

--- a/v2/readkey.go
+++ b/v2/readkey.go
@@ -449,6 +449,48 @@ func IsPEMFormat(keyData string) bool {
 //
 // Returns an error if the algorithm is unknown, PEM decoding/parsing fails, the public key RR
 // cannot be parsed, conversion to BIND format fails, or the legacy BIND parsing logic fails.
+// PrivateKeyCacheFromDB builds a PrivateKeyCache from a keystore row, without
+// ever round-tripping the key through BIND format.
+//
+// This exists because ParsePrivateKeyFromDB does the opposite: for a stored
+// PKCS#8 PEM it parses the key correctly and then THROWS THE RESULT AWAY,
+// re-deriving a BIND-format blob via dns.DNSKEY.PrivateKeyString() for the
+// caller to hand back to PrepareKeyCache. PrepareKeyCache then takes its BIND
+// branch and re-parses with dns.DNSKEY.NewPrivateKey(), which dispatches on the
+// algorithm CODEPOINT. So any key written under a codepoint that has since been
+// renumbered failed with a bare "dns: bad private key" -- even though the PEM
+// had just parsed cleanly moments earlier. That took out slhdsa128s.foo and
+// cpt.p.axfr.net on the gocpt101 testbed: zones served, but signing was dead.
+//
+// PrepareKeyCache already detects and handles PEM properly. The only thing it
+// cannot do is take the legacy bare-base64 form, which has no BIND header --
+// so wrap that case and pass everything else straight through.
+func PrivateKeyCacheFromDB(privatekey, algorithm, keyrrstr string) (*PrivateKeyCache, uint8, error) {
+	alg, ok := dns.StringToAlgorithm[strings.ToUpper(algorithm)]
+	if !ok {
+		return nil, 0, fmt.Errorf("unknown algorithm: %s", algorithm)
+	}
+
+	keydata := privatekey
+	if !IsPEMFormat(privatekey) {
+		// Legacy rows hold the bare base64 with no "Private-key-format:"
+		// header; PrepareKeyCache's BIND branch needs the full blob.
+		var err error
+		keydata, err = PrivKeyToBindFormat(privatekey, algorithm)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to convert stored key to BIND format: %v", err)
+		}
+	}
+
+	pkc, err := PrepareKeyCache(keydata, keyrrstr)
+	if err != nil {
+		return nil, 0, err
+	}
+	return pkc, alg, nil
+}
+
+// Deprecated: use PrivateKeyCacheFromDB. This returns a BIND-format string even
+// for PEM input, which forces callers through a codepoint-sensitive re-parse.
 func ParsePrivateKeyFromDB(privatekey, algorithm, keyrrstr string) (crypto.PrivateKey, uint8, string, error) {
 	var privkey crypto.PrivateKey
 	var alg uint8

--- a/v2/readkey.go
+++ b/v2/readkey.go
@@ -614,3 +614,45 @@ func ReadPubKeys(keydir string) (map[string]dns.KEY, error) {
 
 	return keymap, nil
 }
+
+// reconstructSigningKey resolves the usable private key for a keystore write.
+//
+// Shared by the SIG(0) and DNSSEC import paths, which previously carried this
+// precedence verbatim in two places. Order matters:
+//
+//  1. K, if it is a real key. It is json:"-", so it is populated only
+//     in-process and is nil for anything that arrived over the API. Type-assert
+//     rather than nil-check: a half-succeeded decode can leave a non-nil but
+//     unusable value (a string, a map) here, and every real private key type
+//     implements crypto.Signer.
+//  2. PrivateKeyPEM, the normal API path. PKCS#8 PEM covers every algorithm,
+//     including RSA, which the BIND-base64 route below cannot represent.
+//  3. The legacy BIND base64, for callers predating PrivateKeyPEM.
+//
+// rrstr is the matching public-key RR (KEY or DNSKEY) and wantType the RR type
+// the caller expects, so a mismatched cache is rejected rather than silently
+// reconstructed against the wrong record.
+func reconstructSigningKey(pkc *PrivateKeyCache, rrstr string, wantType uint16) (crypto.PrivateKey, error) {
+	if signer, ok := pkc.K.(crypto.Signer); ok {
+		return signer, nil
+	}
+	if pkc.PrivateKeyPEM != "" {
+		privkey, err := PEMToPrivateKey(pkc.PrivateKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse private key PEM: %v", err)
+		}
+		return privkey, nil
+	}
+	if pkc.KeyType != wantType {
+		return nil, fmt.Errorf("unsupported key type for reconstruction: %d", pkc.KeyType)
+	}
+	bindFormat, err := PrivKeyToBindFormat(pkc.PrivateKey, dns.AlgorithmToString[pkc.Algorithm])
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert private key to BIND format: %v", err)
+	}
+	reconstructed, err := PrepareKeyCache(bindFormat, rrstr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconstruct private key: %v", err)
+	}
+	return reconstructed.K, nil
+}

--- a/v2/readkey.go
+++ b/v2/readkey.go
@@ -329,6 +329,18 @@ func PrepareKeyCache(privkey, pubkey string) (*PrivateKeyCache, error) {
 	}
 	pkc.CS = signer
 
+	// PKCS#8 PEM is the form that crosses the API. Unlike the BIND base64 in
+	// pkc.PrivateKey it is algorithm-agnostic: RSA's BIND private-key format
+	// has eight fields (Modulus, PrivateExponent, Prime1, ...) and no single
+	// "PrivateKey:" line, so pkc.PrivateKey is empty for RSA and the server
+	// has nothing to rebuild from. PEM covers every algorithm uniformly,
+	// including the registered PQ ones.
+	pkc.PrivateKeyPEM, err = PrivateKeyToPEM(pkc.K)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding private key for algorithm %s as PKCS#8 PEM: %v",
+			dns.AlgorithmToString[pkc.Algorithm], err)
+	}
+
 	//	log.Printf("PrepareKeyCache: Zone: %s, algorithm: %s, keyid: %d,\nprivkey: %s,\npubkey: %s\npkc.K: %v",
 	//		rr.Header().Name, dns.AlgorithmToString[pkc.Algorithm], pkc.KeyId, pkc.PrivateKey, pubkey, pkc.K)
 

--- a/v2/signing_keys_snapshot.go
+++ b/v2/signing_keys_snapshot.go
@@ -168,15 +168,14 @@ SELECT keyid, flags, algorithm, privatekey, keyrr FROM DnssecKeyStore WHERE zone
 
 		keysfound = true
 
-		_, alg, bindFormat, err := ParsePrivateKeyFromDB(privatekey, algorithm, keyrrstr)
+		// PrivateKeyCacheFromDB, NOT ParsePrivateKeyFromDB + PrepareKeyCache: the
+		// latter pair re-derives a BIND blob from an already-parsed PEM and
+		// re-parses it via NewPrivateKey, which dispatches on the algorithm
+		// codepoint and fails ("dns: bad private key") for any key stored under
+		// a codepoint that has since been renumbered.
+		pkc, alg, err := PrivateKeyCacheFromDB(privatekey, algorithm, keyrrstr)
 		if err != nil {
-			lgSigner.Error("ParsePrivateKeyFromDB failed", "err", err)
-			return nil, err
-		}
-
-		pkc, err := PrepareKeyCache(bindFormat, keyrrstr)
-		if err != nil {
-			lgSigner.Error("PrepareKeyCache failed", "err", err)
+			lgSigner.Error("PrivateKeyCacheFromDB failed", "err", err)
 			return nil, err
 		}
 

--- a/v2/structs.go
+++ b/v2/structs.go
@@ -895,11 +895,30 @@ type NotifyStatus struct {
 
 // Migrating all DB access to own interface to be able to have local receiver functions.
 type PrivateKeyCache struct {
-	K          crypto.PrivateKey
-	PrivateKey string // This is only used when reading from file with ReadKeyNG()
-	CS         crypto.Signer
-	RR         dns.RR
-	KeyType    uint16
+	// K, CS and RR are interfaces and MUST NOT cross the API boundary.
+	//
+	// json.Marshal writes an ed25519.PrivateKey (a []byte) as a base64
+	// string; on the way back in, that string decodes happily into the
+	// empty interface crypto.PrivateKey but FAILS against the non-empty
+	// crypto.Signer, aborting the decode partway through. The server used
+	// to log that error and carry on, leaving K holding a plain string —
+	// which then reached x509.MarshalPKCS8PrivateKey and produced the
+	// misleading "pkcs8: codec does not support this key/OID".
+	//
+	// The wire form carries PrivateKey (base64) + DnskeyRR/KeyRR, which is
+	// everything the server needs to rebuild the key locally.
+	K crypto.PrivateKey `json:"-"`
+	// PrivateKey is the BIND single-field base64. Kept for existing callers,
+	// but do NOT rely on it across the API: it is empty for RSA, whose BIND
+	// format has eight fields and no "PrivateKey:" line. Use PrivateKeyPEM.
+	PrivateKey string
+	// PrivateKeyPEM is the PKCS#8 PEM encoding and is what the server rebuilds
+	// the key from. Algorithm-agnostic: works for RSA, ECDSA, Ed25519 and the
+	// registered PQ algorithms alike.
+	PrivateKeyPEM string
+	CS            crypto.Signer `json:"-"`
+	RR            dns.RR        `json:"-"`
+	KeyType       uint16
 	Algorithm  uint8
 	KeyId      uint16
 	KeyRR      dns.KEY


### PR DESCRIPTION
Two independent fixes. They share a branch because the second was needed to build and test the first on NetBSD, but they can be split if you'd rather they merge separately — `39592c5` stands alone.

## 1. DNSSEC/SIG(0) key import over the API (`5077b92`)

`tdns-cli auth keystore dnssec import` failed for **every** algorithm:

```
Error: failed to convert private key to PEM: failed to marshal private key to
PKCS#8: dnssec-algorithms/pkcs8: codec does not support this key/OID
```

tdns-cli reads the key files locally and POSTs the whole `PrivateKeyCache` to tdns-auth, so the struct crosses the API. It shipped the key **twice**: as the base64 `PrivateKey` string, and as the live `K`/`CS` interface values — which cannot round-trip.

`ed25519.PrivateKey` is a `[]byte`, so it marshals to a base64 string. Coming back, that string decodes happily into the *empty* interface `crypto.PrivateKey` but fails against the *non-empty* `crypto.Signer`, aborting the decode partway. `APIkeystore` only logged that error and carried on, so the server ran with a half-built request where `K` held a plain `string`. The `if pkc.K != nil` guard passed, reconstruction was skipped, and a string reached `x509.MarshalPKCS8PrivateKey` — producing a pkcs8 complaint that pointed at the algorithm registry rather than the actual cause.

- `K`, `CS`, `RR` are now `json:"-"`
- new `PrivateKeyCache.PrivateKeyPEM` carries the PKCS#8 PEM; the server rebuilds from that
- server guards type-assert `crypto.Signer` rather than nil-checking (DNSSEC **and** SIG(0) paths)
- `APIkeystore` returns 400 on decode error instead of continuing

**This also fixes RSA**, which the old BIND-base64 route could never handle: RSA's BIND private-key format has eight fields and no single `PrivateKey:` line, so `pkc.PrivateKey` was empty for RSA and there was nothing to rebuild from. PEM is algorithm-agnostic and covers the registered PQ algorithms too.

New test covers the full client → JSON → server round trip for ED25519, ECDSA and RSA.

Verified end to end on foffe: all three `p.axfr.net` keys imported and the zone signs with them.

## 2. PQ algorithm builds on NetBSD (`39592c5`)

Three defects that together made PQ builds on NetBSD fragile *with no error message anywhere*:

**genalgs emitted GNU-make-only syntax.** `algs-libs.mk` contained `$(if $(PKG_CONFIG_PATH),…)`. bmake parses that as a variable modifier and dies with `Unknown modifier` as soon as `ALGS_ENV` expands it. (The older generator wrote `export VAR := value` instead — bmake has no `export` directive, so it silently created a variable literally named `export PKG_CONFIG_PATH` and the real one was never set. Same bug, failing quietly. Verified on both 9.3 and 10.1: **neither ever exported it**.)

**The generator was never rebuilt.** `$(GENALGS)` was a file target with no prerequisites, so make only built it when *missing*. On gocpt101 the binary was from 18 July; the tree was pulled forward 185 commits and still regenerated July's broken fragment on every `make`. `cmdv2/genalgs/Makefile` had the identical defect on `$(PROG)`. Both are now `.PHONY`, and the staleness check considers the generator's timestamp.

**`$(dir $(GENALGS))` is also GNU-only** — latent, because that rule had essentially never fired on NetBSD. Making it `.PHONY` would have started firing it and broken the build. Replaced with an explicit `GENALGS_DIR`.

Verified on gocpt101 (NetBSD 9.3, bmake): `make` in a shell with **no** algorithm environment variables now generates a correct fragment and builds a statically linked binary — the first time the generated file has carried its own weight rather than relying on the operator having sourced `liboqs-env.sh`. Touching `cmdv2/genalgs/env.go` correctly rebuilds the generator, regenerates the fragment and relinks the app.

Companion fix in dnssec-algorithms: johanix/dnssec-algorithms#8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed API requests now return a clear HTTP 400 response instead of being processed partially.
  * DNSSEC and SIG(0) key imports now reliably reconstruct supported key types from PKCS#8 PEM data.
  * Private keys can now safely survive API round trips without exposing non-serializable key data.
  * Generated package configuration now preserves inherited library paths and avoids variable conflicts.

* **Tests**
  * Added coverage for Ed25519, ECDSA P-256, and RSA key import, database loading, and round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->