### PR TITLE
build: add "make pkg", producing NetBSD binary packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ cmdv2/dog/dog
 cmdv2/imr/tdns-imr
 cmdv2/agent/tdns-agent
 
+# NetBSD binary packages built by "make pkg"; they land beside the binary in
+# the app directory.
+cmd/*/*.tgz
+cmdv2/*/*.tgz
+
 # old stuff; going away:
 sidecar/music-sidecar
 sidecar-cli/sidecar-cli

--- a/cmdv2/Makefile
+++ b/cmdv2/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all v2 genalgs version clean install install-dirs check-root tarball
+.PHONY: all v2 genalgs version clean install install-dirs check-root tarball pkg
 
 # all apps in this directory
 all: v2
@@ -44,6 +44,24 @@ install: check-root install-dirs
 	$(MAKE) -C ./agent/ install
 	$(MAKE) -C ./imr/ install
 	$(MAKE) -C ./dog/ install
+
+# NetBSD binary packages -- four of them, one per component. See
+# ../utils/mkpkg.sh for the reasoning and ../utils/Makefile.common for the
+# rules. Each app's "pkg" target builds, installs and packs its own binaries,
+# so this needs root for the same reason "install" does.
+#
+# The .tgz files are left in the app directories. Publishing is deliberately
+# NOT a target here: they go into a per-osrelease tree
+# (/var/tmp/axfr.net/ftpfiles/pkg/amd64-<osrelease>/) on a lab dom0, and the
+# same file is copied into EVERY such tree -- OS_VERSION mismatch only warns.
+# Which trees exist is a property of the lab, not of this repo.
+#
+# cli/ also builds and installs dog/, so dog is not listed separately.
+pkg: check-root install-dirs genalgs
+	$(MAKE) -C ./auth/ pkg
+	$(MAKE) -C ./agent/ pkg
+	$(MAKE) -C ./imr/ pkg
+	$(MAKE) -C ./cli/ pkg
 
 TAR_VERSION:=v2
 TARFILE:=/tmp/usr.local.tdns.$(TAR_VERSION).tar.gz

--- a/cmdv2/agent/Makefile
+++ b/cmdv2/agent/Makefile
@@ -9,10 +9,13 @@ include ../../utils/Makefile.common
 -include ../algs-env.mk
 -include algs-libs.mk
 
-.PHONY: clean install
+.PHONY: clean install pkg
 
 install:
 	install -s -b -c ${PROG} /usr/local/libexec/
+
+# NetBSD binary package; rule and rationale in ../../utils/Makefile.common.
+pkg:	pkg_tdns_agent
 
 clean:
 	rm -f $(PROG)

--- a/cmdv2/auth/Makefile
+++ b/cmdv2/auth/Makefile
@@ -11,10 +11,13 @@ include ../../utils/Makefile.common
 -include ../algs-env.mk
 -include algs-libs.mk
 
-.PHONY: clean install
+.PHONY: clean install pkg
 
 install:
 	install -s -b -c ${PROG} /usr/local/libexec/
+
+# NetBSD binary package; rule and rationale in ../../utils/Makefile.common.
+pkg:	pkg_tdns_auth
 
 clean:
 	rm -f $(PROG)

--- a/cmdv2/cli/Makefile
+++ b/cmdv2/cli/Makefile
@@ -10,10 +10,14 @@ include ../../utils/Makefile.common
 -include ../algs-env.mk
 -include algs-libs.mk
 
-.PHONY: clean install docs
+.PHONY: clean install docs pkg
 
 install:
 	install -s -b -c ${PROG} /usr/local/bin/
+
+# NetBSD binary package; rule and rationale in ../../utils/Makefile.common.
+# This one also ships dog, and builds and installs ../dog to get it.
+pkg:	pkg_tdns_cli
 
 # Regenerate the generated CLI reference (reference/cli/*.md) from the live
 # cobra command tree. Output is stable (no auto-gen date footer), so re-running

--- a/cmdv2/dog/Makefile
+++ b/cmdv2/dog/Makefile
@@ -17,6 +17,11 @@ include ../../utils/Makefile.common
 install:
 	install -s -b -c ${PROG} /usr/local/bin/
 
+# No "pkg" target here on purpose: dog ships inside the tdns-cli package, whose
+# recipe (in ../../utils/Makefile.common) builds and installs this directory
+# before packing. A "pkg" alias here would build that same package from a
+# directory that cannot say whether tdns-cli itself is current.
+
 clean:
 	rm -f $(PROG)
 	find . -type f -name '*~' -delete

--- a/cmdv2/imr/Makefile
+++ b/cmdv2/imr/Makefile
@@ -11,10 +11,13 @@ include ../../utils/Makefile.common
 -include ../algs-env.mk
 -include algs-libs.mk
 
-.PHONY: clean install
+.PHONY: clean install pkg
 
 install:
 	install -s -b -c ${PROG} /usr/local/bin/
+
+# NetBSD binary package; rule and rationale in ../../utils/Makefile.common.
+pkg:	pkg_tdns_imr
 
 clean:
 	rm -f $(PROG)

--- a/utils/Makefile.common
+++ b/utils/Makefile.common
@@ -170,6 +170,90 @@ check-no-mutators:
 test:
 	$(ALGS_ENV) $(GO) test -v -cover
 
+# --- packages -----------------------------------------------------------
+#
+# Four NetBSD binary packages, one per component: tdns-auth, tdns-agent and
+# tdns-imr each ship their own daemon, and tdns-cli ships the two client tools
+# (tdns-cli and dog). See utils/mkpkg.sh for why a package rather than a
+# tarball, and for the pkg_create details that are not obvious.
+#
+# The file lists below are exactly the paths each app's OWN "install:" target
+# places under /usr/local -- libexec for the daemons, bin for the clients.
+# They are NOT the v2-suffixed names carried by the old hand-assembled
+# usr.local.tdns bintar: that suffix is a leftover of the v1/v2 split, and the
+# lab configs still naming it are being updated rather than perpetuated here.
+#
+# The package is a REAL make target, with the app's OWN BUILT BINARY as the
+# prerequisite -- not the installed copy under /usr/local.
+#
+# That distinction is the whole point. Depending on /usr/local/libexec/<daemon>
+# looks right and is actively wrong: if the app was rebuilt but not installed,
+# the stale copy still satisfies the dependency, make declares the package
+# current, and a THREE-DAY-OLD BINARY ships inside a package stamped with
+# today's date. That is not hypothetical -- it happened in labstuff, where the
+# first axfr-statusd package carried a build three days older than the tree and
+# nothing said so until the daemon was asked its version on a booted master.
+#
+# So: depend on ./$(PROG) AND on install. Since install is phony it always
+# runs, which means the package is repacked on every "make pkg" -- the no-op
+# optimisation is gone. That is the right trade: a 40MB repack costs seconds,
+# and the alternative cost a stale binary reaching a booted master silently.
+#
+# tdns-cli is the one package shipping a binary built in ANOTHER app directory
+# (dog). Rather than leave that to be remembered, its recipe builds and
+# installs ../dog itself, which closes the cross-directory staleness hole for
+# the only case tdns has.
+
+# VERSION lives at the repo root, and this file is included from three
+# different depths (repo/Makefile, repo/cmd/Makefile, repo/cmdv2/<app>/
+# Makefile), so the lookup walks up rather than assuming one of them.
+#
+# "!=" rather than "$(shell ...)": $(shell) is GNU-make only and under NetBSD's
+# bmake expands to NOTHING -- silently. In labstuff that produced a plausibly
+# named, full-size, VERSIONLESS package. mkpkg.sh now refuses such a version,
+# and this is the other half of that fix.
+PKGBASEVER!= for f in ../../VERSION ../VERSION VERSION; do if [ -f "$$f" ]; then sed -e 's/^[vV]//' -e 's/[^0-9.].*$$//' "$$f"; break; fi; done 2>/dev/null || echo ""
+PKGDATE!= date +%Y%m%d
+PKGVER=$(PKGBASEVER).$(PKGDATE)
+
+PKG_TDNS_AUTH:=tdns-auth-$(PKGVER).tgz
+PKG_TDNS_AGENT:=tdns-agent-$(PKGVER).tgz
+PKG_TDNS_IMR:=tdns-imr-$(PKGVER).tgz
+PKG_TDNS_CLI:=tdns-cli-$(PKGVER).tgz
+
+pkg_tdns_auth: $(PKG_TDNS_AUTH)
+$(PKG_TDNS_AUTH): $(PROG) install
+	PKGVERSION=$(PKGVER) \
+	PKGCOMMENT="tdns-auth, the tdns authoritative nameserver" \
+	/bin/sh ../../utils/mkpkg.sh tdns-auth /usr/local \
+	libexec/tdns-auth
+
+pkg_tdns_agent: $(PKG_TDNS_AGENT)
+$(PKG_TDNS_AGENT): $(PROG) install
+	PKGVERSION=$(PKGVER) \
+	PKGCOMMENT="tdns-agent, the tdns delegation-sync agent" \
+	/bin/sh ../../utils/mkpkg.sh tdns-agent /usr/local \
+	libexec/tdns-agent
+
+pkg_tdns_imr: $(PKG_TDNS_IMR)
+$(PKG_TDNS_IMR): $(PROG) install
+	PKGVERSION=$(PKGVER) \
+	PKGCOMMENT="tdns-imr, the tdns iterative resolver" \
+	/bin/sh ../../utils/mkpkg.sh tdns-imr /usr/local \
+	bin/tdns-imr
+
+# dog ships here rather than in its own package, and is built and installed by
+# this recipe because nothing else in the cli/ directory would do it.
+pkg_tdns_cli: $(PKG_TDNS_CLI)
+$(PKG_TDNS_CLI): $(PROG) install
+	$(MAKE) -C ../dog
+	$(MAKE) -C ../dog install
+	PKGVERSION=$(PKGVER) \
+	PKGCOMMENT="tdns-cli and dog, the tdns command-line tools" \
+	/bin/sh ../../utils/mkpkg.sh tdns-cli /usr/local \
+	bin/tdns-cli \
+	bin/dog
+
 # install:
 # 	install -s -b -c ${PROG} /usr/local/bin/
 
@@ -181,3 +265,4 @@ lint: check-no-mutators
 	golangci-lint run
 
 .PHONY: build generate version clean check-no-mutators
+.PHONY: pkg_tdns_auth pkg_tdns_agent pkg_tdns_imr pkg_tdns_cli

--- a/utils/mkpkg.sh
+++ b/utils/mkpkg.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+#
+# mkpkg.sh -- build a NetBSD binary package from files already installed
+#             under a prefix. Companion to the tarball targets: same file
+#             lists, but producing a registered package instead of a bare
+#             tarball.
+#
+#   usage: mkpkg.sh <pkgbase> <prefix> <file> [file ...]
+#   e.g.   mkpkg.sh tdns-cli /usr/local bin/tdns-cli bin/dog
+#
+# This is a near-verbatim sibling of labstuff's utils/mkpkg.sh. The ~20 lines
+# of duplication are deliberate: they are separate repos, and vendoring one
+# into the other is worse than keeping two copies that rarely change. If you
+# fix something here, fix it there too.
+#
+# WHY A PACKAGE AND NOT A TARBALL. A bintar leaves no record: nothing on the
+# machine can answer "what is installed here, and which build is it?". That
+# question has been expensive more than once -- the tdns bintar sat at Feb 2025
+# on every lab machine and only a timestamp revealed it. pkg_info answers it,
+# and pkg_delete can undo it.
+#
+# And for tdns specifically there is a second reason. tdns-auth starts at boot
+# from rc.d on the lab master, but the binary used to arrive via swprep, which
+# runs AFTER boot -- so a freshly built master had no binary, the daemon
+# failed, and the zones it serves were served by nothing. A package can be
+# pkg_add'ed into the mounted image before first boot; a swprep bintar cannot.
+#
+# FOUR THINGS THAT ARE NOT OBVIOUS, all of which cost a failed attempt:
+#
+#  1. pkg_create infers NEITHER the compression NOR the extension. Without
+#     "-F gzip" and an explicit .tgz name you get an uncompressed tar with no
+#     suffix, which nothing downstream recognises.
+#
+#  2. PKGTOOLS_VERSION must not exceed the INSTALLING host's pkg_install
+#     version, or pkg_add refuses outright with "built with a newer pkg_install
+#     version" -- naming a version, but not which of the two is wrong. Pinned
+#     old below so any host accepts it.
+#
+#  3. -p is where the files are NOW (the staging tree); -I is where they go at
+#     install time. Both take the same relative paths from the packing list.
+#
+#  4. OS_VERSION mismatch only WARNS, and installs anyway (verified both
+#     directions, 9.3<->10.1). So it is metadata, not enforcement: one package
+#     built here is dropped into every per-release tree deliberately. Go
+#     binaries built on an older NetBSD run on a newer one, which is the
+#     direction we are in -- the build host is 9.3 and the lab is moving to
+#     10.1. If that ever inverts, build explicitly on a host of the needed
+#     release rather than lying in this field.
+#
+# The staging copy is required by pkg_create, which needs a tree it can treat as
+# the package root. The files come from $PREFIX, i.e. from wherever "make
+# install" put them -- same source the tarball targets use.
+
+set -e
+
+# pkg_create lives in /usr/sbin, which is NOT on the PATH of a non-interactive
+# ssh session -- so a build driven remotely (which is how the lab builds) fails
+# with "pkg_create: not found" while it works fine when you are logged in.
+# Overridable for a host that keeps it elsewhere.
+PKG_CREATE="${PKG_CREATE:-}"
+if [ -z "$PKG_CREATE" ]; then
+	for c in /usr/sbin/pkg_create /usr/pkg/sbin/pkg_create; do
+		[ -x "$c" ] && PKG_CREATE="$c" && break
+	done
+fi
+[ -z "$PKG_CREATE" ] && PKG_CREATE=$(command -v pkg_create 2>/dev/null || true)
+if [ -z "$PKG_CREATE" ]; then
+	echo "mkpkg.sh: cannot find pkg_create (looked in /usr/sbin, /usr/pkg/sbin, PATH)" >&2
+	exit 1
+fi
+
+PKGBASE="$1"; shift
+PREFIX="$1"; shift
+
+if [ -z "$PKGBASE" ] || [ -z "$PREFIX" ] || [ $# -eq 0 ]; then
+	echo "usage: mkpkg.sh <pkgbase> <prefix> <file> [file ...]" >&2
+	exit 1
+fi
+
+# Version: VERSION.DATE, e.g. tdns-auth-0.8.20260807.
+#
+# A pkgsrc version must START WITH A DIGIT and contain no '-': pkg_add splits
+# name-version on the last hyphen, and its version COMPARISON -- the reason for
+# packaging at all -- gives up on a leading 'v'. Hence the sed below (tdns's
+# VERSION file says "v0.8"), and hence a DOT between version and date rather
+# than a second dash.
+#
+# NO COMMIT HASH, deliberately. A hash makes every build a distinct version, so
+# the published tree accumulates forever and nothing can be pruned without
+# correlating each file back to git history. A date is readable, sorts
+# correctly, and makes "keep the last N" a decision you can take by looking.
+# The commit IS recorded, in the DESC below, where it costs nothing.
+#
+# The cost, worth knowing: two builds on the SAME DAY carry the same version.
+# pkg_add will treat the second as already-installed and skip it, so a
+# rebuild-and-redeploy loop within one day needs pkg_add -U (or pkg_delete
+# first). It will not silently install the old one -- it will decline and say so.
+#
+# PKGVERSION may be supplied by the caller. The Makefile does so, because it
+# needs to know the output filename BEFORE running this script -- that is what
+# lets the package be a real make target with the binaries as prerequisites,
+# instead of a phony target that rebuilds a 40MB package on every invocation.
+if [ -z "$PKGVERSION" ]; then
+	BASEVERSION=$(cat ../../VERSION 2>/dev/null || echo 0)
+	BASEVERSION=$(echo "$BASEVERSION" | sed 's/^[vV]//; s/[^0-9.].*$//; s/\.*$//')
+	[ -z "$BASEVERSION" ] && BASEVERSION=0
+	PKGVERSION="${BASEVERSION}.$(date +%Y%m%d)"
+fi
+
+# Refuse a version that is not one. The caller passing an EMPTY PKGVERSION is
+# not hypothetical: $(shell ...) under BSD make expands to nothing, which in
+# labstuff produced "axfr-statusd-..tgz" -- a full-size package, plausibly
+# named, with no version in it. That is worse than a failure, because it
+# installs.
+case "$PKGVERSION" in
+	[0-9]*.[0-9]*) ;;
+	*)
+		echo "mkpkg.sh: refusing to build with version '$PKGVERSION'" >&2
+		echo "  expected something like 0.8.20260807 (digits, dot, digits)." >&2
+		echo "  If invoked from make, PKGVER did not expand. The two ways that" >&2
+		echo "  happens, both silent: \$(shell ...) is GNU-make only and yields" >&2
+		echo "  nothing under NetBSD's bmake, and '!=' needs bmake or GNU make" >&2
+		echo "  4.0+ (macOS still ships 3.81). Build on the NetBSD build host." >&2
+		exit 1
+		;;
+esac
+PKGNAME="${PKGBASE}-${PKGVERSION}"
+
+STAGE=$(mktemp -d /tmp/mkpkg.XXXXXX)
+trap 'rm -rf "$STAGE"' EXIT
+
+META="$STAGE/.meta"
+ROOT="$STAGE/root"
+mkdir -p "$META" "$ROOT"
+
+: > "$META/PLIST"
+for f in "$@"; do
+	if [ ! -f "$PREFIX/$f" ]; then
+		echo "mkpkg.sh: $PREFIX/$f does not exist -- run the build and install it first" >&2
+		exit 1
+	fi
+	mkdir -p "$ROOT/$(dirname "$f")"
+	cp -p "$PREFIX/$f" "$ROOT/$f"
+	echo "$f" >> "$META/PLIST"
+done
+
+# The exact source revision, for the DESC only -- never for the version field.
+# git describe anchors on whatever tag happens to be nearest, which is not a
+# thing to build a package version out of; as free text next to the date it is
+# exactly what you want when asking "which build is this?".
+SRCREV=$(git describe --dirty=+WiP --always 2>/dev/null || echo unknown)
+SRCBRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+
+# tdns produces four packages from one repo, so a single hardcoded one-line
+# COMMENT would describe none of them. Callers pass PKGCOMMENT; the default
+# below is the fallback for a hand-run invocation.
+COMMENT="${PKGCOMMENT:-$PKGBASE, part of the tdns DNS toolset}"
+echo "$COMMENT (built $(date +%Y-%m-%d))" > "$META/COMMENT"
+
+cat > "$META/DESC" <<EOF
+$COMMENT.
+
+Built from $(basename "$PWD") on $(date +%Y-%m-%d), source $SRCBRANCH/$SRCREV.
+Installed under $PREFIX.
+
+Packaged rather than shipped as a bintar so that the machine keeps a record of
+what it is running: pkg_info reports the exact source revision without having
+to run the binary, and pkg_delete can remove it cleanly. A package can also be
+installed into a VM image before first boot, which is what lets tdns-auth start
+from rc.d on a freshly built lab master.
+EOF
+
+cat > "$META/BUILD_INFO" <<EOF
+OPSYS=NetBSD
+OS_VERSION=$(uname -r)
+MACHINE_ARCH=$(uname -p)
+PKGTOOLS_VERSION=20091115
+EOF
+
+"$PKG_CREATE" -F gzip \
+	-B "$META/BUILD_INFO" \
+	-c "$META/COMMENT" \
+	-d "$META/DESC" \
+	-f "$META/PLIST" \
+	-p "$ROOT" \
+	-I "$PREFIX" \
+	"${PKGNAME}.tgz"
+
+echo "built ${PKGNAME}.tgz ($(ls -l "${PKGNAME}.tgz" | awk '{print $5}') bytes, $# files, OS_VERSION=$(uname -r), src $SRCREV)"


### PR DESCRIPTION
Adds a `pkg` target that builds NetBSD binary packages, mirroring what already
exists in labstuff. Four packages, one per component:

| package | contents |
|---|---|
| `tdns-auth` | `libexec/tdns-auth` |
| `tdns-agent` | `libexec/tdns-agent` |
| `tdns-imr` | `bin/tdns-imr` |
| `tdns-cli` | `bin/tdns-cli`, `bin/dog` |

Contents are exactly what each app's existing `install:` target already places
under `/usr/local`. No install paths change and nothing is renamed.

## Why

`tdns-auth` starts at boot from rc.d on the lab master, but the binary arrived
via swprep, which runs *after* boot. A freshly built master therefore found no
binary, the daemon failed, and the zones it serves — dnslab, com, net, org and
the reverse zones, i.e. what BIND's retired `tld` view used to serve — were
served by nothing. A package can be `pkg_add`ed into the mounted image before
first boot; a bintar in a swprep list cannot.

Second reason: a bintar leaves no record. Nothing on the machine can say what is
installed or which build it is — the tdns bintar sat at Feb 2025 on every lab
machine and only a timestamp revealed it. `pkg_info` answers that, `pkg_admin
check` verifies the files, and `pkg_delete` removes them cleanly.

## Notes on the implementation

`utils/mkpkg.sh` is a near-verbatim sibling of labstuff's, header comment
included. The ~20 lines of duplication are deliberate — separate repos, and
vendoring either into the other is worse than two copies that rarely change. Two
differences: it takes `PKGCOMMENT` from the caller (four packages from one repo
cannot share one COMMENT line), and it records branch and `git describe` in the
DESC. That is free text only — never the version field, which stays VERSION.DATE
so the published tree can be pruned by looking at it.

Each package is a real make target depending on the app's **own built binary**
plus `install`, never on the installed copy. Depending on the installed copy
looks right and is actively wrong: a rebuilt-but-not-installed app leaves the
stale copy satisfying the dependency, and a days-old binary then ships inside a
package stamped with today's date. That happened in labstuff and was caught only
by asking a booted daemon its version. `install` is phony, so the package is
repacked every time — the right trade at a few seconds per 40MB.

`tdns-cli` is the only package shipping a binary built in another app directory,
so its recipe builds and installs `../dog` itself rather than leaving that to be
remembered. `dog` deliberately has no `pkg` alias.

`PKGVER` uses `!=` rather than `$(shell ...)`: `$(shell)` is GNU-make only and
expands to nothing under NetBSD's bmake — silently, which in labstuff produced a
plausibly named, full-size, versionless package. Verified to expand identically
under both makes on the build host. `mkpkg.sh` refusing a malformed version is
the second half of that fix.

## Verification

Built on gocpt101 (NetBSD 9.3, Go 1.25.5), all five apps, 16 PQ algorithms
linked. Packages published to `amd64-9.3` and `amd64-10.1` on cpt, byte-identical
in both — `OS_VERSION` mismatch only warns, and a 9.3-built Go binary runs on
10.1, which is the direction the lab is moving.

- Every binary inside the packages carries
  `v0.8-feature/pkg-target-milestone-3-pq-registry-387-g33dd25ef`, i.e. this
  commit, built today — checked by extracting from the `.tgz`, not from
  `/usr/local`.
- Offline `pkg_add -p <root>/usr/local -K <root>/usr/pkg/pkgdb` of all four into
  an isolated root: all register, `pkg_info` lists all four, `pkg_admin check`
  verifies 5/5 files.
- `pkg_delete` removes all four cleanly, leaving no files behind.
- Installed binaries run and self-report the same version.
- `+BUILD_INFO` matches the already-proven `axfr-statusd` package exactly.

## Follow-up, not in this PR

labconfig needs `tdns-auth` and `tdns-cli` added to `image-pkgs-master` and
`usr.local.tdns` removed from `pkgs.bintars.master` in the same change, so no
machine carries both. Both packages are needed on the master, not just
`tdns-auth`: `axfr_tdns_auth`'s `start_precmd` runs `tdns-cli cert init` on a
fresh master.

Also for labconfig, separately: the configs still reference the v2-suffixed
paths from the hand-assembled bintar (`libexec/tdns-authv2`, `bin/tdns-cliv2`,
`libexec/tdns-agentv2`, `libexec/tdns-imrv2`), and `tdns-imr` installs to `bin/`
rather than `libexec/`.