### PR TITLE
Fix self-deadlock in applyOptionNormalization: no zone ever loads

### DIFF
--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -923,7 +923,13 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 		//
 		// zd.ZoneType is not yet assigned at this point in the parse, so the
 		// locally resolved zonetype is passed explicitly.
+		// Under zd.mu, which applyOptionNormalization requires. The zone is
+		// still being constructed here and is not yet shared, so the lock is
+		// uncontended -- it is taken to honour the contract, not because
+		// anything is racing for it today.
+		zd.mu.Lock()
 		options, zconf.OutboundSoaSerial = zd.applyOptionNormalization(zonetype, options, zconf.OutboundSoaSerial)
+		zd.mu.Unlock()
 
 		var outopts []string
 		for o, val := range options {

--- a/v2/refreshengine.go
+++ b/v2/refreshengine.go
@@ -666,8 +666,14 @@ func RefreshEngine(ctx context.Context, conf *Config) {
 					// Strip origination settings this zone may not act on. The
 					// ZoneData is fully constructed at this point, so the
 					// normalizer sees the final role (Fix B chokepoint).
+					//
+					// Under zd.mu: applyOptionNormalization records the outcome
+					// on the ZoneData and requires the lock. Nothing else holds
+					// it here, so this cannot deadlock.
+					zd.mu.Lock()
 					zd.Options, zd.OutboundSoaSerial =
 						zd.applyOptionNormalization(zd.ZoneType, zd.Options, zd.OutboundSoaSerial)
+					zd.mu.Unlock()
 
 					// Register the OnFirstLoad callbacks BEFORE the initial load:
 					// on a first-load failure the ticker retry path re-runs

--- a/v2/zone_option_normalize.go
+++ b/v2/zone_option_normalize.go
@@ -143,17 +143,28 @@ func normalizeOptionsForRole(appType AppType, ztype ZoneType, opts map[ZoneOptio
 // ztype is passed explicitly rather than read from zd.ZoneType because the
 // static-config path normalizes before the parsed type has been assigned to the
 // ZoneData.
+// The caller MUST already hold zd.mu: this records the outcome on the
+// ZoneData, and two of the four call sites run inside the refresh engine's
+// per-zone critical section. Holding it at the other two costs nothing and
+// makes the contract uniform, which is what keeps this from silently becoming
+// a data race the next time a call site is added.
 func (zd *ZoneData) applyOptionNormalization(ztype ZoneType, opts map[ZoneOption]bool, serialMode string) (map[ZoneOption]bool, string) {
 	effective, effSerial, suppressed, msg := normalizeOptionsForRole(
 		Globals.App.Type, ztype, opts, serialMode)
 
 	zd.SuppressedOptions = suppressed
+	// The *Locked variants, because the CALLER MUST ALREADY HOLD zd.mu (see the
+	// doc comment above). ClearError and SetError take zd.mu themselves, so
+	// calling them from here deadlocked the zone against itself: RefreshEngine
+	// holds the lock across this call, the first zone never finished loading,
+	// and the refresh engine never reached the second. Every zone after it sat
+	// with no published snapshot, answering SERVFAIL.
 	if msg == "" {
-		zd.ClearError(ConfigWarning)
+		zd.clearErrorLocked(ConfigWarning)
 		return effective, effSerial
 	}
 	lg.Warn("zone option normalization", "zone", zd.ZoneName, "detail", msg)
-	zd.SetError(ConfigWarning, "%s", msg)
+	zd.setErrorLocked(ConfigWarning, "%s", msg)
 	return effective, effSerial
 }
 

--- a/v2/zone_option_normalize_test.go
+++ b/v2/zone_option_normalize_test.go
@@ -166,8 +166,10 @@ func TestAsConfiguredOptionsRoundTrip(t *testing.T) {
 	withAppType(t, AppTypeAuth)
 
 	zd := &ZoneData{ZoneName: "sec.example.", ZoneType: Secondary}
+	zd.mu.Lock()
 	opts, serial := zd.applyOptionNormalization(
 		Secondary, optSet(OptAllowUpdates, OptFoldCase), OutboundSoaSerialPersist)
+	zd.mu.Unlock()
 	zd.Options = opts
 	zd.OutboundSoaSerial = serial
 
@@ -204,7 +206,9 @@ func TestApplyOptionNormalizationUsesConfigWarning(t *testing.T) {
 	withAppType(t, AppTypeAuth)
 
 	zd := &ZoneData{ZoneName: "sec.example.", ZoneType: Secondary}
+	zd.mu.Lock()
 	zd.applyOptionNormalization(Secondary, optSet(OptAllowUpdates), "")
+	zd.mu.Unlock()
 
 	if !zd.HasError(ConfigWarning) {
 		t.Fatal("expected a ConfigWarning")
@@ -217,7 +221,9 @@ func TestApplyOptionNormalizationUsesConfigWarning(t *testing.T) {
 	}
 
 	// Recomputed each parse: a clean config clears the warning on reload.
+	zd.mu.Lock()
 	zd.applyOptionNormalization(Secondary, optSet(OptFoldCase), "")
+	zd.mu.Unlock()
 	if zd.HasError(ConfigWarning) {
 		t.Error("warning should clear once the config is clean")
 	}

--- a/v2/zone_option_normalize_test.go
+++ b/v2/zone_option_normalize_test.go
@@ -3,6 +3,7 @@ package tdns
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // Fix B: the option normalizer. It strips origination settings a tdns-auth
@@ -222,5 +223,56 @@ func TestApplyOptionNormalizationUsesConfigWarning(t *testing.T) {
 	}
 	if len(zd.SuppressedOptions) != 0 {
 		t.Error("suppressed set should be empty once the config is clean")
+	}
+}
+
+// applyOptionNormalization records its outcome on the ZoneData and therefore
+// requires zd.mu. Two of its four call sites are inside the refresh engine's
+// per-zone critical section, so it MUST be safe to call with the lock held.
+//
+// It was not. It called ClearError/SetError, which take zd.mu themselves, and
+// deadlocked the zone against itself: on a live master the refresh engine
+// announced "loading pre-registered zone" for the first zone and stopped there
+// forever. Every other zone stayed unloaded and answered SERVFAIL ("no
+// published snapshot"), while the process sat at 0% CPU looking merely idle.
+//
+// Both branches are covered because both recorded an error: the quiet path
+// cleared the warning, the warning path set it, and either deadlocked.
+func TestApplyOptionNormalizationIsSafeUnderLock(t *testing.T) {
+	withAppType(t, AppTypeAuth)
+
+	cases := []struct {
+		name string
+		zt   ZoneType
+		opts map[ZoneOption]bool
+	}{
+		// No normalization needed: takes the clearErrorLocked branch.
+		{"quiet", Primary, optSet(OptOnlineSigning)},
+		// Origination options on a secondary get stripped, so this warns:
+		// takes the setErrorLocked branch.
+		{"warns", Secondary, optSet(OptAllowUpdates)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			zd := &ZoneData{ZoneName: "example.", ZoneType: tc.zt}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				zd.mu.Lock()
+				defer zd.mu.Unlock()
+				zd.applyOptionNormalization(tc.zt, tc.opts, "")
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				// Deliberately not t.Fatal from the goroutine: the point is
+				// that it never returns, so the timeout IS the assertion.
+				t.Fatal("applyOptionNormalization deadlocked while zd.mu was held " +
+					"-- it must use the *Locked error variants")
+			}
+		})
 	}
 }


### PR DESCRIPTION
`tdns-auth` cannot load **any** zone. Found on the lab master this evening while bringing tdns-auth up as the parent for the tld-view zones.

## The bug

`RefreshEngine` holds `zd.mu` across its per-zone critical section and calls `applyOptionNormalization` inside it. That function then called `ClearError` / `SetError`, which take `zd.mu` themselves — so the zone deadlocks against itself on the **first** zone in the list, and the refresh engine never reaches the second.

```
goroutine 22 [sync.Mutex.Lock]:
tdns/v2.(*ZoneData).ClearError                  v2/enums.go:411
tdns/v2.(*ZoneData).applyOptionNormalization    v2/zone_option_normalize.go:152
tdns/v2.RefreshEngine                           v2/refreshengine.go:294
```

The locked variants already exist for exactly this — `clearErrorLocked` and `setErrorLocked`, whose comments read *"the caller MUST already hold zd.mu"*. This call site just didn't use them. Same shape as the `SignZone`/`UpdateSigValidityFloor` self-deadlock fixed in #279.

## Why it took a while to see

None of the symptoms look like a deadlock:

| what you see | what it actually is |
|---|---|
| log stops after `loading pre-registered zone zone=<first>` | the refresh engine is wedged there |
| all other zones SERVFAIL, `no published snapshot` | correct — they never loaded |
| the first zone **times out** instead of failing | queries wait on the zone that never finishes |
| process at **0% CPU**, state `Sl` | blocked on a mutex, not spinning |

On an 11-zone master: 180 SERVFAILs, 60 `zone not yet refreshed`, and exactly one zone-loading line.

## Why it's three files, not two

The four call sites disagreed about the lock:

| call site | held `zd.mu`? |
|---|---|
| `refreshengine.go:294` | yes |
| `refreshengine.go:436` | yes |
| `refreshengine.go:670` | **no** |
| `parseconfig.go:926` | **no** |

Switching to the locked variants alone would have fixed the hang and given the other two an unsynchronised write — trading a visible deadlock for an invisible race. So the contract is uniform instead: `applyOptionNormalization` requires `zd.mu`, stated in its doc comment, and the two call sites that lacked it now take it. Both are uncontended there (one is mid-parse before the zone is shared, the other is after construction with nothing else holding the lock), so it costs nothing and removes the chance of the next call site landing on the wrong side.

## Test

Asserts the property that was violated, not the symptom: `applyOptionNormalization` must return when called with `zd.mu` held. Covers both branches, since both recorded an error and either would hang — the quiet path cleared the warning, the warning path set it.

Verified to **fail against the unfixed code** — both subtests, 10s timeout each — and pass with the fix. `go build`, `go vet` and the v2 suite are clean.

## Not yet verified on a live master

The lab master is the reproducer and has not yet run a patched binary. Worth doing before merge: build, install, and confirm all 11 zones load and answer instead of one hanging and ten SERVFAILing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization during zone creation and dynamic-zone updates.
  * Prevented potential deadlocks while normalizing zone options.
  * Preserved existing error and warning behavior during normalization.

* **Tests**
  * Added regression coverage for normalization while synchronization is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->