### PR TITLE
Say so when allow-child-updates is disabled by the update policy

### DIFF
--- a/v2/parseconfig.go
+++ b/v2/parseconfig.go
@@ -943,12 +943,32 @@ func (conf *Config) ParseZones(ctx context.Context, reload bool) ([]string, []st
 
 		lgConfig.Debug("zone incoming update policy", "zone", zname, "policy", fmt.Sprintf("%+v", zconf.UpdatePolicy))
 
+		// Captured BEFORE the call, because activateUpdatePolicy mutates
+		// options in place: an absent or "none" child policy silently clears
+		// allow-child-updates, and afterwards there is no way to tell a zone
+		// that never asked for it from one whose request was dropped.
+		wantedChildUpdates := options[OptAllowChildUpdates]
+
 		policy, perr := activateUpdatePolicy(zconf, options)
 		if perr != nil {
 			lgConfig.Error("zone update policy invalid, zone in error state", "zone", zname, "err", perr)
 			zd.SetError(ConfigError, "%s", perr)
 			broken_zones = append(broken_zones, zname)
 			continue
+		}
+
+		// Record it ON THE ZONE, not just in the log. The zone is otherwise
+		// perfectly healthy -- it loads, serves, and simply refuses every child
+		// update -- so a log line at startup is the only trace, and by the time
+		// anyone asks why "zone list" no longer shows the option, that line has
+		// scrolled away. ConfigWarning rather than ConfigError deliberately:
+		// the zone is serving correctly for every other purpose and taking it
+		// out of service would be a worse answer than telling the truth about
+		// one disabled option.
+		if wantedChildUpdates && !options[OptAllowChildUpdates] {
+			zd.SetError(ConfigWarning,
+				"allow-child-updates was requested but is DISABLED: updatepolicy.child.type "+
+					"is unset or \"none\". Set it to selfsub or self.")
 		}
 
 		if Globals.App.Type == AppTypeAgent && zconf.Type == "primary" {
@@ -1290,6 +1310,22 @@ func activateUpdatePolicy(zconf *ZoneConf, options map[ZoneOption]bool) (UpdateP
 		// all ok, we know these
 	case "none", "":
 		// these are also ok, but imply that no updates are allowed
+		//
+		// Say so when the operator asked for the opposite. Clearing an option
+		// the config explicitly requested, silently, produces a zone that
+		// starts, looks healthy, and refuses every child update -- with the
+		// option simply absent from "zone list" and nothing anywhere saying
+		// why. An unset policy is the easy way to hit this, because "" lands
+		// in the same case as an explicit "none".
+		if options[OptAllowChildUpdates] {
+			why := "no updatepolicy.child.type is set"
+			if zconf.UpdatePolicy.Child.Type == "none" {
+				why = "updatepolicy.child.type is \"none\""
+			}
+			lgConfig.Error("allow-child-updates requested but DISABLED by update policy",
+				"zone", zconf.Name, "reason", why,
+				"fix", "set updatepolicy.child.type to selfsub or self")
+		}
 		options[OptAllowChildUpdates] = false
 	default:
 		return UpdatePolicy{}, fmt.Errorf("unknown child update policy type: %s", zconf.UpdatePolicy.Child.Type)


### PR DESCRIPTION
An unset `updatepolicy.child.type` parses as `""`, which lands in the same `case` as an explicit `"none"`: `activateUpdatePolicy` clears `OptAllowChildUpdates` and says nothing.

The zone then loads, serves correctly, shows the option **missing** from `zone list` with no explanation, and refuses every child update.

That is expensive to diagnose precisely because nothing is broken. The operator wrote `allow-child-updates`, the parser dropped it, and the only evidence is an absence. It cost an evening on the lab master, where `dnslab` is the delegation-sync parent and child updates are the entire point of the zone.

## Two records, because they answer different questions

- **a log line at parse time** — names the zone, whether the type was unset or `"none"`, and the fix
- **`zd.SetError(ConfigWarning)` on the zone** — so the state is still visible later, when the startup log has scrolled away and someone is asking why the option is gone

`ConfigWarning` rather than `ConfigError` deliberately: the zone serves correctly for every other purpose, and taking it out of service would be a worse answer than telling the truth about one disabled option.

## Note on the caller

The requested value is captured **before** the call, because `activateUpdatePolicy` mutates `options` in place — afterwards a zone that never asked for child updates is indistinguishable from one whose request was dropped.

## Not covered

The dynamic-primary add path (`dynamic_primary.go:198`) gets the log but not the zone error: there is no `ZoneData` at that point. Worth revisiting if API-added zones turn out to hit this too.

## Related

Same family as #336 — config that is silently ignored rather than reported. There is a second instance in the same area worth knowing about: the YAML key is `updatepolicy`, one word, because the struct field carries no yaml tag and binds by lowercased field name, while its neighbours `dnssecpolicy` and `publish-cadence` have explicit tags. Spelling it `update-policy` — what the code comments and error messages call it — binds to nothing and fails identically silently. This PR does not address that; moving the section into the `Config` struct per #336 would.

`go build`, `go vet` and the v2 suite are clean.