### PR TITLE
cli: add "show-cmds" — list a whole command subtree, one line per command

### DIFF
--- a/cmdv2/cli/root.go
+++ b/cmdv2/cli/root.go
@@ -32,11 +32,13 @@ var rootCmd = &cobra.Command{
 			tdns.PrintVersionAndExit()
 		}
 		tdns.SetupCliLogging()
-		// keys generate (root-level), gen-docs (offline doc generator) and
+		// keys generate (root-level), gen-docs (offline doc generator),
+		// show-cmds (pure introspection of the in-memory command tree) and
 		// the cert PKI subtree (offline provisioning; cert init reads the
 		// server config via its own --serverconfig flag) do not need
 		// config or API.
-		if isRootKeysCommand(cmd) || cmd.Name() == "gen-docs" || isCertCommand(cmd) {
+		if isRootKeysCommand(cmd) || cmd.Name() == "gen-docs" ||
+			cmd.Name() == cli.ShowCmdsName || isCertCommand(cmd) {
 			return
 		}
 		initConfig()
@@ -54,12 +56,17 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	cli.AttachShowCmds(rootCmd)
 	cobra.CheckErr(rootCmd.Execute())
 }
 
 // ExecuteContext adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main() with a context for signal handling.
 func ExecuteContext(ctx context.Context) {
+	// Attached here rather than from an init(): the command tree is wired up
+	// by init()s spread over several files in two packages, and show-cmds
+	// must not be attached until all of them have run.
+	cli.AttachShowCmds(rootCmd)
 	cobra.CheckErr(rootCmd.ExecuteContext(ctx))
 }
 

--- a/v2/cli/showcmds_cmds.go
+++ b/v2/cli/showcmds_cmds.go
@@ -49,7 +49,14 @@ in -h at the top level and under each application prefix; deeper down it is
 hidden to keep the help screens clean. It still works there, e.g.
 "tdns-cli auth keystore dnssec show-cmds".`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// 0 is the documented sentinel for "no limit". A negative value
+			// would quietly mean the same thing, turning a typo into a full
+			// 300-line dump instead of an error.
+			if maxDepth < 0 {
+				return fmt.Errorf("--depth must be 0 or greater, got %d", maxDepth)
+			}
+
 			// The subtree to report on is our parent, not us. A show-cmds
 			// with no parent (never wired up) degenerates to itself, which
 			// is empty but not a crash.
@@ -76,6 +83,7 @@ hidden to keep the help screens clean. It still works there, e.g.
 				}
 				fmt.Printf("%s\n", e.path)
 			}
+			return nil
 		},
 	}
 
@@ -137,6 +145,10 @@ func skipInShowCmds(c *cobra.Command, showAll bool) bool {
 // ("tdns-cli show-cmds", "tdns-cli auth show-cmds") are listed in -h. Deeper
 // copies are marked Hidden so that ~60 help screens don't each grow a line
 // for it; they remain fully usable, and are documented in the Long text above.
+//
+// Calling this more than once on the same tree is safe: cobra's AddCommand
+// does not deduplicate, so without a guard a second call would give every
+// parent a second show-cmds child.
 func AttachShowCmds(root *cobra.Command) {
 	attachShowCmds(root, 0)
 }
@@ -150,9 +162,11 @@ func attachShowCmds(cmd *cobra.Command, depth int) {
 	// set and not into the show-cmds we are about to add.
 	kids := append([]*cobra.Command(nil), cmd.Commands()...)
 
-	sc := NewShowCmdsCmd()
-	sc.Hidden = depth >= 2
-	cmd.AddCommand(sc)
+	if !hasShowCmdsChild(kids) {
+		sc := NewShowCmdsCmd()
+		sc.Hidden = depth >= 2
+		cmd.AddCommand(sc)
+	}
 
 	for _, c := range kids {
 		switch c.Name() {
@@ -161,4 +175,15 @@ func attachShowCmds(cmd *cobra.Command, depth int) {
 		}
 		attachShowCmds(c, depth+1)
 	}
+}
+
+// hasShowCmdsChild reports whether a show-cmds is already among these
+// commands, i.e. whether this parent has been attached to before.
+func hasShowCmdsChild(kids []*cobra.Command) bool {
+	for _, c := range kids {
+		if c.Name() == ShowCmdsName {
+			return true
+		}
+	}
+	return false
 }

--- a/v2/cli/showcmds_cmds.go
+++ b/v2/cli/showcmds_cmds.go
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Johan Stenstam, johani@johani.org
+ */
+package cli
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+// ShowCmdsName is the name of the command-tree lister. Exported so the
+// binaries' PersistentPreRun can recognize it and skip config/API setup:
+// show-cmds only inspects the in-memory cobra tree, so it must work with
+// no daemon running and no tdns-cli.yaml present.
+const ShowCmdsName = "show-cmds"
+
+// showCmdsEntry is one line of output: the full invocation path plus the
+// command's own Short text (only printed with --desc).
+type showCmdsEntry struct {
+	path  string
+	short string
+}
+
+// NewShowCmdsCmd returns a fresh "show-cmds" command. Each attachment site
+// needs its own instance -- cobra stores the parent pointer in the command
+// itself, so a single shared instance cannot hang off several parents.
+//
+// The command needs no role argument: it reports on whatever subtree it was
+// attached to, found at run time via cmd.Parent(). "tdns-cli auth show-cmds"
+// lists the auth subtree, "tdns-cli show-cmds" lists everything.
+func NewShowCmdsCmd() *cobra.Command {
+	var withDesc, showAll bool
+	var maxDepth int
+
+	cmd := &cobra.Command{
+		Use:   ShowCmdsName,
+		Short: "List the whole command tree below this command, one line per command",
+		Long: `List every command below this point in the tree, one per line, as a
+full invocation path.
+
+Unlike -h, which only shows the immediate children of one command, this
+walks the entire subtree, so the output is greppable and every line can be
+copied and run as-is.
+
+show-cmds exists on every command that has subcommands, but is only listed
+in -h at the top level and under each application prefix; deeper down it is
+hidden to keep the help screens clean. It still works there, e.g.
+"tdns-cli auth keystore dnssec show-cmds".`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			// The subtree to report on is our parent, not us. A show-cmds
+			// with no parent (never wired up) degenerates to itself, which
+			// is empty but not a crash.
+			root := cmd.Parent()
+			if root == nil {
+				root = cmd
+			}
+
+			entries := collectShowCmds(root, 1, maxDepth, showAll)
+			fmt.Printf("%s has the following command structure:\n\n", root.CommandPath())
+
+			width := 0
+			if withDesc {
+				for _, e := range entries {
+					if len(e.path) > width {
+						width = len(e.path)
+					}
+				}
+			}
+			for _, e := range entries {
+				if withDesc && e.short != "" {
+					fmt.Printf("%-*s   %s\n", width, e.path, e.short)
+					continue
+				}
+				fmt.Printf("%s\n", e.path)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&withDesc, "desc", false,
+		"append each command's short description, column-aligned")
+	cmd.Flags().BoolVar(&showAll, "all", false,
+		"also list hidden and deprecated commands")
+	cmd.Flags().IntVar(&maxDepth, "depth", 0,
+		"only descend N levels below this command (0 = no limit)")
+
+	return cmd
+}
+
+// collectShowCmds walks cmd's children depth-first, in name order, returning
+// one entry per command. depth is the level of cmd's children relative to the
+// subtree root (1 for the root's own children); maxDepth of 0 means no limit.
+func collectShowCmds(cmd *cobra.Command, depth, maxDepth int, showAll bool) []showCmdsEntry {
+	if maxDepth > 0 && depth > maxDepth {
+		return nil
+	}
+
+	kids := append([]*cobra.Command(nil), cmd.Commands()...)
+	sort.Slice(kids, func(i, j int) bool { return kids[i].Name() < kids[j].Name() })
+
+	var entries []showCmdsEntry
+	for _, c := range kids {
+		if skipInShowCmds(c, showAll) {
+			continue
+		}
+		entries = append(entries, showCmdsEntry{path: c.CommandPath(), short: c.Short})
+		entries = append(entries, collectShowCmds(c, depth+1, maxDepth, showAll)...)
+	}
+	return entries
+}
+
+// skipInShowCmds reports whether c should be left out of the listing.
+func skipInShowCmds(c *cobra.Command, showAll bool) bool {
+	// Never list show-cmds itself: it is the command being run, it exists on
+	// every parent, and listing ~60 copies of it would drown out the tree.
+	if c.Name() == ShowCmdsName {
+		return true
+	}
+	// cobra's own scaffolding, not part of the tdns command surface.
+	if c.Name() == "help" || c.Name() == "completion" {
+		return true
+	}
+	if showAll {
+		return false
+	}
+	return c.Hidden || c.Deprecated != ""
+}
+
+// AttachShowCmds hangs a show-cmds on root and on every descendant that has
+// subcommands. Call it once, after all AddCommand wiring is done (i.e. from
+// the binary's Execute path, not from an init(), where file ordering would
+// decide whether the tree is complete yet).
+//
+// Only the copies at the top level and directly under an application prefix
+// ("tdns-cli show-cmds", "tdns-cli auth show-cmds") are listed in -h. Deeper
+// copies are marked Hidden so that ~60 help screens don't each grow a line
+// for it; they remain fully usable, and are documented in the Long text above.
+func AttachShowCmds(root *cobra.Command) {
+	attachShowCmds(root, 0)
+}
+
+func attachShowCmds(cmd *cobra.Command, depth int) {
+	if !cmd.HasSubCommands() {
+		return
+	}
+
+	// Snapshot the children before adding, so we recurse over the original
+	// set and not into the show-cmds we are about to add.
+	kids := append([]*cobra.Command(nil), cmd.Commands()...)
+
+	sc := NewShowCmdsCmd()
+	sc.Hidden = depth >= 2
+	cmd.AddCommand(sc)
+
+	for _, c := range kids {
+		switch c.Name() {
+		case ShowCmdsName, "help", "completion":
+			continue
+		}
+		attachShowCmds(c, depth+1)
+	}
+}

--- a/v2/cli/showcmds_cmds_test.go
+++ b/v2/cli/showcmds_cmds_test.go
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Johan Stenstam, johani@johani.org
+ */
+package cli
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// testTree builds a miniature stand-in for the tdns-cli tree, deep enough to
+// exercise the depth-based Hidden rule:
+//
+//	tdns-cli (0) -> auth (1) -> catalog (2) -> group (3) -> add
+//	                                        -> create
+//	             -> version            (leaf, no subcommands)
+func testTree() *cobra.Command {
+	run := func(cmd *cobra.Command, args []string) {}
+
+	add := &cobra.Command{Use: "add", Short: "add a group", Run: run}
+	group := &cobra.Command{Use: "group", Short: "group ops"}
+	group.AddCommand(add)
+
+	create := &cobra.Command{Use: "create", Short: "create a catalog", Run: run}
+	catalog := &cobra.Command{Use: "catalog", Short: "catalog ops"}
+	catalog.AddCommand(create, group)
+
+	auth := &cobra.Command{Use: "auth", Short: "auth ops"}
+	auth.AddCommand(catalog)
+
+	root := &cobra.Command{Use: "tdns-cli"}
+	root.AddCommand(auth, &cobra.Command{Use: "version", Short: "version", Run: run})
+	return root
+}
+
+// findCmd walks down a path of command names, e.g. "auth", "catalog".
+func findCmd(t *testing.T, root *cobra.Command, path ...string) *cobra.Command {
+	t.Helper()
+	cur := root
+	for _, name := range path {
+		var next *cobra.Command
+		for _, c := range cur.Commands() {
+			if c.Name() == name {
+				next = c
+				break
+			}
+		}
+		if next == nil {
+			t.Fatalf("command %q not found under %q", name, cur.CommandPath())
+		}
+		cur = next
+	}
+	return cur
+}
+
+// countShowCmds returns the total number of show-cmds commands in the tree.
+func countShowCmds(cmd *cobra.Command) int {
+	n := 0
+	for _, c := range cmd.Commands() {
+		if c.Name() == ShowCmdsName {
+			n++
+			continue
+		}
+		n += countShowCmds(c)
+	}
+	return n
+}
+
+// TestAttachShowCmdsIsIdempotent guards the exported entry point: it is meant
+// to be reusable by other binaries (mpcli, tdns-debug), and cobra's AddCommand
+// does not deduplicate, so a second call must not give every parent a second
+// show-cmds child.
+func TestAttachShowCmdsIsIdempotent(t *testing.T) {
+	root := testTree()
+
+	AttachShowCmds(root)
+	first := countShowCmds(root)
+	// root, auth, catalog, group -- "version" is a leaf and gets none.
+	if first != 4 {
+		t.Fatalf("after one attach: got %d show-cmds, want 4", first)
+	}
+
+	AttachShowCmds(root)
+	if second := countShowCmds(root); second != first {
+		t.Errorf("attach is not idempotent: %d show-cmds after second call, want %d",
+			second, first)
+	}
+}
+
+// TestAttachShowCmdsHiddenBelowAppLevel pins Johan's placement rule: visible at
+// the root and under each application prefix, hidden further down so that the
+// deeper help screens stay clean.
+func TestAttachShowCmdsHiddenBelowAppLevel(t *testing.T) {
+	root := testTree()
+	AttachShowCmds(root)
+
+	for _, tc := range []struct {
+		path       []string
+		wantHidden bool
+	}{
+		{path: nil, wantHidden: false},                        // tdns-cli
+		{path: []string{"auth"}, wantHidden: false},           // app prefix
+		{path: []string{"auth", "catalog"}, wantHidden: true}, // below
+		{path: []string{"auth", "catalog", "group"}, wantHidden: true},
+	} {
+		parent := findCmd(t, root, tc.path...)
+		sc := findCmd(t, parent, ShowCmdsName)
+		if sc.Hidden != tc.wantHidden {
+			t.Errorf("%s: Hidden = %v, want %v", sc.CommandPath(), sc.Hidden, tc.wantHidden)
+		}
+	}
+}
+
+// TestAttachShowCmdsSkipsLeaves: a command with no subcommands has nothing to
+// list, so it must not grow a show-cmds.
+func TestAttachShowCmdsSkipsLeaves(t *testing.T) {
+	root := testTree()
+	AttachShowCmds(root)
+
+	version := findCmd(t, root, "version")
+	for _, c := range version.Commands() {
+		if c.Name() == ShowCmdsName {
+			t.Errorf("leaf command %q was given a show-cmds", version.CommandPath())
+		}
+	}
+}
+
+// TestCollectShowCmdsListing covers the listing itself: full invocation paths,
+// name-sorted, with show-cmds and cobra's own scaffolding left out.
+func TestCollectShowCmdsListing(t *testing.T) {
+	root := testTree()
+	AttachShowCmds(root)
+
+	auth := findCmd(t, root, "auth")
+	var got []string
+	for _, e := range collectShowCmds(auth, 1, 0, false) {
+		got = append(got, e.path)
+	}
+
+	want := []string{
+		"tdns-cli auth catalog",
+		"tdns-cli auth catalog create",
+		"tdns-cli auth catalog group",
+		"tdns-cli auth catalog group add",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("listing mismatch:\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestCollectShowCmdsDepth: --depth N stops N levels below the subtree root.
+func TestCollectShowCmdsDepth(t *testing.T) {
+	root := testTree()
+	AttachShowCmds(root)
+	auth := findCmd(t, root, "auth")
+
+	for _, tc := range []struct {
+		depth int
+		want  int
+	}{
+		{depth: 1, want: 1}, // catalog
+		{depth: 2, want: 3}, // + create, group
+		{depth: 3, want: 4}, // + group add
+		{depth: 0, want: 4}, // no limit
+	} {
+		if got := len(collectShowCmds(auth, 1, tc.depth, false)); got != tc.want {
+			t.Errorf("depth %d: got %d entries, want %d", tc.depth, got, tc.want)
+		}
+	}
+}
+
+// TestCollectShowCmdsHiddenAndAll: hidden commands are omitted by default and
+// revealed by --all -- but show-cmds itself stays out either way, since it
+// exists on every parent and would drown out the tree.
+func TestCollectShowCmdsHiddenAndAll(t *testing.T) {
+	root := testTree()
+	auth := findCmd(t, root, "auth")
+	auth.AddCommand(&cobra.Command{
+		Use:    "secret",
+		Hidden: true,
+		Run:    func(cmd *cobra.Command, args []string) {},
+	})
+	AttachShowCmds(root)
+
+	contains := func(entries []showCmdsEntry, path string) bool {
+		for _, e := range entries {
+			if e.path == path {
+				return true
+			}
+		}
+		return false
+	}
+
+	def := collectShowCmds(auth, 1, 0, false)
+	if contains(def, "tdns-cli auth secret") {
+		t.Error("hidden command listed without --all")
+	}
+
+	all := collectShowCmds(auth, 1, 0, true)
+	if !contains(all, "tdns-cli auth secret") {
+		t.Error("hidden command not listed with --all")
+	}
+	if contains(all, "tdns-cli auth "+ShowCmdsName) {
+		t.Error("show-cmds listed itself with --all")
+	}
+}
+
+// TestShowCmdsRejectsNegativeDepth: 0 is the documented "no limit" sentinel, so
+// a negative value must be an error rather than a silent full dump.
+func TestShowCmdsRejectsNegativeDepth(t *testing.T) {
+	root := testTree()
+	AttachShowCmds(root)
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+
+	root.SetArgs([]string{"auth", ShowCmdsName, "--depth", "-1"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("--depth -1 was accepted, want an error")
+	}
+	if !strings.Contains(err.Error(), "--depth") {
+		t.Errorf("error does not mention the offending flag: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

`tdns-cli` has ~330 commands in a tree up to 6 levels deep (`auth` alone has 158
descendants, `agent` 108). Cobra's `-h` only ever shows the *immediate* children
of one command, so finding a command you half-remember means walking the tree by
hand, one `-h` at a time. There was no way to get the whole tree as a flat list.

## What

`show-cmds` walks the subtree it is attached to and prints every command below it
as a full invocation path, one per line:

```
$ tdns-cli auth show-cmds
tdns-cli auth has the following command structure:

tdns-cli auth catalog
tdns-cli auth catalog create
tdns-cli auth catalog delete
tdns-cli auth catalog group
tdns-cli auth catalog group add
...
```

Greppable, and every line can be copied and run as-is.

**Placement.** Attached to every command that has subcommands, so it works at any
depth (`tdns-cli auth keystore dnssec show-cmds`), but only *listed* in `-h` at the
top level and under each application prefix — `auth`, `agent`, `imr`, `scanner`,
`util`, `cert`. Deeper copies are `Hidden`, so ~60 help screens don't each grow a
line for it; the visible ones' `Long` text says the hidden ones exist.

**Flags.** `--desc` appends the column-aligned `Short` text; `--depth N` caps the
descent (`--depth 1` gives just the immediate children); `--all` also lists hidden
and deprecated commands.

## Notes for review

- **No role argument.** The command finds its own subtree via `cmd.Parent()`, so one
  factory serves every attachment site. Each site still needs its own instance —
  cobra stores the parent pointer in the command itself, so a shared instance
  cannot hang off several parents.
- **Wired from `ExecuteContext`, not an `init()`.** The tree is assembled by `init()`s
  spread across `cmdv2/cli` and `v2/cli`; attaching from an `init()` would make
  correctness depend on file ordering.
- **`PersistentPreRun` exemption.** `show-cmds` joins `gen-docs`, `keys` and the `cert`
  subtree. It only inspects the in-memory cobra tree, so it must not require a
  running daemon or an `/etc/tdns/tdns-cli.yaml`. (`-h` escapes `PersistentPreRun`
  on its own, but a *runnable* command does not — without this, `show-cmds` would
  `log.Fatalf` on a host with no config file.)
- **Self-exclusion.** The listing never includes `show-cmds` nodes themselves, nor
  cobra's `help` / `completion` scaffolding.
- **Reusable.** The factory lives in `v2/cli`, so `mpcli` and `tdns-debug` can pick it
  up with a one-line `cli.AttachShowCmds(rootCmd)`.

## Verification

- `make` in `cmdv2/cli` clean; `gofmt` clean; `go vet` and `go test ./...` green in `v2/cli`.
- Output cross-checked against the independently generated reference: the
  `tdns-cli auth` listing matches the `gen-docs` page set exactly, modulo the eight
  `keystore * bulk-*` commands added to main after that reference was generated.
- Visibility verified: `show-cmds` present in `tdns-cli -h` and `tdns-cli auth -h`,
  absent from `tdns-cli auth catalog -h`, and still runnable there.
- Runs with `--config /nonexistent.yaml`, confirming the no-config path.

## Out of scope (pre-existing)

`reference/cli/` is **stale on main**, independently of this change — regenerating it
touches 328 files (it pre-dates the `--version` persistent flag, several `Short`
rewrites, and is missing ~30 pages including the entire `cert` subtree, `config
check`/`mwe`, the `bulk-*` commands and `zone desc`). I deliberately left it out
rather than bury a two-file change under that. Worth a separate docs-only
`make docs` commit; the Makefile already suggests `make docs && git diff --exit-code
reference/cli` as a CI drift check, which would currently fail on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `show-cmds` command that lists available commands in sorted order.
  * Displays command descriptions with aligned formatting.
  * Supports including hidden and deprecated commands, plus limiting listing depth.
  * Excludes helper commands such as `help` and `completion` by default.
  * Works from the main command and relevant nested command levels without requiring configuration or API initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->