### PR TITLE
keystore: import the DNSKEY/KEY record, not the whole .key file

### DIFF
--- a/v2/bind_keyfile_comments_test.go
+++ b/v2/bind_keyfile_comments_test.go
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johani@johani.org
+ *
+ * Regression cover for BIND .key comment headers reaching the keystore.
+ *
+ * dnssec-keygen writes four ";" comment lines above the record in a .key file.
+ * dns.NewRR skips comments, so a .key file kept verbatim parsed fine and passed
+ * every metadata check -- but the text that got STORED in the keyrr column was
+ * the whole file, and "keystore dnssec list" showed the first comment line where
+ * the DNSKEY should be.
+ */
+package tdns
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// bindCommentHeader is what dnssec-keygen puts above the record.
+const bindCommentHeader = `; This is a key-signing key, keyid 59146, for dnslab.
+; Created: 20240917174637 (Tue Sep 17 17:46:37 2024)
+; Publish: 20240917174637 (Tue Sep 17 17:46:37 2024)
+; Activate: 20240917174637 (Tue Sep 17 17:46:37 2024)
+`
+
+func TestCanonicalKeyRRStripsBindComments(t *testing.T) {
+	dnskey := "dnslab.\t3600\tIN\tDNSKEY\t257 3 15 C4RKfg3IUwpjc+CnISaCuDX4OGpxsUIe7dqRVXj0KdU="
+	keyrr := "dnslab.\t3600\tIN\tKEY\t512 3 15 C4RKfg3IUwpjc+CnISaCuDX4OGpxsUIe7dqRVXj0KdU="
+
+	for _, tc := range []struct {
+		name  string
+		in    string
+		want  string
+		isErr bool
+	}{
+		{name: "DNSKEY with bind comments", in: bindCommentHeader + dnskey + "\n", want: dnskey},
+		{name: "KEY with bind comments", in: bindCommentHeader + keyrr + "\n", want: keyrr},
+		{name: "already clean DNSKEY", in: dnskey, want: dnskey},
+		{name: "trailing newlines", in: dnskey + "\n\n", want: dnskey},
+		{name: "comments only", in: bindCommentHeader, isErr: true},
+		{name: "empty", in: "", isErr: true},
+		{name: "wrong RR type", in: "dnslab. 3600 IN TXT \"nope\"", isErr: true},
+		{name: "unparsable", in: "this is not a resource record", isErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := canonicalKeyRR(tc.in)
+			if tc.isErr {
+				if err == nil {
+					t.Fatalf("expected an error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("canonicalKeyRR: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got  %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// writeBindStyleKeyFiles lays down a .key/.private pair the way an operator's
+// BIND9 key directory has them, comment header included.
+func writeBindStyleKeyFiles(t *testing.T, dir, zone string, sig0 bool) (base, wantRR, privPEM string) {
+	t.Helper()
+
+	rrtype, flags := dns.TypeDNSKEY, uint16(257)
+	if sig0 {
+		rrtype, flags = dns.TypeKEY, uint16(512)
+	}
+	dnskey := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: dns.Fqdn(zone), Rrtype: rrtype, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     flags,
+		Protocol:  3,
+		Algorithm: dns.ED25519,
+	}
+	priv, err := dnskey.Generate(256)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	privPEM, err = PrivateKeyToPEM(priv)
+	if err != nil {
+		t.Fatalf("converting key to PEM: %v", err)
+	}
+
+	var rr dns.RR = dnskey
+	if sig0 {
+		rr = &dns.KEY{DNSKEY: *dnskey}
+	}
+	wantRR = rr.String()
+
+	base = KeyFileBasename(dns.Fqdn(zone), dns.ED25519, dnskey.KeyTag())
+	if err := os.WriteFile(filepath.Join(dir, base+".key"),
+		[]byte(bindCommentHeader+wantRR+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, base+".private"), []byte(privPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return base, wantRR, privPEM
+}
+
+// TestManifestLoadStripsBindComments is the bug as reported: BIND9 keys reached
+// the keystore through a manifest, and the keyrr column ended up holding the
+// comment header instead of the record.
+func TestManifestLoadStripsBindComments(t *testing.T) {
+	t.Run("DNSSEC", func(t *testing.T) {
+		dir := t.TempDir()
+		base, wantRR, _ := writeBindStyleKeyFiles(t, dir, "dnslab.", false)
+
+		m := &KeystoreManifest{Dnssec: []ManifestDnssecKey{{
+			Zone: "dnslab.", Keyid: 1, Flags: 257, Algorithm: "ED25519",
+			State: DnskeyStateActive, PrivateFile: base + ".private", PublicFile: base + ".key",
+		}}}
+
+		keys, err := m.LoadDnssecKeys(dir)
+		if err != nil {
+			t.Fatalf("LoadDnssecKeys: %v", err)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("got %d keys, want 1", len(keys))
+		}
+		if strings.Contains(keys[0].KeyRR, ";") {
+			t.Errorf("comment header survived into KeyRR:\n%s", keys[0].KeyRR)
+		}
+		if keys[0].KeyRR != wantRR {
+			t.Errorf("got  %q\nwant %q", keys[0].KeyRR, wantRR)
+		}
+	})
+
+	t.Run("SIG0", func(t *testing.T) {
+		dir := t.TempDir()
+		base, wantRR, _ := writeBindStyleKeyFiles(t, dir, "dnslab.", true)
+
+		m := &KeystoreManifest{Sig0: []ManifestSig0Key{{
+			Zone: "dnslab.", Keyid: 1, Algorithm: "ED25519",
+			State: Sig0StateActive, PrivateFile: base + ".private", PublicFile: base + ".key",
+		}}}
+
+		keys, err := m.LoadSig0Keys(dir)
+		if err != nil {
+			t.Fatalf("LoadSig0Keys: %v", err)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("got %d keys, want 1", len(keys))
+		}
+		if strings.Contains(keys[0].KeyRR, ";") {
+			t.Errorf("comment header survived into KeyRR:\n%s", keys[0].KeyRR)
+		}
+		if keys[0].KeyRR != wantRR {
+			t.Errorf("got  %q\nwant %q", keys[0].KeyRR, wantRR)
+		}
+	})
+}
+
+// TestManifestLoadRejectsRecordlessKeyFile: a .key file with nothing but
+// comments used to sail through here and fail much later, with an error about
+// the wire key rather than about the file.
+func TestManifestLoadRejectsRecordlessKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	base, _, privPEM := writeBindStyleKeyFiles(t, dir, "dnslab.", false)
+	if err := os.WriteFile(filepath.Join(dir, base+".key"), []byte(bindCommentHeader), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_ = privPEM
+
+	m := &KeystoreManifest{Dnssec: []ManifestDnssecKey{{
+		Zone: "dnslab.", Keyid: 1, Flags: 257, Algorithm: "ED25519",
+		State: DnskeyStateActive, PrivateFile: base + ".private", PublicFile: base + ".key",
+	}}}
+
+	_, err := m.LoadDnssecKeys(dir)
+	if err == nil {
+		t.Fatal("a comment-only .key file was accepted")
+	}
+	if !strings.Contains(err.Error(), base+".key") {
+		t.Errorf("error does not name the offending file: %v", err)
+	}
+}
+
+// TestBulkValidateCanonicalisesKeyRR covers the backstop: a bulk payload that
+// never went through a manifest -- hand-written, or produced by a tdns old
+// enough to have copied .key files verbatim -- must still be canonicalised
+// before it is stored.
+func TestBulkValidateCanonicalisesKeyRR(t *testing.T) {
+	t.Run("DNSSEC", func(t *testing.T) {
+		k := testDnssecKey(t, "dnslab.", 257)
+		want := k.KeyRR
+		k.KeyRR = bindCommentHeader + k.KeyRR + "\n"
+
+		got, err := validateDnssecKeyRR(k)
+		if err != nil {
+			t.Fatalf("validateDnssecKeyRR: %v", err)
+		}
+		if got != want {
+			t.Errorf("got  %q\nwant %q", got, want)
+		}
+	})
+
+	t.Run("SIG0", func(t *testing.T) {
+		k := testBulkSig0Key(t, "dnslab.")
+		want := k.KeyRR
+		k.KeyRR = bindCommentHeader + k.KeyRR + "\n"
+
+		got, err := validateSig0KeyRR(k)
+		if err != nil {
+			t.Fatalf("validateSig0KeyRR: %v", err)
+		}
+		if got != want {
+			t.Errorf("got  %q\nwant %q", got, want)
+		}
+	})
+}
+
+// TestBulkImportStoresCanonicalKeyRR is the end-to-end shape of the bug: import
+// a key whose RR text carries the comment header, then read the column back.
+func TestBulkImportStoresCanonicalKeyRR(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	k := testDnssecKey(t, "dnslab.", 257)
+	want := k.KeyRR
+	k.KeyRR = bindCommentHeader + k.KeyRR + "\n"
+
+	if _, err := kdb.BulkImportDnssec(nil, []BulkDnssecKey{k}, false); err != nil {
+		t.Fatalf("BulkImportDnssec: %v", err)
+	}
+
+	var stored string
+	row := kdb.DB.QueryRow(`SELECT keyrr FROM DnssecKeyStore WHERE zonename=? AND keyid=?`,
+		"dnslab.", int(k.Keyid))
+	if err := row.Scan(&stored); err != nil {
+		t.Fatalf("reading back keyrr: %v", err)
+	}
+	if strings.Contains(stored, ";") {
+		t.Errorf("comment header was stored in the keyrr column:\n%s", stored)
+	}
+	if stored != want {
+		t.Errorf("got  %q\nwant %q", stored, want)
+	}
+}
+
+// TestBulkImportCommentedRRIsNotAConflict: with the RR canonicalised before the
+// diff, re-offering the same key from a still-commented .key file must read as
+// "unchanged" rather than a keyrr conflict needing --force.
+func TestBulkImportCommentedRRIsNotAConflict(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	k := testDnssecKey(t, "dnslab.", 257)
+	if _, err := kdb.BulkImportDnssec(nil, []BulkDnssecKey{k}, false); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+
+	commented := k
+	commented.KeyRR = bindCommentHeader + k.KeyRR + "\n"
+
+	disp, err := kdb.BulkImportDnssec(nil, []BulkDnssecKey{commented}, false)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if len(disp) != 1 {
+		t.Fatalf("got %d dispositions, want 1", len(disp))
+	}
+	if disp[0].Status != BulkStatusUnchanged {
+		t.Errorf("status = %q (%s), want %q",
+			disp[0].Status, disp[0].Detail, BulkStatusUnchanged)
+	}
+}
+
+// TestTruststoreStoresCanonicalKeyRR: SIG(0) bulk-import mirrors each imported
+// key into the truststore, and that mirror is fed from the CALLER's slice --
+// canonicalising inside the import loop does not reach it. The truststore keeps
+// RR text in a column of its own, so it canonicalises at its own boundary.
+func TestTruststoreStoresCanonicalKeyRR(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	k := testBulkSig0Key(t, "dnslab.")
+	want := k.KeyRR
+	k.KeyRR = bindCommentHeader + k.KeyRR + "\n"
+
+	if _, err := kdb.Sig0TrustMgmt(nil, TruststorePost{
+		Command: "truststore", SubCommand: "add",
+		Keyname: "dnslab.", Keyid: int(k.Keyid),
+		Validated: true, Trusted: true, Src: "keystore",
+		KeyRR: k.KeyRR,
+	}); err != nil {
+		t.Fatalf("Sig0TrustMgmt add: %v", err)
+	}
+
+	var stored string
+	row := kdb.DB.QueryRow(`SELECT keyrr FROM Sig0TrustStore WHERE zonename=? AND keyid=?`,
+		"dnslab.", int(k.Keyid))
+	if err := row.Scan(&stored); err != nil {
+		t.Fatalf("reading back keyrr: %v", err)
+	}
+	if strings.Contains(stored, ";") {
+		t.Errorf("comment header was stored in the truststore keyrr column:\n%s", stored)
+	}
+	if stored != want {
+		t.Errorf("got  %q\nwant %q", stored, want)
+	}
+}
+
+// TestTruststoreRejectsRecordlessKeyRR: an "add" carrying text with no record in
+// it used to be stored as-is. src=dns legitimately carries no key at all, which
+// is why the canonicalisation is guarded on a non-empty KeyRR rather than
+// required outright.
+func TestTruststoreRejectsRecordlessKeyRR(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	_, err := kdb.Sig0TrustMgmt(nil, TruststorePost{
+		Command: "truststore", SubCommand: "add",
+		Keyname: "dnslab.", Keyid: 1, Src: "file",
+		KeyRR: bindCommentHeader,
+	})
+	if err == nil {
+		t.Fatal("a comment-only KeyRR was accepted")
+	}
+
+	// src=dns supplies no key and must still be accepted.
+	if _, err := kdb.Sig0TrustMgmt(nil, TruststorePost{
+		Command: "truststore", SubCommand: "add",
+		Keyname: "dnslab.", Keyid: 1, Src: "dns",
+	}); err != nil {
+		t.Errorf("src=dns with no KeyRR was rejected: %v", err)
+	}
+}

--- a/v2/bind_keyfile_comments_test.go
+++ b/v2/bind_keyfile_comments_test.go
@@ -329,3 +329,59 @@ func TestTruststoreRejectsRecordlessKeyRR(t *testing.T) {
 		t.Errorf("src=dns with no KeyRR was rejected: %v", err)
 	}
 }
+
+// TestTruststoreRejectsDnskey: the SIG(0) truststore must hold KEY records only.
+// LoadSig0ChildKeys reads the table back through a *dns.KEY assertion and
+// silently skips anything else, so a DNSKEY accepted here would be stored, then
+// be absent from the runtime cache, with nothing logged at either end. Refusing
+// it at the write boundary is the only place the operator finds out.
+func TestTruststoreRejectsDnskey(t *testing.T) {
+	kdb := newTestKeyDB(t)
+
+	// Same key material, published as a DNSKEY rather than a KEY.
+	dnssec := testDnssecKey(t, "dnslab.", 257)
+
+	_, err := kdb.Sig0TrustMgmt(nil, TruststorePost{
+		Command: "truststore", SubCommand: "add",
+		Keyname: "dnslab.", Keyid: int(dnssec.Keyid),
+		Validated: true, Trusted: true, Src: "keystore",
+		KeyRR: dnssec.KeyRR,
+	})
+	if err == nil {
+		t.Fatal("a DNSKEY was accepted into the SIG(0) truststore")
+	}
+	if !strings.Contains(err.Error(), "KEY") {
+		t.Errorf("error does not say what was expected: %v", err)
+	}
+
+	var n int
+	if err := kdb.DB.QueryRow(`SELECT COUNT(*) FROM Sig0TrustStore WHERE zonename=?`,
+		"dnslab.").Scan(&n); err != nil {
+		t.Fatalf("counting rows: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("the rejected DNSKEY was stored anyway: %d row(s)", n)
+	}
+}
+
+// TestCanonicalSig0KeyRRRequiresKEY is the unit-level counterpart: KEY through,
+// DNSKEY refused, comments stripped either way.
+func TestCanonicalSig0KeyRRRequiresKEY(t *testing.T) {
+	keyrr := "dnslab.\t3600\tIN\tKEY\t512 3 15 C4RKfg3IUwpjc+CnISaCuDX4OGpxsUIe7dqRVXj0KdU="
+	dnskey := "dnslab.\t3600\tIN\tDNSKEY\t257 3 15 C4RKfg3IUwpjc+CnISaCuDX4OGpxsUIe7dqRVXj0KdU="
+
+	got, err := canonicalSig0KeyRR(bindCommentHeader + keyrr + "\n")
+	if err != nil {
+		t.Fatalf("canonicalSig0KeyRR on a KEY: %v", err)
+	}
+	if got != keyrr {
+		t.Errorf("got  %q\nwant %q", got, keyrr)
+	}
+
+	if _, err := canonicalSig0KeyRR(dnskey); err == nil {
+		t.Error("a DNSKEY was accepted by canonicalSig0KeyRR")
+	}
+	if _, err := canonicalSig0KeyRR(bindCommentHeader); err == nil {
+		t.Error("a comment-only input was accepted by canonicalSig0KeyRR")
+	}
+}

--- a/v2/bind_keyfile_comments_test.go
+++ b/v2/bind_keyfile_comments_test.go
@@ -12,6 +12,9 @@
 package tdns
 
 import (
+	"bytes"
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -383,5 +386,71 @@ func TestCanonicalSig0KeyRRRequiresKEY(t *testing.T) {
 	}
 	if _, err := canonicalSig0KeyRR(bindCommentHeader); err == nil {
 		t.Error("a comment-only input was accepted by canonicalSig0KeyRR")
+	}
+}
+
+// captureSignerLog swaps lgSigner for one writing into a buffer, for the
+// duration of the test.
+func captureSignerLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := lgSigner
+	lgSigner = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { lgSigner = prev })
+	return &buf
+}
+
+// TestLoadSig0ChildKeysReportsNonKeyRows: writes are guarded now, but a database
+// deployed before that can already hold a non-KEY row. Loading used to fall
+// through a bare type assertion with no else, so such a row was skipped in total
+// silence -- the key was just missing from the runtime cache with nothing said
+// about why. It must now be reported, must NOT abort the load, and must not stop
+// the good rows around it from loading.
+func TestLoadSig0ChildKeysReportsNonKeyRows(t *testing.T) {
+	kdb := newTestKeyDB(t)
+	buf := captureSignerLog(t)
+
+	good := testBulkSig0Key(t, "good.dnslab.")
+	dnskey := testDnssecKey(t, "bad.dnslab.", 257)
+
+	// Straight to SQL: Sig0TrustMgmt now refuses these, which is the point --
+	// this is the legacy row it can no longer create.
+	ins := `INSERT INTO Sig0TrustStore (zonename, keyid, validated, dnssecvalidated, trusted, source, keyrr)
+	        VALUES (?, ?, 1, 0, 1, 'keystore', ?)`
+	for _, r := range []struct {
+		zone  string
+		keyid uint16
+		rr    string
+	}{
+		{"bad.dnslab.", dnskey.Keyid, dnskey.KeyRR}, // a DNSKEY where a KEY belongs
+		{"empty.dnslab.", 1, "; nothing but a comment"},
+		{"good.dnslab.", good.Keyid, good.KeyRR},
+	} {
+		if _, err := kdb.DB.Exec(ins, r.zone, int(r.keyid), r.rr); err != nil {
+			t.Fatalf("seeding %s: %v", r.zone, err)
+		}
+	}
+
+	if err := kdb.LoadSig0ChildKeys(); err != nil {
+		t.Fatalf("one unusable row aborted the whole load: %v", err)
+	}
+
+	// The good row still loaded -- a bad row must not shadow its neighbours.
+	if _, ok := kdb.TruststoreSig0Cache.Map.Get(
+		fmt.Sprintf("good.dnslab.::%d", good.Keyid)); !ok {
+		t.Error("the valid KEY row was not loaded into the cache")
+	}
+	// The bad ones did not.
+	if _, ok := kdb.TruststoreSig0Cache.Map.Get(
+		fmt.Sprintf("bad.dnslab.::%d", dnskey.Keyid)); ok {
+		t.Error("a DNSKEY row was loaded into the SIG(0) cache")
+	}
+
+	// And, the whole point of this change, it is no longer silent.
+	log := buf.String()
+	for _, want := range []string{"not a KEY record", "bad.dnslab.", "DNSKEY", "empty.dnslab."} {
+		if !strings.Contains(log, want) {
+			t.Errorf("log does not mention %q:\n%s", want, log)
+		}
 	}
 }

--- a/v2/keystore_bulk.go
+++ b/v2/keystore_bulk.go
@@ -397,9 +397,15 @@ func (kdb *KeyDB) BulkImportDnssec(tx *Tx, keys []BulkDnssecKey, force bool) (di
 	out := make([]BulkKeyDisposition, 0, len(keys))
 	for _, k := range keys {
 		zone := dns.Fqdn(k.Zone)
-		if err := validateDnssecKeyRR(k); err != nil {
+		canonRR, err := validateDnssecKeyRR(k)
+		if err != nil {
 			return nil, fmt.Errorf("%s keyid %d: %v", zone, k.Keyid, err)
 		}
+		// Store the canonical record, never the caller's text. Also makes the
+		// diff below compare like with like, so re-importing a .key file that
+		// still has its comment header reports "unchanged" against an
+		// already-clean row rather than a spurious keyrr conflict.
+		k.KeyRR = canonRR
 
 		var (
 			curState, curAlg                          string
@@ -501,9 +507,11 @@ func (kdb *KeyDB) BulkImportSig0(tx *Tx, keys []BulkSig0Key, force bool) (dispos
 	out := make([]BulkKeyDisposition, 0, len(keys))
 	for _, k := range keys {
 		zone := dns.Fqdn(k.Zone)
-		if err := validateSig0KeyRR(k); err != nil {
+		canonRR, err := validateSig0KeyRR(k)
+		if err != nil {
 			return nil, fmt.Errorf("%s keyid %d: %v", zone, k.Keyid, err)
 		}
+		k.KeyRR = canonRR
 
 		var (
 			curState, curAlg                          string
@@ -897,29 +905,40 @@ var sig0KeyStates = []string{
 	Sig0StateCreated, Sig0StatePublished, Sig0StateActive, Sig0StateRetired,
 }
 
-func validateDnssecKeyRR(k BulkDnssecKey) error {
+// validateDnssecKeyRR checks a wire key and returns its DNSKEY in canonical
+// presentation form. The caller must store the returned string rather than
+// k.KeyRR: a payload assembled by hand, or by a tdns old enough to have copied
+// .key files verbatim, can carry dnssec-keygen's ";" comment header, and every
+// check below would still pass -- dns.NewRR skips comments, so the record parses
+// and all the metadata matches. Storing that text put the comment in the
+// keystore's keyrr column, where "keystore dnssec list" showed it in place of
+// the DNSKEY.
+func validateDnssecKeyRR(k BulkDnssecKey) (string, error) {
 	if err := validateBulkPrivateKey(k.PrivateKey); err != nil {
-		return err
+		return "", err
 	}
 	rr, err := dns.NewRR(k.KeyRR)
 	if err != nil {
-		return fmt.Errorf("unparsable DNSKEY RR: %v", err)
+		return "", fmt.Errorf("unparsable DNSKEY RR: %v", err)
+	}
+	if rr == nil {
+		return "", fmt.Errorf("no DNSKEY RR found")
 	}
 	dnskey, isDnskey := rr.(*dns.DNSKEY)
 	if !isDnskey {
-		return fmt.Errorf("expected a DNSKEY RR, got %s", dns.TypeToString[rr.Header().Rrtype])
+		return "", fmt.Errorf("expected a DNSKEY RR, got %s", dns.TypeToString[rr.Header().Rrtype])
 	}
 	if !strings.EqualFold(dnskey.Header().Name, dns.Fqdn(k.Zone)) {
-		return fmt.Errorf("DNSKEY owner %q does not match zone %q", dnskey.Header().Name, dns.Fqdn(k.Zone))
+		return "", fmt.Errorf("DNSKEY owner %q does not match zone %q", dnskey.Header().Name, dns.Fqdn(k.Zone))
 	}
 	if dnskey.Flags != k.Flags {
-		return fmt.Errorf("DNSKEY flags %d do not match the recorded flags %d", dnskey.Flags, k.Flags)
+		return "", fmt.Errorf("DNSKEY flags %d do not match the recorded flags %d", dnskey.Flags, k.Flags)
 	}
 	if tag := dnskey.KeyTag(); tag != k.Keyid {
-		return fmt.Errorf("DNSKEY keytag %d does not match the recorded keyid %d", tag, k.Keyid)
+		return "", fmt.Errorf("DNSKEY keytag %d does not match the recorded keyid %d", tag, k.Keyid)
 	}
 	if name, ok := dns.AlgorithmToString[dnskey.Algorithm]; ok && !strings.EqualFold(name, k.Algorithm) {
-		return fmt.Errorf("DNSKEY algorithm %s does not match the recorded algorithm %s", name, k.Algorithm)
+		return "", fmt.Errorf("DNSKEY algorithm %s does not match the recorded algorithm %s", name, k.Algorithm)
 	}
 	// Everything above is metadata: it would pass just as happily on a manifest
 	// entry that files one zone's public key beside another zone's private key,
@@ -933,45 +952,49 @@ func validateDnssecKeyRR(k BulkDnssecKey) error {
 	// zone is bound. On a build that could actually serve the zone, the check
 	// runs.
 	if _, err := VerifyStoredKeyPair(k.PrivateKey, dnskey); err != nil {
-		return err
+		return "", err
 	}
 	if err := validKeyState(k.State, dnssecKeyStates); err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return dnskey.String(), nil
 }
 
-// validateSig0KeyRR is the KEY-RR counterpart of validateDnssecKeyRR.
-func validateSig0KeyRR(k BulkSig0Key) error {
+// validateSig0KeyRR is the KEY-RR counterpart of validateDnssecKeyRR, and
+// returns the canonical KEY for the same reason: see that function.
+func validateSig0KeyRR(k BulkSig0Key) (string, error) {
 	if err := validateBulkPrivateKey(k.PrivateKey); err != nil {
-		return err
+		return "", err
 	}
 	rr, err := dns.NewRR(k.KeyRR)
 	if err != nil {
-		return fmt.Errorf("unparsable KEY RR: %v", err)
+		return "", fmt.Errorf("unparsable KEY RR: %v", err)
+	}
+	if rr == nil {
+		return "", fmt.Errorf("no KEY RR found")
 	}
 	key, isKey := rr.(*dns.KEY)
 	if !isKey {
-		return fmt.Errorf("expected a KEY RR, got %s", dns.TypeToString[rr.Header().Rrtype])
+		return "", fmt.Errorf("expected a KEY RR, got %s", dns.TypeToString[rr.Header().Rrtype])
 	}
 	if !strings.EqualFold(key.Header().Name, dns.Fqdn(k.Zone)) {
-		return fmt.Errorf("KEY owner %q does not match zone %q", key.Header().Name, dns.Fqdn(k.Zone))
+		return "", fmt.Errorf("KEY owner %q does not match zone %q", key.Header().Name, dns.Fqdn(k.Zone))
 	}
 	if tag := key.KeyTag(); tag != k.Keyid {
-		return fmt.Errorf("KEY keytag %d does not match the recorded keyid %d", tag, k.Keyid)
+		return "", fmt.Errorf("KEY keytag %d does not match the recorded keyid %d", tag, k.Keyid)
 	}
 	if name, ok := dns.AlgorithmToString[key.Algorithm]; ok && !strings.EqualFold(name, k.Algorithm) {
-		return fmt.Errorf("KEY algorithm %s does not match the recorded algorithm %s", name, k.Algorithm)
+		return "", fmt.Errorf("KEY algorithm %s does not match the recorded algorithm %s", name, k.Algorithm)
 	}
 	// Same reasoning as validateDnssecKeyRR: the checks above are all metadata,
 	// and a SIG(0) key that cannot verify against its own public half signs
 	// UPDATEs nobody will accept. dns.KEY embeds DNSKEY, and the signature
 	// maths is identical.
 	if _, err := VerifyStoredKeyPair(k.PrivateKey, &key.DNSKEY); err != nil {
-		return err
+		return "", err
 	}
 	if err := validKeyState(k.State, sig0KeyStates); err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return key.String(), nil
 }

--- a/v2/keystore_manifest.go
+++ b/v2/keystore_manifest.go
@@ -414,6 +414,13 @@ func ManifestEntryForTsig(k BulkTsigKey) ManifestTsigKey {
 // manifest entry. Paths are resolved against dir and are refused if they try to
 // escape it: a manifest is a data file, and an export directory pulled from
 // somewhere else must not be able to make the reader open ../../etc/anything.
+//
+// The public half is returned as the RR alone. A .key file written by
+// dnssec-keygen carries four ";" comment lines above the record, and returning
+// the file verbatim used to put all of that in the keystore's keyrr column --
+// the comment is what "keystore dnssec list" then showed instead of the DNSKEY.
+// Nothing downstream caught it: dns.NewRR skips comments, so the record parsed
+// fine and every metadata check passed.
 func readManifestKeyFiles(dir, privateFile, publicFile string) (privPEM, keyRR string, err error) {
 	priv, err := readContainedFile(dir, privateFile)
 	if err != nil {
@@ -423,7 +430,11 @@ func readManifestKeyFiles(dir, privateFile, publicFile string) (privPEM, keyRR s
 	if err != nil {
 		return "", "", err
 	}
-	return priv, strings.TrimRight(pub, "\n"), nil
+	rr, err := canonicalKeyRR(pub)
+	if err != nil {
+		return "", "", fmt.Errorf("public key file %q: %v", publicFile, err)
+	}
+	return priv, rr, nil
 }
 
 // readContainedFile reads one file named by the manifest, refusing an absolute

--- a/v2/readkey.go
+++ b/v2/readkey.go
@@ -34,6 +34,35 @@ func StripKeyFileComments(data []byte) []byte {
 	return []byte(strings.Join(out, "\n"))
 }
 
+// canonicalKeyRR parses one DNSKEY or KEY record out of the text of a .key file
+// and returns it in canonical presentation form, discarding everything else in
+// the file.
+//
+// BIND's dnssec-keygen writes four ";" comment lines above the record; tdns's
+// own exports write none. dns.NewRR skips comments, so keeping a .key file
+// verbatim was never a parse error -- it just meant that whatever consumed the
+// text kept the comment header along with the record. Where that text is stored
+// rather than re-parsed, as in the keystore's keyrr column, the comment is what
+// surfaces later.
+func canonicalKeyRR(s string) (string, error) {
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		return "", fmt.Errorf("unparsable public key RR: %v", err)
+	}
+	// NewRR reports no error for input that holds no record at all -- an empty
+	// file, or one that is nothing but comments.
+	if rr == nil {
+		return "", fmt.Errorf("no DNSKEY or KEY record found")
+	}
+	switch rr.(type) {
+	case *dns.DNSKEY, *dns.KEY:
+		return rr.String(), nil
+	default:
+		return "", fmt.Errorf("expected a DNSKEY or KEY record, got %s",
+			dns.TypeToString[rr.Header().Rrtype])
+	}
+}
+
 type BindPrivateKey struct {
 	Private_Key_Format string `yaml:"Private-key-format"`
 	Algorithm          string `yaml:"Algorithm"`

--- a/v2/readkey.go
+++ b/v2/readkey.go
@@ -45,14 +45,9 @@ func StripKeyFileComments(data []byte) []byte {
 // rather than re-parsed, as in the keystore's keyrr column, the comment is what
 // surfaces later.
 func canonicalKeyRR(s string) (string, error) {
-	rr, err := dns.NewRR(s)
+	rr, err := parseKeyRR(s)
 	if err != nil {
-		return "", fmt.Errorf("unparsable public key RR: %v", err)
-	}
-	// NewRR reports no error for input that holds no record at all -- an empty
-	// file, or one that is nothing but comments.
-	if rr == nil {
-		return "", fmt.Errorf("no DNSKEY or KEY record found")
+		return "", err
 	}
 	switch rr.(type) {
 	case *dns.DNSKEY, *dns.KEY:
@@ -61,6 +56,41 @@ func canonicalKeyRR(s string) (string, error) {
 		return "", fmt.Errorf("expected a DNSKEY or KEY record, got %s",
 			dns.TypeToString[rr.Header().Rrtype])
 	}
+}
+
+// canonicalSig0KeyRR is canonicalKeyRR narrowed to KEY, for the SIG(0)
+// truststore.
+//
+// That table is read back with a *dns.KEY type assertion (LoadSig0ChildKeys),
+// and anything else is SILENTLY skipped -- no error, no log. So a DNSKEY written
+// there is accepted at write time and then simply absent from the runtime
+// truststore cache, which is a much harder thing to notice than a refusal.
+func canonicalSig0KeyRR(s string) (string, error) {
+	rr, err := parseKeyRR(s)
+	if err != nil {
+		return "", err
+	}
+	key, isKey := rr.(*dns.KEY)
+	if !isKey {
+		return "", fmt.Errorf("expected a KEY record, got %s",
+			dns.TypeToString[rr.Header().Rrtype])
+	}
+	return key.String(), nil
+}
+
+// parseKeyRR pulls the single record out of key-file text, rejecting input that
+// holds none.
+func parseKeyRR(s string) (dns.RR, error) {
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		return nil, fmt.Errorf("unparsable public key RR: %v", err)
+	}
+	// NewRR reports no error for input that holds no record at all -- an empty
+	// file, or one that is nothing but comments.
+	if rr == nil {
+		return nil, fmt.Errorf("no DNSKEY or KEY record found")
+	}
+	return rr, nil
 }
 
 type BindPrivateKey struct {

--- a/v2/truststore.go
+++ b/v2/truststore.go
@@ -349,15 +349,38 @@ SELECT child, keyid, validated, trusted, source, keyrr FROM Sig0TrustStore WHERE
 			return fmt.Errorf("error from dns.NewRR(%s): %v", keyrrstr, err)
 		}
 
-		if keyrr, ok := rr.(*dns.KEY); ok {
-			mapkey := fmt.Sprintf("%s::%d", keyname, keyrr.KeyTag())
-			kdb.TruststoreSig0Cache.Map.Set(mapkey, Sig0Key{
-				Name:      keyname,
-				Validated: validated,
-				Trusted:   trusted,
-				Key:       *keyrr,
-			})
+		keyrr, isKey := rr.(*dns.KEY)
+		if !isKey {
+			// This used to be a bare "if ok" with no else, which made a
+			// non-KEY row invisible twice over: the write was accepted, and
+			// then the key was simply absent from the runtime cache with
+			// nothing said about why. Sig0TrustMgmt now refuses anything but
+			// a KEY, so this is for rows already sitting in a deployed
+			// database, which no code change can reach.
+			//
+			// Logged rather than fatal on purpose. One unusable row must not
+			// stop a daemon from starting with the keys that are good --
+			// SIG(0) verification failing closed for one child is a much
+			// smaller outage than not booting.
+			//
+			// dns.NewRR yields (nil, nil) for text that holds no record at
+			// all, so rr can be nil here as well as the wrong type.
+			rrtype := "empty"
+			if rr != nil {
+				rrtype = dns.TypeToString[rr.Header().Rrtype]
+			}
+			lgSigner.Warn("SIG(0) truststore row is not a KEY record, skipping it",
+				"zone", keyname, "keyid", keyid, "rrtype", rrtype)
+			continue
 		}
+
+		mapkey := fmt.Sprintf("%s::%d", keyname, keyrr.KeyTag())
+		kdb.TruststoreSig0Cache.Map.Set(mapkey, Sig0Key{
+			Name:      keyname,
+			Validated: validated,
+			Trusted:   trusted,
+			Key:       *keyrr,
+		})
 	}
 
 	// If a validator trusted key config file is found, read it in.

--- a/v2/truststore.go
+++ b/v2/truststore.go
@@ -116,9 +116,14 @@ DELETE FROM Sig0TrustStore WHERE zonename=? AND keyid=?`
 		// keystore had via the manifest reader; fixed here at the storage
 		// boundary so it covers file, keystore and child-update alike.
 		//
+		// Narrowed to KEY, not "DNSKEY or KEY": LoadSig0ChildKeys reads this
+		// table back through a *dns.KEY assertion and silently skips anything
+		// else, so a DNSKEY accepted here would vanish from the runtime cache
+		// with nothing logged at either end.
+		//
 		// src=dns supplies no key (it schedules a fetch), hence the guard.
 		if tp.KeyRR != "" {
-			canon, cerr := canonicalKeyRR(tp.KeyRR)
+			canon, cerr := canonicalSig0KeyRR(tp.KeyRR)
 			if cerr != nil {
 				err = fmt.Errorf("SIG(0) key for %s keyid %d: %v", tp.Keyname, tp.Keyid, cerr)
 				resp.Error = true

--- a/v2/truststore.go
+++ b/v2/truststore.go
@@ -108,6 +108,26 @@ DELETE FROM Sig0TrustStore WHERE zonename=? AND keyid=?`
 		resp.Msg = "Here are all the child SIG(0) keys that we know"
 
 	case "add":
+		// The keyrr column holds RR text that is displayed and re-parsed later,
+		// so it must hold the record and nothing else. A KEY read out of a
+		// dnssec-keygen .key file arrives with four ";" comment lines above it,
+		// and every path below stores tp.KeyRR verbatim -- so without this the
+		// comment header is what "truststore list" shows. Same defect the
+		// keystore had via the manifest reader; fixed here at the storage
+		// boundary so it covers file, keystore and child-update alike.
+		//
+		// src=dns supplies no key (it schedules a fetch), hence the guard.
+		if tp.KeyRR != "" {
+			canon, cerr := canonicalKeyRR(tp.KeyRR)
+			if cerr != nil {
+				err = fmt.Errorf("SIG(0) key for %s keyid %d: %v", tp.Keyname, tp.Keyid, cerr)
+				resp.Error = true
+				resp.ErrorMsg = err.Error()
+				return &resp, err
+			}
+			tp.KeyRR = canon
+		}
+
 		// 1. If src=file and key is supplied then add it (but as untrusted)
 		// 2. If src=dns then schedule some soort of DNS fetching exercise.
 		if tp.Src == "file" {


### PR DESCRIPTION
## The symptom

`keystore dnssec list` shows a comment where the DNSKEY should be, for every key
imported from BIND9:

```
dnslab.  active  20518  256  ED25519  dnslab.	3600	IN	DNSKEY	256 3 15 wsn+9ZEVeQALU/O530...
dnslab.  active  27008  257  ED25519  dnslab.	3600	IN	DNSKEY	257 3 15 6W03w5E6fJZWFb7sCn...
dnslab.  active  2760   256  ED25519  ; This is a zone-signing key, keyid 2760, for dnsl...
dnslab.  active  59146  257  ED25519  ; This is a key-signing key, keyid 59146, for dnsl...
```

## The cause

`dnssec-keygen` writes four `;` comment lines above the record in a `.key` file.
`readManifestKeyFiles` returned that file body verbatim (trailing newlines
trimmed) as the key's RR text, so the whole thing went into the `keyrr` column.
That reader feeds both `bulk-import` and the startup `keystore.preload` — every
path a BIND9 key takes into the keystore.

**Nothing downstream caught it because `dns.NewRR` skips comments.** Verified
directly against the reported file: it returns the correct DNSKEY, keytag 59146.
So the record parsed, and the owner / flags / keytag / algorithm checks in
`validateDnssecKeyRR` all matched, as did `VerifyStoredKeyPair`. Validation was
never the weak point — storing text that had only ever been *validated*, never
re-emitted, was.

## Scope correction

**The single `keystore dnssec import` command did not have this bug** and is
unchanged. It goes through `ReadPrivateKey` → `PrepareKeyCache` and stores
`pkc.DnskeyRR.String()`, the parsed record. Probed both paths against a real
BIND9-style pair before touching anything:

```
single import stores: "dnslab.\t3600\tIN\tDNSKEY\t257 3 15 gZkXgDAL..."          <- clean
bulk   import stores: "; This is a key-signing key, keyid 59146, ...\ndnslab..." <- the bug
```

## The fix, in three layers

**1. `readManifestKeyFiles`** returns the record alone, via a new `canonicalKeyRR`
helper that parses one DNSKEY or KEY and re-emits it canonically. A `.key` file
holding no record at all — previously passed along to fail later with an error
about the wire key rather than the file — is now refused by name here.

**2. `validateDnssecKeyRR` / `validateSig0KeyRR`** return the canonical RR, and the
bulk import loops store that rather than the caller's text. Backstop for payloads
that never went through a manifest: hand-written, or produced by a tdns old enough
to have copied `.key` files verbatim. It also makes the conflict diff compare like
with like, so re-offering a still-commented `.key` reads as `unchanged` against an
already-clean row instead of a `keyrr` conflict needing `--force`.

**3. `Sig0TrustMgmt` "add"** canonicalises at its own storage boundary. This one was
not in the original report: SIG(0) `bulk-import` mirrors each imported key into the
truststore, and that mirror is fed from the **caller's** slice — so canonicalising
inside the import loop does not reach it, and the comment header would have landed
in the truststore's `keyrr` column instead. Fixing it here also covers
`truststore add --src file` aimed straight at a `.key` file. `src=dns` carries no
key, hence the non-empty guard.

## Existing rows

Not rewritten. The damage is cosmetic rather than functional — every reader goes
through `dns.NewRR`, so affected keys sign and publish correctly — but the text does
round-trip back out through `bulk-export`. Re-running `bulk-import` with `--force`
against the original key directory repairs them now that the reader is fixed.

## Verification

- New `v2/bind_keyfile_comments_test.go`: `canonicalKeyRR` directly (8 cases incl.
  comment-only, empty, wrong RR type, already-clean), both manifest loaders
  (DNSSEC + SIG(0)), both bulk validators, bulk import through to the stored
  column, the truststore leg, both recordless-input rejections, and the
  not-a-conflict property.
- **Every regression test was confirmed to fail with its fix backed out** — not
  merely to pass with it applied.
- Full `v2` suite green; `go vet` clean; `gofmt` clean on all touched files;
  `tdns-auth` and `tdns-cli` both build via `make`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of BIND `.key` files by removing comments and formatting noise from stored DNSKEY and SIG(0) records.
  * Prevented commented records from being incorrectly treated as conflicting keys.
  * Rejected empty or invalid key files with clear errors.
  * Preserved valid DNS-sourced truststore requests when no key record is provided.

* **Tests**
  * Added coverage for manifest loading, validation, bulk import, and truststore behavior involving commented key records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->