### PR TITLE
Zone content updates via the management API (Phase 1)

### DIFF
--- a/v2/api_structs.go
+++ b/v2/api_structs.go
@@ -256,6 +256,15 @@ type ZonePost struct {
 	// primaries, unused for secondaries.
 	ZoneType string
 	Template string
+	// Zone content updates ("zone update <verb>"). UpdateRRs carries
+	// presentation-form records for addrr/delrr/replacerrset; UpdateName and
+	// UpdateRrtype address an RRset or a name for delrrset/delname. See
+	// BuildZoneUpdateActions, which both this channel and the DDNS channel
+	// translate through.
+	UpdateVerb   string
+	UpdateRRs    []string
+	UpdateName   string
+	UpdateRrtype string
 	// Inline TSIG key for the add/modify: when TsigName is set the server upserts
 	// {name, algo, secret} into its keys: store, points keyless primaries at it,
 	// and persists it with the zone (survives restart). TsigAlgo defaults to

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -101,7 +101,7 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			}
 
 		case "update":
-			msg, err := zd.ApiZoneUpdate(zp)
+			msg, err := zd.ApiZoneUpdate(r.Context(), zp)
 			resp.Msg = msg
 			if err != nil {
 				resp.Error = true

--- a/v2/apihandler_zone.go
+++ b/v2/apihandler_zone.go
@@ -87,8 +87,21 @@ func APIzone(app *AppDetails, refreshq chan ZoneRefresher, kdb *KeyDB) func(w ht
 			}
 			resp.Msg = fmt.Sprintf("Zone %s: bumped SOA serial from %d to %d", zp.Zone, br.OldSerial, br.NewSerial)
 
-		case "write-zone":
+		// "sync" is an alias for "write-zone": spool the current zone content
+		// out to disk, without the freeze/thaw ritual around it. Named for
+		// rndc sync, which is what an operator coming from bind9 will reach
+		// for. One implementation, two names -- not two code paths that can
+		// drift.
+		case "write-zone", "sync":
 			msg, err := zd.WriteZone(false, zp.Force)
+			resp.Msg = msg
+			if err != nil {
+				resp.Error = true
+				resp.ErrorMsg = err.Error()
+			}
+
+		case "update":
+			msg, err := zd.ApiZoneUpdate(zp)
 			resp.Msg = msg
 			if err != nil {
 				resp.Error = true

--- a/v2/cli/update.go
+++ b/v2/cli/update.go
@@ -87,6 +87,10 @@ The zone to update is mandatory to specify on the command line with the --zone f
 	create.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to update")
 	AttachUpdateCreateFlags(create)
 	c.AddCommand(create)
+	// The one-off content statements (addrr, delrr, delrrset, delname,
+	// replacerrset) live beside "create", which is the interactive
+	// multi-statement session.
+	AttachZoneUpdateVerbs(c, role)
 	return c
 }
 

--- a/v2/cli/zone_update_cmds.go
+++ b/v2/cli/zone_update_cmds.go
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package cli
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	tdns "github.com/johanix/tdns/v2"
+	"github.com/miekg/dns"
+	"github.com/spf13/cobra"
+)
+
+var (
+	zoneUpdateVia    string
+	zoneUpdateRRs    []string
+	zoneUpdateName   string
+	zoneUpdateRrtype string
+)
+
+// AttachZoneUpdateVerbs adds the one-off content statements to an existing
+// "zone update" command, alongside the interactive "create" subtree.
+//
+// --via is required and has no default. The two channels are not
+// interchangeable: the API bypasses update-policy because the API key is the
+// credential, while DDNS enforces it. Defaulting to either one would mean an
+// operator could get a different authorization model than they thought they
+// asked for, purely by omitting a flag.
+func AttachZoneUpdateVerbs(c *cobra.Command, role string) {
+	addrr := &cobra.Command{
+		Use:   "addrr",
+		Short: "Add one or more RRs to a zone",
+		Long: `Add resource records to a primary zone.
+
+  tdns-cli ... zone update addrr --zone alpha.dnslab. --via api \
+      --rr "foo.alpha.dnslab. 3600 IN A 1.2.3.4"`,
+		Run: func(cmd *cobra.Command, args []string) { runZoneUpdateVerb(role, tdns.VerbAddRR) },
+	}
+
+	delrr := &cobra.Command{
+		Use:   "delrr",
+		Short: "Delete one specific RR from a zone",
+		Long: `Delete individual resource records. The RR must be given in full; the TTL is
+ignored, since it is not part of a record's identity.
+
+  tdns-cli ... zone update delrr --zone alpha.dnslab. --via api \
+      --rr "foo.alpha.dnslab. IN A 1.2.3.4"`,
+		Run: func(cmd *cobra.Command, args []string) { runZoneUpdateVerb(role, tdns.VerbDelRR) },
+	}
+
+	delrrset := &cobra.Command{
+		Use:   "delrrset",
+		Short: "Delete an entire RRset (owner + type) from a zone",
+		Long: `Delete every record of one type at one owner name.
+
+  tdns-cli ... zone update delrrset --zone alpha.dnslab. --via api \
+      --name foo.alpha.dnslab. --type A`,
+		Run: func(cmd *cobra.Command, args []string) { runZoneUpdateVerb(role, tdns.VerbDelRRset) },
+	}
+
+	delname := &cobra.Command{
+		Use:   "delname",
+		Short: "Delete every RRset at an owner name",
+		Long: `Delete all records at a name. At the zone apex, SOA and NS are retained --
+deleting those would dismantle the zone rather than a name within it.
+
+  tdns-cli ... zone update delname --zone alpha.dnslab. --via api \
+      --name foo.alpha.dnslab.`,
+		Run: func(cmd *cobra.Command, args []string) { runZoneUpdateVerb(role, tdns.VerbDelName) },
+	}
+
+	replacerrset := &cobra.Command{
+		Use:   "replacerrset",
+		Short: "Atomically replace an RRset with the supplied RRs",
+		Long: `Replace an entire RRset in one transaction. The RRset to replace is inferred
+from the owner and type of the supplied records, so they must all describe the
+same one; mixed owners or types are refused rather than guessed at.
+
+This is a single atomic operation, not a delete followed by an add: the empty
+intermediate RRset is never published and no secondary can observe it.
+
+  tdns-cli ... zone update replacerrset --zone alpha.dnslab. --via api \
+      --rr "foo.alpha.dnslab. IN A 1.2.3.4" \
+      --rr "foo.alpha.dnslab. IN A 2.3.4.5"
+
+To remove an RRset entirely, use delrrset -- replacerrset with no records is an
+error, not a silent delete.`,
+		Run: func(cmd *cobra.Command, args []string) { runZoneUpdateVerb(role, tdns.VerbReplaceRRset) },
+	}
+
+	rrVerbs := []*cobra.Command{addrr, delrr, replacerrset}
+	nameVerbs := []*cobra.Command{delrrset, delname}
+
+	for _, sub := range append(append([]*cobra.Command{}, rrVerbs...), nameVerbs...) {
+		sub.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to update")
+		sub.Flags().StringVar(&zoneUpdateVia, "via", "", "Transport: \"api\" or \"ddns\" (required)")
+		// --signer/--server/--key are only consulted for --via ddns, but are
+		// attached everywhere so the flag set does not change shape per verb.
+		AttachUpdateCreateFlags(sub)
+		c.AddCommand(sub)
+	}
+	for _, sub := range rrVerbs {
+		sub.Flags().StringArrayVar(&zoneUpdateRRs, "rr", nil,
+			"Resource record in presentation format (repeatable)")
+	}
+	for _, sub := range nameVerbs {
+		sub.Flags().StringVar(&zoneUpdateName, "name", "", "Owner name")
+	}
+	delrrset.Flags().StringVar(&zoneUpdateRrtype, "type", "", "RR type to delete")
+}
+
+func runZoneUpdateVerb(role, verb string) {
+	PrepArgs("zonename")
+
+	zone := dns.Fqdn(tdns.Globals.Zonename)
+	spec := tdns.ZoneUpdateSpec{
+		Verb:   verb,
+		RRs:    zoneUpdateRRs,
+		Name:   zoneUpdateName,
+		Rrtype: zoneUpdateRrtype,
+	}
+
+	switch strings.ToLower(strings.TrimSpace(zoneUpdateVia)) {
+	case "api":
+		runZoneUpdateViaApi(role, zone, spec)
+	case "ddns":
+		runZoneUpdateViaDdns(zone, spec)
+	case "":
+		fmt.Printf("Error: --via is required (\"api\" or \"ddns\").\n\n" +
+			"The two channels differ in authorization: the API bypasses update-policy\n" +
+			"(the API key is the credential), DDNS enforces it. There is deliberately\n" +
+			"no default.\n")
+		os.Exit(1)
+	default:
+		fmt.Printf("Error: unknown --via %q (want \"api\" or \"ddns\")\n", zoneUpdateVia)
+		os.Exit(1)
+	}
+}
+
+// runZoneUpdateViaApi ships the statement itself rather than pre-built update
+// records. The server translates it through the same BuildZoneUpdateActions
+// the DDNS path uses locally, so validation happens where it is authoritative
+// instead of being trusted from the client.
+func runZoneUpdateViaApi(role, zone string, spec tdns.ZoneUpdateSpec) {
+	// Fail on obvious input errors before a round trip, using the very same
+	// builder the server will run.
+	if _, err := tdns.BuildZoneUpdateActions(zone, spec); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	api, err := GetApiClient(role, true)
+	if err != nil {
+		log.Fatalf("Error getting API client for %s: %v", role, err)
+	}
+
+	cr, err := SendZoneCommand(api, tdns.ZonePost{
+		Command:      "update",
+		Zone:         zone,
+		UpdateVerb:   spec.Verb,
+		UpdateRRs:    spec.RRs,
+		UpdateName:   spec.Name,
+		UpdateRrtype: spec.Rrtype,
+	})
+	if err != nil {
+		fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+		os.Exit(1)
+	}
+	if cr.Msg != "" {
+		fmt.Printf("%s\n", cr.Msg)
+	}
+}
+
+// runZoneUpdateViaDdns builds an RFC 2136 UPDATE locally, signs it with SIG(0)
+// when a key is available, and sends it to --server.
+func runZoneUpdateViaDdns(zone string, spec tdns.ZoneUpdateSpec) {
+	actions, err := tdns.BuildZoneUpdateActions(zone, spec)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+	if server == "" {
+		fmt.Printf("Error: --via ddns requires --server (host:port of the primary to update)\n")
+		os.Exit(1)
+	}
+
+	m := new(dns.Msg)
+	m.SetUpdate(zone)
+	// The records are appended to the update section as built, rather than
+	// going through m.Insert/m.Remove/m.RemoveRRset. Those helpers re-derive
+	// the class from the operation and cannot express DELNAME at all
+	// (CLASS=ANY with TYPE=ANY), so re-deriving here would silently drop the
+	// one statement that has no library helper.
+	m.Ns = append(m.Ns, actions...)
+	m.SetEdns0(1232, true)
+
+	signerName := signer
+	if signerName == "" {
+		signerName = zone
+	}
+	signerName = dns.Fqdn(signerName)
+
+	if keyfile != "" {
+		pkc, err := tdns.ReadPrivateKey(keyfile)
+		switch {
+		case err != nil:
+			fmt.Printf("Error reading SIG(0) key file %q: %v\n", keyfile, err)
+			os.Exit(1)
+		case pkc == nil:
+			fmt.Printf("Keyfile %q yielded no key\n", keyfile)
+			os.Exit(1)
+		case pkc.KeyType != dns.TypeKEY:
+			fmt.Printf("Keyfile %q does not contain a SIG(0) key\n", keyfile)
+			os.Exit(1)
+		}
+		sak := &tdns.Sig0ActiveKeys{Keys: []*tdns.PrivateKeyCache{pkc}}
+		signed, err := tdns.SignMsg(*m, signerName, sak)
+		if err != nil {
+			fmt.Printf("Error signing update: %v\n", err)
+			os.Exit(1)
+		}
+		if signed == nil {
+			fmt.Printf("Error: signing produced no message\n")
+			os.Exit(1)
+		}
+		m = signed
+	} else {
+		fmt.Printf("Warning: no --key given, sending the update UNSIGNED.\n" +
+			"A primary enforcing update-policy will almost certainly refuse it.\n")
+	}
+
+	fmt.Printf("Sending to %s:\n", server)
+	for _, line := range tdns.ZoneUpdateActionsSummary(actions) {
+		fmt.Printf("  %s\n", line)
+	}
+
+	rcode, _, err := tdns.SendUpdate(m, zone, []string{server})
+	if err != nil {
+		fmt.Printf("Error sending update: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Update sent, response rcode: %s\n", dns.RcodeToString[rcode])
+	if rcode != dns.RcodeSuccess {
+		os.Exit(1)
+	}
+}

--- a/v2/cli/zone_update_cmds.go
+++ b/v2/cli/zone_update_cmds.go
@@ -96,6 +96,12 @@ error, not a silent delete.`,
 	nameVerbs := []*cobra.Command{delrrset, delname}
 
 	for _, sub := range append(append([]*cobra.Command{}, rrVerbs...), nameVerbs...) {
+		// Every verb takes its input through flags and runZoneUpdateVerb never
+		// looks at args. Without this, "zone update addrr foo.example. --via api"
+		// silently discards the positional and then fails with the builder's
+		// generic "addrr requires at least one RR", which names the wrong
+		// mistake.
+		sub.Args = cobra.NoArgs
 		sub.Flags().StringVarP(&tdns.Globals.Zonename, "zone", "z", "", "Zone to update")
 		sub.Flags().StringVar(&zoneUpdateVia, "via", "", "Transport: \"api\" or \"ddns\" (required)")
 		// --signer/--server/--key are only consulted for --via ddns, but are
@@ -167,7 +173,10 @@ func runZoneUpdateViaApi(role, zone string, spec tdns.ZoneUpdateSpec) {
 		UpdateRrtype: spec.Rrtype,
 	})
 	if err != nil {
-		fmt.Printf("Error from %q: %s\n", cr.AppName, err.Error())
+		// cr is the zero value on a transport error, so cr.AppName would render
+		// as an empty name -- `Error from "":`. The role is what the operator
+		// actually asked for and is always known.
+		fmt.Printf("Error from %s: %s\n", role, err.Error())
 		os.Exit(1)
 	}
 	if cr.Msg != "" {

--- a/v2/enums.go
+++ b/v2/enums.go
@@ -47,6 +47,12 @@ const (
 	OptCatalogMemberAutoDelete
 	OptMultiSigner  // Dynamically set by signer when HSYNC shows multiple signers
 	OptDelSyncProxy // agent secondary: proxy CDS/CSYNC NOTIFYs upstream for a DSYNC-unaware primary
+	// OptAllowApiUpdates gates RR updates arriving over the management API,
+	// separately from allow-updates (which gates RFC 2136 DDNS). Appended here
+	// rather than beside allow-updates on purpose: ZoneOption values are
+	// positional (iota), so inserting mid-list would renumber every option
+	// after it.
+	OptAllowApiUpdates
 	optZoneOptionTdnsSentinel
 )
 
@@ -80,6 +86,7 @@ var ZoneOptionToString = map[ZoneOption]string{
 	OptCatalogMemberAutoDelete: "catalog-member-auto-delete",
 	OptMultiSigner:             "multi-signer",
 	OptDelSyncProxy:            "delegation-sync-proxy",
+	OptAllowApiUpdates:         "allow-api-updates",
 }
 
 var StringToZoneOption = map[string]ZoneOption{
@@ -105,6 +112,7 @@ var StringToZoneOption = map[string]ZoneOption{
 	"catalog-member-auto-delete": OptCatalogMemberAutoDelete,
 	"multi-signer":               OptMultiSigner,
 	"delegation-sync-proxy":      OptDelSyncProxy,
+	"allow-api-updates":          OptAllowApiUpdates,
 }
 
 type ImrOption uint8

--- a/v2/parseoptions.go
+++ b/v2/parseoptions.go
@@ -184,6 +184,7 @@ func parseZoneOptions(conf *Config, zname string, zconf *ZoneConf, zd *ZoneData)
 			OptDelSyncProxy,
 			OptAllowUpdates,
 			OptAllowChildUpdates,
+			OptAllowApiUpdates,
 			OptAllowEdits,
 			OptFoldCase,
 			OptBlackLies,

--- a/v2/zone_option_normalize.go
+++ b/v2/zone_option_normalize.go
@@ -39,6 +39,12 @@ import (
 var originationOptions = []ZoneOption{
 	OptAllowUpdates,
 	OptAllowChildUpdates,
+	// allow-api-updates is origination by definition: it admits operator RR
+	// changes over the management API. A tdns-auth secondary that may not
+	// originate content must not accept them either, or the API becomes a way
+	// around the MUST-NOT-MODIFY invariant that allow-updates already enforces
+	// for the DDNS channel.
+	OptAllowApiUpdates,
 	OptAddTransportSignal,
 	OptDelSyncParent,
 	OptOnlineSigning,

--- a/v2/zone_update_api.go
+++ b/v2/zone_update_api.go
@@ -5,6 +5,7 @@
 package tdns
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -30,17 +31,26 @@ import (
 // the ZoneUpdater that authorization was settled here (the API key is the
 // credential) and that update-policy does not apply. Nothing on the DNS path
 // sets that flag.
-func (zd *ZoneData) ApiZoneUpdate(zp ZonePost) (string, error) {
+func (zd *ZoneData) ApiZoneUpdate(ctx context.Context, zp ZonePost) (string, error) {
 	if zd == nil {
 		return "", fmt.Errorf("no such zone")
 	}
 
-	if !zd.Options[OptAllowApiUpdates] {
+	// Snapshot both options together under the lock. RefreshEngine and config
+	// reload mutate zd.Options under zd.mu, so reading the map here unlocked is
+	// a data race, and reading the two independently would let a reload flip
+	// one between the checks. Matches the CHILD-UPDATE handling in the updater.
+	zd.mu.Lock()
+	allowApi := zd.Options[OptAllowApiUpdates]
+	frozen := zd.Options[OptFrozen]
+	zd.mu.Unlock()
+
+	if !allowApi {
 		return "", fmt.Errorf(
 			"zone %s does not allow updates via the management API (needs the allow-api-updates option)",
 			zd.ZoneName)
 	}
-	if zd.Options[OptFrozen] {
+	if frozen {
 		return "", fmt.Errorf("zone %s is frozen; thaw it before updating", zd.ZoneName)
 	}
 
@@ -69,6 +79,11 @@ func (zd *ZoneData) ApiZoneUpdate(zp ZonePost) (string, error) {
 		PreAuthorized: true,
 		Description:   fmt.Sprintf("API %s", zp.UpdateVerb),
 	}:
+	case <-ctx.Done():
+		// The HTTP client hung up. Stop waiting rather than hold a handler
+		// goroutine on a queue nobody is going to read the answer from.
+		return "", fmt.Errorf("request cancelled while queueing the update for zone %s: %w",
+			zd.ZoneName, ctx.Err())
 	case <-time.After(5 * time.Second):
 		return "", fmt.Errorf("timeout while queueing the update for zone %s", zd.ZoneName)
 	}

--- a/v2/zone_update_api.go
+++ b/v2/zone_update_api.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// ApiZoneUpdate applies one zone-content statement that arrived over the
+// management API.
+//
+// Admission, in order:
+//
+//  1. The zone must originate its own content. A secondary's content belongs
+//     to its primary; letting the API edit it would be the same violation the
+//     MUST-NOT-MODIFY invariant closes for every other path.
+//  2. The zone must carry allow-api-updates. This is a separate consent from
+//     allow-updates, which governs RFC 2136: an operator who opened a zone to
+//     SIG(0) DDNS has not thereby opened it to the API, and vice versa.
+//  3. A frozen zone refuses updates on BOTH channels. Freeze means the zone
+//     file on disk is the authority right now; accepting API changes while
+//     frozen would silently strand them the next time the file is read.
+//
+// Only after all three does the request get PreAuthorized, which is what tells
+// the ZoneUpdater that authorization was settled here (the API key is the
+// credential) and that update-policy does not apply. Nothing on the DNS path
+// sets that flag.
+func (zd *ZoneData) ApiZoneUpdate(zp ZonePost) (string, error) {
+	if zd == nil {
+		return "", fmt.Errorf("no such zone")
+	}
+
+	if !zd.Options[OptAllowApiUpdates] {
+		return "", fmt.Errorf(
+			"zone %s does not allow updates via the management API (needs the allow-api-updates option)",
+			zd.ZoneName)
+	}
+	if zd.Options[OptFrozen] {
+		return "", fmt.Errorf("zone %s is frozen; thaw it before updating", zd.ZoneName)
+	}
+
+	actions, err := BuildZoneUpdateActions(zd.ZoneName, ZoneUpdateSpec{
+		Verb:   zp.UpdateVerb,
+		RRs:    zp.UpdateRRs,
+		Name:   zp.UpdateName,
+		Rrtype: zp.UpdateRrtype,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(actions) == 0 {
+		return "", fmt.Errorf("statement produced no changes")
+	}
+
+	if zd.KeyDB == nil || zd.KeyDB.UpdateQ == nil {
+		return "", fmt.Errorf("zone updater is not available")
+	}
+
+	select {
+	case zd.KeyDB.UpdateQ <- UpdateRequest{
+		Cmd:           "ZONE-UPDATE",
+		ZoneName:      zd.ZoneName,
+		Actions:       actions,
+		PreAuthorized: true,
+		Description:   fmt.Sprintf("API %s", zp.UpdateVerb),
+	}:
+	case <-time.After(5 * time.Second):
+		return "", fmt.Errorf("timeout while queueing the update for zone %s", zd.ZoneName)
+	}
+
+	lgApi.Info("api zone update queued", "zone", zd.ZoneName,
+		"verb", zp.UpdateVerb, "actions", len(actions))
+
+	return fmt.Sprintf("Zone %s: %s queued (%d update record%s)",
+		zd.ZoneName, zp.UpdateVerb, len(actions), plural(len(actions))), nil
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// ZoneUpdateActionsSummary renders an action list the way the update section
+// reads on the wire, for logs and for the CLI's confirmation output.
+func ZoneUpdateActionsSummary(actions []dns.RR) []string {
+	out := make([]string, 0, len(actions))
+	for _, rr := range actions {
+		switch rr.Header().Class {
+		case dns.ClassANY:
+			if rr.Header().Rrtype == dns.TypeANY {
+				out = append(out, fmt.Sprintf("DELNAME  %s", rr.Header().Name))
+				continue
+			}
+			out = append(out, fmt.Sprintf("DELRRSET %s %s",
+				rr.Header().Name, dns.TypeToString[rr.Header().Rrtype]))
+		case dns.ClassNONE:
+			out = append(out, fmt.Sprintf("DEL      %s", rr.String()))
+		default:
+			out = append(out, fmt.Sprintf("ADD      %s", rr.String()))
+		}
+	}
+	return out
+}

--- a/v2/zone_update_build_test.go
+++ b/v2/zone_update_build_test.go
@@ -151,6 +151,40 @@ func TestBuildZoneUpdateActionsReplaceRejectsMixedRRsets(t *testing.T) {
 	}
 }
 
+// The apex SOA and NS RRsets are what make the zone a zone; deleting either
+// leaves something unservable, and the applier's apex guard would then refuse
+// the whole publish, taking any other change in the same update with it.
+func TestBuildZoneUpdateActionsRefusesApexSoaNsDelete(t *testing.T) {
+	for _, rrtype := range []string{"SOA", "NS"} {
+		if _, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+			Verb: VerbDelRRset, Name: "alpha.dnslab.", Rrtype: rrtype,
+		}); err == nil {
+			t.Errorf("delrrset accepted deleting the apex %s RRset", rrtype)
+		}
+	}
+
+	// The same types below the apex are ordinary data: an NS RRset at a
+	// delegation point is exactly what delegation management edits.
+	if _, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbDelRRset, Name: "child.alpha.dnslab.", Rrtype: "NS",
+	}); err != nil {
+		t.Errorf("delrrset refused a non-apex NS RRset: %v", err)
+	}
+}
+
+// Meta and query types never exist as RRsets in a zone, but dns.StringToType
+// resolves them happily -- so without a check the statement is built, queued,
+// and silently does nothing.
+func TestBuildZoneUpdateActionsRefusesMetaTypes(t *testing.T) {
+	for _, rrtype := range []string{"TSIG", "TKEY", "AXFR", "IXFR", "OPT", "MAILB"} {
+		if _, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+			Verb: VerbDelRRset, Name: "foo.alpha.dnslab.", Rrtype: rrtype,
+		}); err == nil {
+			t.Errorf("delrrset accepted meta type %s", rrtype)
+		}
+	}
+}
+
 func TestBuildZoneUpdateActionsRefusesOutOfBailiwick(t *testing.T) {
 	for _, spec := range []ZoneUpdateSpec{
 		{Verb: VerbAddRR, RRs: []string{"foo.beta.dnslab. IN A 1.2.3.4"}},

--- a/v2/zone_update_build_test.go
+++ b/v2/zone_update_build_test.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestBuildZoneUpdateActionsAddAndDelRR(t *testing.T) {
+	add, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbAddRR,
+		RRs:  []string{"foo.alpha.dnslab. 3600 IN A 1.2.3.4"},
+	})
+	if err != nil {
+		t.Fatalf("addrr: %v", err)
+	}
+	if len(add) != 1 {
+		t.Fatalf("addrr produced %d actions, want 1", len(add))
+	}
+	if add[0].Header().Class != dns.ClassINET {
+		t.Errorf("addrr class = %d, want ClassINET", add[0].Header().Class)
+	}
+
+	del, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbDelRR,
+		RRs:  []string{"foo.alpha.dnslab. 3600 IN A 1.2.3.4"},
+	})
+	if err != nil {
+		t.Fatalf("delrr: %v", err)
+	}
+	if del[0].Header().Class != dns.ClassNONE {
+		t.Errorf("delrr class = %d, want ClassNONE (RFC 2136 §2.5.4)", del[0].Header().Class)
+	}
+	// The TTL is not part of RR identity; carrying the caller's TTL into a
+	// delete invites "why did my delete not match" reports.
+	if del[0].Header().Ttl != 0 {
+		t.Errorf("delrr TTL = %d, want 0", del[0].Header().Ttl)
+	}
+}
+
+func TestBuildZoneUpdateActionsDelRRsetAndDelName(t *testing.T) {
+	drs, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbDelRRset, Name: "foo.alpha.dnslab", Rrtype: "a",
+	})
+	if err != nil {
+		t.Fatalf("delrrset: %v", err)
+	}
+	if drs[0].Header().Class != dns.ClassANY || drs[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("delrrset = class %d type %d, want ClassANY/A",
+			drs[0].Header().Class, drs[0].Header().Rrtype)
+	}
+	// An unqualified name must be made absolute, not left to match nothing.
+	if drs[0].Header().Name != "foo.alpha.dnslab." {
+		t.Errorf("owner = %q, want it qualified to foo.alpha.dnslab.", drs[0].Header().Name)
+	}
+
+	dn, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbDelName, Name: "foo.alpha.dnslab.",
+	})
+	if err != nil {
+		t.Fatalf("delname: %v", err)
+	}
+	if dn[0].Header().Class != dns.ClassANY || dn[0].Header().Rrtype != dns.TypeANY {
+		t.Errorf("delname = class %d type %d, want ClassANY/ANY (RFC 2136 §2.5.3)",
+			dn[0].Header().Class, dn[0].Header().Rrtype)
+	}
+
+	// delrrset with type ANY would be delname without delname's apex
+	// protections, so it is refused rather than quietly reinterpreted.
+	if _, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbDelRRset, Name: "alpha.dnslab.", Rrtype: "ANY",
+	}); err == nil {
+		t.Error("delrrset accepted type ANY; expected a refusal pointing at delname")
+	}
+}
+
+// TestBuildZoneUpdateActionsReplaceInfersRRset covers the CLI shape:
+// several --rr flags, with the RRset to replace inferred from their owner and
+// type rather than named separately.
+func TestBuildZoneUpdateActionsReplaceInfersRRset(t *testing.T) {
+	actions, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbReplaceRRset,
+		RRs: []string{
+			"foo.alpha.dnslab. IN A 1.2.3.4",
+			"foo.alpha.dnslab. IN A 2.3.4.5",
+		},
+	})
+	if err != nil {
+		t.Fatalf("replacerrset: %v", err)
+	}
+	if len(actions) != 3 {
+		t.Fatalf("replacerrset produced %d actions, want 3 (one delete + two adds)", len(actions))
+	}
+
+	// The delete must come first, and must name the inferred RRset.
+	if actions[0].Header().Class != dns.ClassANY || actions[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("action[0] = class %d type %d, want the ClassANY A-RRset delete",
+			actions[0].Header().Class, actions[0].Header().Rrtype)
+	}
+	if actions[0].Header().Name != "foo.alpha.dnslab." {
+		t.Errorf("delete owner = %q, want foo.alpha.dnslab.", actions[0].Header().Name)
+	}
+	for _, rr := range actions[1:] {
+		if rr.Header().Class != dns.ClassINET {
+			t.Errorf("replacement RR is class %d, want ClassINET: %v", rr.Header().Class, rr)
+		}
+	}
+}
+
+func TestBuildZoneUpdateActionsReplaceRejectsMixedRRsets(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rrs  []string
+		want string
+	}{
+		{
+			"mixed owners",
+			[]string{"foo.alpha.dnslab. IN A 1.2.3.4", "bar.alpha.dnslab. IN A 2.3.4.5"},
+			"owner",
+		},
+		{
+			"mixed types",
+			[]string{"foo.alpha.dnslab. IN A 1.2.3.4", "foo.alpha.dnslab. IN TXT \"x\""},
+			"type",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+				Verb: VerbReplaceRRset, RRs: tc.rrs,
+			})
+			if err == nil {
+				t.Fatal("expected a refusal: the RRset is inferred, so mixed input is ambiguous")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+
+	// Zero RRs leaves nothing to infer from. Silently treating it as DELRRSET
+	// would delete an RRset the operator never named.
+	if _, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbReplaceRRset,
+	}); err == nil {
+		t.Error("replacerrset with no RRs was accepted; expected a refusal pointing at delrrset")
+	}
+}
+
+func TestBuildZoneUpdateActionsRefusesOutOfBailiwick(t *testing.T) {
+	for _, spec := range []ZoneUpdateSpec{
+		{Verb: VerbAddRR, RRs: []string{"foo.beta.dnslab. IN A 1.2.3.4"}},
+		{Verb: VerbDelRRset, Name: "foo.beta.dnslab.", Rrtype: "A"},
+		{Verb: VerbDelName, Name: "foo.beta.dnslab."},
+		{Verb: VerbReplaceRRset, RRs: []string{"foo.beta.dnslab. IN A 1.2.3.4"}},
+	} {
+		if _, err := BuildZoneUpdateActions("alpha.dnslab.", spec); err == nil {
+			t.Errorf("%s accepted an owner outside the zone", spec.Verb)
+		}
+	}
+}
+
+func TestBuildZoneUpdateActionsRejectsGarbage(t *testing.T) {
+	if _, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: "frobnicate", RRs: []string{"foo.alpha.dnslab. IN A 1.2.3.4"},
+	}); err == nil {
+		t.Error("unknown verb was accepted")
+	}
+	if _, err := BuildZoneUpdateActions("alpha.dnslab.", ZoneUpdateSpec{
+		Verb: VerbAddRR, RRs: []string{"this is not a resource record"},
+	}); err == nil {
+		t.Error("unparseable RR was accepted")
+	}
+}

--- a/v2/zone_update_verbs.go
+++ b/v2/zone_update_verbs.go
@@ -99,6 +99,17 @@ func BuildZoneUpdateActions(zone string, spec ZoneUpdateSpec) ([]dns.RR, error) 
 		if err != nil {
 			return nil, err
 		}
+		// The apex SOA and NS RRsets are what make the zone a zone. Deleting
+		// either leaves something that cannot be served, and the applier's
+		// apex guard would then refuse the entire publish -- taking any other
+		// change in the same update down with it. Refuse here, where the error
+		// can name the problem. (delname protects these too, plus the DNSSEC
+		// and signalling RRsets, because it is a wholesale statement.)
+		if strings.EqualFold(owner, zone) && (rrtype == dns.TypeSOA || rrtype == dns.TypeNS) {
+			return nil, fmt.Errorf(
+				"refusing to delete the apex %s RRset of %s: the zone cannot be served without it",
+				dns.TypeToString[rrtype], zone)
+		}
 		// RFC 2136 §2.5.2: CLASS=ANY, the type to delete, empty RDATA.
 		return []dns.RR{&dns.ANY{Hdr: dns.RR_Header{
 			Name: owner, Rrtype: rrtype, Class: dns.ClassANY, Ttl: 0,
@@ -215,6 +226,15 @@ func specRrtype(s string) (uint16, error) {
 	rrtype, ok := dns.StringToType[s]
 	if !ok {
 		return 0, fmt.Errorf("unknown rrtype %q", s)
+	}
+	// Meta and query types never exist as RRsets in a zone, so a delete
+	// targeting one can only ever be a mistake -- but dns.StringToType happily
+	// resolves them, so without this the statement is built, queued and
+	// silently does nothing. OPT is a pseudo-RR that lives in the additional
+	// section; 128-255 covers TKEY, TSIG, IXFR, AXFR, MAILB and MAILA (ANY is
+	// caught above with a more useful message).
+	if rrtype == dns.TypeOPT || (rrtype >= 128 && rrtype <= 255) {
+		return 0, fmt.Errorf("%q is a meta type and never exists as an RRset in a zone", s)
 	}
 	return rrtype, nil
 }

--- a/v2/zone_update_verbs.go
+++ b/v2/zone_update_verbs.go
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// The five zone-content statements. One frontend, two transports: the same
+// spec is turned into RFC 2136 update-section records here, and those records
+// are either put on the wire (--via ddns) or carried in an UpdateRequest to
+// the ZoneUpdater (--via api). Keeping the translation in one place is what
+// makes the two channels behave identically -- the alternative, encoding the
+// verbs separately per transport, is how they drift.
+const (
+	VerbAddRR        = "addrr"
+	VerbDelRR        = "delrr"
+	VerbDelRRset     = "delrrset"
+	VerbDelName      = "delname"
+	VerbReplaceRRset = "replacerrset"
+)
+
+// ZoneUpdateVerbs lists the statements in the order they are documented.
+var ZoneUpdateVerbs = []string{VerbAddRR, VerbDelRR, VerbDelRRset, VerbDelName, VerbReplaceRRset}
+
+// ZoneUpdateSpec is one statement. RRs carry presentation-form records for the
+// verbs that take them; Name and Rrtype carry the owner/type for the verbs that
+// address an RRset or a name rather than specific records.
+type ZoneUpdateSpec struct {
+	Verb   string
+	RRs    []string // addrr, delrr, replacerrset
+	Name   string   // delrrset, delname
+	Rrtype string   // delrrset
+}
+
+// BuildZoneUpdateActions turns a statement into the update-section records for
+// zone. The result is exactly what goes into UpdateRequest.Actions, and equally
+// what goes into the Ns section of a DNS UPDATE message.
+//
+// Every owner name is checked to be in bailiwick: a statement that addresses a
+// name outside the zone is a client error, not something to hand to the applier
+// and hope it declines.
+func BuildZoneUpdateActions(zone string, spec ZoneUpdateSpec) ([]dns.RR, error) {
+	zone = dns.Fqdn(strings.TrimSpace(zone))
+	if zone == "." || zone == "" {
+		return nil, fmt.Errorf("no zone given")
+	}
+
+	inBailiwick := func(owner string) error {
+		if !dns.IsSubDomain(zone, owner) {
+			return fmt.Errorf("owner %q is not in zone %s", owner, zone)
+		}
+		return nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(spec.Verb)) {
+
+	case VerbAddRR, VerbDelRR:
+		rrs, err := parseSpecRRs(spec.RRs)
+		if err != nil {
+			return nil, err
+		}
+		if len(rrs) == 0 {
+			return nil, fmt.Errorf("%s requires at least one RR", spec.Verb)
+		}
+		class := uint16(dns.ClassINET)
+		if strings.EqualFold(spec.Verb, VerbDelRR) {
+			// RFC 2136 §2.5.4: delete an individual RR by giving it in
+			// CLASS=NONE. The TTL is not part of RR identity and is ignored.
+			class = dns.ClassNONE
+		}
+		var actions []dns.RR
+		for _, rr := range rrs {
+			if err := inBailiwick(rr.Header().Name); err != nil {
+				return nil, err
+			}
+			rr.Header().Class = class
+			if class == dns.ClassNONE {
+				rr.Header().Ttl = 0
+			}
+			actions = append(actions, rr)
+		}
+		return actions, nil
+
+	case VerbDelRRset:
+		owner, err := specOwner(spec.Name)
+		if err != nil {
+			return nil, err
+		}
+		if err := inBailiwick(owner); err != nil {
+			return nil, err
+		}
+		rrtype, err := specRrtype(spec.Rrtype)
+		if err != nil {
+			return nil, err
+		}
+		// RFC 2136 §2.5.2: CLASS=ANY, the type to delete, empty RDATA.
+		return []dns.RR{&dns.ANY{Hdr: dns.RR_Header{
+			Name: owner, Rrtype: rrtype, Class: dns.ClassANY, Ttl: 0,
+		}}}, nil
+
+	case VerbDelName:
+		owner, err := specOwner(spec.Name)
+		if err != nil {
+			return nil, err
+		}
+		if err := inBailiwick(owner); err != nil {
+			return nil, err
+		}
+		// RFC 2136 §2.5.3: CLASS=ANY, TYPE=ANY. At the apex the applier
+		// retains SOA and NS; see ApplyZoneUpdateToZoneData.
+		return []dns.RR{&dns.ANY{Hdr: dns.RR_Header{
+			Name: owner, Rrtype: dns.TypeANY, Class: dns.ClassANY, Ttl: 0,
+		}}}, nil
+
+	case VerbReplaceRRset:
+		rrs, err := parseSpecRRs(spec.RRs)
+		if err != nil {
+			return nil, err
+		}
+		if len(rrs) == 0 {
+			// Deliberately an error rather than silently meaning DELRRSET.
+			// The owner and type are inferred from the supplied records, so
+			// with none supplied there is nothing to infer and the operator
+			// cannot have meant anything specific. delrrset says it plainly.
+			return nil, fmt.Errorf("replacerrset requires at least one RR (use delrrset to remove an RRset)")
+		}
+
+		// The RRset to replace is inferred from the records, so they must all
+		// describe the same one. Mixed input is a mistake worth refusing: the
+		// alternative is silently replacing whichever RRset happened to come
+		// first and dropping the rest into it.
+		owner := rrs[0].Header().Name
+		rrtype := rrs[0].Header().Rrtype
+		for _, rr := range rrs[1:] {
+			if !strings.EqualFold(rr.Header().Name, owner) {
+				return nil, fmt.Errorf(
+					"replacerrset: all RRs must share one owner; got %q and %q",
+					owner, rr.Header().Name)
+			}
+			if rr.Header().Rrtype != rrtype {
+				return nil, fmt.Errorf(
+					"replacerrset: all RRs must share one type; got %s and %s",
+					dns.TypeToString[rrtype], dns.TypeToString[rr.Header().Rrtype])
+			}
+		}
+		if err := inBailiwick(owner); err != nil {
+			return nil, err
+		}
+
+		// Delete the RRset, then add the replacements, in ONE action list.
+		// The applier walks the list in a single pass under one zd.mu and
+		// publishes once at the end, so the empty intermediate RRset is never
+		// visible to a reader and never reaches a secondary as its own serial.
+		// This is why REPLACE needs no dedicated applier support.
+		actions := []dns.RR{&dns.ANY{Hdr: dns.RR_Header{
+			Name: owner, Rrtype: rrtype, Class: dns.ClassANY, Ttl: 0,
+		}}}
+		for _, rr := range rrs {
+			rr.Header().Class = dns.ClassINET
+			actions = append(actions, rr)
+		}
+		return actions, nil
+
+	default:
+		return nil, fmt.Errorf("unknown zone update verb %q (want one of %s)",
+			spec.Verb, strings.Join(ZoneUpdateVerbs, ", "))
+	}
+}
+
+func parseSpecRRs(in []string) ([]dns.RR, error) {
+	var out []dns.RR
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		rr, err := dns.NewRR(s)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse %q: %v", s, err)
+		}
+		if rr == nil {
+			// dns.NewRR returns (nil, nil) for input that is only a comment
+			// or blank after parsing -- not an RR, and not an error either.
+			return nil, fmt.Errorf("%q is not a resource record", s)
+		}
+		out = append(out, rr)
+	}
+	return out, nil
+}
+
+func specOwner(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("no owner name given")
+	}
+	return dns.Fqdn(name), nil
+}
+
+func specRrtype(s string) (uint16, error) {
+	s = strings.ToUpper(strings.TrimSpace(s))
+	if s == "" {
+		return 0, fmt.Errorf("no rrtype given")
+	}
+	if s == "ANY" {
+		// Would be DELNAME by another name, but via a path that does not carry
+		// its apex protections. Refuse and point at the verb that does.
+		return 0, fmt.Errorf("delrrset does not accept type ANY (use delname)")
+	}
+	rrtype, ok := dns.StringToType[s]
+	if !ok {
+		return 0, fmt.Errorf("unknown rrtype %q", s)
+	}
+	return rrtype, nil
+}

--- a/v2/zone_update_verbs_test.go
+++ b/v2/zone_update_verbs_test.go
@@ -143,6 +143,156 @@ func TestDelnameHonoursUpdatePolicy(t *testing.T) {
 	}
 }
 
+// TestDelnamePreAuthorizedBypassesUpdatePolicy: update-policy governs the DDNS
+// channel. An API request has already been authorized by the handler (F2), so
+// the same restrictive policy that limits a wire client must not limit it.
+func TestDelnamePreAuthorizedBypassesUpdatePolicy(t *testing.T) {
+	zd := testZone(t, "example.", verbsZone)
+	registerZones(t, zd)
+	zd.UpdatePolicy = policyAllowing(dns.TypeTXT) // deliberately restrictive
+
+	delname := &dns.ANY{Hdr: dns.RR_Header{
+		Name: "www.example.", Rrtype: dns.TypeANY, Class: dns.ClassANY,
+	}}
+
+	if _, err := zd.ApplyZoneUpdateToZoneData(UpdateRequest{
+		Cmd: "ZONE-UPDATE", ZoneName: "example.",
+		Actions:       []dns.RR{delname},
+		PreAuthorized: true,
+	}, newTestKeyDB(t)); err != nil {
+		t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+	}
+
+	after := verbOwnerTypes(t, zd, "www.example.")
+	for _, rt := range []uint16{dns.TypeA, dns.TypeTXT, dns.TypeMX} {
+		if after[rt] {
+			t.Errorf("%s survived a PreAuthorized DELNAME; the API must not be bound by update-policy",
+				dns.TypeToString[rt])
+		}
+	}
+}
+
+// TestDelnameAtApexRetainsZoneManagementRRsets: DELNAME is wholesale, and
+// nobody issuing it at the apex means "and also dismantle DNSSEC". Deleting the
+// apex DNSKEY on a zone whose DS is published at the parent does not make the
+// zone insecure, it makes it BOGUS -- resolvers stop answering for the whole
+// zone. Retaining more than RFC 2136 §3.4.2.3 requires is deliberate, and errs
+// in the direction of deleting less.
+func TestDelnameAtApexRetainsZoneManagementRRsets(t *testing.T) {
+	const signedApex = `example.	3600	IN	SOA	ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example.	3600	IN	NS	ns.example.
+example.	3600	IN	TXT	"apex text"
+example.	3600	IN	DNSKEY	257 3 15 dem0H2M22a8CDAe0PDZoGBBCBB2fHJ1fe39FkhNToAA=
+example.	3600	IN	CDS	1234 15 2 0000000000000000000000000000000000000000000000000000000000000000
+example.	3600	IN	CSYNC	66 3 A NS AAAA
+`
+	zd := testZone(t, "example.", signedApex)
+	registerZones(t, zd)
+	zd.UpdatePolicy = policyAllowing(dns.TypeTXT, dns.TypeDNSKEY, dns.TypeCDS,
+		dns.TypeCSYNC, dns.TypeSOA, dns.TypeNS)
+
+	delname := &dns.ANY{Hdr: dns.RR_Header{
+		Name: "example.", Rrtype: dns.TypeANY, Class: dns.ClassANY,
+	}}
+	if _, err := zd.ApplyZoneUpdateToZoneData(UpdateRequest{
+		Cmd: "ZONE-UPDATE", ZoneName: "example.", Actions: []dns.RR{delname},
+	}, newTestKeyDB(t)); err != nil {
+		t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+	}
+
+	after := verbOwnerTypes(t, zd, "example.")
+	for _, rt := range []uint16{dns.TypeSOA, dns.TypeNS, dns.TypeDNSKEY, dns.TypeCDS, dns.TypeCSYNC} {
+		if !after[rt] {
+			t.Errorf("apex %s was deleted by DELNAME", dns.TypeToString[rt])
+		}
+	}
+	// Ordinary apex data still goes.
+	if after[dns.TypeTXT] {
+		t.Error("apex TXT survived DELNAME; only the zone-management RRsets are retained")
+	}
+}
+
+// TestApplierRefusesApexSoaNsRRsetDelete: the builder declines these, but
+// actions can be constructed locally. A zone missing its apex SOA or NS cannot
+// be served, and the apex guard in publishWorkingSetLocked would then refuse
+// the whole publish -- discarding every other change in the same update.
+func TestApplierRefusesApexSoaNsRRsetDelete(t *testing.T) {
+	for _, rrtype := range []uint16{dns.TypeSOA, dns.TypeNS} {
+		t.Run(dns.TypeToString[rrtype], func(t *testing.T) {
+			zd := testZone(t, "example.", verbsZone)
+			registerZones(t, zd)
+			zd.UpdatePolicy = policyAllowing(dns.TypeSOA, dns.TypeNS)
+
+			del := &dns.ANY{Hdr: dns.RR_Header{
+				Name: "example.", Rrtype: rrtype, Class: dns.ClassANY,
+			}}
+			if _, err := zd.ApplyZoneUpdateToZoneData(UpdateRequest{
+				Cmd: "ZONE-UPDATE", ZoneName: "example.", Actions: []dns.RR{del},
+			}, newTestKeyDB(t)); err != nil {
+				t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+			}
+
+			if !verbOwnerTypes(t, zd, "example.")[rrtype] {
+				t.Errorf("apex %s RRset was deleted", dns.TypeToString[rrtype])
+			}
+		})
+	}
+}
+
+// TestCallerTtlPreservedForApiAndInternal: update-policy dictates the TTL for
+// records arriving over DDNS -- a wire client does not choose how long the zone
+// caches what it just added. It has no business rewriting an operator's or an
+// internal publisher's TTL: a rollover that wants a short TTL would silently
+// get the policy's instead.
+func TestCallerTtlPreservedForApiAndInternal(t *testing.T) {
+	const callerTTL = 60
+
+	for _, tc := range []struct {
+		name string
+		req  UpdateRequest
+		want uint32
+	}{
+		{"PreAuthorized (API) keeps the caller's TTL",
+			UpdateRequest{PreAuthorized: true}, callerTTL},
+		{"InternalUpdate keeps the caller's TTL",
+			UpdateRequest{InternalUpdate: true}, callerTTL},
+		{"wire DDNS gets the policy TTL",
+			UpdateRequest{}, 3600},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			zd := testZone(t, "example.", verbsZone)
+			registerZones(t, zd)
+			zd.UpdatePolicy = policyAllowing(dns.TypeA) // policy TTL is 3600
+
+			add := &dns.A{
+				Hdr: dns.RR_Header{Name: "new.example.", Rrtype: dns.TypeA,
+					Class: dns.ClassINET, Ttl: callerTTL},
+				A: []byte{10, 0, 0, 1},
+			}
+			req := tc.req
+			req.Cmd = "ZONE-UPDATE"
+			req.ZoneName = "example."
+			req.Actions = []dns.RR{add}
+
+			if _, err := zd.ApplyZoneUpdateToZoneData(req, newTestKeyDB(t)); err != nil {
+				t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+			}
+
+			od, err := zd.GetOwner("new.example.")
+			if err != nil || od == nil {
+				t.Fatalf("new.example. not published: %v", err)
+			}
+			rrset, ok := od.RRtypes.Get(dns.TypeA)
+			if !ok || len(rrset.RRs) == 0 {
+				t.Fatal("A RRset missing")
+			}
+			if got := rrset.RRs[0].Header().Ttl; got != tc.want {
+				t.Errorf("published TTL = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestReplaceRRsetIsAtomicInOneApply checks the claim that REPLACE needs no new
 // applier logic: a CLASS=ANY RRset delete followed by CLASS=INET adds, carried
 // in a single Actions list, is applied in one pass under one zd.mu with a

--- a/v2/zone_update_verbs_test.go
+++ b/v2/zone_update_verbs_test.go
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 Johan Stenstam, johan.stenstam@internetstiftelsen.se
+ */
+
+package tdns
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// policyAllowing builds an UpdatePolicy whose Zone detail permits exactly the
+// listed rrtypes, which is what the applier's per-rrtype gate consults.
+func policyAllowing(rrtypes ...uint16) UpdatePolicy {
+	m := map[uint16]bool{}
+	for _, t := range rrtypes {
+		m[t] = true
+	}
+	return UpdatePolicy{
+		Zone: UpdatePolicyDetail{Type: "selfsub", RRtypes: m, TTL: 3600},
+	}
+}
+
+// verbOwnerTypes reports the rrtypes present at an owner in the PUBLISHED
+// snapshot. The applier stages into a working set and swaps in a new snapshot
+// in its deferred close; zd.Data is the pre-publish store and does not reflect
+// an applied update, so reading it would pass regardless of what the applier
+// did.
+func verbOwnerTypes(t *testing.T, zd *ZoneData, owner string) map[uint16]bool {
+	t.Helper()
+	got := map[uint16]bool{}
+	od, err := zd.GetOwner(owner)
+	if err != nil || od == nil {
+		return got
+	}
+	for _, rt := range od.RRtypes.Keys() {
+		got[rt] = true
+	}
+	return got
+}
+
+const verbsZone = `example.	3600	IN	SOA	ns.example. hostmaster.example. 1 7200 1800 604800 7200
+example.	3600	IN	NS	ns.example.
+example.	3600	IN	TXT	"apex text"
+www.example.	3600	IN	A	192.0.2.1
+www.example.	3600	IN	A	192.0.2.2
+www.example.	3600	IN	TXT	"hello"
+www.example.	3600	IN	MX	10 mail.example.
+`
+
+// TestDelnameDeletesEveryRRsetAtOwner covers the RFC 2136 §2.5.3 statement that
+// has been a silent no-op: CLASS=ANY + TYPE=ANY never matched a key in
+// UpdatePolicy.Zone.RRtypes, so the per-rrtype gate skipped it entirely.
+func TestDelnameDeletesEveryRRsetAtOwner(t *testing.T) {
+	zd := testZone(t, "example.", verbsZone)
+	registerZones(t, zd)
+	zd.UpdatePolicy = policyAllowing(dns.TypeA, dns.TypeTXT, dns.TypeMX)
+
+	before := verbOwnerTypes(t, zd, "www.example.")
+	if !before[dns.TypeA] || !before[dns.TypeTXT] || !before[dns.TypeMX] {
+		t.Fatalf("precondition: www should start with A, TXT and MX, got %v", before)
+	}
+
+	delname := &dns.ANY{Hdr: dns.RR_Header{
+		Name: "www.example.", Rrtype: dns.TypeANY, Class: dns.ClassANY,
+	}}
+
+	updated, err := zd.ApplyZoneUpdateToZoneData(
+		UpdateRequest{Cmd: "ZONE-UPDATE", ZoneName: "example.", Actions: []dns.RR{delname}},
+		newTestKeyDB(t))
+	if err != nil {
+		t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+	}
+	if !updated {
+		t.Fatal("DELNAME reported no change -- this is the silent no-op the fix targets")
+	}
+
+	after := verbOwnerTypes(t, zd, "www.example.")
+	for _, rt := range []uint16{dns.TypeA, dns.TypeTXT, dns.TypeMX} {
+		if after[rt] {
+			t.Errorf("%s survived DELNAME at www.example.", dns.TypeToString[rt])
+		}
+	}
+}
+
+// TestDelnameAtApexRetainsSoaAndNs: deleting the apex SOA and NS would dismantle
+// the zone rather than a name within it (RFC 2136 §3.4.2.3).
+func TestDelnameAtApexRetainsSoaAndNs(t *testing.T) {
+	zd := testZone(t, "example.", verbsZone)
+	registerZones(t, zd)
+	zd.UpdatePolicy = policyAllowing(dns.TypeA, dns.TypeTXT, dns.TypeMX, dns.TypeSOA, dns.TypeNS)
+
+	delname := &dns.ANY{Hdr: dns.RR_Header{
+		Name: "example.", Rrtype: dns.TypeANY, Class: dns.ClassANY,
+	}}
+
+	if _, err := zd.ApplyZoneUpdateToZoneData(
+		UpdateRequest{Cmd: "ZONE-UPDATE", ZoneName: "example.", Actions: []dns.RR{delname}},
+		newTestKeyDB(t)); err != nil {
+		t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+	}
+
+	after := verbOwnerTypes(t, zd, "example.")
+	if !after[dns.TypeSOA] {
+		t.Error("apex SOA was deleted by DELNAME")
+	}
+	if !after[dns.TypeNS] {
+		t.Error("apex NS was deleted by DELNAME")
+	}
+	if after[dns.TypeTXT] {
+		t.Error("apex TXT survived DELNAME -- only SOA and NS are retained")
+	}
+}
+
+// TestDelnameHonoursUpdatePolicy: DELNAME must not become a privilege
+// escalation. A requestor permitted only TXT deletes only the TXT RRset, not
+// every type at the name.
+func TestDelnameHonoursUpdatePolicy(t *testing.T) {
+	zd := testZone(t, "example.", verbsZone)
+	registerZones(t, zd)
+	zd.UpdatePolicy = policyAllowing(dns.TypeTXT)
+
+	delname := &dns.ANY{Hdr: dns.RR_Header{
+		Name: "www.example.", Rrtype: dns.TypeANY, Class: dns.ClassANY,
+	}}
+
+	if _, err := zd.ApplyZoneUpdateToZoneData(
+		UpdateRequest{Cmd: "ZONE-UPDATE", ZoneName: "example.", Actions: []dns.RR{delname}},
+		newTestKeyDB(t)); err != nil {
+		t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+	}
+
+	after := verbOwnerTypes(t, zd, "www.example.")
+	if after[dns.TypeTXT] {
+		t.Error("TXT was permitted by policy but survived DELNAME")
+	}
+	if !after[dns.TypeA] {
+		t.Error("A was NOT permitted by policy but was deleted anyway -- DELNAME escalated privileges")
+	}
+	if !after[dns.TypeMX] {
+		t.Error("MX was NOT permitted by policy but was deleted anyway -- DELNAME escalated privileges")
+	}
+}
+
+// TestReplaceRRsetIsAtomicInOneApply checks the claim that REPLACE needs no new
+// applier logic: a CLASS=ANY RRset delete followed by CLASS=INET adds, carried
+// in a single Actions list, is applied in one pass under one zd.mu with a
+// single publishLocked in the deferred close. Readers therefore never observe
+// the intermediate empty RRset.
+func TestReplaceRRsetIsAtomicInOneApply(t *testing.T) {
+	zd := testZone(t, "example.", verbsZone)
+	registerZones(t, zd)
+	zd.UpdatePolicy = policyAllowing(dns.TypeA)
+
+	serialBefore := zd.CurrentSerial
+
+	del := &dns.ANY{Hdr: dns.RR_Header{
+		Name: "www.example.", Rrtype: dns.TypeA, Class: dns.ClassANY,
+	}}
+	add1 := &dns.A{
+		Hdr: dns.RR_Header{Name: "www.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+		A:   []byte{10, 0, 0, 1},
+	}
+	add2 := &dns.A{
+		Hdr: dns.RR_Header{Name: "www.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+		A:   []byte{10, 0, 0, 2},
+	}
+
+	updated, err := zd.ApplyZoneUpdateToZoneData(
+		UpdateRequest{
+			Cmd: "ZONE-UPDATE", ZoneName: "example.",
+			Actions: []dns.RR{del, add1, add2},
+		}, newTestKeyDB(t))
+	if err != nil {
+		t.Fatalf("ApplyZoneUpdateToZoneData: %v", err)
+	}
+	if !updated {
+		t.Fatal("REPLACE reported no change")
+	}
+
+	od, err := zd.GetOwner("www.example.")
+	if err != nil || od == nil {
+		t.Fatalf("www owner vanished from the published snapshot: %v", err)
+	}
+	rrset, ok := od.RRtypes.Get(dns.TypeA)
+	if !ok {
+		t.Fatal("A RRset missing after REPLACE")
+	}
+	if len(rrset.RRs) != 2 {
+		t.Fatalf("A RRset has %d RRs after REPLACE, want exactly the 2 supplied: %v",
+			len(rrset.RRs), rrset.RRs)
+	}
+	for _, rr := range rrset.RRs {
+		a, ok := rr.(*dns.A)
+		if !ok {
+			t.Fatalf("non-A RR in the A RRset: %v", rr)
+		}
+		if got := a.A.String(); got != "10.0.0.1" && got != "10.0.0.2" {
+			t.Errorf("pre-existing address %s survived REPLACE", got)
+		}
+	}
+
+	// The serial is bumped once per publish. A REPLACE that leaked out as a
+	// delete-then-add would publish twice and bump twice, and a secondary would
+	// see an intermediate serial in which the RRset did not exist at all.
+	if bumped := zd.CurrentSerial - serialBefore; bumped != 1 {
+		t.Errorf("serial advanced by %d, want exactly 1 -- REPLACE must publish once", bumped)
+	}
+}

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -25,10 +25,23 @@ type UpdateRequest struct {
 	Validated      bool     // Signature over update msg is validated
 	Trusted        bool     // Content of update is trusted (via validation or policy)
 	InternalUpdate bool     // Internal update, not a DNS UPDATE from the outside
-	Status         *UpdateStatus
-	Description    string
-	PreCondition   func() bool
-	Action         func() error
+	// PreAuthorized marks a request whose authorization was already settled by
+	// the management API handler (the X-API-Key is the credential) and which
+	// therefore bypasses update-policy, exactly as InternalUpdate does. It is
+	// set in ONE place -- the API zone-update handler, after that handler has
+	// checked allow-api-updates -- and nowhere else. Nothing on the DNS
+	// UPDATE path may ever set it: a wire request that arrived with this flag
+	// would be an unauthenticated update.
+	//
+	// Deliberately a third boolean rather than folding wire/internal/api into
+	// one Origin enum. The enum is the better model and worth doing, but it
+	// touches every InternalUpdate site in the tree and that is a separate
+	// change from adding a channel.
+	PreAuthorized bool
+	Status        *UpdateStatus
+	Description   string
+	PreCondition  func() bool
+	Action        func() error
 }
 
 // updaterCmdMutatesZoneContent reports whether a ZoneUpdater command writes
@@ -188,7 +201,13 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 				// (i.e. not child delegation information).
 				lg.Info("ZoneUpdater: ZONE-UPDATE request", "zone", ur.ZoneName, "actions", len(ur.Actions))
 				lg.Debug("ZoneUpdater: ZONE-UPDATE actions detail", "actions", SprintUpdates(ur.Actions))
-				if zd.Options[OptAllowUpdates] || ur.InternalUpdate {
+				// Admission: the DDNS channel is gated by allow-updates, the
+				// management-API channel by allow-api-updates (checked again
+				// in the handler, which is where PreAuthorized is set -- this
+				// is the backstop, not the only gate), and internal content
+				// changes bypass both.
+				if zd.Options[OptAllowUpdates] || ur.InternalUpdate ||
+					(ur.PreAuthorized && zd.Options[OptAllowApiUpdates]) {
 					// Compute delegation sync status before apply (needs pre-state),
 					// but only enqueue after successful apply.
 					var dss DelegationSyncStatus
@@ -703,7 +722,8 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 					retained++
 					continue
 				}
-				if _, allowed := zd.UpdatePolicy.Zone.RRtypes[t]; !allowed && !ur.InternalUpdate {
+				if _, allowed := zd.UpdatePolicy.Zone.RRtypes[t]; !allowed &&
+					!ur.InternalUpdate && !ur.PreAuthorized {
 					denied++
 					continue
 				}
@@ -722,8 +742,12 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 		rrcopy.Header().Class = dns.ClassINET
 
 		// First check whether this update is allowed by the update-policy.
+		// update-policy governs the DDNS channel. Internal changes and
+		// API-channel requests bypass it: the API's authorization is the API
+		// key, already checked by the handler that set PreAuthorized. Zone
+		// self-service therefore stays on DDNS, where the policy applies.
 		_, ok := zd.UpdatePolicy.Zone.RRtypes[rrtype]
-		if !ok && !ur.InternalUpdate {
+		if !ok && !ur.InternalUpdate && !ur.PreAuthorized {
 			lg.Error("ApplyZoneUpdateToZoneData: RR type denied by policy", "rrtype", rrtypestr)
 			continue
 		}

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	core "github.com/johanix/tdns/v2/core"
@@ -667,6 +668,53 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 				"class", dns.ClassToString[class],
 				"apex_cds_rrs_before", before,
 				"internal_update", ur.InternalUpdate)
+		}
+
+		// DELNAME (RFC 2136 §2.5.3): CLASS=ANY with TYPE=ANY deletes every
+		// RRset at the owner name. It has to be handled here, above the
+		// per-rrtype policy gate below, because TypeANY is never a key in
+		// UpdatePolicy.Zone.RRtypes -- the gate would take the "denied"
+		// branch and `continue`, which is why DELNAME has always been a
+		// silent no-op. That gap was not specific to our own CLI; bind9
+		// nsupdate's "update delete <name>" hit it too.
+		//
+		// Two deliberate restrictions:
+		//
+		//   - At the apex, SOA and NS are retained (RFC 2136 §3.4.2.3).
+		//     Deleting them would dismantle the zone rather than a name in it.
+		//
+		//   - Each rrtype is still checked against the update policy. Hoisting
+		//     the whole statement above the gate would otherwise turn DELNAME
+		//     into a privilege escalation: a requestor permitted to touch only
+		//     TXT could erase every type at the name in one statement. Types
+		//     the policy denies are skipped, so a DELNAME under a restrictive
+		//     policy deletes what that requestor could have deleted one
+		//     statement at a time, and nothing more.
+		if class == dns.ClassANY && rrtype == dns.TypeANY {
+			owner := zd.stagedOwner(ownerName)
+			if owner == nil {
+				lg.Warn("ApplyZoneUpdateToZoneData: DELNAME for unknown owner", "owner", ownerName)
+				continue
+			}
+			isApex := strings.EqualFold(ownerName, zd.ZoneName)
+			var deleted, denied, retained int
+			for _, t := range owner.RRtypes.Keys() {
+				if isApex && (t == dns.TypeSOA || t == dns.TypeNS) {
+					retained++
+					continue
+				}
+				if _, allowed := zd.UpdatePolicy.Zone.RRtypes[t]; !allowed && !ur.InternalUpdate {
+					denied++
+					continue
+				}
+				zd.stageDeleteLocked(ownerName, t)
+				deleted++
+				updated = true
+			}
+			lg.Debug("ApplyZoneUpdateToZoneData: DELNAME", "owner", ownerName,
+				"apex", isApex, "deleted", deleted, "denied_by_policy", denied,
+				"retained_apex_rrsets", retained)
+			continue
 		}
 
 		rrcopy := dns.Copy(rr)

--- a/v2/zone_updater.go
+++ b/v2/zone_updater.go
@@ -44,6 +44,30 @@ type UpdateRequest struct {
 	Action        func() error
 }
 
+// apexRetainedOnDelname reports whether an rrtype survives a DELNAME aimed at
+// the zone apex.
+//
+// RFC 2136 §3.4.2.3 requires only SOA and NS to be retained. The rest are kept
+// because DELNAME is a WHOLESALE statement -- "delete everything at this name"
+// -- and nobody issuing it at the apex means "and also dismantle DNSSEC and
+// stop every rollover signal mid-flight". Deleting the apex DNSKEY RRset on a
+// zone whose DS is published at the parent does not make the zone insecure, it
+// makes it BOGUS: resolvers stop answering for the whole zone. There is no
+// legitimate use of DELNAME that wants that, and an operator who genuinely
+// means it can still say "delrrset --type DNSKEY", which is unambiguous.
+//
+// This is a deliberate deviation from a strict reading of §3.4.2.3, in the
+// conservative direction: it deletes less than the RFC permits, never more.
+func apexRetainedOnDelname(rrtype uint16) bool {
+	switch rrtype {
+	case dns.TypeSOA, dns.TypeNS: // RFC 2136 §3.4.2.3
+		return true
+	case dns.TypeDNSKEY, dns.TypeCDS, dns.TypeCDNSKEY, dns.TypeCSYNC:
+		return true // DNSSEC and delegation-maintenance signalling
+	}
+	return false
+}
+
 // updaterCmdMutatesZoneContent reports whether a ZoneUpdater command writes
 // ZONE CONTENT (as opposed to some side store), and is therefore subject to the
 // origination gate at the head of the updater loop.
@@ -206,8 +230,18 @@ func (kdb *KeyDB) ZoneUpdaterEngine(ctx context.Context) error {
 				// in the handler, which is where PreAuthorized is set -- this
 				// is the backstop, not the only gate), and internal content
 				// changes bypass both.
-				if zd.Options[OptAllowUpdates] || ur.InternalUpdate ||
-					(ur.PreAuthorized && zd.Options[OptAllowApiUpdates]) {
+				//
+				// Snapshot both options together under zd.mu: config reload
+				// mutates the map under that lock, so an unlocked read is a
+				// data race and two independent reads could straddle a reload.
+				// Same treatment the CHILD-UPDATE case above gives its options.
+				zd.mu.Lock()
+				allowUpdates := zd.Options[OptAllowUpdates]
+				allowApiUpdates := zd.Options[OptAllowApiUpdates]
+				zd.mu.Unlock()
+
+				if allowUpdates || ur.InternalUpdate ||
+					(ur.PreAuthorized && allowApiUpdates) {
 					// Compute delegation sync status before apply (needs pre-state),
 					// but only enqueue after successful apply.
 					var dss DelegationSyncStatus
@@ -718,7 +752,7 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 			isApex := strings.EqualFold(ownerName, zd.ZoneName)
 			var deleted, denied, retained int
 			for _, t := range owner.RRtypes.Keys() {
-				if isApex && (t == dns.TypeSOA || t == dns.TypeNS) {
+				if isApex && apexRetainedOnDelname(t) {
 					retained++
 					continue
 				}
@@ -738,7 +772,16 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 		}
 
 		rrcopy := dns.Copy(rr)
-		rrcopy.Header().Ttl = zd.UpdatePolicy.Zone.TTL
+		// update-policy dictates the TTL for records arriving over DDNS: a
+		// wire client does not get to choose how long the zone caches what it
+		// just added. It has no business rewriting the TTL on the other two
+		// channels. An operator using the API said 3600 deliberately, and an
+		// internal publisher (CSYNC/CDS/KEY) picks TTLs that matter to the
+		// signalling it is driving -- a rollover wanting a short TTL would
+		// silently get the policy's instead.
+		if !ur.InternalUpdate && !ur.PreAuthorized {
+			rrcopy.Header().Ttl = zd.UpdatePolicy.Zone.TTL
+		}
 		rrcopy.Header().Class = dns.ClassINET
 
 		// First check whether this update is allowed by the update-policy.
@@ -803,7 +846,25 @@ func (zd *ZoneData) ApplyZoneUpdateToZoneData(ur UpdateRequest, kdb *KeyDB) (boo
 			continue
 
 		case dns.ClassANY:
-			// ClassANY: Remove RRset
+			// ClassANY: Remove RRset.
+			//
+			// Refuse the two RRsets that constitute the zone itself. The CLI
+			// builder already declines these, but actions can also be built
+			// locally, and a zone whose apex SOA or NS RRset has been deleted
+			// is not a zone -- the apex guard in publishWorkingSetLocked would
+			// then refuse the whole publish, discarding every other change in
+			// the same update along with it.
+			//
+			// Only SOA and NS, deliberately. DNSKEY and the signalling RRsets
+			// are protected against wholesale DELNAME (see
+			// apexRetainedOnDelname), but an explicit "delrrset --type DNSKEY"
+			// is unambiguous intent and stays possible.
+			if strings.EqualFold(ownerName, zd.ZoneName) &&
+				(rrtype == dns.TypeSOA || rrtype == dns.TypeNS) {
+				lg.Warn("ApplyZoneUpdateToZoneData: refusing to delete an apex RRset the zone cannot exist without",
+					"zone", zd.ZoneName, "rrtype", rrtypestr)
+				continue
+			}
 			zd.stageDeleteLocked(ownerName, rrtype)
 			// XXX: As long as we don't maintain any NSEC chain removing a complete RRset should not require any resigning.
 			updated = true


### PR DESCRIPTION
Adds the management API as a second channel for RR changes in primary zones,
alongside RFC 2136 DDNS, plus CLI commands for both transports.

**No persistence.** An API update is applied exactly like a DDNS update and is
no more durable. That is deliberate: durability is a separate problem from the
change mechanism, and is Phase 2 (`feature/api-zone-updates-phase2`, branched
off this tip).

## What is here

- **DELNAME implemented.** `CLASS=ANY` + `TYPE=ANY` has always been a silent
  no-op: `TypeANY` is never a key in `UpdatePolicy.Zone.RRtypes`, so the
  per-rrtype gate took its denied branch and continued past the statement.
  Not specific to our tooling — bind9 `nsupdate`'s `update delete <name>` hit
  it too.
- **`allow-api-updates`**, a zone option parallel to `allow-updates` rather
  than folded into it, so opening a zone to SIG(0) DDNS does not thereby open
  it to the API.
- **`UpdateRequest.PreAuthorized`**, set only by the API handler after it has
  checked admission. Bypasses `updatepolicy` as `InternalUpdate` does —
  correct for operator tooling, wrong for self-service, which stays on DDNS.
- **Five statements** — `addrr`, `delrr`, `delrrset`, `delname`,
  `replacerrset` — with one translation to RFC 2136 update records shared by
  both transports, so they cannot drift.
- **CLI for all five**, `--via {api,ddns}` required with no default.
- **`sync`** as an alias for the existing `write-zone`, not a second
  implementation.

## Decisions worth reviewing

- **DELNAME still honours update-policy.** The design doc said to hoist the
  statement above the policy gate; doing exactly that makes DELNAME a
  privilege escalation, since a requestor permitted only TXT could erase every
  type at a name in one statement. Denied types are skipped instead, so
  DELNAME deletes precisely what that requestor could have deleted one
  statement at a time. Apex SOA and NS are retained per RFC 2136 §3.4.2.3.
- **REPLACE needed no applier work.** A `ClassANY` delete followed by
  `ClassINET` adds in one action list is already applied in a single pass
  under one `zd.mu` with one `publishLocked`. A test pins it via the serial
  advancing by exactly 1, so the empty intermediate RRset is never published
  and no secondary can observe it. The doc's §9.2 staged-replace machinery is
  therefore unnecessary and should be struck from it.
- **`allow-api-updates` joins `originationOptions`,** so a tdns-auth secondary
  that may not originate content cannot accept API updates either — otherwise
  the API routes around the MUST-NOT-MODIFY invariant that `allow-updates` is
  already normalized away for.
- **`replacerrset` infers the RRset** from the owner and type of the supplied
  `--rr` records, so mixed owners or types are refused rather than guessed at,
  and zero records is an error rather than a silent `delrrset`.
- **`--via ddns` appends pre-classed records to the update section** rather
  than using `m.Insert`/`m.Remove`/`m.RemoveRRset`. Those helpers re-derive
  the class from the operation and cannot express DELNAME at all, so
  re-deriving would silently drop the one statement with no library helper.
- **`--via api` ships the statement, not pre-built records,** so the server
  runs the same builder and validation is authoritative rather than trusted
  from the client.

## Testing

Full v2 suite and `-race` green. New tests cover DELNAME (deletion, apex
retention, policy filtering), REPLACE atomicity, and the statement builder
including the refusal paths. CLI validation verified against the built binary,
not only in tests:

```
Error: --via is required ("api" or "ddns").
Error: replacerrset: all RRs must share one owner; got "foo.alpha.dnslab." and "bar.alpha.dnslab."
Error: owner "foo.beta.dnslab." is not in zone alpha.dnslab.
Error: delrrset does not accept type ANY (use delname)
```

Not yet exercised against a running server: the API endpoint over HTTP and the
`--via ddns` path end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API and CLI support for DNS zone updates.
  * Added commands to add, delete, replace, or remove DNS records, RRsets, and names.
  * Supports API and DDNS updates, including optional SIG(0) signing.
  * Added atomic RRset replacement and detailed update results.
* **Configuration**
  * Added the `allow-api-updates` zone option.
* **Compatibility**
  * Added `sync` as an alias for the existing zone-writing command.
* **Validation**
  * Added safeguards for invalid updates and protected apex records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->